### PR TITLE
[pacemaker] Call crm_report with --sos-mode option

### DIFF
--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -64,7 +64,8 @@ class Pacemaker(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             self._log_warn("scrubbing of crm passwords has been disabled:")
             self._log_warn("data collected by crm_report may contain"
                            " sensitive values.")
-        self.add_cmd_output('crm_report %s -S -d --dest %s --from "%s"' %
+        self.add_cmd_output('crm_report --sos-mode %s -S -d '
+                            ' --dest %s --from "%s"' %
                             (crm_scrub, crm_dest, crm_from),
                             chroot=self.tmp_in_sysroot())
 # vim: et ts=4 sw=4


### PR DESCRIPTION
crm_report should be called with --sos-mode option for preffered
collection of log files.

Resolves: #795

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>