### PR TITLE
[ldap] Fix plugin runtime failure on debian based

### DIFF
--- a/sos/plugins/ldap.py
+++ b/sos/plugins/ldap.py
@@ -94,9 +94,9 @@ class DebianLdap(Ldap, DebianPlugin, UbuntuPlugin):
             suggest_filename="access_control_lists")
 
     def postproc(self):
-        super(RedHatLdap, self).postproc()
+        super(DebianLdap, self).postproc()
         self.do_cmd_output_sub(
-            "ldapsearch"
+            "ldapsearch",
             r"(olcRootPW\: \s*)\S+",
             r"\1********"
         )


### PR DESCRIPTION
Plugin should call DebianPlugin class and missing comma in call.
Closes #626

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>