### PR TITLE
[last] information about login actions

### DIFF
--- a/sos/plugins/last.py
+++ b/sos/plugins/last.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class Last(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """login information
+    """
+
+    plugin_name = 'last'
+    profiles = ('system',)
+
+    def setup(self):
+        self.add_cmd_output("last", root_symlink="last")
+        self.add_cmd_output([
+                "last reboot",
+                "last shutdown",
+                "lastlog"
+                ])
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
Resending after fixing according to comments from previous pull request.
 
This is useful information to be correlated with shutdown/reboot
events in /var/log/messages to identify graceful shutdowns/reboots
and lower false positives about system crashes.

Signed-off-by: Alexandru Juncu <alexj@linux.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sosreport/sos/572)
<!-- Reviewable:end -->
