### PR TITLE
[policies] Add dist_version to policy class

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -179,6 +179,12 @@ No changes will be made to system configuration.
         """
         return False
 
+    def dist_version(self):
+        """
+        Return the OS version
+        """
+        pass
+
     def get_preferred_archive(self):
         """
         Return the class object of the prefered archive format for this

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -30,14 +30,16 @@ class DebianPolicy(LinuxPolicy):
            It returns True or False."""
         return os.path.isfile('/etc/debian_version')
 
-    def debianVersion(self):
+    def dist_version(self):
         try:
-            fp = open("/etc/debian_version").read()
-            if "wheezy/sid" in fp:
-                return 6
-            fp.close()
+            with open('/etc/lsb-release', 'r') as fp:
+                rel_string = fp.read()
+                if "wheezy/sid" in rel_string:
+                    return 6
+                elif "jessie/sid" in rel_string:
+                    return 7
+            return False
         except:
-            pass
-        return False
+            return False
 
 # vim: et ts=4 sw=4

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -128,7 +128,7 @@ No changes will be made to system configuration.
         return (os.path.isfile('/etc/redhat-release')
                 and not os.path.isfile('/etc/fedora-release'))
 
-    def rhel_version(self):
+    def dist_version(self):
         try:
             pkg = self.pkg_by_name("redhat-release") or \
                 self.all_pkgs_by_name_regex("redhat-release-.*")[-1]

--- a/sos/policies/ubuntu.py
+++ b/sos/policies/ubuntu.py
@@ -23,4 +23,17 @@ class UbuntuPolicy(DebianPolicy):
         except:
             return False
 
+    def dist_version(self):
+        """ Returns the version stated in DISTRIB_RELEASE
+        """
+        try:
+            with open('/etc/lsb-release', 'r') as fp:
+                lines = fp.readlines()
+                for line in lines:
+                    if "DISTRIB_RELEASE" in line:
+                        return line.split("=")[1].strip()
+            return False
+        except:
+            return False
+
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Exposes a `dist_version` to be inherited by policy classes to provide
distribution release numbers.

For example, on Ubuntu calling this method would return with `14.04`.

Fixes #216

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
