### PR TITLE
[dpkg] Collect debconf db, add verify and all logs options

### DIFF
--- a/sos/plugins/dpkg.py
+++ b/sos/plugins/dpkg.py
@@ -24,7 +24,19 @@ class Dpkg(Plugin, DebianPlugin, UbuntuPlugin):
     profiles = ('sysmgmt', 'packagemanager')
 
     def setup(self):
-        self.add_copy_spec("/var/log/dpkg.log")
         self.add_cmd_output("dpkg -l", root_symlink="installed-debs")
+        if self.get_option("verify"):
+            self.add_cmd_output("dpkg -V")
+            self.add_cmd_output("dpkg -C")
+        self.add_copy_spec([
+            "/var/cache/debconf/config.dat",
+            "/etc/debconf.conf"
+        ])
+        if not self.get_option("all_logs"):
+            limit = self.get_option("log_size")
+            self.add_copy_spec_limit("/var/log/dpkg.log",
+                                     sizelimit=limit)
+        else:
+            self.add_copy_spec("/var/log/dpkg.log*")
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Collect debconf db, which is really dpkg configuration info
Add verify option to dpkg, to verify and check. On a machine
in a good state that only took 20 seconds or so.
Add all logs option to collect more than the last dpkg log.

Closes: #483

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>