### PR TITLE
[systemd] Collect detailed runtime info on each unit

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -25,22 +25,24 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     profiles = ('system', 'services', 'boot')
 
     packages = ('systemd',)
-    files = ('/usr/lib/systemd/systemd',)
+    files = ('/usr/lib/systemd/systemd', '/lib/systemd/systemd')
 
     def setup(self):
         self.add_cmd_output([
+            "systemctl status --all",
             "systemctl show --all",
+            "systemctl show *service --all",
+            # It is possible to do systemctl show with target, slice,
+            # device, socket, scope, and mount too but service and
+            # status --all mostly seems to cover the others.
             "systemctl list-units",
             "systemctl list-units --failed",
-            "systemctl list-units --all",
             "systemctl list-unit-files",
             "systemctl show-environment",
             "systemd-delta",
+            "systemd-analyze",
             "journalctl --list-boots",
-            "ls -l /lib/systemd",
-            "ls -l /lib/systemd/system-shutdown",
-            "ls -l /lib/systemd/system-generators",
-            "ls -l /lib/systemd/user-generators",
+            "ls -lR /lib/systemd",
             "timedatectl"
         ])
 


### PR DESCRIPTION
This runs status and show on each systemd unit. Which
gives us structured data on the environment of services,
limits and much more.

It also adds:
systemd-analyze - provides boot performance info
systemctl status - shows system status and nice process
tree

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>