### PR TITLE
New Plugin for Openshift

### DIFF
--- a/sos/plugins/openshift.py
+++ b/sos/plugins/openshift.py
@@ -56,17 +56,17 @@ class Openshift(Plugin, RedHatPlugin):
 
     def postproc(self):
 	    self.do_file_sub('/etc/openshift/broker.conf',
-			    r"(MONGO_PASSWORD=(.*)",
+			    r"MONGO_PASSWORD=(.*)",
 			    r"\1*******")
 
 	    self.do_file_sub('/etc/openshift/broker.conf',
-			    r"(SESSION_SECRET=(.*)",
+			    r"(SESSION_SECRET=)(.*)",
 			    r"\1*******")
 
 	    self.do_file_sub('/etc/openshift/console.conf',
-			    r"(SESSION_SECRET=(.*)",
+			    r"(SESSION_SECRET=)(.*)",
 			    r"\1*******")
 
 	    self.do_file_sub('/etc/openshift/htpasswd',
-			    r"(:(.*))",
+			    r"(:)(.*)",
 			    r"\1********")


### PR DESCRIPTION
I created a plugin that will gather all of the essential logs and output needed to troubleshoot Openshift. Also since different things need to be collected for both the broker and the node, plugin options were created so the user could specify. 
