### PR TITLE
[ovirt_hosted_engine] Add new location for vm.conf

### DIFF
--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -52,6 +52,8 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
             '/etc/ovirt-hosted-engine-ha/broker.conf',
             '/etc/ovirt-hosted-engine-ha/broker-log.conf',
             '/etc/ovirt-hosted-engine-ha/notifications/state_transition.txt',
+            '/var/run/ovirt-hosted-engine-ha/vm.conf',
+            '/var/lib/ovirt-hosted-engine-ha/broker.conf',
         ])
 
         all_setup_logs = glob.glob(self.SETUP_LOG_GLOB)


### PR DESCRIPTION
From ovirt 3.6, vm.conf is in the shared storage and not at  /etc/ovirt-hosted-engine/vm.conf . ha keeps a local copy of vm.conf under /var/run/ovirt-hosted-engine-ha/ which is extracted from the shared storage. Including /var/run/ovirt-hosted-engine-ha/vm.conf in the list of files to be collected

Signed-off-by: Nijin Ashok nashok@redhat.com
