### PR TITLE
[cgroups] collect systemd-cgls output

### DIFF
--- a/sos/plugins/cgroups.py
+++ b/sos/plugins/cgroups.py
@@ -28,6 +28,9 @@ class Cgroups(Plugin, DebianPlugin, UbuntuPlugin):
             "/proc/cgroups",
             "/sys/fs/cgroup"
         ])
+
+        self.add_cmd_output(["systemd-cgls"])
+
         return
 
 


### PR DESCRIPTION
Resolves #731 

Checked that `system-cgls` command exists both on Red Hat and Debian/Ubuntu families of distros, so added to main class.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>