### PR TITLE
[logs] Implement all-logs, limits and small fixes.

### DIFF
--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -25,7 +25,8 @@ class Logs(Plugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/syslog.conf",
-            "/etc/rsyslog.conf"
+            "/etc/rsyslog.conf",
+            "/etc/rsyslog.d"
         ])
 
         self.limit = self.get_option("log_size")
@@ -79,15 +80,20 @@ class DebianLogs(Logs, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         super(DebianLogs, self).setup()
-        self.add_copy_spec([
-            "/var/log/syslog",
-            "/var/log/udev",
-            "/var/log/kern*",
-            "/var/log/mail*",
-            "/var/log/dist-upgrade",
-            "/var/log/installer",
-            "/var/log/unattended-upgrades"
-        ])
+        if not self.get_option("all_logs"):
+            limit = self.get_option("log_size")
+            self.add_copy_spec_limit("/var/log/syslog", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/syslog.1", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/kern.log", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/kern.log.1", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/udev", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/dist-upgrade", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/installer", sizelimit=limit)
+            self.add_copy_spec_limit("/var/log/unattended-upgrades",
+                                     sizelimit=limit)
+            self.add_cmd_output('ls -alRh /var/log/')
+        else:
+            self.add_copy_spec("/var/log/")
 
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Implement all logs option to collect everything
in /var/log.  Add size limits around all key log
files.  When not doing all logs capture ls output
showing everything in /var/log.  This will help with
realizing when sosreport has missed some other file.

mail* was dropped because it seems to be covered for the most
commom case by mail.* in sendmail plugin.

kern* was changed to capture kern.log and kern.log.1.

syslog.1 is now captured.

Closes LP: 1356211

Captures /etc/rsyslog.d directory.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>