### PR TITLE
[networking] Collect plotnetcfg output if the tool is installed.

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -91,6 +91,7 @@ class Networking(Plugin):
 
         self.add_cmd_output("ip -o addr", root_symlink="ip_addr")
         self.add_cmd_output("route -n", root_symlink="route")
+        self.add_cmd_output("plotnetcfg")
         self.collect_iptable("filter")
         self.collect_iptable("nat")
         self.collect_iptable("mangle")


### PR DESCRIPTION
The plotnetcfg tool [1] has recently been packaged for Fedora
and provides a useful method of visualising complex host
network toplogies. In the case of Openstack hosts this includes
Openvswitch devices, flows etc.

The resulting file can be used to generate a PDF visualising
this with the following command :

`cat plotnetcfg.output | dot -Tpdf > output.pdf`

[1] https://github.com/jbenc/plotnetcfg

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>