### PR TITLE
[apport] Add information on specific crashes

### DIFF
--- a/sos/plugins/apport.py
+++ b/sos/plugins/apport.py
@@ -25,5 +25,12 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         self.add_copy_spec("/etc/apport/*")
+        self.add_copy_spec("/var/lib/whoopsie/whoopsie-id")
+        self.add_cmd_output(
+            "gdbus call -y -d com.ubuntu.WhoopsiePreferences \
+            -o /com/ubuntu/WhoopsiePreferences \
+            -m com.ubuntu.WhoopsiePreferences.GetIdentifier")
+        self.add_cmd_output("ls -alh /var/crash/")
+        self.add_cmd_output("bash -c 'grep -B 50 -m 1 ProcMaps /var/crash/*'")
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
The whoopsie ID let's us look the machine up
on errors.ubuntu.com for crash reports.
Partial output from /var/crash let's us
better know what crashdumps the user has without
uploading all of them.

Two ways to collect the whoopsie ID are needed 
(/var/lib/w.. was only added in 14.10+)

The ProcMaps grep is limited to just collect information 
about the crash and not any debugging information.

Signed-off-by: Bryan Quigley <Bryan.Quigley@Canonical.com>