### PR TITLE
[docker] capture logs of running containers, add ubuntu support

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -13,30 +13,63 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-from sos.plugins import Plugin, RedHatPlugin
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
-class Docker(Plugin, RedHatPlugin):
+class Docker(Plugin):
     """Docker information
     """
 
     plugin_name = 'docker'
+    docker_bin = "docker"
 
     def setup(self):
         self.add_copy_specs([
-            "/etc/udev/rules.d/80-docker.rules",
             "/var/lib/docker/repositories-*"
         ])
 
         self.add_cmd_outputs([
-            "docker info",
-            "docker ps",
-            "docker images"
+            "{0} info".format(self.docker_bin),
+            "{0} ps".format(self.docker_bin),
+            "{0} images".format(self.docker_bin)
+        ])
+
+        result = self.get_command_output("{0} ps".format(
+            self.docker_bin))
+        if result['status'] == 0:
+            result['output'] = result['output'].split("\n")
+            for line in result['output'][1:]:
+                container_id = line.split(" ")[0]
+                self.add_cmd_outputs([
+                    "{0} logs {1}".format(self.docker_bin, container_id)
+                ])
+
+
+class RedHatDocker(Docker, RedHatPlugin):
+
+    packages = ('docker-io',)
+
+    def setup(self):
+        super(RedHatDocker, self).setup()
+
+        self.add_copy_specs([
+            "/etc/udev/rules.d/80-docker.rules"
         ])
 
 
-class RedHatDocker(Plugin, RedHatPlugin):
+class UbuntuDocker(Docker, UbuntuPlugin):
+    """ Docker information on Ubuntu
+    """
 
-    packages = ('docker-io',)
+    packages = ('docker.io',)
+
+    # Name collision with another package requires docker binary rename
+    docker_bin = 'docker.io'
+
+    def setup(self):
+        super(UbuntuDocker, self).setup()
+        self.add_copy_specs([
+            "/etc/default/docker.io"
+        ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Query `docker ps` and capture log output from current running containers.
Additionally, add support for Ubuntu systems and address a nuance where Ubuntu
systems use a different binary name for docker since a previous package already
owns the docker binary name.

Closes: #360 

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
