### PR TITLE
Collect /etc/haproxy/conf.d/*

### DIFF
--- a/sos/plugins/haproxy.py
+++ b/sos/plugins/haproxy.py
@@ -27,6 +27,7 @@ class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
 
     def setup(self):
         self.add_copy_spec("/etc/haproxy/haproxy.cfg")
+        self.add_copy_spec("/etc/haproxy/conf.d/*")
         self.add_cmd_output("haproxy -f /etc/haproxy/haproxy.cfg -c")
 
         self.add_copy_spec("/var/log/haproxy.log")


### PR DESCRIPTION
Some openstack installations split out the configuration files
via an "include conf.d/*.cfg" directive. Add the whole directory
in order to collect that as well.

Fixes Issue #674