### PR TITLE
[systemd] Collect timedatectl for timezone

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -40,7 +40,8 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "ls -l /lib/systemd",
             "ls -l /lib/systemd/system-shutdown",
             "ls -l /lib/systemd/system-generators",
-            "ls -l /lib/systemd/user-generators"
+            "ls -l /lib/systemd/user-generators",
+            "timedatectl"
         ])
 
         if self.get_option("verify"):


### PR DESCRIPTION
There is currently no way to see the system timezone in text format on
a systemd system (eg: "America/New_York"). timedatectl provides this.

Signed-off-by: Jamie Bainbridge <jbainbri at redhat dot com>