### PR TITLE
[kubernetes] Change 'minions' to 'nodes'.

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -31,7 +31,7 @@ class kubernetes(Plugin, RedHatPlugin):
         # Kubernetes master info
         self.add_cmd_output("kubectl version")
         self.add_cmd_output("kubectl get -o json pods")
-        self.add_cmd_output("kubectl get -o json minions")
+        self.add_cmd_output("kubectl get -o json nodes")
         self.add_cmd_output("kubectl get -o json services")
         self.add_cmd_output("kubectl get -o json replicationController")
         self.add_cmd_output("kubectl get -o json events")


### PR DESCRIPTION
Kube no longer uses 'minions' and only accepts 'nodes' in kubectl.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>