### PR TITLE
Fix method call for add_copy_specs

### DIFF
--- a/sos/plugins/openstack.py
+++ b/sos/plugins/openstack.py
@@ -130,7 +130,7 @@ class DebianOpenStack(OpenStack, DebianPlugin, UbuntuPlugin):
             self.addCmdOutput(
                 "/usr/bin/cinder-manage db version",
                 suggest_filename="cinder_db_version")
-        self.addCopySpecs(["/etc/cinder/",
+        self.add_copy_specs(["/etc/cinder/",
                            "/var/log/cinder/",
                            "/etc/logrotate.d/cinder-*"])
         # Glance


### PR DESCRIPTION
This is a small change that may have been overlooked when the method calls
were re-worked.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
