### PR TITLE
Add collection of /etc/network/interfaces.d for Ubuntu

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -153,6 +153,7 @@ class UbuntuNetworking(Networking, UbuntuPlugin):
         self.add_copy_specs([
             "/etc/resolvconf",
             "/etc/network/interfaces",
+            "/etc/network/interfaces.d",
             "/etc/ufw",
             "/var/log/ufw.Log",
             "/etc/resolv.conf"


### PR DESCRIPTION
Since 14.04 Trusty, ubuntu uses config scripts in
/etc/network/interfaces.d. Collect those.
Closes: #264

Signed-off-by: Louis Bouchard louis.bouchard@canonical.com
