### PR TITLE
[travis-ci] run pep8 against code tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ notifications:
       - "us.freenode.net#sosreport"
     on_success: change
 install:
-  - "pip install six nose nose-cov --use-mirrors"
+  - "pip install six nose nose-cov pep8 --use-mirrors"
   - "python setup.py install"
 script:
+  - "pep8 sos"
   - "nosetests -v --with-cover --cover-package=sos --cover-html"


### PR DESCRIPTION
To ensure proper code formatting and syntax is being done this enables
travis-ci to continually check pep8 compliance. This is useful as it will tend
to spot a lot of syntax errors that the unittests may not pick up.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
