### PR TITLE
[openshift] Obfuscate LDAP bind passwords

### DIFF
--- a/sos/plugins/openshift.py
+++ b/sos/plugins/openshift.py
@@ -147,5 +147,10 @@ class Openshift(Plugin, RedHatPlugin):
         self.do_file_sub(plugin_dir + 'openshift-origin-dns-nsupdate.conf',
                          r"(BIND_KEYVALUE\s*=\s*)(.*)",
                          r"\1********")
+        # LDAP authentication:  AuthLDAPBindPassword "IShouldNotBeHere"
+        ldap_paths = '/var/www/openshift/(broker|console)/httpd/conf.d/.*'
+        self.do_path_regex_sub(ldap_paths,
+                               r"(AuthLDAPBindPassword)\s*(.*)",
+                               r"\1********")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
OpenShift broker and console can be configured with different authentication backends. If LDAP is being used with a server that requires authentication for search the configuration files will capture the credentials of the BindDN.

https://bugzilla.redhat.com/show_bug.cgi?id=1227462