### PR TITLE
[docker] Red Hat package rename

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -54,7 +54,7 @@ class Docker(Plugin):
 
 class RedHatDocker(Docker, RedHatPlugin):
 
-    packages = ('docker-io',)
+    packages = ('docker-io', 'docker')
 
     def setup(self):
         super(RedHatDocker, self).setup()


### PR DESCRIPTION
The package for "docker.io" in current Red Hat distributions is called "docker", renamed from "docker-io" after the previously named "docker" package was renamed to "wmdocker".

See https://bugzilla.redhat.com/show_bug.cgi?id=1043676 and https://bugzilla.redhat.com/show_bug.cgi?id=1055712

This is to update the docker plugin to reflect that package name change.