### PR TITLE
[plugin] pass stderr through _collect_cmd_output

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -696,7 +696,7 @@ class Plugin(object):
             self._log_info("collecting output of '%s'" % prog)
             self.get_cmd_output_now(prog, suggest_filename=suggest_filename,
                                     root_symlink=root_symlink, timeout=timeout,
-                                    chroot=chroot, runat=runat)
+                                    stderr=stderr, chroot=chroot, runat=runat)
 
     def _collect_strings(self):
         for string, file_name in self.copy_strings:


### PR DESCRIPTION
Commit f06efd6 removed passing stderr in _collect_cmd_output to
get_cmd_output_now. That prevents passing stderr=False in several
scenarios.

This fix adds the argument to be passed back.

Resolves: #600

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>