### PR TITLE
[reporting] deal with UTF-8 characters

### DIFF
--- a/sos/reporting.py
+++ b/sos/reporting.py
@@ -26,6 +26,7 @@ except ImportError:
 
 # PYCOMPAT
 from six import iteritems
+import six
 
 
 class Node(object):
@@ -138,7 +139,7 @@ class PlainTextReport(object):
     def __init__(self, report_node):
         self.report_node = report_node
 
-    def __str__(self):
+    def unicode(self):
         self.buf = buf = []
         for section_name, section_contents in sorted(iteritems(
                 self.report_node.data)):
@@ -146,8 +147,12 @@ class PlainTextReport(object):
             for type_, format_, header in self.subsections:
                 self.process_subsection(section_contents, type_.ADDS_TO,
                                         header, format_)
-
-        return "\n".join(buf)
+        output = u'\n'.join(map(lambda i: (i if isinstance(i, six.text_type)
+                                           else six.u(i)), buf))
+        if six.PY2:
+            return output.encode('utf8')
+        else:
+            return output
 
     def process_subsection(self, section, key, header, format_):
         if key in section:

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1339,7 +1339,8 @@ class SoSReport(object):
             report.add(section)
         try:
             fd = self.get_temp_file()
-            fd.write(str(PlainTextReport(report)))
+            output = PlainTextReport(report).unicode()
+            fd.write(output)
             fd.flush()
             self.archive.add_file(fd.name, dest=os.path.join('sos_reports',
                                                              'sos.txt'))

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -66,19 +66,19 @@ class TestPlainReport(unittest.TestCase):
         self.div = PlainTextReport.DIVIDER
 
     def test_basic(self):
-        self.assertEquals("", str(PlainTextReport(self.report)))
+        self.assertEquals("", PlainTextReport(self.report).unicode())
 
     def test_one_section(self):
         self.report.add(self.section)
 
-        self.assertEquals("plugin\n" + self.div, str(PlainTextReport(self.report)))
+        self.assertEquals("plugin\n" + self.div, PlainTextReport(self.report).unicode())
 
     def test_two_sections(self):
         section1 = Section(name="first")
         section2 = Section(name="second")
         self.report.add(section1, section2)
 
-        self.assertEquals("first\n" + self.div + "\nsecond\n" + self.div, str(PlainTextReport(self.report)))
+        self.assertEquals("first\n" + self.div + "\nsecond\n" + self.div, PlainTextReport(self.report).unicode())
 
     def test_command(self):
         cmd = Command(name="ls -al /foo/bar/baz",
@@ -88,7 +88,7 @@ class TestPlainReport(unittest.TestCase):
         self.report.add(self.section)
 
         self.assertEquals("plugin\n" + self.div + "\n-  commands executed:\n  * ls -al /foo/bar/baz",
-                str(PlainTextReport(self.report)))
+                PlainTextReport(self.report).unicode())
 
     def test_copied_file(self):
         cf = CopiedFile(name="/etc/hosts", href="etc/hosts")
@@ -96,7 +96,7 @@ class TestPlainReport(unittest.TestCase):
         self.report.add(self.section)
 
         self.assertEquals("plugin\n" + self.div + "\n-  files copied:\n  * /etc/hosts",
-                str(PlainTextReport(self.report)))
+                PlainTextReport(self.report).unicode())
 
     def test_created_file(self):
         crf = CreatedFile(name="sample.txt")
@@ -104,7 +104,7 @@ class TestPlainReport(unittest.TestCase):
         self.report.add(self.section)
 
         self.assertEquals("plugin\n" + self.div + "\n-  files created:\n  * sample.txt",
-                str(PlainTextReport(self.report)))
+                PlainTextReport(self.report).unicode())
 
     def test_alert(self):
         alrt = Alert("this is an alert")
@@ -112,7 +112,7 @@ class TestPlainReport(unittest.TestCase):
         self.report.add(self.section)
 
         self.assertEquals("plugin\n" + self.div + "\n-  alerts:\n  ! this is an alert",
-                str(PlainTextReport(self.report)))
+                PlainTextReport(self.report).unicode())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
replace str class functions by unicode variants:
1) "\n".join(buf) needs to pass decoded UTF-8 text
2) fd.write needs to replace str(..) by some other function name
3) fd.write needs to encode UTF-8

Resolves: #722

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>