### PR TITLE
[ovirt] Collect engine-config tunable settings and domain information

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -83,6 +83,7 @@ class Ovirt(Plugin, RedHatPlugin):
 
         self.add_forbidden_path('/etc/ovirt-engine/.pgpass')
         self.add_forbidden_path('/etc/rhevm/.pgpass')
+        # Collect engine tunables
         self.collectExtOutput("rhevm-config --all")
         self.collectExtOutput("rhevm-manage-domains list")
         # Copy engine config files.


### PR DESCRIPTION
Having the settings for engine tunables on hand can be helpful when looking into issues with starting or migrating VMs, MAC address conflicts, various timeouts being hit, etc...

Capturing the output from manage-domains is similarly helpful for probing potential AD/IPA problems. 
