### PR TITLE
Only specify the var/log/juju dir

### DIFF
--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -20,5 +20,5 @@ class juju(Plugin, UbuntuPlugin):
     """ Juju Plugin
     """
     def setup(self):
-        self.addCopySpecs(["/var/log/juju*",
+        self.addCopySpecs(["/var/log/juju",
                            "/var/lib/juju"])


### PR DESCRIPTION
Only the juju directory exists in /var/log/ so grab that rather than globbing for the files.
