### PR TITLE
[process] Add LWP centered output for ps

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -35,6 +35,7 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "ps auxwwwm",
             "ps alxwww",
+            "ps -elfL",
             "%s %s" % (ps_axo, ps_group_opts),
             "%s %s" % (ps_axo, ps_sched_opts)
         ])


### PR DESCRIPTION
Add out put for the following command:

ps -elfL

This is a more friendly output for viewing thread related information.

See  #668

Signed-off-by: Alexandru Juncu alexj@linux.com
