### PR TITLE
[ovirt] Remove database password from AAA_JDBC profile files

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -193,7 +193,8 @@ class Ovirt(Plugin, RedHatPlugin):
         protect_keys = [
             "vars.password",
             "pool.default.auth.simple.password",
-            "pool.default.ssl.truststore.password"
+            "pool.default.ssl.truststore.password",
+            "config.datasource.dbpassword"
         ]
         regexp = r"((?m)^\s*#*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
 


### PR DESCRIPTION
Ovirt AAA_JDBC ( http://www.ovirt.org/Features/AAA_JDBC) stores database password in plain text under /etc/ovirt-engine/aaa/*.properties file. It contains password in the format config.datasource.dbpassword=<password> . The engine PostgreSQL user password and the custom build domain's  user password exist in plain text format in these files. The commit removes these password from the sosreport.

Signed-off-by: Nijin Ashok <nashok@redhat.com>