### PR TITLE
[libvirt] gather virt-manager logs and some domains info

### DIFF
--- a/sos/plugins/libvirt.py
+++ b/sos/plugins/libvirt.py
@@ -52,26 +52,13 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                                      sizelimit=5)
             self.add_copy_spec_limit("/var/log/libvirt/lxc/*.log", sizelimit=5)
             self.add_copy_spec_limit("/var/log/libvirt/uml/*.log", sizelimit=5)
-            self.add_copy_spec_limit("/root/.virt-manager/*", sizelimit=5)
         else:
-            self.add_copy_spec([
-                "/var/log/libvirt",
-                "/root/.virt-manager/*"
-            ])
+            self.add_copy_spec("/var/log/libvirt")
 
         if os.path.exists(libvirt_keytab):
             self.add_cmd_output("klist -ket %s" % libvirt_keytab)
 
         self.add_cmd_output("ls -lR /var/lib/libvirt/qemu")
-
-        domains_file = self.get_cmd_output_now('virsh list --all')
-
-        # cycle through the VMs/domains list, ignore 2 header lines and latest
-        # empty line, and dumpxml domain name in 2nd column
-        domains_lines = open(domains_file, "r").read().splitlines()[2:]
-        for domain in domains_lines:
-             if domain:
-                 self.add_cmd_output("virsh dumpxml %s" % domain.split()[1])
 
     def postproc(self):
         for xmlfile in glob.glob("/etc/libvirt/qemu/*.xml"):

--- a/sos/plugins/libvirt.py
+++ b/sos/plugins/libvirt.py
@@ -52,11 +52,26 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                                      sizelimit=5)
             self.add_copy_spec_limit("/var/log/libvirt/lxc/*.log", sizelimit=5)
             self.add_copy_spec_limit("/var/log/libvirt/uml/*.log", sizelimit=5)
+            self.add_copy_spec_limit("/root/.virt-manager/*", sizelimit=5)
         else:
-            self.add_copy_spec("/var/log/libvirt")
+            self.add_copy_spec([
+                "/var/log/libvirt",
+                "/root/.virt-manager/*"
+            ])
 
         if os.path.exists(libvirt_keytab):
             self.add_cmd_output("klist -ket %s" % libvirt_keytab)
+
+        self.add_cmd_output("ls -lR /var/lib/libvirt/qemu")
+
+        domains_file = self.get_cmd_output_now('virsh list --all')
+
+        # cycle through the VMs/domains list, ignore 2 header lines and latest
+        # empty line, and dumpxml domain name in 2nd column
+        domains_lines = open(domains_file, "r").read().splitlines()[2:]
+        for domain in domains_lines:
+             if domain:
+                 self.add_cmd_output("virsh dumpxml %s" % domain.split()[1])
 
     def postproc(self):
         for xmlfile in glob.glob("/etc/libvirt/qemu/*.xml"):

--- a/sos/plugins/libvirt_client.py
+++ b/sos/plugins/libvirt_client.py
@@ -1,0 +1,47 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+import glob
+import os
+
+
+class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+    """client for libvirt virtualization API
+    """
+
+    plugin_name = 'libvirt_client'
+    profiles = ('system', 'virt')
+
+    packages = ('libvirt-client')
+
+    def setup(self):
+        # virt-manager logs
+        if not self.get_option("all_logs"):
+            self.add_copy_spec_limit("/root/.virt-manager/*", sizelimit=5)
+        else:
+            self.add_copy_spec("/root/.virt-manager/*")
+
+        # get lit of VMs/domains
+        domains_file = self.get_cmd_output_now('virsh list --all')
+
+        # cycle through the VMs/domains list, ignore 2 header lines and latest
+        # empty line, and dumpxml domain name in 2nd column
+        if domains_file:
+            domains_lines = open(domains_file, "r").read().splitlines()[2:]
+            for domain in filter(lambda x: x, domains_lines)
+                self.add_cmd_output("virsh dumpxml %s" % domain.split()[1])
+
+
+# vim: et ts=4 sw=4

--- a/sos/plugins/libvirt_client.py
+++ b/sos/plugins/libvirt_client.py
@@ -40,8 +40,7 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         # empty line, and dumpxml domain name in 2nd column
         if domains_file:
             domains_lines = open(domains_file, "r").read().splitlines()[2:]
-            for domain in filter(lambda x: x, domains_lines)
+            for domain in filter(lambda x: x, domains_lines):
                 self.add_cmd_output("virsh dumpxml %s" % domain.split()[1])
-
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/virsh.py
+++ b/sos/plugins/virsh.py
@@ -41,6 +41,7 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         if domains_file:
             domains_lines = open(domains_file, "r").read().splitlines()[2:]
             for domain in filter(lambda x: x, domains_lines):
-                self.add_cmd_output("virsh dumpxml %s" % domain.split()[1])
+                self.add_cmd_output("virsh -r dumpxml %s" % domain.split()[1],
+                                    timeout=180)
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/virsh.py
+++ b/sos/plugins/virsh.py
@@ -21,7 +21,7 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     """client for libvirt virtualization API
     """
 
-    plugin_name = 'libvirt_client'
+    plugin_name = 'virsh'
     profiles = ('system', 'virt')
 
     packages = ('libvirt-client')


### PR DESCRIPTION
Resolves #544

virt-manager logs gathered with sizelimit like others
dumpxml output is already password free (contrary to /etc/libvirt/qemu)

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>