### PR TITLE
[landscape] Collect landscape status

### DIFF
--- a/sos/plugins/landscape.py
+++ b/sos/plugins/landscape.py
@@ -41,6 +41,7 @@ class Landscape(Plugin, UbuntuPlugin):
             self.add_copy_spec("/var/log/landscape-server")
         self.add_cmd_output("gpg --verify /etc/landscape/license.txt")
         self.add_cmd_output("head -n 5 /etc/landscape/license.txt")
+        self.add_cmd_output("lsctl status")
 
     def postproc(self):
         self.do_file_sub(


### PR DESCRIPTION
The lsctl command gives more details on the current
status of landscape.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>