### PR TITLE
[networking] iptables: check module version and do ipv6

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -63,8 +63,17 @@ class Networking(Plugin):
         the command.  If they aren't loaded, there can't possibly be any
         relevant rules in that table """
 
-        if self.check_ext_prog("grep -q %s /proc/modules" % tablename):
+        modname = "iptable_"+tablename
+        if self.check_ext_prog("grep -q %s /proc/modules" % modname):
             cmd = "iptables -t "+tablename+" -nvL"
+            self.add_cmd_output(cmd)
+
+    def collect_ip6table(self, tablename):
+        """ Same as function above, but for ipv6 """
+
+        modname = "ip6table_"+tablename
+        if self.check_ext_prog("grep -q %s /proc/modules" % modname):
+            cmd = "ip6tables -t "+tablename+" -nvL"
             self.add_cmd_output(cmd)
 
     def setup(self):
@@ -95,6 +104,9 @@ class Networking(Plugin):
         self.collect_iptable("filter")
         self.collect_iptable("nat")
         self.collect_iptable("mangle")
+        self.collect_ip6table("filter")
+        self.collect_ip6table("nat")
+        self.collect_ip6table("mangle")
         self.add_cmd_output("netstat -neopa", root_symlink="netstat")
         self.add_cmd_output([
             "netstat -s",
@@ -113,7 +125,8 @@ class Networking(Plugin):
             "ip netns",
             "biosdevname -d",
             "tc -s qdisc show",
-            "iptables -vnxL"
+            "iptables -vnxL",
+            "ip6tables -vnxL"
         ])
 
         # There are some incompatible changes in nmcli since


### PR DESCRIPTION
If we grep for "mangle", both ipv4 and ipv6 versions might come up.
This patch ensure that the right version is considered.

Also, do the same we do for ipv4, but for ipv6.
Filter, Mangle, NAT and exact counters.