### PR TITLE
[apport] Move apport logging to apport plugin

### DIFF
--- a/sos/plugins/apport.py
+++ b/sos/plugins/apport.py
@@ -24,6 +24,14 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
     profiles = ('debug',)
 
     def setup(self):
+        if not self.get_option("all_logs"):
+            limit = self.get_option("log_size")
+            self.add_copy_spec_limit("/var/log/apport.log",
+                                     sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/apport.log.1",
+                                     sizelimit=limit)
+        else:
+            self.add_copy_spec("/var/log/apport*")
         self.add_copy_spec("/etc/apport/*")
         self.add_copy_spec("/var/lib/whoopsie/whoopsie-id")
         self.add_cmd_output(

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -86,8 +86,7 @@ class DebianLogs(Logs, DebianPlugin, UbuntuPlugin):
             "/var/log/mail*",
             "/var/log/dist-upgrade",
             "/var/log/installer",
-            "/var/log/unattended-upgrades",
-            "/var/log/apport.log"
+            "/var/log/unattended-upgrades"
         ])
 
 


### PR DESCRIPTION
Apport logging was in the logs plugin previously.
Also added "all logs" support so it could collect
more than it previously did.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>