### PR TITLE
Options to reduce size of sar data collected

### DIFF
--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -40,14 +40,14 @@ class Sar(Plugin,):
         if self.get_option("all_sar"):
             self.sa_size = 0
 
-        self.add_copy_spec_limit("/var/log/sa/sar[0-9]*",
-                                 sizelimit = self.sa_size)
-        self.add_copy_spec_limit("/var/log/sa/sa[0-9]*",
-                              sizelimit = self.sa_size)
+        self.add_copy_spec_limit(os.path.join(self.sa_path, "sar[0-9]*"),
+                                              sizelimit = self.sa_size)
+        self.add_copy_spec_limit(os.path.join(self.sa_path, "sa[0-9]*"),
+                                              sizelimit = self.sa_size)
         try:
             dirList = os.listdir(self.sa_path)
         except:
-            self.soslog.warning("sar: could not list /var/log/sa")
+            self.soslog.warning("sar: could not list %s", self.sa_path)
             return
         # find all the sa file that don't have an existing sar file
         for fname in dirList:
@@ -72,5 +72,5 @@ class RedHatSar(Sar, RedHatPlugin):
 class DebianSar(Sar, DebianPlugin, UbuntuPlugin):
     """ Collect system activity reporter data
     """
-    
+
     sa_path = '/var/log/sysstat'

--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -23,7 +23,8 @@ class Sar(Plugin,):
 
     packages = ('sysstat',)
     sa_path = '/var/log/sa'
-    option_list = [("all_sar", "gather all system activity records", "", False)]
+    option_list = [("all_sar", "gather all system activity records", "", False),
+                   ("skip_sar_reports", "don't gather sar?? generated reports", "", False)]
 
     # size-limit SAR data collected by default (MB)
     sa_size = 20
@@ -40,9 +41,13 @@ class Sar(Plugin,):
         if self.get_option("all_sar"):
             self.sa_size = 0
 
-        self.add_copy_spec_limit(os.path.join(self.sa_path, "sar[0-9]*"),
-                                              sizelimit = self.sa_size)
         self.add_copy_spec_limit(os.path.join(self.sa_path, "sa[0-9]*"),
+                                              sizelimit = self.sa_size)
+
+        if self.get_option("skip_sar_reports"):
+            return
+
+        self.add_copy_spec_limit(os.path.join(self.sa_path, "sar[0-9]*"),
                                               sizelimit = self.sa_size)
         try:
             dirList = os.listdir(self.sa_path)

--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -13,7 +13,7 @@
 ## Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-import os
+import os, glob
 
 class Sar(Plugin,):
     """ Collect system activity reporter data
@@ -24,6 +24,7 @@ class Sar(Plugin,):
     packages = ('sysstat',)
     sa_path = '/var/log/sa'
     option_list = [("all_sar", "gather all system activity records", "", False),
+                   ("data_file_limit", "limit the number of binary sa?? data files collected to the N most recent", "", 0),
                    ("skip_sar_reports", "don't gather sar?? generated reports", "", False)]
 
     # size-limit SAR data collected by default (MB)
@@ -41,8 +42,14 @@ class Sar(Plugin,):
         if self.get_option("all_sar"):
             self.sa_size = 0
 
-        self.add_copy_spec_limit(os.path.join(self.sa_path, "sa[0-9]*"),
-                                              sizelimit = self.sa_size)
+        glob_path = os.path.join(self.sa_path, "sa[0-9]*")
+        limit = self.get_option("data_file_limit")
+        if limit > 0:
+            # Get the most recent N binary datafiles
+            files = sorted(glob.glob(glob_path), key=os.path.getmtime)
+            self.add_copy_specs(files[:limit])
+        else:
+            self.add_copy_spec_limit(glob_path, sizelimit = self.sa_size)
 
         if self.get_option("skip_sar_reports"):
             return


### PR DESCRIPTION
Red Hat, Inc. would like to considerably reduce the size of the sar data collected. We present two options, "skip_sar_reports", where no sar?? files are collected, or .xml files generated, and "data_file_limit", which places a cap on the number of raw sa?? data files collected in the report.

This request also fixes the hard-coded /var/log/sa references.