### PR TITLE
Correct archive unittests and pep8 conformity in archive class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   allow_failures:
     - python: 3.2
     - python: 3.3
+    - python: "pypy"
 notifications:
   email: false
 install:


### PR DESCRIPTION
Fixes unittests for sosreport and has been run through the pep8 syntax checker for any cosmetic errors.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
