### PR TITLE
README clarificaction for running from git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pull requests.
 ### Manual Installation
 
 ```
-You can simply run from the git checkout now ==> Ex: sudo ./sosreport -a
+You can simply run from the git checkout now ==> Ex: sudo ./sosreport -a --config-file sos.conf
 to install locally (as root) ==> make install
 to build an rpm ==> make rpm
 ```


### PR DESCRIPTION
Without specifying the config file and if there is no config file in
/etc/sos.conf, sosreport fails.

(Tested on CentOS 7.2)