### PR TITLE
[block] Don't use parted human readable output - rhbz #1183770

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -46,7 +46,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                 disk_path = os.path.join('/dev/', disk)
                 self.add_cmd_output([
                     "udevadm info -ap /sys/block/%s" % (disk),
-                    "parted -s %s print" % (disk_path),
+                    "parted -s %s unit s print" % (disk_path),
                     "fdisk -l %s" % disk_path
                 ])
 


### PR DESCRIPTION
Changed the parted command to return data in sectors units
instead of human readable form.

Signed-off-by: Shane Bradley <sbradley@redhat.com>