### PR TITLE
[sosreport] fix command-line report defaults

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -647,7 +647,7 @@ class SoSOptions(object):
                           default=None)
         parser.add_option("--no-report", action="store_true",
                           dest="report",
-                          help="Disable HTML/XML reporting", default=False)
+                          help="Disable HTML/XML reporting", default=True)
         parser.add_option("-s", "--sysroot", action="store", dest="sysroot",
                           help="system root directory path (default='/')",
                           default=None)


### PR DESCRIPTION
Original commit a7ef3ca was accidentally reverted in cb3d265. This
commit applies the a7ef3ca again.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>