### PR TITLE
Add support for distutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@ tags
 buildjar/
 gpgkeys/rhsupport.*
 dist-build/*
-sos/__init__.py
 cover/
 .coverage
 *.mo
 sos.conf.5.gz
 sosreport.1.gz
 venv
+MANIFEST
+build/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 python:
   - 2.7
-  - 3.2
   - 3.3
-  - "pypy"
 matrix:
   allow_failures:
-    - python: 3.2
     - python: 3.3
-    - python: "pypy"
 notifications:
   email: false
 install:
   - "pip install nose nose-cov --use-mirrors"
-  - "DESTDIR=. make install"
+  - "python setup.py install"
 script:
-  - "make test"
+  - "nosetests -v --with-cover --cover-package=sos --cover-html"

--- a/debian/docs
+++ b/debian/docs
@@ -1,0 +1,1 @@
+README.md AUTHORS

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+sos.conf etc/

--- a/debian/pkg.pyinstall
+++ b/debian/pkg.pyinstall
@@ -1,1 +1,0 @@
-sos/* /usr/share/sosreport/

--- a/debian/rules
+++ b/debian/rules
@@ -5,4 +5,17 @@ DH_ALWAYS_EXCLUDE=.git
 %:
 	dh $@ --with python2
 
-override_dh_auto_test:
+override_dh_auto_install:
+	python setup.py \
+	install \
+	--install-lib=usr/share/sosreport/ \
+	--install-data=usr/ \
+	--install-scripts=usr/share/sosreport/ \
+	--root=$(CURDIR)/debian/sosreport/ \
+	--no-compile -O0
+
+override_dh_clean:
+	rm -rf build/
+	rm -rf dist/
+	find . -name '*.pyc' -delete
+

--- a/debian/sosreport.links
+++ b/debian/sosreport.links
@@ -1,0 +1,1 @@
+/usr/share/sosreport/sosreport /usr/bin/sosreport

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from distutils.command.build import build
+from distutils.command.install_data import install_data
+from distutils.dep_util import newer
+from distutils.log import warn, info, error
+
+import glob
+import os
+import subprocess
+
+from sos import __version__ as VERSION
+
+PO_DIR = 'po'
+MO_DIR = os.path.join('build', 'mo')
+
+class BuildData(build):
+  def run(self):
+    build.run(self)
+    for po in glob.glob(os.path.join(PO_DIR, '*.po')):
+      lang = os.path.basename(po[:-3])
+      mo = os.path.join(MO_DIR, lang, 'sos.mo')
+
+      directory = os.path.dirname(mo)
+      if not os.path.exists(directory):
+        os.makedirs(directory)
+
+      if newer(po, mo):
+        try:
+          rc = subprocess.call(['msgfmt', '-o', mo, po])
+          if rc != 0:
+            raise Warning("msgfmt returned %d" % (rc,))
+        except Exception, e:
+          error("Failed gettext.")
+          sys.exit(1)
+
+class InstallData(install_data):
+  def run(self):
+    self.data_files.extend(self._find_mo_files())
+    install_data.run(self)
+
+  def _find_mo_files(self):
+    data_files = []
+    for mo in glob.glob(os.path.join(MO_DIR, '*', 'sos.mo')):
+      lang = os.path.basename(os.path.dirname(mo))
+      dest = os.path.join('share', 'locale', lang, 'LC_MESSAGES')
+      data_files.append((dest, [mo]))
+    return data_files
+
+setup(name='sosreport',
+      version=VERSION,
+      description="""Set of tools to gather troubleshooting data
+      from a system Sos is a set of tools that gathers information about system 
+      hardware and configuration. The information can then be used for
+      diagnostic purposes and debugging. Sos is commonly used to help
+      support technicians and developers.""",
+      author='Bryn M. Reeves',
+      author_email='bmr@redhat.com',
+      url='https://github.com/sosreport/sosreport',
+      license="GPLv2+",
+      scripts=['sosreport'],
+      data_files=[
+        ('share/man/man1', ['man/en/sosreport.1']),
+        ('share/man/man5', ['man/en/sos.conf.5']),
+        ],
+      packages=['sos', 'sos.plugins', 'sos.policies'],
+      cmdclass={'build': BuildData, 'install_data': InstallData},
+     )
+

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -1,0 +1,34 @@
+## Copyright 2010 Red Hat, Inc.
+## Author: Adam Stokes <astokes@fedoraproject.org>
+
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+"""
+This module houses the i18n setup and message function. The default is to use
+gettext to internationalize messages.
+"""
+
+__version__ = "3.0"
+
+import gettext
+gettext_dir = "/usr/share/locale"
+gettext_app = "sos"
+
+gettext.bindtextdomain(gettext_app, gettext_dir)
+
+def _default(msg):
+    return gettext.dgettext(gettext_app, msg)
+
+_sos = _default

--- a/tests/utilities_tests.py
+++ b/tests/utilities_tests.py
@@ -46,7 +46,7 @@ class DirTreeTest(unittest.TestCase):
         # I'll admit, this a pretty lame test, but it will at least sniff out
         # some syntax issues
         t = DirTree(os.path.dirname(sos.__file__)).as_string()
-        self.assertTrue('Makefile' in t)
+        self.assertTrue('sos' in t)
 
 
 class ChecksumTest(unittest.TestCase):


### PR DESCRIPTION
- We are planning on moving to python distutils for future packaging
  however, we still want to keep our current build infrastructure around
  until we are able to test the builds overtime. For now distutils will
  live alongside the current build process and slowly replace the Makefiles
  once deemed fit.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
