### PR TITLE
[plugin] Rename several plugins according to the plugin filename

### DIFF
--- a/sos/plugins/cs.py
+++ b/sos/plugins/cs.py
@@ -25,7 +25,7 @@ class CertificateSystem(Plugin, RedHatPlugin):
     """Certificate System and Dogtag
     """
 
-    plugin_name = 'certificatesystem'
+    plugin_name = 'cs'
     profiles = ('identity', 'security')
 
     packages = (

--- a/sos/plugins/ds.py
+++ b/sos/plugins/ds.py
@@ -23,7 +23,7 @@ class DirectoryServer(Plugin, RedHatPlugin):
     """Directory Server
     """
 
-    plugin_name = 'directoryserver'
+    plugin_name = 'ds'
     profiles = ('identity',)
 
     files = ('/etc/dirsrv', '/opt/redhat-ds')

--- a/sos/plugins/hts.py
+++ b/sos/plugins/hts.py
@@ -19,7 +19,7 @@ class HardwareTestSuite(Plugin, RedHatPlugin):
     """Red Hat Hardware Test Suite
     """
 
-    plugin_name = 'hardwaretestsuite'
+    plugin_name = 'hts'
     profiles = ('debug',)
 
     def setup(self):

--- a/sos/plugins/subscription_manager.py
+++ b/sos/plugins/subscription_manager.py
@@ -19,7 +19,7 @@ class SubscriptionManager(Plugin, RedHatPlugin):
     """subscription-manager information
     """
 
-    plugin_name = 'subscription-manager'
+    plugin_name = 'subscription_manager'
     profiles = ('system', 'packagemanager', 'sysmgmt')
 
     files = ('/etc/rhsm/rhsm.conf',)


### PR DESCRIPTION
Set plugin_name accordingly to the plugin filename, to let
"sosreport -l" to print plugin names that can be used in
"sosreport -[o|e|n]".

Affected plugins:

sos/plugins/cs.py:    plugin_name = 'certificatesystem'
sos/plugins/ds.py:    plugin_name = 'directoryserver'
sos/plugins/hts.py:    plugin_name = 'hardwaretestsuite'
sos/plugins/subscription_manager.py:    plugin_name = 'subscription-manager'

Resolves: #811

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>