### PR TITLE
[apt] Add apt-cache policy info for installed pkg

### DIFF
--- a/sos/plugins/apt.py
+++ b/sos/plugins/apt.py
@@ -28,7 +28,7 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
             "/etc/apt", "/var/log/apt"
         ])
 
-        shell_cmd = "sh -c '%s'" % (
+        apt_cache_policy_ext = "sh -c '%s'" % (
             "dpkg -l | grep ^ii |"
             "cut -d \" \" -f3 |"
             "xargs apt-cache policy"
@@ -38,7 +38,7 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
             "apt-config dump",
             "apt-cache stats",
             "apt-cache policy",
-            shell_cmd
+            apt_cache_policy_ext
         ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
apt-cache policy information for each package can be
useful to identify the source of the installed package.
Fixes #389

Signed-off-by: Louis Bouchard louis.bouchard@canonical.com
