### PR TITLE
[apache] Added collection of conf.modules.d dir for httpd 2.4

### DIFF
--- a/sos/plugins/apache.py
+++ b/sos/plugins/apache.py
@@ -34,7 +34,8 @@ class RedHatApache(Apache, RedHatPlugin):
 
         self.add_copy_spec([
             "/etc/httpd/conf/httpd.conf",
-            "/etc/httpd/conf.d/*.conf"
+            "/etc/httpd/conf.d/*.conf",
+            "/etc/httpd/conf.modules.d/*.conf"
         ])
 
         self.add_forbidden_path("/etc/httpd/conf/password.conf")


### PR DESCRIPTION
I am submitting this pull request so that sosreport will collect all of the configuration for httpd 2.4 instead of the previous versions conf and conf.d directories. httpd 2.4 utilizes a new config directory (conf.modules.d) to init modules that are loaded into the server.

I wasn't sure if you guys preferred an issue to be logged for this for tracking purposes first, but if I should add one, comment and I will and amend my commit to address it.

Signed-off-by: Coty Sutherland <sutherland.coty@gmail.com>