### PR TITLE
[mysql] Collect log file

### DIFF
--- a/sos/plugins/mysql.py
+++ b/sos/plugins/mysql.py
@@ -37,6 +37,7 @@ class Mysql(Plugin):
 
         self.add_copy_spec([
             self.mysql_cnf,
+            "/var/log/mysqld.log",
             "/var/log/mysql/mysqld.log",
             "/var/log/mariadb/mariadb.log",
         ])


### PR DESCRIPTION
By default the log file will be collected /var/log/mysqld.log.

Fixes: #554

Signed-off-by: Shane Bradley <sbradley@redhat.com>