### PR TITLE
[plugins/rabbitmq] Added cluster_status command output

### DIFF
--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -25,6 +25,8 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         self.add_cmd_output("rabbitmqctl report")
+        self.add_cmd_output("rabbitmqctl cluster_status")
+
         self.add_copy_spec("/etc/rabbitmq/*")
         self.add_copy_spec_limit("/var/log/rabbitmq/*",
                                  sizelimit=self.get_option('log_size'))


### PR DESCRIPTION
- Added the 'rabbitmqctl cluster_status' output command

Signed-off-by: Jorge Niedbalski R. niedbalski@gmail.com
