### PR TITLE
[hpasm] hpasmcli commands hang under timeout

### DIFF
--- a/sos/plugins/hpasm.py
+++ b/sos/plugins/hpasm.py
@@ -30,6 +30,6 @@ class Hpasm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "hpasmcli -s 'show asr'",
             "hpasmcli -s 'show server'"
-        ])
+        ], timeout=0)
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Calling python calling timeout calling hpasmcli can hung until the
timeout expires. As a sort of workaround, sosreport should not wrap
the hpasmcli command by timeout.

Fixes: #559

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>