### PR TITLE
[archive] log add_string exception

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -177,8 +177,9 @@ class FileCacheArchive(Archive):
         if os.path.exists(src):
             try:
                 shutil.copystat(src, dest)
-            except OSError:
-                pass
+            except OSError as e:
+                self.log_error(
+                    "Unable to add '%s' to FileCacheArchive: %s" % (dest, e))
         self.log_debug("added string at '%s' to FileCacheArchive '%s'"
                        % (src, self._archive_root))
 


### PR DESCRIPTION
Log any permission related exceptions when running plugins as non-root.
Eventually this information can be reviewed to see the impact of running
plugins as non-root users to better decide where root is needed on a per
plugin basis.

References #164

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
