### PR TITLE
[rpm] Add Signature tag to the output of 'installed-rpms'

### DIFF
--- a/sos/plugins/rpm.py
+++ b/sos/plugins/rpm.py
@@ -39,8 +39,9 @@ class Rpm(Plugin, RedHatPlugin):
         if self.get_option("rpmq"):
             query_fmt = '"%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}~~'
             query_fmt = query_fmt + '%{INSTALLTIME:date}\t%{INSTALLTIME}\t'
-            query_fmt = query_fmt + '%{VENDOR}\t%{BUILDHOST}\n"'
-            rpmq_cmd = "rpm --nosignature --nodigest -qa --qf=%s" % query_fmt
+            query_fmt = query_fmt + '%{VENDOR}\t%{BUILDHOST}\t'
+            query_fmt = query_fmt + '%{SIGPGP}\t%{SIGPGP:pgpsig}\n"'
+            rpmq_cmd = "rpm --nodigest -qa --qf=%s" % query_fmt
             filter_cmd = 'awk -F "~~" ' \
                 '"{printf \\"%-59s %s\\n\\",\$1,\$2}"|sort'
             shell_cmd = "sh -c '%s'" % (rpmq_cmd + "|" + filter_cmd)


### PR DESCRIPTION
 RPM meta data consists of Signature,Packager,BuildHost,Vendor tags
 it is useful for identifying 3rd party packages present on a system.
 This patch adds the signature column to installed-rpms.

Signed-off-by: Poornima M. Kshirsagar pkshiras@redhat.com
