### PR TITLE
[openshift] Collect additional configuration files

### DIFF
--- a/sos/plugins/openshift.py
+++ b/sos/plugins/openshift.py
@@ -30,6 +30,12 @@ class Openshift(Plugin, RedHatPlugin):
 
     ruby = "ruby193"
     vendor = "rh"
+    mco_config_dir = "/opt/%s/%s/root/etc/mcollective" % (vendor, ruby)
+
+    gear_base_dir = "/var/lib/openshift"
+    node_settings_dir = os.path.join(gear_base_dir, ".settings")
+    node_proxy_dir = os.path.join(gear_base_dir, ".httpd.d")
+    httpd_config_dir = "/etc/httpd/conf.d"
 
     def is_broker(self):
         return os.path.exists("/etc/openshift/broker.conf")
@@ -51,7 +57,10 @@ class Openshift(Plugin, RedHatPlugin):
             self.add_copy_spec([
                 "/etc/openshift/quickstarts.json",
                 "/etc/openshift/plugins.d/*.conf",
+                os.path.join(self.mco_config_dir, "client.cfg"),
+                "/var/www/openshift/broker/httpd/httpd.conf",
                 "/var/www/openshift/broker/httpd/conf.d/*.conf",
+                "/var/www/openshift/console/httpd/httpd.conf",
                 "/var/www/openshift/console/httpd/conf.d/*.conf",
             ])
 
@@ -67,7 +76,23 @@ class Openshift(Plugin, RedHatPlugin):
                 "/etc/openshift/cart.conf.d",
                 "/etc/openshift/iptables.*.rules",
                 "/etc/openshift/env",
-                "/opt/%s/%s/root/etc/mcollective" % (self.vendor, self.ruby),
+                os.path.join(self.httpd_config_dir,
+                             "openshift-vhost-logconf.include"),
+                os.path.join(self.httpd_config_dir,
+                             "openshift-http-vhost.include"),
+                os.path.join(self.httpd_config_dir,
+                             "openshift_restorer.include"),
+                os.path.join(self.mco_config_dir, "server.cfg"),
+                os.path.join(self.mco_config_dir, "facts.yaml"),
+                os.path.join(self.node_settings_dir, "district.info"),
+                os.path.join(self.node_proxy_dir, "*.conf"),
+                os.path.join(self.node_proxy_dir, "aliases.txt"),
+                os.path.join(self.node_proxy_dir, "nodes.txt"),
+                os.path.join(self.node_proxy_dir, "idler.txt"),
+                os.path.join(self.node_proxy_dir, "sts.txt"),
+                os.path.join(self.node_proxy_dir, "routes.json"),
+                os.path.join(self.node_proxy_dir, "geardb.json"),
+                os.path.join(self.node_proxy_dir, "sniproxy.json"),
                 "/var/log/httpd/openshift_log",
                 "/var/log/mcollective.log",
                 "/var/log/node-web-proxy/access.log",
@@ -79,7 +104,8 @@ class Openshift(Plugin, RedHatPlugin):
             self.add_cmd_output([
                 "oo-accept-node -v",
                 "oo-admin-ctl-gears list",
-                "ls -laZ /var/lib/openshift"
+                "ls -laZ %s" % self.gear_base_dir,
+                "ls -la %s" % self.node_proxy_dir
             ])
 
     def postproc(self):
@@ -100,12 +126,10 @@ class Openshift(Plugin, RedHatPlugin):
 
         # Redact passwords of the form:
         # plugin.activemq.pool.1.password = Pa$sW0Rd
-        self.do_file_sub("/opt/%s/%s/root/etc/mcollective/server.cfg" %
-                         (self.vendor, self.ruby),
+        self.do_file_sub(os.path.join(self.mco_config_dir, "server.cfg"),
                          r"(.*password\s*=\s*)\S+",
                          r"\1********")
-        self.do_file_sub("/opt/%s/%s/root/etc/mcollective/client.cfg" %
-                         (self.vendor, self.ruby),
+        self.do_file_sub(os.path.join(self.mco_config_dir, "client.cfg"),
                          r"(.*password\s*=\s*)\S+",
                          r"\1********")
 


### PR DESCRIPTION
The openshift node routing plugins place configuration in files
that are not collected by the Apache plugin. Adding these here.

Signed-off-by: Pep Turro Mauri <pep@redhat.com>