### PR TITLE
[rpm] Add Sha1header to the output of 'installed-rpms'

### DIFF
--- a/sos/plugins/rpm.py
+++ b/sos/plugins/rpm.py
@@ -41,6 +41,7 @@ class Rpm(Plugin, RedHatPlugin):
             query_fmt = '"%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}~~'
             query_fmt = query_fmt + '%{INSTALLTIME:date}\t%{INSTALLTIME}\t'
             query_fmt = query_fmt + '%{VENDOR}\t%{BUILDHOST}\t'
+            query_fmt = query_fmt + '%{RPMTAG_SHA1HEADER}\t'
             query_fmt = query_fmt + '%{SIGPGP}\t%{SIGPGP:pgpsig}\n"'
             rpmq_cmd = "rpm --nodigest -qa --qf=%s" % query_fmt
             filter_cmd = 'awk -F "~~" ' \


### PR DESCRIPTION
RPM meta data is useful for identifying 3rd party packages present on a system.
This patch adds the Sha1header column to installed-rpms.
Sha1headers identify uniqueness of installed RPM with rpm tag

Signed-off-by: Poornima M. Kshirsagar <pkshiras@redhat.com>