### PR TITLE
[ovirt] Collect engine tunables and domain information.

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -83,6 +83,9 @@ class Ovirt(Plugin, RedHatPlugin):
 
         self.add_forbidden_path('/etc/ovirt-engine/.pgpass')
         self.add_forbidden_path('/etc/rhevm/.pgpass')
+        # Copy all engine tunables and domain information
+        self.add_cmd_output("engine-config --all")
+        self.add_cmd_output("engine-manage-domains list")
         # Copy engine config files.
         self.add_copy_spec([
             "/etc/ovirt-engine",


### PR DESCRIPTION
We should collect engine-config tunables and domain information so they don't need to be dug out from the DB dump that may or may not get collected.