### PR TITLE
[plugins] New ubuntu-support-status plugin

### DIFF
--- a/sos/plugins/ubuntu_support_status.py
+++ b/sos/plugins/ubuntu_support_status.py
@@ -1,0 +1,36 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+class UbuntuSupportStatus(Plugin, UbuntuPlugin):
+    """ Ubuntu-support-status Show packages support status
+    """
+
+    plugin_name = 'ubuntu-support-status'
+
+    option_list = [
+        ('show-all',
+         'Show all packages with their status', '', False),
+    ]
+
+    def setup(self):
+        cmd = ["ubuntu-support-status"]
+
+        if self.get_option('show-all'):
+            cmd.append("--show-all")
+
+        self.add_cmd_output(" ".join(cmd),
+                            suggest_filename=self.plugin_name)


### PR DESCRIPTION
This ubuntu-specific plugin exposes the ubuntu-support-status
command for gathering package support status information.

Signed-off-by: Jorge Niedbalski R niedbalski@gmail.com
