### PR TITLE
Germano ip6tables iptables networking

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -63,7 +63,7 @@ class Networking(Plugin):
         the command.  If they aren't loaded, there can't possibly be any
         relevant rules in that table """
 
-        if self.check_ext_prog("grep -q %s /proc/modules" % tablename):
+        if self.check_ext_prog("grep -q %s /proc/modules" % ("iptable_"+tablename)):
             cmd = "iptables -t "+tablename+" -nvL"
             self.add_cmd_output(cmd)
 

--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -67,6 +67,11 @@ class Networking(Plugin):
             cmd = "iptables -t "+tablename+" -nvL"
             self.add_cmd_output(cmd)
 
+    def collect_ip6table(self, tablename):
+        if self.check_ext_prog("grep -q %s /proc/modules" % ("ip6table_"+tablename)):
+            cmd = "ip6tables -t "+tablename+" -nvL"
+            self.add_cmd_output(cmd)
+
     def setup(self):
         super(Networking, self).setup()
         self.add_copy_spec([
@@ -95,6 +100,9 @@ class Networking(Plugin):
         self.collect_iptable("filter")
         self.collect_iptable("nat")
         self.collect_iptable("mangle")
+        self.collect_ip6table("filter")
+        self.collect_ip6table("nat")
+        self.collect_ip6table("mangle")
         self.add_cmd_output("netstat -neopa", root_symlink="netstat")
         self.add_cmd_output([
             "netstat -s",
@@ -113,7 +121,8 @@ class Networking(Plugin):
             "ip netns",
             "biosdevname -d",
             "tc -s qdisc show",
-            "iptables -vnxL"
+            "iptables -vnxL",
+            "ip6tables -vnxL"
         ])
 
         # There are some incompatible changes in nmcli since


### PR DESCRIPTION
Hi folks. I am sending two commits for review.

[networking] collect_iptable: check for correct module version 
fixes a bug that considered ipv6
tables as ipv4 tables and resulted in ipv4 being loaded if only ipv6 tables were present.

[networking] collect ip6tables info too
enables collection of ip6 stuff like we already for ipv4 (regarding iptables only)

Regards,
Germano
