### PR TITLE
getOption now handles multiply named keys properly

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -299,7 +299,7 @@ class Plugin(object):
         any of the option names is returned."""
 
         def _check(key):
-            if hasattr(key, "__iter__"):
+            if hasattr(optionname, "__iter__"):
                 return key in optionname
             else:
                 return key == optionname

--- a/tests/option_tests.py
+++ b/tests/option_tests.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import unittest
+
+from sos.plugins import Plugin
+
+class GlobalOptionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.commons = {
+            'global_plugin_options': {
+                'test_option': 'foobar',
+            },
+        }
+        self.plugin = Plugin(self.commons)
+
+    def test_simple_lookup(self):
+        self.assertEquals(self.plugin.getOption('test_option'), 'foobar')
+
+    def test_multi_lookup(self):
+        self.assertEquals(self.plugin.getOption(('not_there', 'test_option')), 'foobar')
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
getOptions api allows for a list of key names to be passed in like so:

getOption(('option1', 'option2'))

if option1 is not found then option2 will be searched for. The logic for searching was inverted so this never worked properly. I've provided a fix and a test demonstrating the expected behavior.
