### PR TITLE
Remove methods related to java and internationalization.

### DIFF
--- a/sos/__init__.py.in
+++ b/sos/__init__.py.in
@@ -17,9 +17,7 @@
 
 """
 This module houses the i18n setup and message function. The default is to use
-gettext to internationalize messages. If the client calls set_i18n and passes a
-path to a resource bundle the _ method will be changed to use java
-ResourceBundle code to present messages.
+gettext to internationalize messages.
 """
 
 __version__ = "@SOSVERSION@"
@@ -34,41 +32,3 @@ def _default(msg):
     return gettext.dgettext(gettext_app, msg)
 
 _sos = _default
-
-def _get_classloader(jarfile):
-    """Makes a new classloader loaded with the jarfile. This is useful since it
-    seems very difficult to get jars added to the correct classpath for
-    ResourceBundle.getBundle to find."""
-    from java.net import URLClassLoader, URL
-    from java.io import File
-    import jarray
-
-    file_ = File(jarfile)
-    ary = jarray.array([file_.toURL()], URL)
-    classloader = URLClassLoader.newInstance(ary)
-    return classloader
-
-def set_i18n(path=None, basename="sos.po.sos"):
-    """Use this method to change the default i18n behavior from gettext to java
-    ResourceBundle.getString. This is really only useful when using jython.
-    Path is expected to be the path to a jarfile that contains the translation
-    files (.properties)"""
-
-    # Since we are trying to modify the module-level _sos variable
-    # we have to declare it global
-    global _sos
-
-    try:
-        from java.util import ResourceBundle, Locale
-
-        rb = ResourceBundle.getBundle(basename,
-                Locale.getDefault(), _get_classloader(path))
-
-        def _java(msg):
-            try:
-                return rb.getString(msg).encode('utf-8')
-            except:
-                return msg
-        _sos = _java
-    except:
-        pass


### PR DESCRIPTION
- Old methods not needed anymore, set_i18n and _get_classloader both only
  useful if we were still supporting jython.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
