### PR TITLE
[openstack_neutron] with latest sos-3.2-4.el7.noarch neutron configurati...

### DIFF
--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -40,11 +40,12 @@ class Neutron(Plugin):
     component_name = "neutron"
 
     def setup(self):
-        if os.path.exists("/etc/neutron/") and \
+        if os.path.exists("/etc/quantum/") and \
                 self.get_option("quantum", False):
-            self.component_name = self.plugin_name
-        else:
             self.component_name = "quantum"
+        else:
+            if os.path.exists("/etc/neutron/"):
+                self.component_name = "neutron"
 
         self.add_copy_spec([
             "/etc/%s/" % self.component_name,


### PR DESCRIPTION
...on and logs files are not captured.

 When running openstack_neutron plugin with commands "sosreport -o openstack_neutron"
 openstack_neutron plugin does not collect /var/log/neutron logs and /etc/neutron files.
 This patch captures the configuration files at /etc/neutron and
 relative logs at /var/log/neutron location

 Signed-off-by: Poornima M. Kshirsagar <pkshiras@redhat.com>