### PR TITLE
[ldap] - fix undefined variable ldap_conf

### DIFF
--- a/sos/plugins/ldap.py
+++ b/sos/plugins/ldap.py
@@ -78,7 +78,7 @@ class DebianLdap(Ldap, DebianPlugin, UbuntuPlugin):
         ldap_search = "ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// "
 
         self.add_copy_specs([
-            ldap_conf,
+            self.ldap_conf,
             "/etc/slapd.conf",
             "/etc/ldap/slapd.d"
         ])


### PR DESCRIPTION
Code was attempting to access a variable within the incorrect scope.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
