### PR TITLE
[apt]: switching shell crap to python syntax

### DIFF
--- a/sos/plugins/apt.py
+++ b/sos/plugins/apt.py
@@ -15,7 +15,6 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, UbuntuPlugin, DebianPlugin
-import pdb
 
 
 class Apt(Plugin, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Avoid long string of piped shell commands at all cost
Fixes: #398

Signed-off-by: Louis Bouchard louis.bouchard@canonical.com
