### PR TITLE
[doc] Add notification that "--verify" must be specified in order for

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -103,8 +103,9 @@ sysmgmt, system, performance, virt, and webserver.
 .B \--verify
 Instructs plugins to perform plugin-specific verification during data
 collection. This may include package manager verification, log integrity
-testing or other plugin defined behaviour. Use of \--verify may cause
-the time taken to generate a report to be considerably longer.
+testing or other plugin defined behaviour. Use of \--verify may cause the
+time taken to generate a report to be considerably longer.  The \--verify
+option must be specified when enabling the rpm.rpmva option.
 .TP
 .B \--log-size
 Places a global limit on the size of any collected set of logs. The


### PR DESCRIPTION
rpm.rpmva option to be executed.

Fixes: #735

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>