### PR TITLE
[apparmor] Capture AppArmor profiles and status

### DIFF
--- a/sos/plugins/apparmor.py
+++ b/sos/plugins/apparmor.py
@@ -25,7 +25,15 @@ class Apparmor(Plugin, UbuntuPlugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/etc/apparmor"
+            "/etc/apparmor*"
+        ])
+        self.add_forbidden_path("/etc/apparmor.d/cache")
+        self.add_forbidden_path("/etc/apparmor.d/libvirt/libvirt*")
+        self.add_forbidden_path("/etc/apparmor.d/abstractions")
+        self.add_cmd_output([
+            "apparmor_status",
+            "ls -alh /etc/apparmor.d/abstractions",
+            "ls -alh /etc/apparmor.d/libvirt",
         ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Captures /etc/apparmor.d for profiles

Excludes /cache - because it's not config
Excludes libvirt/libvirt because it can grow
quite large and the TEMPLATE file should usually
be enough.
Excludes abstractions because they are usually
not modified by user and are quite big

For both libvirt and abstractions capture an ls,
just to be sure permissions, etc aren't messed up.

Captures apparmor_status to get the effective profiles.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>