### PR TITLE
[yum] split out subscription-manager into its own plugin

### DIFF
--- a/sos/plugins/subscription_manager.py
+++ b/sos/plugins/subscription_manager.py
@@ -1,0 +1,43 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class SubscriptionManager(Plugin, RedHatPlugin):
+    """subscription-manager information
+    """
+
+    plugin_name = 'subscription-manager'
+    profiles = ('system', 'packagemanager', 'sysmgmt')
+
+    files = ('/etc/rhsm/rhsm.conf',)
+    packages = ('subscription-manager',)
+
+    def setup(self):
+        # rhsm config and logs
+        self.add_copy_spec([
+            "/etc/rhsm/",
+            "/var/log/rhsm/rhsm.log",
+            "/var/log/rhsm/rhsmcertd.log"])
+        self.add_cmd_output([
+            "subscription-manager list --installed",
+            "subscription-manager list --consumed",
+            "subscription-manager identity"
+        ])
+        self.add_cmd_output("rhsm-debug system --sos --no-archive "
+                            "--no-subscriptions --destination %s"
+                            % self.get_cmd_output_path())
+
+# vim: et ts=4 sw=4

--- a/sos/plugins/yum.py
+++ b/sos/plugins/yum.py
@@ -45,18 +45,7 @@ class Yum(Plugin, RedHatPlugin):
         self.add_copy_spec([
             "/etc/pki/product/*.pem",
             "/etc/pki/consumer/cert.pem",
-            "/etc/pki/entitlement/*.pem",
-            "/etc/rhsm/",
-            "/var/log/rhsm/rhsm.log",
-            "/var/log/rhsm/rhsmcertd.log"])
-        self.add_cmd_output([
-            "subscription-manager list --installed",
-            "subscription-manager list --consumed",
-            "subscription-manager identity"
-        ])
-        self.add_cmd_output("rhsm-debug system --sos --no-archive "
-                            "--no-subscriptions --destination %s"
-                            % self.get_cmd_output_path())
+            "/etc/pki/entitlement/*.pem"])
 
         if self.get_option("yumlist"):
             # List various information about available packages


### PR DESCRIPTION
subscription-manager and rhsm* stuff separated from yum plugin into
a new one (subscription-manager). Resolves #451

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>