### PR TITLE
[openshift] Obfuscate only DNS plugin credential values

### DIFF
--- a/sos/plugins/openshift.py
+++ b/sos/plugins/openshift.py
@@ -138,14 +138,14 @@ class Openshift(Plugin, RedHatPlugin):
         plugin_dir = '/etc/openshift/plugins.d/'
         self.do_file_sub(plugin_dir + 'openshift-origin-dns-dynect.conf',
                          r"(DYNECT_PASSWORD\s*=\s*)(.*)",
-                         r"********")
+                         r"\1********")
         # Fog cloud: FOG_RACKSPACE_API_KEY="apikey"
         self.do_file_sub(plugin_dir + 'openshift-origin-dns-fog.conf',
                          r"(FOG_RACKSPACE_API_KEY\s*=\s*)(.*)",
-                         r"********")
+                         r"\1********")
         # ISC bind: BIND_KEYVALUE="rndc key"
         self.do_file_sub(plugin_dir + 'openshift-origin-dns-nsupdate.conf',
                          r"(BIND_KEYVALUE\s*=\s*)(.*)",
-                         r"********")
+                         r"\1********")
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Obfuscate only the value, not the entire directive and value pair.

Signed-off-by: Timothy Williams <tiwillia@redhat.com>