### PR TITLE
import tempfile into policies

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -6,6 +6,7 @@ import platform
 import time
 import fnmatch
 import sys
+import tempfile
 from os import environ
 
 from sos.utilities import ImporterHelper, \


### PR DESCRIPTION
Looks like we just forgot to import tempfile for method 'get_tmp_dir'

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
