### PR TITLE
Fix backtrace from juju plugin

### DIFF
--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -42,6 +42,7 @@ class Juju(Plugin, UbuntuPlugin):
 
     plugin_name = 'juju'
     profiles = ('virt', 'sysmgmt')
+    packages = ('juju',)
 
     option_list = [
         ('export-mongodb',


### PR DESCRIPTION
Restrict plugin execution to when juju is installed
Fixes: #400

Signed-off-by: Louis Bouchard louis.bouchard@canonical.com
