### PR TITLE
[s390] Enable on Ubuntu/Debian, and on s390x architecture

### DIFF
--- a/sos/plugins/s390.py
+++ b/sos/plugins/s390.py
@@ -14,10 +14,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-from sos.plugins import Plugin, RedHatPlugin
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class S390(Plugin, RedHatPlugin):
+class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     """IBM S/390
     """
 
@@ -27,7 +27,7 @@ class S390(Plugin, RedHatPlugin):
     # Check for s390 arch goes here
 
     def check_enabled(self):
-        return (self.policy().get_arch() == "s390")
+        return (self.policy().get_arch() in ["s390", "s390x"])
 
     # Gather s390 specific information
 


### PR DESCRIPTION
All the tools & calls are the same on s390x as on s390. The tools
called are available on Ubuntu/Debian s390x port (and old s390 port).
All of this should also be available on RedHat s390x port.

Tested to work correctly on Ubuntu s390x port.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>