### PR TITLE
Try to ensure FQDN of host is collected

### DIFF
--- a/sos/plugins/general.py
+++ b/sos/plugins/general.py
@@ -32,6 +32,7 @@ class General(Plugin):
         ])
 
         self.add_cmd_output("hostname", root_symlink="hostname")
+        self.add_cmd_output("hostname -f", root_symlink="hostname-f")
         self.add_cmd_output("date", root_symlink="date")
         self.add_cmd_output("uptime", root_symlink="uptime")
 


### PR DESCRIPTION
Not all systems are required to have the generic hostname command return
the FQDN. We have encountered customers who require the a short name by
default. Adding the "-f" output helps to get that information.
