### PR TITLE
Gather OVS database in 'list' format

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -38,7 +38,7 @@ class OpenVSwitch(Plugin):
             # to the Open vSwitch server, avoiding hangs when running sos.
             "ovs-vsctl -t 5 show",
             # Gather the database.
-            "ovsdb-client dump"
+            "ovsdb-client -f list dump"
         ])
 
         # Gather additional output for each OVS bridge on the host.


### PR DESCRIPTION
This changes database dump collection format to 'list' which is a more readable and easy to parse.

Signed-off-by: Prasad Mukhedkar <eprasad96@gmail.com>