### PR TITLE
Add prominent link to user focused docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,10 @@ SoS
 
 Sos is an extensible, portable, support data collection tool primarily aimed at Linux distributions and other UNIX-like operating systems.
 
+This is the SoS developer documentation, for user documentation refer to:
+
+https://github.com/sosreport/sos/wiki
+
 This project is hosted at:
 
 http://github.com/sosreport/sos


### PR DESCRIPTION
It wasn't immediately clear to me from the developer docs what SoS actually _does_, but the user docs made it clear.
