### PR TITLE
Change add_copy_spec calls that are passed array to use add_copy_specs

### DIFF
--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -106,7 +106,7 @@ class DebianOpenStackNova(OpenStackNova, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         super(DebianOpenStackNova, self).setup()
-        self.add_copy_spec(["/etc/sudoers.d/nova_sudoers"])
+        self.add_copy_specs(["/etc/sudoers.d/nova_sudoers"])
 
 
 class RedHatOpenStackNova(OpenStackNova, RedHatPlugin):

--- a/sos/plugins/openstack_quantum.py
+++ b/sos/plugins/openstack_quantum.py
@@ -58,7 +58,7 @@ class DebianOpenStackQuantum(OpenStackQuantum, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         super(DebianOpenStackQuantum, self).setup()
-        self.add_copy_spec(["/etc/sudoers.d/quantum_sudoers"])
+        self.add_copy_specs(["/etc/sudoers.d/quantum_sudoers"])
 
 
 class RedHatOpenStackQuantum(OpenStackQuantum, RedHatPlugin):


### PR DESCRIPTION
This is just fixing a simple typo.  Before the fix I got the following exception:

```
  File "/usr/local/lib/python2.7/dist-packages/sos/plugins/openstack_nova.py", line 109, in setup
    self.add_copy_spec(["/etc/sudoers.d/nova_sudoers"])
  File "/usr/local/lib/python2.7/dist-packages/sos/plugins/__init__.py", line 478, in add_copy_spec
    for filespec in glob.glob(copyspec):
  File "/usr/lib/python2.7/glob.py", line 16, in glob
    return list(iglob(pathname))
  File "/usr/lib/python2.7/glob.py", line 24, in iglob
    if not has_magic(pathname):
  File "/usr/lib/python2.7/glob.py", line 78, in has_magic
    return magic_check.search(s) is not None
TypeError: expected string or buffer

openstack-quantum
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/sos/sosreport.py", line 940, in setup
    plug.setup()
  File "/usr/local/lib/python2.7/dist-packages/sos/plugins/openstack_quantum.py", line 61, in setup
    self.add_copy_spec(["/etc/sudoers.d/quantum_sudoers"])
  File "/usr/local/lib/python2.7/dist-packages/sos/plugins/__init__.py", line 478, in add_copy_spec
    for filespec in glob.glob(copyspec):
  File "/usr/lib/python2.7/glob.py", line 16, in glob
    return list(iglob(pathname))
  File "/usr/lib/python2.7/glob.py", line 24, in iglob
    if not has_magic(pathname):
  File "/usr/lib/python2.7/glob.py", line 78, in has_magic
    return magic_check.search(s) is not None
TypeError: expected string or buffer
```
