### PR TITLE
[docs] Remove make deb, run from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ pull requests.
 ### Manual Installation
 
 ```
+You can simply run from the git checkout now ==> Ex: sudo ./sosreport -a
 to install locally (as root) ==> make install
 to build an rpm ==> make rpm
-to build a deb ==> make deb
 ```
 
 ### Pre-built Packaging


### PR DESCRIPTION
Make deb was removed
You can also just run ./sosreport from git now.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>