### PR TITLE
[tomcat] Added collection for JBoss Web Server

### DIFF
--- a/sos/plugins/tomcat.py
+++ b/sos/plugins/tomcat.py
@@ -22,12 +22,14 @@ class Tomcat(Plugin, RedHatPlugin):
     plugin_name = 'tomcat'
     profiles = ('webserver', 'java', 'services', 'sysmgmt')
 
-    packages = ('tomcat6', 'tomcat')
+    packages = ('tomcat', 'tomcat6', 'tomcat7', 'tomcat8')
 
     def setup(self):
         self.add_copy_spec([
             "/etc/tomcat",
-            "/etc/tomcat6"
+            "/etc/tomcat6",
+            "/etc/tomcat7",
+            "/etc/tomcat8"
         ])
 
         limit = self.get_option("log_size")


### PR DESCRIPTION
This commit was made to add the tomcat7 and tomcat8 package data collection which the JBoss Web Server product provides. It is a follow-up commit to https://github.com/sosreport/sos/commit/5ebd0bd9 and now the JBoss Web Server technology offering is completely covered by sosreport.

Signed-off-by: Coty Sutherland <csutherl@redhat.com>