### PR TITLE
[virsh] use read-only option to list all domains

### DIFF
--- a/sos/plugins/virsh.py
+++ b/sos/plugins/virsh.py
@@ -34,7 +34,7 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             self.add_copy_spec("/root/.virt-manager/*")
 
         # get lit of VMs/domains
-        domains_file = self.get_cmd_output_now('virsh list --all')
+        domains_file = self.get_cmd_output_now('virsh -r list --all')
 
         # cycle through the VMs/domains list, ignore 2 header lines and latest
         # empty line, and dumpxml domain name in 2nd column


### PR DESCRIPTION
If authentication is required to use virsh, sos will timeout on
'virsh list --all'. Use '-r' option to avoid this.

2016-02-10 00:24:02,761 WARNING: [plugin:virsh] command 'virsh list
--all' timed out after 300s

$ virsh list --all
Please enter your authentication name:
Please enter your password:
error: failed to connect to the hypervisor
error: no valid connection
error: authentication failed: Failed to step SASL negotiation: -1
(SASL(-1): generic failure: All-whitespace username.)

$ virsh -r list --all

 Id    Name                           State
----------------------------------------------------