### PR TITLE
[kernel] Add collection of /sys/kernel/slabs

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -30,6 +30,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         # compat
         self.add_cmd_output("uname -a", root_symlink="uname")
         self.add_cmd_output("lsmod", root_symlink="lsmod")
+        self.add_cmd_output("ls -lt /sys/kernel/slab")
 
         try:
             modules = os.listdir(self.sys_module)


### PR DESCRIPTION
Needed when investigating slab related issue to identify
how slabs are merged together. ls -lt shows symlink of
merged slabs.
Closes: #653

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>