### PR TITLE
[requirements] Added necessary python dependencies in requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ patches and commit messages.
 User and API [documentation][6] is automatically generated using [Sphinx][7]
 and [Read the Docs][8].
 
+Ex. To generate HTML documents locally
+
+* Install requirements
+
+```
+pip install -r requirements.txt
+cd docs
+make html
+```
+
+Now open `sos/docs/_build/html/index.html` in your browser
+
 ### Wiki
 
 * [How to write a plugin][1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+alabaster==0.7.7
+Babel==2.2.0
+docutils==0.12
+Jinja2==2.8
+MarkupSafe==0.23
+nose==1.3.7
+Pygments==2.1.1
+pytz==2015.7
+six==1.10.0
+snowballstemmer==1.2.1
+Sphinx==1.3.5
+sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
May be a good idea to have requirements.txt file. This is helpful to generate docs and run 'make test'

* Updated instructions in README to install Python dependencies.
* Added an example to create HTML docs.

Signed-off-by: Sachin Patil <sacpatil@redhat.com>