### PR TITLE
[grub2] grub2-mkconfig loads ext4 and brctl kernel modules

### DIFF
--- a/sos/plugins/grub2.py
+++ b/sos/plugins/grub2.py
@@ -33,10 +33,13 @@ class Grub2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/grub2.cfg",
             "/etc/grub.d"
         ])
-        self.add_cmd_output([
-            "ls -lanR /boot",
-            "grub2-mkconfig"
-        ])
+
+        self.add_cmd_output("ls -lanR /boot")
+        # call grub2-mkconfig with GRUB_DISABLE_OS_PROBER=true to prevent
+        # possible unwanted loading of some kernel modules
+        env = {}
+        env['GRUB_DISABLE_OS_PROBER'] = 'true'
+        self.add_cmd_output("grub2-mkconfig", env=env)
 
     def postproc(self):
         # the trailing space is required; python treats '_' as whitespace

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -110,7 +110,7 @@ def is_executable(command):
 
 
 def sos_get_command_output(command, timeout=300, stderr=False,
-                           chroot=None, chdir=None):
+                           chroot=None, chdir=None, env=None):
     """Execute a command and return a dictionary of status and output,
     optionally changing root or current working directory before
     executing command.
@@ -127,6 +127,10 @@ def sos_get_command_output(command, timeout=300, stderr=False,
     cmd_env = os.environ
     # ensure consistent locale for collected command output
     cmd_env['LC_ALL'] = 'C'
+    # optionally add an environment change for the command
+    if env:
+        for key, value in env.iteritems():
+            cmd_env[key] = value
     # use /usr/bin/timeout to implement a timeout
     if timeout and is_executable("timeout"):
         command = "timeout %ds %s" % (timeout, command)


### PR DESCRIPTION
Execute grub2-mkconfig only when both ext4 and brctl kernel modules
are loaded.

Resolves #821

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>