### PR TITLE
[unity] new plugin to collect unity-support-status

### DIFF
--- a/sos/plugins/unity.py
+++ b/sos/plugins/unity.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+class unity(Plugin, UbuntuPlugin):
+    """Unity
+    """
+
+    plugin_name = 'unity'
+    profiles = ('hardware', 'desktop')
+
+    packages = (
+        'nux-tools',
+        'unity'
+    )
+
+    def setup(self):
+        self.add_cmd_output("/usr/lib/nux/unity_support_test -p")
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
This plugin is for Ubuntu's Unity DE and just collects
3d support information similar to a simplified glxinfo.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>