### PR TITLE
[openvswitch] Add new plugin

### DIFF
--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -51,26 +51,6 @@ class Neutron(Plugin):
         ])
 
         self.netns_dumps()
-        self.get_ovs_dumps()
-
-    def get_ovs_dumps(self):
-        # Check to see if we are using the Open vSwitch plugin. If not we
-        # should be able to skip the rest of the dump.
-        ovs_conf_check = self.call_ext_prog(
-            'grep "^core_plugin.*openvswitch" ' +
-            ("/etc/%s/*.conf" + self.component_name))
-        if not (ovs_conf_check['status'] == 0):
-            return
-        if len(ovs_conf_check['output'].splitlines()) == 0:
-            return
-
-        # The '-s' option enables dumping of packet counters on the
-        # ports.
-        self.add_cmd_output("ovs-dpctl -s show")
-
-        # The '-t 5' adds an upper bound on how long to wait to connect
-        # to the Open vSwitch server, avoiding hangs when running sosreport.
-        self.add_cmd_output("ovs-vsctl -t 5 show")
 
     def netns_dumps(self):
         # It would've been beautiful if we could get parts of the networking

--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2014 Adam Stokes <adam.stokes@ubuntu.com>
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class OpenVSwitch(Plugin):
+    """ OpenVSwitch related information
+    """
+    plugin_name = "openvswitch"
+
+    def setup(self):
+        # The '-s' option enables dumping of packet counters on the
+        # ports.
+        self.add_cmd_output("ovs-dpctl -s show")
+
+        # The '-t 5' adds an upper bound on how long to wait to connect
+        # to the Open vSwitch server, avoiding hangs when running sosreport.
+        self.add_cmd_output("ovs-vsctl -t 5 show")
+
+
+class RedHatOpenVSwitch(OpenVSwitch, RedHatPlugin):
+    """ OpenVSwitch on Ubuntu/Debian related information
+    """
+    packages = ('openvswitch',)
+
+
+class DebianOpenVSwitch(OpenVSwitch, DebianPlugin, UbuntuPlugin):
+    """ OpenVSwitch on Ubuntu/Debian related information
+    """
+    packages = ('openvswitch-switch',)
+
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
This splits out the ovs collection data from the Neutron plugin.

Fixes #328

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
