### PR TITLE
Add FirewallD support to networking

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -105,7 +105,9 @@ class Networking(Plugin):
             "ifenslave -a",
             "ip mroute show",
             "ip maddr show",
-            "ip neigh show"
+            "ip neigh show",
+            "firewall-cmd --list-all-zones",
+            "firewall-cmd --permanent --list-all-zones"
         ])
         ip_link_result=self.call_ext_prog("ip -o link")
         if ip_link_result['status'] == 0:


### PR DESCRIPTION
The --list-all-zones command gives a sufficient overview of the firewall state, listing all zones (used or not) and their interfaces, plus any services, ports, or rich rules which apply.

It is required to collect --permanent separately, as it is possible to have a different "runtime" state than "permanent" state.

Solves #291.
