### PR TITLE
[fcoe] Add plugin to get information about FCoE.

### DIFF
--- a/sos/plugins/fcoe.py
+++ b/sos/plugins/fcoe.py
@@ -1,0 +1,38 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class fcoe(Plugin, RedHatPlugin):
+    """fcoe related information
+    """
+
+    plugin_name = 'fcoe'
+    packages = ('fcoe-utils',)
+
+    def setup(self):
+        # Here we capture the information about all
+        # FCoE instances with the -i option, and
+        # information about all discovered FCFs
+        # with the -f option
+        self.add_cmd_outputs([
+            "fcoeadm -i",
+            "fcoeadm -f"
+        ])
+        # Here we grab information about the
+        # interfaces's config files
+        self.add_copy_spec("/etc/fcoe")
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
This plugin gets the configuration files present in the
directory  /etc/fcoe and the output of two commands:
- 'fcoeadmin -i' shows information about all FCoE instances, and
- 'fcoeadmin -s' shows information about all discovered
  Fibre Channel Forwarders (FCFs).

Attempts to fix issue #369

Signed-off-by: Jose Castillo jcastillo@redhat.com
