### PR TITLE
yum: add output for yum history

### DIFF
--- a/sos/plugins/yum.py
+++ b/sos/plugins/yum.py
@@ -57,6 +57,7 @@ class Yum(Plugin, RedHatPlugin):
         self.add_cmd_output("rhsm-debug system --sos --no-archive "
                             "--no-subscriptions --destination %s"
                             % self.get_cmd_output_path())
+        self.add_cmd_output("yum history")
 
         if self.get_option("yumlist"):
             # List various information about available packages


### PR DESCRIPTION
Sometimes it is useful to see recent packet changes in the system.
Yum history provides time information about actions like install,
remove or update operations on system packages.

Signed-off-by: Alexandru Juncu <alexj@linux.com>