### PR TITLE
[networking] brctl command is run when bridge kernel module is loaded only

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -660,6 +660,13 @@ class Plugin(object):
 
         return os.path.join(self.archive.get_archive_path(), outfn)
 
+    def is_module_loaded(self, module_name):
+        """Return whether specified moudle as module_name is loaded or not"""
+        if len(grep("^" + module_name + " ", "/proc/modules")) == 0:
+            return None
+        else:
+            return True
+
     # For adding output
     def add_alert(self, alertstring):
         """Add an alert to the collection of alerts for this plugin. These


### PR DESCRIPTION
Previously, bridge information were collected even if bridge kernel module were not loaded.
brctl command requires and loads bridge and related kernel modules to accomplish its purporse.
This behaviour causes unexpected and unnecessary kernel module loading.

sosreport should not change the system configuration.

This patch will change this behaviour to run brctl command only if bridge module is loaded.

Signed-off-by: Keigo Noha <knoha@redhat.com>