### PR TITLE
[openvswitch] Capture additional output for OVS bridges.

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -32,6 +32,14 @@ class OpenVSwitch(Plugin):
         # to the Open vSwitch server, avoiding hangs when running sosreport.
         self.add_cmd_output("ovs-vsctl -t 5 show")
 
+        # Gather additional output for each OVS bridge on the host.
+        br_list_result = self.call_ext_prog("ovs-vsctl list-br")
+        if br_list_result['status'] == 0:
+            for br in br_list_result['output'].splitlines():
+                self.add_cmd_output("ovs-ofctl show %s" % br)
+                self.add_cmd_output("ovs-ofctl dump-flows %s" % br)
+                self.add_cmd_output("ovs-appctl fdb/show %s" % br)
+
 
 class RedHatOpenVSwitch(OpenVSwitch, RedHatPlugin):
 


### PR DESCRIPTION
This includes `dump-flows` and `fdb/show` output useful for debugging
Openstack tenant and L3 networking issues.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>