### PR TITLE
[openvswitch] dump and capture the db and the logs

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -44,6 +44,9 @@ class OpenVSwitch(Plugin):
                 self.add_cmd_output("ovs-ofctl dump-flows %s" % br)
                 self.add_cmd_output("ovs-appctl fdb/show %s" % br)
 
+        # Gather the database.
+        self.add_cmd_output("ovsdb-client dump")
+
 
 class RedHatOpenVSwitch(OpenVSwitch, RedHatPlugin):
 

--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -24,6 +24,10 @@ class OpenVSwitch(Plugin):
     profiles = ('network', 'virt')
 
     def setup(self):
+        self.add_copy_spec([
+            "/var/log/openvswitch/ovs-vswitchd.log",
+            "/var/log/openvswitch/ovsdb-server.log"
+        ])
         # The '-s' option enables dumping of packet counters on the
         # ports.
         self.add_cmd_output("ovs-dpctl -s show")


### PR DESCRIPTION
The database is essential to understand the vswitch configuration and the logs are useful for troubleshooting.