### PR TITLE
[Yum] Add subscription-manager identity output

### DIFF
--- a/sos/plugins/yum.py
+++ b/sos/plugins/yum.py
@@ -51,7 +51,8 @@ class Yum(Plugin, RedHatPlugin):
             "/var/log/rhsm/rhsmcertd.log"])
         self.add_cmd_output([
             "subscription-manager list --installed",
-            "subscription-manager list --consumed"
+            "subscription-manager list --consumed",
+            "subscription-manager identity"
         ])
         self.add_cmd_output("rhsm-debug system --sos --no-archive "
                             "--no-subscriptions --destination %s"


### PR DESCRIPTION
 "subscription-manager identity" display consumer registered uuid
 and registered org uuid/name , which is useful to track rhn related issues

Signed-off-by: spandey spandey@redhat.com
