### PR TITLE
[processor.py] Added cpuid command http://www.etallen.com/cpuid.html

### DIFF
--- a/sos/plugins/processor.py
+++ b/sos/plugins/processor.py
@@ -22,7 +22,7 @@ class Processor(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     plugin_name = 'processor'
     profiles = ('system', 'hardware', 'memory')
     files = ('/proc/cpuinfo',)
-    packages = ('cpufreq-utils')
+    packages = ('cpufreq-utils', 'cpuid')
 
     def setup(self):
         self.add_copy_spec([
@@ -35,7 +35,9 @@ class Processor(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "lscpu",
             "cpupower info",
             "cpupower idle-info",
-            "cpupower frequency-info"
+            "cpupower frequency-info",
+            "cpuid",
+            "cpuid -r"
         ])
 
         if '86' in self.policy().get_arch():


### PR DESCRIPTION
Hello, 

I propose to add output of cpuid utility to sosreport. The source code of cpuid utility can be found here: http://www.etallen.com/cpuid.html

It provides the details about CPU which no other utility in sosreport does. cpuid is provided as package in the most Linux distributions. 

Thanks for considering it.
Jirka