### PR TITLE
[networking] Add `/proc/net/cdp` to forbidden paths.

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -128,6 +128,7 @@ class Networking(Plugin):
         self.add_forbidden_path("/proc/net/rpc/use-gss-proxy")
         self.add_forbidden_path("/proc/net/rpc/*/channel")
         self.add_forbidden_path("/proc/net/rpc/*/flush")
+        self.add_forbidden_path("/proc/net/cdp")
 
         self.add_cmd_output("ip -o addr", root_symlink="ip_addr")
         self.add_cmd_output("route -n", root_symlink="route")


### PR DESCRIPTION
Add /proc/net/cdp forbidden paths in order to prevent
collecting possibly gigantic files that can be present
in this directory.

Fixes: #740

Signed-off-by: Shane Bradley <sbradley@redhat.com>