### PR TITLE
[general] verify --profile contains valid plugins only

### DIFF
--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -89,6 +89,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
         var_conf_dir = os.path.join(self.pcp_var_dir, 'config')
         self.add_copy_spec([
             self.pcp_sysconf_dir,
+            self.pcp_conffile,
             var_conf_dir
         ])
 

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -869,6 +869,7 @@ class SoSReport(object):
             extra_classes.append(sos.plugins.ExperimentalPlugin)
         valid_plugin_classes = tuple(policy_classes + extra_classes)
         validate_plugin = self.policy.validate_plugin
+        unknown_profiles = list(self.opts.profiles)
         # validate and load plugins
         for plug in plugins:
             plugbase, ext = os.path.splitext(plug)
@@ -921,12 +922,20 @@ class SoSReport(object):
                     self._skip(plugin_class, _("not specified"))
                     continue
 
+                for i in plugin_class.profiles:
+                    if i in unknown_profiles:
+                        unknown_profiles.remove(i)
                 self._load(plugin_class)
             except Exception as e:
                 self.soslog.warning(_("plugin %s does not install, "
                                       "skipping: %s") % (plug, e))
                 if self.raise_plugins:
                     raise
+        if len(unknown_profiles) > 0:
+            self.soslog.error(_("Unknown or inactive profile(s) provided:"
+                                " %s") % unknown_profiles)
+            self.list_profiles()
+            self._exit(1)
 
     def _set_all_options(self):
         if self.opts.usealloptions:


### PR DESCRIPTION
If --profile contains an invalid profile name, stop and
print list of available profiles. Resolves #505.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>