### PR TITLE
add docker to list of possible package names for docker plugin

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -54,7 +54,7 @@ class Docker(Plugin):
 
 class RedHatDocker(Docker, RedHatPlugin):
 
-    packages = ('docker-io',)
+    packages = ('docker', 'docker-io')
 
     def setup(self):
         super(RedHatDocker, self).setup()


### PR DESCRIPTION
docker package is called docker in rhel and docker-io in fedora.  without this change, sos does not run the docker plugin automatically, even when docker is installed/running