### PR TITLE
Collect network interfaces flags

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -79,7 +79,8 @@ class Networking(Plugin):
             "/etc/network*",
             "/etc/NetworkManager/NetworkManager.conf",
             "/etc/NetworkManager/system-connections",
-            "/etc/dnsmasq*"])
+            "/etc/dnsmasq*",
+            "/sys/class/net/*/flags"])
         self.add_forbidden_path("/proc/net/rpc/use-gss-proxy")
         self.add_forbidden_path("/proc/net/rpc/*/channel")
         self.add_forbidden_path("/proc/net/rpc/*/flush")


### PR DESCRIPTION
The output of ifconfig or ip link is not enough to understand the full
state of the network card flags. In particular IFF_PROMISC is set on a
a bridge port-member but that is not displayed via ifconfig nor ip link.

See also https://bugzilla.redhat.com/show_bug.cgi?id=199979c#17 why we
need to do this.

Signed-off-by: Michele Baldessari michele@acksyn.org
