### PR TITLE
fix unexpected keyword argument with policy

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -35,7 +35,7 @@ def load(cache={}, sysroot=None):
     for module in helper.get_modules():
         for policy in import_policy(module):
             if policy.check():
-                cache['policy'] = policy(sysroot=sysroot)
+                cache['policy'] = policy()
 
     if 'policy' not in cache:
         cache['policy'] = GenericPolicy()


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/sbin/sosreport", line 25, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/sos/sosreport.py", line 1592, in main
    sos = SoSReport(args)
  File "/usr/lib/python2.7/site-packages/sos/sosreport.py", line 676, in __init__
    self.policy = sos.policies.load(sysroot=self.opts.sysroot)
  File "/usr/lib/python2.7/site-packages/sos/policies/__init__.py", line 38, in load
    cache['policy'] = policy(sysroot=sysroot)
TypeError: __init__() got an unexpected keyword argument 'sysroot'

Signed-off-by: Leno Hou <lenohou@gmail.com>