### PR TITLE
[Openstack] New plugin to capture configs and logs from sahara system.

### DIFF
--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2015 Red Hat, Inc.,Poornima M. Kshirsagar <pkshiras@redhat.com>
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class OpenStackSahara(Plugin):
+    """OpenStack Sahara"""
+    plugin_name = "openstack_sahara"
+    profiles = ('openstack',)
+
+    option_list = [("log", "gathers openstack sahara logs", "slow", True)]
+
+    def setup(self):
+        self.add_copy_spec(["/etc/sahara/"])
+        self.add_cmd_output(["journalctl -u openstack-sahara-all"])
+
+        if self.get_option("log"):
+            self.add_copy_spec(["/var/log/sahara/"])
+
+
+class DebianOpenStackSahara(OpenStackSahara, DebianPlugin, UbuntuPlugin):
+    """OpenStackSahara related information for Debian based distributions."""
+
+    packages = (
+        'sahara-api',
+        'sahara-common',
+        'sahara-engine',
+        'python-sahara',
+        'python-saharaclient',
+    )
+
+    def setup(self):
+        super(DebianOpenStackSahara, self).setup()
+
+
+class RedHatOpenStackSahara(OpenStackSahara, RedHatPlugin):
+    """OpenStack sahara related information for Red Hat distributions."""
+
+    packages = (
+        'openstack-sahara',
+        'python-saharaclient'
+    )
+
+    def setup(self):
+        super(RedHatOpenStackSahara, self).setup()
+        self.add_copy_spec(["/etc/sudoers.d/sahara"])
+
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
Plugin captures OpenStack Sahara related information.
This is needed to get openstack system environment details
and must be enabled plugin when running 'sosreport -o openstack_sahara'.
which is redundant with only plugins tagges as well.

This plugin also has openstack profiles coverage
'sosreport -p openstack'.

Signed-off-by: Poornima M. Kshirsagar pkshiras@redhat.com