### PR TITLE
[logs] Fix missing rsyslog_conf variable

### DIFF
--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -42,6 +42,7 @@ class Logs(Plugin):
             logs = self.do_regex_find_all("^\S+\s+(-?\/.*$)\s+", syslog_conf)
             if self.is_installed("rsyslog") \
                     or os.path.exists("/etc/rsyslog.conf"):
+                rsyslog_conf = self.join_sysroot("/etc/rsyslog.conf")
                 logs += self.do_regex_find_all("^\S+\s+(-?\/.*$)\s+",
                                                rsyslog_conf)
             for i in logs:

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -38,13 +38,14 @@ class Logs(Plugin):
         ])
 
         if self.get_option('all_logs'):
-            syslog_conf = self.join_sysroot("/etc/syslog.conf")
-            logs = self.do_regex_find_all("^\S+\s+(-?\/.*$)\s+", syslog_conf)
-            if self.is_installed("rsyslog") \
-                    or os.path.exists("/etc/rsyslog.conf"):
-                rsyslog_conf = self.join_sysroot("/etc/rsyslog.conf")
-                logs += self.do_regex_find_all("^\S+\s+(-?\/.*$)\s+",
-                                               rsyslog_conf)
+            syslogs = [self.join_sysroot('/etc/%s.conf' % f)
+                       for f in ['syslog', 'rsyslog']]
+            logs = []
+            for syslog_conf in syslogs:
+                if os.path.exists(syslog_conf):
+                    logs += self.do_regex_find_all("^\S+\s+(-?\/.*$)\s+",
+                                                   syslog_conf)
+
             for i in logs:
                 if i.startswith("-"):
                     i = i[1:]


### PR DESCRIPTION
Adds missing rsyslog_conf variable. Bug only visible if --all-logs
is used with the logs plugin.
Resolves: #606

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>