### PR TITLE
Enable S3 as an upload option.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Navid Sheikhol-Eslami <navid@redhat.com>
 Pierre Amadio  <pamadio@redhat.com>
 Pierre Carrier <pcarrier@redhat.com>
 Ranjith Rajaram <rrajaram@redhat.com>
+Richard Isaacson <richard@eucalyptus.com>
 Sadique Puthen <sputhenp@redhat.com>
 Shijoe George <spanjikk@redhat.com>
 Steve Conklin <sconklin@redhat.com>

--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -50,6 +50,10 @@ specified value in the plug-in PLUGNAME.
 .B \-a, \--alloptions
 Set all boolean options to True for all enabled plug-ins.
 .TP
+.B \--s3
+Upload the report to a S3 bucket. Requires the S3_URL, EC2_ACCESS_KEY
+and EC2_SECRET_KEY environment variables to be set.
+.TP
 .B \--upload FTP_SERVER
 Upload the report to the configured destination.
 .TP

--- a/sos.spec
+++ b/sos.spec
@@ -12,6 +12,7 @@ BuildArch: noarch
 Url: http://fedorahosted.org/sos
 BuildRequires: python-devel
 BuildRequires: gettext
+Requires: python-boto
 Requires: libxml2-python
 Requires: tar
 Requires: bzip2

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -203,6 +203,7 @@ class SoSOptions(object):
     _plugopts = []
     _usealloptions = False
     _upload = False
+    _s3 = False
     _batch = False
     _verbosity = 0
     _quiet = False
@@ -305,6 +306,13 @@ class SoSOptions(object):
         if self._options != None:
             return self._options.upload
         return self._upload
+
+    @property
+    def s3(self):
+        if self._options != None:
+            return self._options.s3
+        return self._s3
+    
 
     @upload.setter
     def upload(self, value):
@@ -472,6 +480,9 @@ class SoSOptions(object):
         parser.add_option("-u", "--upload", action="store",
                              dest="upload", default=False,
                              help="upload the report to an ftp server")
+        parser.add_option("--s3", action="store_true",
+                             dest="s3", default=False,
+                             help="upload the report to a s3 bucket")
         parser.add_option("--batch", action="store_true",
                              dest="batch", default=False,
                              help="batch mode - do not prompt interactively")
@@ -1094,10 +1105,12 @@ class SoSReport(object):
             return False
 
         # automated submission will go here
-        if not self.opts.upload:
-            self.policy.display_results(final_filename)
-        else:
+        if self.opts.s3:
+            self.policy.s3_results(final_filename)
+        elif self.opts.upload:
             self.policy.upload_results(final_filename)
+        else:
+            self.policy.display_results(final_filename)
 
         self.tempfile_util.clean()
 


### PR DESCRIPTION
Our support organization is looking at standardizing how we collect data from customers. Due to our business model we have moved away from ftp and are targeting as S3 bucket as our target. This is for the initial work that I have done to implement this functionality via boto.
