### PR TITLE
[cloud-image] Added Ubuntu plugin for Cloud-Images

### DIFF
--- a/sos/plugins/cloud-image.py
+++ b/sos/plugins/cloud-image.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2015 Ben Howard <ben.howard@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+class CloudImage(Plugin, UbuntuPlugin):
+    """ Cloud Image plugin for Cloud-init driven instances
+    """
+
+    plugin_name = 'cloudimage'
+    profiles = ('virt',)
+    packages = ('cloud-init',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/var/lib/cloud",
+            "/etc/cloud",
+            "/run/cloud-init",
+        ])
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
Ubuntu Cloud Images are defined by the presence of cloud-init being
  installed. This plugin gathers the base logs for cloud-init and is
  useful for determining boot failures in the cloud.

Signed-off-by: Ben Howard ben.howard@ubuntu.com
