### PR TITLE
[openstack_*] Limit log collection to .log files by default

### DIFF
--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -26,14 +26,18 @@ class OpenStackCeilometer(Plugin):
     plugin_name = "openstack_ceilometer"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 
-    option_list = [("log", "gathers openstack-ceilometer logs", "slow", False)]
+    option_list = []
 
     def setup(self):
         # Ceilometer
-        self.add_copy_spec([
-            "/etc/ceilometer/",
-            "/var/log/ceilometer"
-        ])
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/ceilometer/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/ceilometer/*.log",
+                                     sizelimit=self.limit)
+        self.add_copy_spec("/etc/ceilometer/")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -27,8 +27,7 @@ class OpenStackCinder(Plugin):
     plugin_name = "openstack_cinder"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("log", "gathers openstack cinder logs", "slow", True),
-                   ("db", "gathers openstack cinder db version", "slow",
+    option_list = [("db", "gathers openstack cinder db version", "slow",
                     False)]
 
     def setup(self):
@@ -39,8 +38,13 @@ class OpenStackCinder(Plugin):
 
         self.add_copy_spec(["/etc/cinder/"])
 
-        if self.get_option("log"):
-            self.add_copy_spec(["/var/log/cinder/"])
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/cinder/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/cinder/*.log",
+                                     sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -25,7 +25,7 @@ class OpenStackGlance(Plugin):
     plugin_name = "openstack_glance"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("log", "gathers openstack-glance logs", "slow", False)]
+    option_list = []
 
     def setup(self):
         # Glance
@@ -33,10 +33,16 @@ class OpenStackGlance(Plugin):
             "glance-manage db_version",
             suggest_filename="glance_db_version"
         )
-        self.add_copy_spec([
-            "/etc/glance/",
-            "/var/log/glance/"
-        ])
+
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/glance/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/glance/*.log",
+                                     sizelimit=self.limit)
+
+        self.add_copy_spec("/etc/glance/")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -23,7 +23,7 @@ class OpenStackHeat(Plugin):
     plugin_name = "openstack_heat"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("log", "gathers openstack-heat logs", "slow", False)]
+    option_list = []
 
     def setup(self):
         # Heat
@@ -31,10 +31,16 @@ class OpenStackHeat(Plugin):
             "heat-manage db_version",
             suggest_filename="heat_db_version"
         )
-        self.add_copy_spec([
-            "/etc/heat/",
-            "/var/log/heat/"
-        ])
+
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/heat/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/heat/*.log",
+                                     sizelimit=self.limit)
+
+        self.add_copy_spec("/etc/heat/")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -26,12 +26,19 @@ class OpenStackHorizon(Plugin):
 
     plugin_name = "openstack_horizon"
     profiles = ('openstack', 'openstack_controller')
-    option_list = [("log", "gathers openstack horizon logs", "slow", True)]
+    option_list = []
 
     def setup(self):
+
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/horizon/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/horizon/*.log",
+                                     sizelimit=self.limit)
+
         self.add_copy_spec("/etc/openstack-dashboard/")
-        if self.get_option("log"):
-            self.add_copy_spec("/var/log/horizon/")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -26,7 +26,14 @@ class OpenStackIronic(Plugin):
     def setup(self):
         self.conf_list = ['/etc/ironic/*']
         self.add_copy_spec('/etc/ironic/')
-        self.add_copy_spec('/var/log/ironic/')
+
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/ironic/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/ironic/*.log",
+                                     sizelimit=self.limit)
 
         self.add_cmd_output('ls -laRt /var/lib/ironic/')
 

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -23,8 +23,7 @@ class OpenStackKeystone(Plugin):
     plugin_name = "openstack_keystone"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("log", "gathers openstack keystone logs", "slow", True),
-                   ("nopw", "dont gathers keystone passwords", "slow", True)]
+    option_list = [("nopw", "dont gathers keystone passwords", "slow", True)]
 
     def setup(self):
         self.add_copy_spec([
@@ -34,8 +33,13 @@ class OpenStackKeystone(Plugin):
             "/etc/keystone/policy.json"
         ])
 
-        if self.get_option("log"):
-            self.add_copy_spec("/var/log/keystone/")
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/keystone/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/keystone/*.log",
+                                     sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -33,8 +33,7 @@ class Neutron(Plugin):
     plugin_name = "openstack_neutron"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 
-    option_list = [("log", "Gathers all Neutron logs", "slow", False),
-                   ("quantum", "Overrides checks for newer Neutron components",
+    option_list = [("quantum", "Overrides checks for newer Neutron components",
                     "fast", False)]
 
     component_name = "neutron"
@@ -43,10 +42,15 @@ class Neutron(Plugin):
         if not os.path.exists("/etc/neutron/") or self.get_option("quantum"):
             self.component_name = "quantum"
 
-        self.add_copy_spec([
-            "/etc/%s/" % self.component_name,
-            "/var/log/%s/" % self.component_name
-        ])
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/%s/" % self.component_name,
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/%s/*.log" % self.component_name,
+                                     sizelimit=self.limit)
+
+        self.add_copy_spec("/etc/%s/" % self.component_name)
 
         self.netns_dumps()
 

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -22,14 +22,19 @@ class OpenStackSahara(Plugin):
     plugin_name = 'openstack_sahara'
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("log", "gathers openstack sahara logs", "slow", True)]
+    option_list = []
 
     def setup(self):
         self.add_copy_spec("/etc/sahara/")
         self.add_cmd_output("journalctl -u openstack-sahara-all")
 
-        if self.get_option("log"):
-            self.add_copy_spec("/var/log/sahara/")
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/sahara/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/sahara/*.log",
+                                     sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -25,11 +25,17 @@ class OpenStackSwift(Plugin):
     plugin_name = "openstack_swift"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("log", "gathers openstack-swift logs", "slow", False)]
+    option_list = []
 
     def setup(self):
-        if self.get_option("log"):
-            self.add_copy_spec("/var/log/swift/")
+
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/swift/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/swift/*.log",
+                                     sizelimit=self.limit)
 
         self.add_copy_spec("/etc/swift/")
 

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -24,13 +24,19 @@ class OpenStackTrove(Plugin):
 
     plugin_name = "openstack_trove"
     profiles = ('openstack', 'openstack_controller')
-    option_list = [("log", "gathers openstack trove logs", "slow", True)]
+    option_list = []
 
     def setup(self):
-        self.add_copy_spec('/etc/trove/')
 
-        if self.get_option('log'):
-            self.add_copy_spec('/var/log/trove')
+        self.limit = self.get_option("log_size")
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/trove/",
+                                     sizelimit=self.limit)
+        else:
+            self.add_copy_spec_limit("/var/log/trove/*.log",
+                                     sizelimit=self.limit)
+
+        self.add_copy_spec('/etc/trove/')
 
     def postproc(self):
 


### PR DESCRIPTION
Also introduce the global all_logs and log_size options within the
plugin. Allowing users to control when all logs are collected and
limit the overall size of the logs collected.

This series completes work started as part of bb7996737 for openstack_nova.