### PR TITLE
[Openstack_swift] fix regex issue in openstack_swift plugin

### DIFF
--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -42,7 +42,7 @@ class OpenStackSwift(Plugin):
         ]
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/swift/*.conf*", regexp, r"\1*********")
+        self.do_path_regex_sub("/etc/swift/.*\.conf.*", regexp, r"\1*********")
 
 
 class DebianOpenStackSwift(OpenStackSwift, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
 patch to fix below regex errors in openstack_swift
 "substitution failed for '/etc/swift/container.builder'"
 "regex substitution failed for '/etc/swift/container.ring.gz'"

Signed-off-by: Poornima M. Kshirsagar pkshiras@redhat.com