### PR TITLE
Remove .decode method calls on strings in plugins

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -548,7 +548,7 @@ class Plugin(object):
     def add_string_as_file(self, content, filename):
         """Add a string to the archive as a file named `filename`"""
         self.copy_strings.append((content, filename))
-        content = "..." + (content.splitlines()[0]).decode('utf8', 'ignore')
+        content = "..." + (content.splitlines()[0])
         self._log_debug("added string '%s' as '%s'" % (content, filename))
 
     def get_cmd_output_now(self, exe, suggest_filename=None,
@@ -621,7 +621,7 @@ class Plugin(object):
     def _collect_strings(self):
         for string, file_name in self.copy_strings:
             content = "..."
-            content += (string.splitlines()[0]).decode('utf8', 'ignore')
+            content += (string.splitlines()[0])
             self._log_info("collecting string '%s' as '%s'"
                            % (content, file_name))
             try:


### PR DESCRIPTION
Running under python3 and using plugins.add_string_as_file
and the plugins._collect_strings() methods both attempt to
decode a string which produces this backtrace:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'

Remove the .decode as it's not needed in python3.

Signed-off-by: Ryan Harper <ryan.harper@canonical.com>