### PR TITLE
[process] Collect the basics per-process from /proc/$PID/

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -30,5 +30,13 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "ps auxwwwm",
             "ps alxwww"
         ])
+        self.add_copy_spec([
+            "/proc/*/comm",
+            "/proc/*/limits",
+            "/proc/*/stack",
+            "/proc/*/status",
+            "/proc/*/cpuset",
+            "/proc/*/oom_*"
+        ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
This includes the limits, the command, status, cpuset,
stack, environment info, and out of memory scores.

Signed-off-by: Bryan Quigley <Bryan.Quigley@Canonical.com>