### PR TITLE
[juju] Add /etc/juju to collection

### DIFF
--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -77,7 +77,8 @@ class Juju(Plugin, UbuntuPlugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/var/lib/juju"
+            "/var/lib/juju",
+            "/etc/juju",
         ])
         limit = self.get_option("log_size")
         self.add_copy_spec_limit("/var/log/upstart/juju-db.log",


### PR DESCRIPTION
Since juju-core 1.25.0 /etc/juju is used to store certificates,
whithout this patch just the old certificates kept under /var/lib/juju
are collected.

Signed-off-by: Felipe Reyes felipe.reyes@canonical.com
