### PR TITLE
Force foreman plugin to be quiet

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -27,5 +27,5 @@ class Foreman(Plugin, RedHatPlugin):
     def setup(self):
         foreman_debug_path = os.path.join(
             self.get_cmd_path(),"foreman-debug")
-        self.add_cmd_output("%s -a -d %s"
+        self.add_cmd_output("%s -q -a -d %s"
             % ("foreman-debug", foreman_debug_path))


### PR DESCRIPTION
Recently, we added an interactive question to our foreman-debug script which
could cause troubles to sosreport in some cases. If `-q` option (quiet) is
passed, user is never asked anything. This prevents future issues with this
plugin.
