### PR TITLE
[networking] blacklist Dialogic Diva ISDN driver pseudo-files

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -136,6 +136,9 @@ class Networking(Plugin):
         # Cisco CDP
         self.add_forbidden_path("/proc/net/cdp")
         self.add_forbidden_path("/sys/net/cdp")
+        # Dialogic Diva
+        self.add_forbidden_path("/proc/net/eicon/di*")
+        self.add_forbidden_path("/proc/net/eicon/adapter*/dynamic_l1_down")
 
         self.add_cmd_output("ip -o addr", root_symlink="ip_addr")
         self.add_cmd_output("route -n", root_symlink="route")


### PR DESCRIPTION
blacklisting everything except for:

/proc/net/eicon/adapter*/group_optimization
/proc/net/eicon/adapter*/info

Fixes #777

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>