### PR TITLE
Collect corosync-cfgtool -s output and added Pacemaker support

### DIFF
--- a/sos/plugins/corosync.py
+++ b/sos/plugins/corosync.py
@@ -34,6 +34,7 @@ class Corosync(Plugin):
             "corosync-quorumtool -s",
             "corosync-cpgtool",
             "corosync-objctl -a",
+            "corosync-cfgtool -s",
             "corosync-fplay",
             "corosync-objctl -w runtime.blackbox.dump_state=$(date +\%s)",
             "corosync-objctl -w runtime.blackbox.dump_flight_data=$(date +\%s)"

--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -1,0 +1,32 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class Pacemaker(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    "HA Cluster resource manager"
+
+    plugin_name = "pacemaker"
+    profiles = ("cluster", )
+    packages = ("pacemaker", )
+
+    def setup(self):
+        self.add_copy_spec([
+            "/var/lib/pacemaker/cib/cib.xml"
+        ])
+        self.add_cmd_output([
+            "crm status",
+            "crm configure show",
+        ])


### PR DESCRIPTION
This patch improves HA clustering information gathering adding a new a
new plugin for Pacemaker.

Here is a portion of the list of files that were included in a report generated with this change:

```
...
 -rw-r--r--    root/root        116 sosreport-freyes-local-machine-3.1234-20141118160449/sos_commands/corosync/corosync-cfgtool_-s
 drwx------    root/root          0 sosreport-freyes-local-machine-3.1234-20141118160449/sos_commands/pacemaker/
 -rw-r--r--    root/root        467 sosreport-freyes-local-machine-3.1234-20141118160449/sos_commands/pacemaker/crm_status
 -rw-r--r--    root/root        532 sosreport-freyes-local-machine-3.1234-20141118160449/sos_commands/pacemaker/crm_configure_show
...
 drwxr-xr-x    root/root          0 sosreport-freyes-local-machine-3.1234-20141118160449/var/lib/pacemaker/
 drwxr-xr-x    root/root          0 sosreport-freyes-local-machine-3.1234-20141118160449/var/lib/pacemaker/cib/
 -rw------- hacluster/haclient    1943 sosreport-freyes-local-machine-3.1234-20141118160449/var/lib/pacemaker/cib/cib.xml
...
```
