### PR TITLE
[openstack] Ensure openstack passwords and secrets are obfuscated.

### DIFF
--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -35,6 +35,18 @@ class OpenStackCeilometer(Plugin):
             "/var/log/ceilometer"
         ])
 
+    def postproc(self):
+        protect_keys = [
+            "admin_password", "connection_password", "host_password",
+            "memcache_secret_key", "os_password", "password", "qpid_password",
+            "rabbit_password", "readonly_user_password", "secret_key",
+            "ssl_key_password", "telemetry_secret", "connection",
+            "metering_secret"
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/ceilometer/*", regexp, r"\1*********")
+
 
 class DebianOpenStackCeilometer(OpenStackCeilometer, DebianPlugin,
                                 UbuntuPlugin):

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -42,6 +42,23 @@ class OpenStackCinder(Plugin):
         if self.get_option("log"):
             self.add_copy_spec(["/var/log/cinder/"])
 
+    def postproc(self):
+        protect_keys = [
+            "admin_password", "backup_tsm_password", "chap_password",
+            "nas_password", "cisco_fc_fabric_password", "coraid_password",
+            "eqlx_chap_password", "fc_fabric_password",
+            "hitachi_auth_password", "hitachi_horcm_password",
+            "hp3par_password", "hplefthand_password", "memcache_secret_key",
+            "netapp_password", "netapp_sa_password", "nexenta_password",
+            "password", "qpid_password", "rabbit_password", "san_password",
+            "ssl_key_password", "vmware_host_password", "zadara_password",
+            "zfssa_initiator_password", "connection", "zfssa_target_password",
+            "os_privileged_user_password", "hmac_keys"
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/cinder/*", regexp, r"\1*********")
+
 
 class DebianOpenStackCinder(OpenStackCinder, DebianPlugin, UbuntuPlugin):
 

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -38,6 +38,16 @@ class OpenStackGlance(Plugin):
             "/var/log/glance/"
         ])
 
+    def postproc(self):
+        protect_keys = [
+            "admin_password", "password", "qpid_password", "rabbit_password",
+            "s3_store_secret_key", "ssl_key_password", "connection",
+            "vmware_server_password"
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/glance/*", regexp, r"\1*********")
+
 
 class DebianGlance(OpenStackGlance, DebianPlugin, UbuntuPlugin):
 

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -36,6 +36,15 @@ class OpenStackHeat(Plugin):
             "/var/log/heat/"
         ])
 
+    def postproc(self):
+        protect_keys = [
+            "admin_password", "memcache_secret_key", "password", "connection",
+            "qpid_password", "rabbit_password", "stack_domain_admin_password",
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/heat/*", regexp, r"\1*********")
+
 
 class DebianHeat(OpenStackHeat, DebianPlugin, UbuntuPlugin):
 

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -33,6 +33,15 @@ class OpenStackHorizon(Plugin):
         if self.get_option("log"):
             self.add_copy_spec("/var/log/horizon/")
 
+    def postproc(self):
+        protect_keys = [
+            "SECRET_KEY", "EMAIL_HOST_PASSWORD"
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/openstack-dashboard/*",
+                               regexp, r"\1*********")
+
 
 class DebianOpenStackHorizon(OpenStackHorizon, DebianPlugin):
 

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -38,21 +38,14 @@ class OpenStackKeystone(Plugin):
             self.add_copy_spec("/var/log/keystone/")
 
     def postproc(self):
-        self.do_file_sub('/etc/keystone/keystone.conf',
-                         r"(?m)^(admin_password.*=)(.*)",
-                         r"\1 ******")
-        self.do_file_sub('/etc/keystone/keystone.conf',
-                         r"(?m)^(admin_token.*=)(.*)",
-                         r"\1 ******")
-        self.do_file_sub('/etc/keystone/keystone.conf',
-                         r"(?m)^(connection.*=.*mysql://)(.*)(:)(.*)(@)(.*)",
-                         r"\1\2:******@\6")
-        self.do_file_sub('/etc/keystone/keystone.conf',
-                         r"(?m)^(password.*=)(.*)",
-                         r"\1 ******")
-        self.do_file_sub('/etc/keystone/keystone.conf',
-                         r"(?m)^(ca_password.*=)(.*)",
-                         r"\1 ******")
+        protect_keys = [
+            "password", "qpid_password", "rabbit_password", "ssl_key_password",
+            "ldap_dns_password", "neutron_admin_password", "host_password",
+            "connection", "admin_password", "admin_token", "ca_password"
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/keystone/*", regexp, r"\1*********")
 
 
 class DebianOpenStackKeystone(OpenStackKeystone, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -14,7 +14,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-import glob
 import os
 import re
 
@@ -55,16 +54,16 @@ class Neutron(Plugin):
         protect_keys = [
             "rabbit_password", "qpid_password", "nova_admin_password",
             "xenapi_connection_password", "password", "connection",
-            "admin_password", "metadata_proxy_shared_secret", "qpid_password",
-            "eapi_password", "crd_password", "primary_l3_host_password",
-            "serverauth", "ucsm_password", "ha_vrrp_auth_password",
-            "ssl_key_password", "nsx_password", "vcenter_password",
-            "edge_appliance_password", "tenant_admin_password", "apic_password"
+            "admin_password", "metadata_proxy_shared_secret", "eapi_password",
+            "crd_password", "primary_l3_host_password", "serverauth",
+            "ucsm_password", "ha_vrrp_auth_password", "ssl_key_password",
+            "nsx_password", "vcenter_password", "edge_appliance_password",
+            "tenant_admin_password", "apic_password"
         ]
-        regexp = r"((?m)^\s*#*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
 
-        for config_file in glob.glob("/etc/%s/*" % self.component_name):
-            self.do_file_sub(config_file, regexp, r"\1*********")
+        self.do_path_regex_sub("/etc/%s/*" % self.component_name,
+                               regexp, r"\1*********")
 
     def netns_dumps(self):
         # It would've been beautiful if we could get parts of the networking

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -66,13 +66,13 @@ class OpenStackNova(Plugin):
             "ldap_dns_password", "neutron_admin_password", "rabbit_password",
             "qpid_password", "powervm_mgr_passwd", "virtual_power_host_pass",
             "xenapi_connection_password", "password", "host_password",
-            "vnc_password", "connection", "sql_connection", "admin_password"
+            "vnc_password", "connection", "sql_connection", "admin_password",
+            "connection_password", "memcache_secret_key", "s3_secret_key",
+            "metadata_proxy_shared_secret"
         ]
 
-        regexp = r"((?m)^\s*#*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-
-        for conf_file in ["/etc/nova/nova.conf", "/etc/nova/api-paste.ini"]:
-            self.do_file_sub(conf_file, regexp, r"\1*********")
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/nova/*", regexp, r"\1*********")
 
 
 class DebianOpenStackNova(OpenStackNova, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -33,14 +33,13 @@ class OpenStackSahara(Plugin):
 
     def postproc(self):
         protect_keys = [
-            'memcache_secret_key', 'qpid_password', 'rabbit_password',
-            'admin_password', 'password', 'ssl_key_password',
-            'admin_token', 'connection'
+            "admin_password", "memcache_secret_key", "password",
+            "qpid_password", "rabbit_password", "ssl_key_password",
+            "xenapi_connection_password", "connection"
         ]
 
-        regexp = r"((?m)^\s*#*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-
-        self.do_file_sub('/etc/sahara/sahara.conf', regexp, r"\1*********")
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/sahara/*", regexp, r"\1*********")
 
 
 class DebianOpenStackSahara(OpenStackSahara, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -33,6 +33,17 @@ class OpenStackSwift(Plugin):
 
         self.add_copy_spec("/etc/swift/")
 
+    def postproc(self):
+        protect_keys = [
+            "ldap_dns_password", "neutron_admin_password", "rabbit_password",
+            "qpid_password", "powervm_mgr_passwd", "virtual_power_host_pass",
+            "xenapi_connection_password", "password", "host_password",
+            "vnc_password", "connection", "sql_connection", "admin_password"
+        ]
+
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/swift/*.conf*", regexp, r"\1*********")
+
 
 class DebianOpenStackSwift(OpenStackSwift, DebianPlugin, UbuntuPlugin):
 

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
+
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
@@ -34,21 +35,13 @@ class OpenStackTrove(Plugin):
     def postproc(self):
 
         protect_keys = [
-            "dns_passkey", "nova_proxy_admin_pass", "rabbit_password",
-            "qpid_password", "connection", "sql_connection", "admin_password"
+            "default_password_length", "notifier_queue_password",
+            "rabbit_password", "replication_password", "connection",
+            "admin_password", "dns_passkey"
         ]
 
-        conf_list = [
-            '/etc/trove/trove.conf',
-            '/etc/trove/trove-conductor.conf',
-            '/etc/trove/trove-guestmanager.conf',
-            '/etc/trove/trove-taskmanager.conf'
-        ]
-
-        regexp = r"((?m)^\s*#*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-
-        for conf in conf_list:
-            self.do_file_sub(conf, regexp, r"\1*********")
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        self.do_path_regex_sub("/etc/trove/*", regexp, r"\1*********")
 
 
 class DebianOpenStackTrove(OpenStackTrove, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
- Add a postproc method to ceilometer, cinder, glance, hoirzon and swift.
- Add missing keys to the remaining plugins.
- Modify the regular expression used by all plugins to ignore commented
  out keys.

Resolves: #574

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>