### PR TITLE
Collect local FirewallD XML config

### DIFF
--- a/sos/plugins/firewalld.py
+++ b/sos/plugins/firewalld.py
@@ -27,6 +27,9 @@ class FirewallD(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_specs([
             "/etc/firewalld/firewalld.conf",
+            "/etc/firewalld/icmptypes/*.xml",
+            "/etc/firewalld/services/*.xml",
+            "/etc/firewalld/zones/*.xml",
             "/etc/sysconfig/firewalld"
         ])
 


### PR DESCRIPTION
FirewallD looks for config files for icmptypes, zones, and services in `/etc/firewalld/` and if none are found, falls back to `/usr/lib/firewalld/`. This way, changes made on the system are stored under `/etc/firewalld/` which overrides the default.

Resolves #332
