### PR TITLE
[networking] fix modules check and add ip6tables

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -63,8 +63,17 @@ class Networking(Plugin):
         the command.  If they aren't loaded, there can't possibly be any
         relevant rules in that table """
 
-        if self.check_ext_prog("grep -q %s /proc/modules" % ("iptable_"+tablename)):
+	modname = "iptable_"+tablename
+        if self.check_ext_prog("grep -q %s /proc/modules" % modname):
             cmd = "iptables -t "+tablename+" -nvL"
+            self.add_cmd_output(cmd)
+
+    def collect_ip6table(self, tablename):
+	""" Same as function above, but for ipv6 """
+
+	modname = "ip6table_"+tablename
+        if self.check_ext_prog("grep -q %s /proc/modules" % modname):
+            cmd = "ip6tables -t "+tablename+" -nvL"
             self.add_cmd_output(cmd)
 
     def setup(self):
@@ -95,6 +104,9 @@ class Networking(Plugin):
         self.collect_iptable("filter")
         self.collect_iptable("nat")
         self.collect_iptable("mangle")
+        self.collect_ip6table("filter")
+        self.collect_ip6table("nat")
+        self.collect_ip6table("mangle")
         self.add_cmd_output("netstat -neopa", root_symlink="netstat")
         self.add_cmd_output([
             "netstat -s",
@@ -113,7 +125,8 @@ class Networking(Plugin):
             "ip netns",
             "biosdevname -d",
             "tc -s qdisc show",
-            "iptables -vnxL"
+            "iptables -vnxL",
+            "ip6tables -vnxL"
         ])
 
         # There are some incompatible changes in nmcli since

--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -63,7 +63,7 @@ class Networking(Plugin):
         the command.  If they aren't loaded, there can't possibly be any
         relevant rules in that table """
 
-        if self.check_ext_prog("grep -q %s /proc/modules" % tablename):
+        if self.check_ext_prog("grep -q %s /proc/modules" % ("iptable_"+tablename)):
             cmd = "iptables -t "+tablename+" -nvL"
             self.add_cmd_output(cmd)
 


### PR DESCRIPTION
Two patches:

[networking] collect_iptable: check for correct module version
If we grep for "mangle", both ipv4 and ipv6 versions might come up.
This patch ensure that only ipv4 version is considered.

[networking] collect ip6tables info too
The same we do for ipv4, but for ipv6.
filter, mangle, nat, exact counters.