### PR TITLE
[networking] disable nmcli vs. NetworkManager version mismatch warning

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -206,14 +206,14 @@ class Networking(Plugin):
 
         if len(nmcli_con_details_cmd) > 0:
             nmcli_con_show_result = self.call_ext_prog(
-                "nmcli --terse --fields NAME con")
+                "nmcli --nocheck --terse --fields NAME con")
             if nmcli_con_show_result['status'] == 0:
                 for con in nmcli_con_show_result['output'].splitlines():
                     self.add_cmd_output("%s '%s'" %
                                         (nmcli_con_details_cmd, con))
 
             nmcli_dev_status_result = self.call_ext_prog(
-                "nmcli --terse --fields DEVICE dev")
+                "nmcli --nocheck --terse --fields DEVICE dev")
             if nmcli_dev_status_result['status'] == 0:
                 for dev in nmcli_dev_status_result['output'].splitlines():
                     self.add_cmd_output("%s '%s'" %


### PR DESCRIPTION
Resolves: #710

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>