### PR TITLE
fixups for rhel-6-openstack backports

### DIFF
--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -19,7 +19,7 @@
 import sos.plugintools
 
 
-class OpenStackCeilometer(sos.plugintools.PluginBase):
+class openstack_ceilometer(sos.plugintools.PluginBase):
     """Openstack Ceilometer related information."""
 
     optionList = [("log", "gathers openstack-ceilometer logs", "slow", False)]
@@ -34,7 +34,5 @@ class OpenStackCeilometer(sos.plugintools.PluginBase):
 
     def setup(self):
         # Ceilometer
-        self.addCopySpecs([
-            "/etc/ceilometer/", "/var/log/ceilometer"
-        ])
-
+        self.addCopySpec("/etc/ceilometer/")
+        self.addCopySpec("/var/log/ceilometer")

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -22,7 +22,7 @@ import os
 import sos.plugintools
 
 
-class OpenStackCinder(sos.Plugintools.PluginBase):
+class openstack_cinder(sos.plugintools.PluginBase):
     """openstack cinder related information
     """
 
@@ -38,12 +38,10 @@ class OpenStackCinder(sos.Plugintools.PluginBase):
             self.collectExtOutput("cinder-manage db version",
                          suggest_filename="cinder_db_version")
 
-        self.addCopySpecs([
-            "/etc/sudoers.d/cinder",
-            "/etc/cinder/"
-        ])
+        self.addCopySpec("/etc/sudoers.d/cinder")
+        self.addCopySpec("/etc/cinder/")
 
-        if self.option_enabled("log"):
-            self.addCopySpecs(["/var/log/cinder/"])
+        if self.getOption("log"):
+            self.addCopySpec("/var/log/cinder/")
 
 

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -19,7 +19,7 @@
 import sos.plugintools
 
 
-class OpenStackGlance(plugins.Plugin.PluginBase):
+class openstack_glance(sos.plugintools.PluginBase):
     """OpenstackGlance related information."""
 
     optionList = [("log", "gathers openstack-glance logs", "slow", False)]
@@ -32,9 +32,7 @@ class OpenStackGlance(plugins.Plugin.PluginBase):
         self.collectExtOutput(
             "glance-manage db_version",
             suggest_filename="glance_db_version")
-        self.addCopySpecs([
-            "/etc/glance/",
-            "/var/log/glance/"
-        ])
+        self.addCopySpec("/etc/glance/")
+        self.addCopySpec("/var/log/glance/")
 
 

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -14,10 +14,10 @@
 ## along with this program; if not, write to the Free Software
 ## Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-from sos import plugins
+import sos.plugintools
 
 
-class OpenStackHeat(plugins.Plugin):
+class openstack_heat(sos.plugintools.PluginBase):
     """openstack related information
     """
 
@@ -36,9 +36,7 @@ class OpenStackHeat(plugins.Plugin):
         self.collectExtOutput(
             "heat-manage db_version",
             suggest_filename="heat_db_version")
-        self.addCopySpecs([
-            "/etc/heat/",
-            "/var/log/heat/"
-        ])
+        self.addCopySpec("/etc/heat/")
+        self.addCopySpec("/var/log/heat/")
 
 

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -21,7 +21,7 @@ import os
 import sos.plugintools
 
 
-class OpenStackHorizon(sos.plugintools.PluginBase):
+class openstack_horizon(sos.plugintools.PluginBase):
     """openstack horizon related information
     """
 
@@ -31,13 +31,9 @@ class OpenStackHorizon(sos.plugintools.PluginBase):
                 'openstack-dashboard')
 
     def setup(self):
-        self.addCopySpecs([
-            "/etc/openstack-dashboard/"
-            "/etc/httpd/conf.d/openstack-dashboard.conf"
-        ])
+        self.addCopySpec("/etc/openstack-dashboard/")
+        self.addCopySpec("/etc/httpd/conf.d/openstack-dashboard.conf")
 
-        if self.option_enabled("log"):
-            self.addCopySpecs([
-                "/var/log/horizon/",
-                "/var/log/httpd/"
-            ])
+        if self.getOption("log"):
+            self.addCopySpec("/var/log/horizon/")
+            self.addCopySpec("/var/log/httpd/")

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -19,7 +19,7 @@ import os
 import sos.plugintools
 
 
-class OpenStackKeystone(sos.plugintools.PluginBase):
+class openstack_keystone(sos.plugintools.PluginBase):
     """openstack keystone related information
     """
 
@@ -32,12 +32,10 @@ class OpenStackKeystone(sos.plugintools.PluginBase):
                 'python-keystoneclient')
 
     def setup(self):
-        self.addCopySpecs([
-            "/etc/keystone/default_catalog.templates",
-            "/etc/keystone/keystone.conf",
-            "/etc/keystone/logging.conf",
-            "/etc/keystone/policy.json"
-        ])
+        self.addCopySpec("/etc/keystone/default_catalog.templates")
+        self.addCopySpec("/etc/keystone/keystone.conf")
+        self.addCopySpec("/etc/keystone/logging.conf")
+        self.addCopySpec("/etc/keystone/policy.json")
 
         if self.getOption("log"):
             self.addCopySpec("/var/log/keystone/")

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -18,7 +18,7 @@
 
 import sos.plugintools
 
-class OpenStackNova(sos.plugintools.PluginBase):
+class openstack_nova(sos.plugintools.PluginBase):
     """openstack nova related information
     """
 
@@ -71,14 +71,12 @@ class OpenStackNova(sos.plugintools.PluginBase):
         if self.getOption("log"):
             self.addCopySpec("/var/log/nova/")
 
-        self.addCopySpecs([
-                "/etc/logrotate.d/openstack-nova",
-                "/etc/polkit-1/localauthority/50-local.d/50-nova.pkla",
-                "/etc/sudoers.d/nova",
-                "/etc/security/limits.d/91-nova.conf",
-                "/etc/sysconfig/openstack-nova-novncproxy",
-                "/etc/nova/"
-        ])
+        self.addCopySpec("/etc/logrotate.d/openstack-nova")
+        self.addCopySpec("/etc/polkit-1/localauthority/50-local.d/50-nova.pkla")
+        self.addCopySpec("/etc/sudoers.d/nova")
+        self.addCopySpec("/etc/security/limits.d/91-nova.conf")
+        self.addCopySpec("/etc/sysconfig/openstack-nova-novncproxy")
+        self.addCopySpec("/etc/nova/")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_quantum.py
+++ b/sos/plugins/openstack_quantum.py
@@ -21,7 +21,7 @@ import os
 import sos.plugintools
 
 
-class OpenStackQuantum(sos.plugintools.PluginBase):
+class openstack_quantum(sos.plugintools.PluginBase):
     """openstack quantum related information
     """
     plugin_name = "openstack-quantum"

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -18,7 +18,7 @@
 
 import sos.plugintools
 
-class OpenStackSwift(sos.plugintools.PluginBase):
+class openstack_swift(sos.plugintools.PluginBase):
     """OpenstackSwift related information."""
 
     packages = ('openstack-swift',


### PR DESCRIPTION
Summary of adjustments for sosreport 2.2:
- change classnames to match filenames
- make all classes derive from sos.plugintools.PluginBase
- addCopySpecs is not present in rhel6 sosreport
  (I was testing with sos-2.2-38.el6_4.2.noarch)
- option_enabled -> getOption
