### PR TITLE
[omsa] Include output from chassis biossetup and chassis summary

### DIFF
--- a/sos/plugins/omsa.py
+++ b/sos/plugins/omsa.py
@@ -47,6 +47,8 @@ class omsa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "{0} system summary".format(self.omreport),
             "{0} system events".format(self.omreport),
             "{0} chassis info".format(self.omreport),
+            "{0} chassis biossetup".format(self.omreport),
+            "{0} chassis summary".format(self.omreport),
         ], timeout=30)
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
The output from 'omreport chassis biossetup' identifies a system's power
profile, which is very handy when troubleshooting performance issues.

Closes: #725

Signed-off-by: Bill Yodlowsky <byodlows@redhat.com>