### PR TITLE
[md] Add collection of per-device and global device parameters

### DIFF
--- a/sos/plugins/md.py
+++ b/sos/plugins/md.py
@@ -27,7 +27,9 @@ class Md(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec([
             "/proc/mdstat",
             "/etc/mdadm.conf",
-            "/dev/md/md-device-map"
+            "/dev/md/md-device-map",
+            "/proc/sys/dev/raid/*",
+            "/sys/block/md*/md*"
         ])
 
 


### PR DESCRIPTION
Some additional parameters can be set for md in both `/proc/sys/dev/raid/` and and `/sys/block/md*`, and this pull request implements the functionality to include them in sosreport archives.