### PR TITLE
[lvm] Extend reporting fields for pvs, vgs and lvs.

### DIFF
--- a/sos/plugins/lvm2.py
+++ b/sos/plugins/lvm2.py
@@ -53,9 +53,9 @@ class Lvm2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_outputs([
             "vgscan -vvv %s" % lvm_opts,
             "pvscan -v %s" % lvm_opts,
-            "pvs -a -v %s" % lvm_opts,
-            "vgs -v %s" % lvm_opts,
-            "lvs -a -o +devices %s" % lvm_opts
+            "pvs -a -v -o +pv_mda_free,pv_mda_size,pv_mda_count,pv_mda_used_count %s" % lvm_opts,
+            "vgs -v -o +vg_tags,vg_mda_count,vg_mda_free,vg_mda_size,vg_mda_used_count %s" % lvm_opts,
+            "lvs -a -o +lv_tags,devices %s" % lvm_opts
         ])
 
         self.add_copy_spec("/etc/lvm")


### PR DESCRIPTION
There were some useful columns missing from the output of the commands 'pvs', 'vgs' and 'lvs'
that we gather in the lvm plugin. This patch extends the reporting fields with:
- Information about metadata, like copies and size of mda, to the output of the 'pvs'
  command.
- Information about metadata and tags for the output of the 'vgs' command, and
- information about tags for the output of 'lvs'.

Attempts to solve at least partially issue #331.

Signed-off-by: Jose Castillo jcastillo@redhat.com
