### PR TITLE
[rabbitmq] Add list_policies output for the default virtual host.

### DIFF
--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -26,6 +26,7 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_cmd_output("rabbitmqctl report")
         self.add_cmd_output("rabbitmqctl cluster_status")
+        self.add_cmd_output("rabbitmqctl list_policies")
 
         self.add_copy_spec("/etc/rabbitmq/*")
         self.add_copy_spec_limit("/var/log/rabbitmq/*",


### PR DESCRIPTION
Useful for ensuring that highly available queues are enabled [1].

[1] https://www.rabbitmq.com/ha.html

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>