### PR TITLE
[cluster] Removed some files and command that are no longer needed. rhbz...

### DIFF
--- a/sos/plugins/cluster.py
+++ b/sos/plugins/cluster.py
@@ -92,7 +92,10 @@ class Cluster(Plugin, RedHatPlugin):
             "fence_tool dump",
             "dlm_tool dump",
             "dlm_tool ls -n",
-            "mkqdisk -L"
+            "mkqdisk -L",
+            "pcs config",
+            "pcs status",
+            "pcs property list --all"
         ])
 
         # crm_report needs to be given a --from "YYYY-MM-DD HH:MM:SS" start

--- a/sos/plugins/cluster.py
+++ b/sos/plugins/cluster.py
@@ -32,6 +32,7 @@ class Cluster(Plugin, RedHatPlugin):
     ]
 
     packages = [
+        "luci",
         "ricci",
         "corosync",
         "openais",

--- a/sos/plugins/cluster.py
+++ b/sos/plugins/cluster.py
@@ -111,7 +111,7 @@ class Cluster(Plugin, RedHatPlugin):
                     "crm_from parameter '%s' is not a valid date: using "
                     "default" % self.get_option('crm_from'))
 
-        crm_dest = self.get_cmd_output_path(name='crm_report')
+        crm_dest = self.get_cmd_output_path(name='crm_report', make=False)
         self.add_cmd_output('crm_report -S -d --dest %s --from "%s"'
                             % (crm_dest, crm_from))
 


### PR DESCRIPTION
... #1083656

Removed some of the files and commands that are no longer needed on RHEL6+.
In addition, the gfs_lockdump option did not capture gfs2 lock dumps.
The option isnow called gfs2_lockdump and will mount the /sys/kernel/debug
directory and the gfs2 lockdumps will be copied from that mount point.

In addition added a couple files that are needed for pacemaker/dlm.

Signed-off-by: Shane Bradley <sbradley@redhat.com>