### PR TITLE
[docs] Mention python3 and update Ubuntu note.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ pull requests.
 
 ```
 You can simply run from the git checkout now ==> Ex: sudo ./sosreport -a
+or if you only have python3 installed ==> sudo python3 ./sosreport -a
 to install locally (as root) ==> make install
 to build an rpm ==> make rpm
 ```
@@ -77,7 +78,7 @@ apt-get install sosreport
 ```
 
 
-Ubuntu(Saucy 13.10 and above) users install via apt:
+Ubuntu(14.04 LTS and above) users install via apt:
 
 ```
 sudo apt-get install sosreport


### PR DESCRIPTION
Mention how to run sosreport on a system with only
python3.

Update the first release sosreport got into Ubuntu to a
supported LTS which should be more recognizable to people.

Fixes: #830

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>