### PR TITLE
[x11|opengl|opencl|vulkan] Create seperate plugin for each gpu api

### DIFF
--- a/sos/plugins/opencl.py
+++ b/sos/plugins/opencl.py
@@ -15,25 +15,17 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """X windowing system
+class OpenCL(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """OpenCL
     """
 
-    plugin_name = 'x11'
-    profiles = ('hardware', 'desktop')
-
-    files = ('/etc/X11',)
+    plugin_name = 'opencl'
+    profiles = ('hardware', 'desktop', 'gpu')
+    files = ('/usr/bin/clinfo',)
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/X11",
-            "/var/log/Xorg.*.log",
-            "/var/log/XFree86.*.log",
-        ])
-        self.add_forbidden_path("/etc/X11/X")
-        self.add_forbidden_path("/etc/X11/fontpath.d")
         self.add_cmd_output([
-            "xrandr --verbose"
+            "clinfo",
         ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/opengl.py
+++ b/sos/plugins/opengl.py
@@ -15,25 +15,17 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """X windowing system
+class OpenGL(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """OpenGL
     """
 
-    plugin_name = 'x11'
-    profiles = ('hardware', 'desktop')
-
-    files = ('/etc/X11',)
+    plugin_name = 'opengl'
+    profiles = ('hardware', 'desktop', 'gpu')
+    files = ('/usr/bin/glxinfo',)
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/X11",
-            "/var/log/Xorg.*.log",
-            "/var/log/XFree86.*.log",
-        ])
-        self.add_forbidden_path("/etc/X11/X")
-        self.add_forbidden_path("/etc/X11/fontpath.d")
         self.add_cmd_output([
-            "xrandr --verbose"
+            "glxinfo",
         ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/vulkan.py
+++ b/sos/plugins/vulkan.py
@@ -15,25 +15,17 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """X windowing system
+class Vulkan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """Vulkan
     """
 
-    plugin_name = 'x11'
-    profiles = ('hardware', 'desktop')
-
-    files = ('/etc/X11',)
+    plugin_name = 'vulkan'
+    profiles = ('hardware', 'desktop', 'gpu')
+    files = ('/usr/bin/vulkaninfo',)
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/X11",
-            "/var/log/Xorg.*.log",
-            "/var/log/XFree86.*.log",
-        ])
-        self.add_forbidden_path("/etc/X11/X")
-        self.add_forbidden_path("/etc/X11/fontpath.d")
         self.add_cmd_output([
-            "xrandr --verbose"
+            "vulkaninfo",
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This takes glxinfo out of x11 and moves it to a new opengl plugin.
It also provides clinfo and vulkaninfo in their own individual plugins.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>