### PR TITLE
[vhostmd] add SAP virtualization metrics collection plugin

### DIFF
--- a/sos/plugins/vhostmd.py
+++ b/sos/plugins/vhostmd.py
@@ -22,7 +22,7 @@ class vhostmd(Plugin, RedHatPlugin):
     plugin_name = 'vhostmd'
     profiles = ['sap']
 
-    packages = ['virt-what'] 
+    packages = ['virt-what']
 
     def setup(self):
         vw = self.get_command_output("virt-what")['output'].splitlines()

--- a/sos/plugins/vhostmd.py
+++ b/sos/plugins/vhostmd.py
@@ -15,16 +15,21 @@
 from sos.plugins import Plugin, RedHatPlugin
 
 
-class vm_dump_metrics(Plugin, RedHatPlugin):
+class vhostmd(Plugin, RedHatPlugin):
     """vhostmd virtualization metrics collection
     """
 
-    plugin_name = 'vm_dump_metrics'
+    plugin_name = 'vhostmd'
     profiles = ['sap']
 
-    def setup(self):
+    packages = ['virt-what'] 
 
+    def setup(self):
         vw = self.get_command_output("virt-what")['output'].splitlines()
+
+        if not vw:
+            return
+
         if "vmware" in vw or "kvm" in vw or "xen" in vw:
             # if vm-dump-metrics is installed use it
             if self.is_installed("vm-dump-metrics"):

--- a/sos/plugins/vm_dump_metrics.py
+++ b/sos/plugins/vm_dump_metrics.py
@@ -1,0 +1,42 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class vm_dump_metrics(Plugin, RedHatPlugin):
+    """vhostmd virtualization metrics collection
+    """
+
+    plugin_name = 'vm_dump_metrics'
+    profiles = ['sap']
+
+    def setup(self):
+
+        vw = self.get_command_output("virt-what")['output'].splitlines()
+        if "vmware" in vw or "kvm" in vw or "xen" in vw:
+            # if vm-dump-metrics is installed use it
+            if self.is_installed("vm-dump-metrics"):
+                self.add_cmd_output("vm-dump-metrics",
+                                    suggest_filename="virt_metrics")
+            else:
+                # otherwise use the raw vhostmd disk presented (256k size)
+                d = self.get_command_output("lsblk -d")
+                for disk in d['output'].splitlines():
+                    if "256K" in disk:
+                        self.add_cmd_output("dd if=/dev/%s bs=256k count=1"
+                                            % disk,
+                                            suggest_filename="virt_metrics")
+
+# vim: et ts=4 sw=4

--- a/sos/plugins/vm_dump_metrics.py
+++ b/sos/plugins/vm_dump_metrics.py
@@ -36,8 +36,12 @@ class vm_dump_metrics(Plugin, RedHatPlugin):
                 for disk in d['output'].splitlines():
                     if "256K" in disk:
                         dev = disk.split()[0]
-                        self.add_cmd_output("dd if=/dev/%s bs=256k count=1"
-                                            % dev,
-                                            suggest_filename="virt_metrics")
+                        check = self.get_command_output(
+                            "dd if=/dev/%s bs=25 count=1" % dev)
+                        if 'metric' in check['output']:
+                            self.add_cmd_output("dd if=/dev/%s bs=256k count=1"
+                                                % dev,
+                                                suggest_filename="virt_\
+                                                        metrics")
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/vm_dump_metrics.py
+++ b/sos/plugins/vm_dump_metrics.py
@@ -35,8 +35,9 @@ class vm_dump_metrics(Plugin, RedHatPlugin):
                 d = self.get_command_output("lsblk -d")
                 for disk in d['output'].splitlines():
                     if "256K" in disk:
+                        dev = disk.split()[0]
                         self.add_cmd_output("dd if=/dev/%s bs=256k count=1"
-                                            % disk,
+                                            % dev,
                                             suggest_filename="virt_metrics")
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Proposing a plugin to collect virtualization metrics exposed by the hypervisor.
Exposure of these metrics is one of the requirements for a virtualization platform to be certified by SAP.

Signed-off-by: Luca Miccini lmiccini@redhat.com