### PR TITLE
[policies] Fix ibmkvm policy initialize function

### DIFF
--- a/sos/policies/ibmkvm.py
+++ b/sos/policies/ibmkvm.py
@@ -29,8 +29,8 @@ class PowerKVMPolicy(RedHatPolicy):
     vendor = "IBM"
     vendor_url = "http://www-03.ibm.com/systems/power/software/linux/powerkvm"
 
-    def __init__(self):
-        super(PowerKVMPolicy, self).__init__()
+    def __init__(self, sysroot=None):
+        super(PowerKVMPolicy, self).__init__(sysroot=sysroot)
         self.valid_subclasses = [PowerKVMPlugin, RedHatPlugin]
 
     @classmethod
@@ -54,8 +54,8 @@ class ZKVMPolicy(RedHatPolicy):
     vendor = "IBM Hypervisor"
     vendor_url = "http://www.ibm.com/systems/z/linux/IBMHypervisor/support/"
 
-    def __init__(self):
-        super(ZKVMPolicy, self).__init__()
+    def __init__(self, sysroot=None):
+        super(ZKVMPolicy, self).__init__(sysroot=sysroot)
         self.valid_subclasses = [ZKVMPlugin, RedHatPlugin]
 
     @classmethod


### PR DESCRIPTION
When loading policy, its leads failed load with sysroot.
This patch updates the initialize function with sysroot

Signed-off-by: Leno Hou <lenohou@gmail.com>