### PR TITLE
[x11] Add clinfo and vulkaninfo

### DIFF
--- a/sos/plugins/x11.py
+++ b/sos/plugins/x11.py
@@ -34,6 +34,8 @@ class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_forbidden_path("/etc/X11/fontpath.d")
         self.add_cmd_output([
             "glxinfo",
+            "clinfo",
+            "vulkaninfo",
             "xrandr --verbose"
         ])
 


### PR DESCRIPTION
We should collect clinfo and vulkaninfo like we do
for glxinfo.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>