### PR TITLE
[openstack_horizon] Only use regex against configuration files

### DIFF
--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -39,7 +39,9 @@ class OpenStackHorizon(Plugin):
         ]
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/openstack-dashboard/*",
+        self.do_path_regex_sub("/etc/openstack-dashboard/.*\.json",
+                               regexp, r"\1*********")
+        self.do_path_regex_sub("/etc/openstack-dashboard/local_settings",
                                regexp, r"\1*********")
 
 


### PR DESCRIPTION
Ignore files from plugins such as tuskar [1] that can also be
found in the `/etc/openstack-dashboard/` directory.

[1] https://github.com/openstack/tuskar-ui

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>