### PR TITLE
[openstack_neutron] Collect plotnetcfg output if the tool is installed

### DIFF
--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -168,4 +168,7 @@ class RedHatNeutron(Neutron, RedHatPlugin):
         self.packages = self.gen_pkg_tuple(self.package_list_template)
         self.add_copy_spec("/etc/sudoers.d/%s-rootwrap" % self.component_name)
 
+        if self.is_installed("plotnetcfg"):
+            self.add_cmd_output("plotnetcfg")
+
 # vim: et ts=4 sw=4


### PR DESCRIPTION
The plotnetcfg [1] has recently been packaged for Fedora and provides
a useful method of visualising complex host network toplogies. In the
case of Openstack hosts this includes Openvswitch devices, flows etc.

The resulting file can be used to generate a PDF visualising this with
the following command :

`cat plotnetcfg.output | dot -Tpdf > output.pdf`

[1] https://github.com/jbenc/plotnetcfg