### PR TITLE
[openstack] Complete the removal of `OpenStack` from distro plugin names

### DIFF
--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -78,7 +78,7 @@ class DebianCinder(OpenStackCinder, DebianPlugin, UbuntuPlugin):
         return self.cinder
 
     def setup(self):
-        super(DebianOpenStackCinder, self).setup()
+        super(DebianCinder, self).setup()
 
 
 class RedHatCinder(OpenStackCinder, RedHatPlugin):
@@ -93,7 +93,7 @@ class RedHatCinder(OpenStackCinder, RedHatPlugin):
         return self.cinder
 
     def setup(self):
-        super(RedHatOpenStackCinder, self).setup()
+        super(RedHatCinder, self).setup()
         self.add_copy_spec(["/etc/sudoers.d/cinder"])
 
 

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -54,7 +54,7 @@ class DebianHorizon(OpenStackHorizon, DebianPlugin):
     )
 
     def setup(self):
-        super(DebianOpenStackHorizon, self).setup()
+        super(DebianHorizon, self).setup()
         self.add_copy_spec("/etc/apache2/sites-available/")
 
 
@@ -67,7 +67,7 @@ class UbuntuHorizon(OpenStackHorizon, UbuntuPlugin):
     )
 
     def setup(self):
-        super(UbuntuOpenStackHorizon, self).setup()
+        super(UbuntuHorizon, self).setup()
         self.add_copy_spec("/etc/apache2/conf.d/openstack-dashboard.conf")
 
 
@@ -79,7 +79,7 @@ class RedHatHorizon(OpenStackHorizon, RedHatPlugin):
     )
 
     def setup(self):
-        super(RedHatOpenStackHorizon, self).setup()
+        super(RedHatHorizon, self).setup()
         self.add_copy_spec("/etc/httpd/conf.d/openstack-dashboard.conf")
         if self.get_option("log"):
             self.add_copy_spec("/var/log/httpd/")

--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -62,7 +62,7 @@ class OpenStackInstack(Plugin):
                          r"\1*********")
 
 
-class RedHatOpenStackRDOManager(OpenStackInstack, RedHatPlugin):
+class RedHatRDOManager(OpenStackInstack, RedHatPlugin):
 
     packages = [
         'instack',
@@ -70,6 +70,6 @@ class RedHatOpenStackRDOManager(OpenStackInstack, RedHatPlugin):
     ]
 
     def setup(self):
-        super(RedHatOpenStackRDOManager, self).setup()
+        super(RedHatRDOManager, self).setup()
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -42,7 +42,7 @@ class OpenStackIronic(Plugin):
             self.do_path_regex_sub(conf, regexp, r"\1*********")
 
 
-class DebianOpenStackIronic(OpenStackIronic, DebianPlugin, UbuntuPlugin):
+class DebianIronic(OpenStackIronic, DebianPlugin, UbuntuPlugin):
 
     packages = [
         'ironic-api',
@@ -51,10 +51,10 @@ class DebianOpenStackIronic(OpenStackIronic, DebianPlugin, UbuntuPlugin):
     ]
 
     def setup(self):
-        super(DebianOpenStackIronic, self).setup()
+        super(DebianIronic, self).setup()
 
 
-class RedHatOpenStackIronic(OpenStackIronic, RedHatPlugin):
+class RedHatIronic(OpenStackIronic, RedHatPlugin):
 
     packages = [
         'openstack-ironic-api',
@@ -68,7 +68,7 @@ class RedHatOpenStackIronic(OpenStackIronic, RedHatPlugin):
     ]
 
     def setup(self):
-        super(RedHatOpenStackIronic, self).setup()
+        super(RedHatIronic, self).setup()
 
         # is the optional ironic-discoverd service installed?
         if any([self.is_installed(p) for p in self.discoverd_packages]):

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -27,7 +27,7 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 # info...
 
 
-class Neutron(Plugin):
+class OpenStackNeutron(Plugin):
     """OpenStack Networking
     """
     plugin_name = "openstack_neutron"
@@ -131,7 +131,7 @@ class Neutron(Plugin):
         return tuple(names)
 
 
-class DebianNeutron(Neutron, DebianPlugin, UbuntuPlugin):
+class DebianNeutron(OpenStackNeutron, DebianPlugin, UbuntuPlugin):
     package_list_template = [
         '%(comp)s-common',
         '%(comp)s-plugin-cisco',
@@ -155,7 +155,7 @@ class DebianNeutron(Neutron, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec("/etc/sudoers.d/%s_sudoers" % self.component_name)
 
 
-class RedHatNeutron(Neutron, RedHatPlugin):
+class RedHatNeutron(OpenStackNeutron, RedHatPlugin):
 
     package_list_template = [
         'openstack-%(comp)s',

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -111,7 +111,7 @@ class DebianNova(OpenStackNova, DebianPlugin, UbuntuPlugin):
         return self.nova
 
     def setup(self):
-        super(DebianOpenStackNova, self).setup()
+        super(DebianNova, self).setup()
         self.add_copy_spec(["/etc/sudoers.d/nova_sudoers"])
 
 
@@ -141,7 +141,7 @@ class RedHatNova(OpenStackNova, RedHatPlugin):
         return self.nova
 
     def setup(self):
-        super(RedHatOpenStackNova, self).setup()
+        super(RedHatNova, self).setup()
         self.add_copy_spec([
             "/etc/logrotate.d/openstack-nova",
             "/etc/polkit-1/localauthority/50-local.d/50-nova.pkla",

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -54,7 +54,7 @@ class DebianSahara(OpenStackSahara, DebianPlugin, UbuntuPlugin):
     )
 
     def setup(self):
-        super(DebianOpenStackSahara, self).setup()
+        super(DebianSahara, self).setup()
 
 
 class RedHatSahara(OpenStackSahara, RedHatPlugin):
@@ -66,7 +66,7 @@ class RedHatSahara(OpenStackSahara, RedHatPlugin):
     )
 
     def setup(self):
-        super(RedHatOpenStackSahara, self).setup()
+        super(RedHatSahara, self).setup()
         self.add_copy_spec("/etc/sudoers.d/sahara")
 
 

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -54,7 +54,7 @@ class DebianTrove(OpenStackTrove, DebianPlugin, UbuntuPlugin):
     ]
 
     def setup(self):
-        super(DebianOpenStackTrove, self).setup()
+        super(DebianTrove, self).setup()
 
 
 class RedHatTrove(OpenStackTrove, RedHatPlugin):
@@ -62,6 +62,6 @@ class RedHatTrove(OpenStackTrove, RedHatPlugin):
     packages = ['openstack-trove']
 
     def setup(self):
-        super(RedHatOpenStackTrove, self).setup()
+        super(RedHatTrove, self).setup()
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
1699eabd partially did this however a number of plugins had not been
completed when it was pulled in. This led to the cinder, horizon, nova
and sahara plugins all failing to run.

Resolves: #655

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>