### PR TITLE
[openstack_swift] Correct file path regex when obfuscating secrets.

### DIFF
--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -42,7 +42,7 @@ class OpenStackSwift(Plugin):
         ]
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/swift/*.conf*", regexp, r"\1*********")
+        self.do_path_regex_sub("/etc/swift/.*\.conf.*", regexp, r"\1*********")
 
 
 class DebianOpenStackSwift(OpenStackSwift, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Only .conf files should be scrubbed and not the various .gz ring
files that can also be present in /etc/swift/.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>