### PR TITLE
[docs] add policies api reference

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,5 +92,6 @@ Core Reference
    :maxdepth: 2
 
    archive
+   policies
    reporting
    utilities

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -1,0 +1,8 @@
+``sos.plugins`` --- Policy Interface
+====================================
+
+.. automodule:: sos.policy
+    :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Include the base policy plugin reference in the auto-generated
documentation.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
