### PR TITLE
Fix 586 all logs truncate files

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -180,6 +180,8 @@ class FileCacheArchive(Archive):
         dest = self.dest_path(dest)
         self._check_path(dest)
         f = codecs.open(dest, 'w', encoding='utf-8')
+        if isinstance(content, bytes):
+            content = content.decode('utf8', 'ignore')
         f.write(content)
         if os.path.exists(src):
             try:

--- a/tests/archive_tests.py
+++ b/tests/archive_tests.py
@@ -8,6 +8,7 @@ import tempfile
 import shutil
 
 from sos.archive import TarFileArchive
+from sos.utilities import tail
 
 # PYCOMPAT
 import six
@@ -37,6 +38,19 @@ class TarFileArchiveTest(unittest.TestCase):
         self.tf.finalize('auto')
 
         self.check_for_file('test/tests/ziptest')
+
+    # when the string comes from tail() output
+    def test_add_string_from_file(self):
+        self.copy_strings = []
+        testfile = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)
+        testfile.write(six.b("*" * 1000))
+        testfile.flush()
+        testfile.close()
+
+        self.copy_strings.append((tail(testfile.name, 100), 'string_test.txt'))
+        self.tf.add_string(self.copy_strings[0][0], 'tests/string_test.txt')
+        self.tf.finalize('auto')
+
 
 # Since commit 179d9bb add_file does not support recursive directory
 # addition. Disable this test for now.


### PR DESCRIPTION
When content comes from add_copy_spec_limit(), in py2 the f.read() from tail()
is a 'str' and in py3 it is a 'bytes'. This is the heart of the problem.

Forcing it into a 'str' early in the process fails as in py3, str has no
.decode() method so it fails later on where content.decode() is called.

Trying to systematically do a content.decode() also fails as, when content is a
'str' in py3, once again it doesn't have a decode() method.

So doing a selective content.decode() only if content is 'bytes' work, as it
will only be 'bytes' if it comes from a py3 f.read() and, in that case, 'bytes'
has the adequate method.

This apparently works for all py2 & py3 tests.