### PR TITLE
Added missing commas in powerpc plugin

### DIFF
--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -83,8 +83,8 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         if isPowerNV:
             self.add_copy_spec([
                 "/proc/ppc64/eeh",
-                "/proc/ppc64/systemcfg"
-                "/proc/ppc64/topology_updates"
+                "/proc/ppc64/systemcfg",
+                "/proc/ppc64/topology_updates",
                 "/sys/firmware/opal/msglog",
                 "/var/log/opal-elog/"
             ])


### PR DESCRIPTION
The commas prevent concatenation of `"/proc/ppc64/systemcfg"`, `"/proc/ppc64/topology_updates"` and `"/sys/firmware/opal/msglog"` into a single string.