### PR TITLE
[logs] Collect old syslog and apport logs

### DIFF
--- a/sos/plugins/apport.py
+++ b/sos/plugins/apport.py
@@ -25,5 +25,9 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         self.add_copy_spec("/etc/apport/*")
+        self.add_copy_spec("/var/lib/whoopsie/whoopsie-id")
+        self.add_cmd_output("gdbus call -y -d com.ubuntu.WhoopsiePreferences -o /com/ubuntu/WhoopsiePreferences -m com.ubuntu.WhoopsiePreferences.GetIdentifier")
+        self.add_cmd_output("ls -alh /var/crash/")
+        self.add_cmd_output("grep ProcMaps -B 50 -m 1 /var/crash/")
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -79,17 +79,26 @@ class DebianLogs(Logs, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         super(DebianLogs, self).setup()
-        self.add_copy_spec([
-            "/var/log/syslog",
-            "/var/log/udev",
-            "/var/log/kern*",
-            "/var/log/mail*",
-            "/var/log/dist-upgrade",
-            "/var/log/installer",
-            "/var/log/unattended-upgrades",
-            "/var/log/apport.log",
-            "/var/log/landscape"
-        ])
+
+        if not self.get_option("all_logs"):
+            limit = self.get_option("log_size")
+            self.add_copy_spec_limit("/var/log/syslog", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/syslog.1", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/kern", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/kern.1", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/apport.log", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/apport.log.1", sizelimit=limit)
+
+            self.add_copy_spec_limit("/var/log/udev", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/mail", sizelimit=limit)
+
+            self.add_copy_spec_limit("/var/log/dist-upgrade", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/installer", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/unattended-upgrades",
+                                     sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/landscape", sizelimit=limit)
+        else:
+            self.add_copy_spec("/var/log/");
 
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -30,5 +30,14 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "ps auxwwwm",
             "ps alxwww"
         ])
+        self.add_copy_spec([
+            "/proc/*/comm",
+            "/proc/*/limits",
+            "/proc/*/stack",
+            "/proc/*/status",
+            "/proc/*/cpuset",
+            "/proc/*/environ",
+            "/proc/*/oom_*",
+        ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Previously we were only collecting the most recent syslog
and apport log.  Now we collect all the old ones too.

Signed-off-by: Bryan Quigley <Bryan.Quigley@Canonical.com>