### PR TITLE
[ovirt] Collect engine tunables and domain information.

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -83,6 +83,9 @@ class Ovirt(Plugin, RedHatPlugin):
 
         self.add_forbidden_path('/etc/ovirt-engine/.pgpass')
         self.add_forbidden_path('/etc/rhevm/.pgpass')
+        # Copy all engine tunables and domain information
+        self.add_cmd_output("engine-config --all")
+        self.add_cmd_output("engine-manage-domains list")
         # Copy engine config files.
         self.add_copy_spec([
             "/etc/ovirt-engine",


### PR DESCRIPTION
Currently sos does not capture engine-config values or domain information.
We should capture both of these as the tunables can help in troubleshooting.

Similarly the domain information can help track AD/IPA issues.

These can currently be dug out from the DB dump, however having them in a plaintext
file makes checking these much faster and easier, and a DB is not always available.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>