### PR TITLE
[lxd] Use add_copy_spec_limit

### DIFF
--- a/sos/plugins/lxd.py
+++ b/sos/plugins/lxd.py
@@ -28,9 +28,8 @@ class LXD(Plugin, UbuntuPlugin):
             "/etc/default/lxc-bridge",
         ])
 
-        self.add_copy_spec([
-            "/var/log/lxd*"
-        ], sizelimit=self.get_option("log_size"))
+        self.add_copy_spec_limit("/var/log/lxd*",
+                                 sizelimit=self.get_option("log_size"))
 
         # List of containers available on the machine
         self.add_cmd_output([


### PR DESCRIPTION
sizelimit is only available with add_copy_spec_limit. Replace it.
Closes: #843

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>