### PR TITLE
Add collection of /var/log/cloud-init.log and

### DIFF
--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -36,6 +36,7 @@ class Logs(Plugin):
 
         self.limit = self.get_option("logsize")
         self.add_copy_spec_limit("/var/log/boot*", sizelimit = self.limit)
+        self.add_copy_spec_limit("/var/log/cloud-init*", sizelimit = self.limit)
 
         if self.get_option('all_logs'):
             logs = self.do_regex_find_all("^\S+\s+(-?\/.*$)\s+",


### PR DESCRIPTION
/var/log/cloud-init-output.log if they exist.
Closes: #250

Signed-off-by: Louis Bouchard louis.bouchard@canonical.com
