### PR TITLE
[kubernetes] Collect additional data, be namespace aware, and update options

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -180,6 +180,40 @@ class Plugin(object):
         '''Is the package $package_name installed?'''
         return self.policy().pkg_by_name(package_name) is not None
 
+    def do_cmd_private_sub(self, cmd):
+        '''Remove certificate and key output archived by sosreport. cmd
+        is the command name from which output is collected (i.e. excluding
+        parameters). Any matching instances are replaced with: '-----SCRUBBED'
+        and this function does not take a regexp or substituting string.
+
+        This function returns the number of replacements made.
+        '''
+        globstr = '*' + cmd + '*'
+        self._log_debug("Scrubbing certs and keys for commands matching %s"
+                        % (cmd))
+
+        if not self.executed_commands:
+            return 0
+
+        replacements = None
+        try:
+            for called in self.executed_commands:
+                if called['file'] is None:
+                    continue
+                if fnmatch.fnmatch(called['exe'], globstr):
+                    path = os.path.join(self.commons['cmddir'], called['file'])
+                    readable = self.archive.open_file(path)
+                    certmatch = re.compile("-----BEGIN.*?-----END", re.DOTALL)
+                    result, replacements = certmatch.subn(
+                        "-----SCRUBBED", readable.read())
+                    if replacements:
+                        self.archive.add_string(result, path)
+        except Exception as e:
+            msg = "Certificate/key scrubbing failed for '%s' with: '%s'"
+            self._log_error(msg % (called['exe'], e))
+            replacements = None
+        return replacements
+
     def do_cmd_output_sub(self, cmd, regexp, subst):
         '''Apply a regexp substitution to command output archived by sosreport.
         cmd is the command name from which output is collected (i.e. excluding

--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -15,6 +15,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin
+from os import path
 
 
 class kubernetes(Plugin, RedHatPlugin):
@@ -22,41 +23,118 @@ class kubernetes(Plugin, RedHatPlugin):
     """Kubernetes plugin
     """
 
-    option_list = [("podslog", "capture logs for pods", 'slow', False)]
+    # Red Hat Atomic Platform and OpenShift Enterprise use the
+    # atomic-openshift-master package to provide kubernetes
+    packages = ('kubernetes', 'kubernetes-master', 'atomic-openshift-master')
+    files = ("/etc/origin/master/master-config.yaml",)
+
+    option_list = [
+        ("all", "also collect --all-namespaces output separately",
+            'fast', True),
+        ("describe", "capture descriptions of all kube resources",
+            'fast', True),
+        ("podlogs", "capture logs for pods", 'slow', False),
+    ]
+
+    def check_is_master(self):
+        return any([
+            path.exists("/var/run/kubernetes/apiserver.key"),
+            path.exists("/etc/origin/master/master-config.yaml")
+        ])
 
     def setup(self):
         self.add_copy_spec("/etc/kubernetes")
         self.add_copy_spec("/var/run/flannel")
 
-        # Kubernetes master info
-        self.add_cmd_output("kubectl version")
-        self.add_cmd_output("kubectl get -o json pods")
-        self.add_cmd_output("kubectl get -o json nodes")
-        self.add_cmd_output("kubectl get -o json services")
-        self.add_cmd_output("kubectl get -o json replicationController")
-        self.add_cmd_output("kubectl get -o json events")
+        svcs = [
+            'kubelet',
+            'kube-apiserver',
+            'kube-proxy',
+            'kube-scheduler',
+            'kube-controller-manager'
+        ]
 
-        # This could use a single call:
-        #
-        #   add_journal(units=["kubelet", "kube-apiserver", ... ])
-        #
-        # But this would merge all units into a single text stream - to
-        # preserve existing file layout in archives keep these as
-        # separate journalctl calls.
-        self.add_journal(units="kubelet")
-        self.add_journal(units="kube-apiserver")
-        self.add_journal(units="kube-controller-manager")
-        self.add_journal(units="kube-scheduler")
-        self.add_journal(units="kube-proxy")
+        for svc in svcs:
+            self.add_journal(units=svc)
 
-        if self.get_option('podslog'):
-            result = self.get_command_output("kubectl get pods")
-            if result['status'] == 0:
-                for line in result['output'].splitlines()[1:]:
-                    pod_name = line.split(" ")[0]
-                    self.add_cmd_output([
-                        "{0} log {1}".format("kubectl", pod_name)
-                    ])
+        # We can only grab kubectl output from the master
+        if self.check_is_master():
+            kube_cmd = "kubectl "
+            if path.exists('/etc/origin/master/admin.kubeconfig'):
+                kube_cmd += "--config=/etc/origin/master/admin.kubeconfig"
 
+            kube_get_cmd = "get -o json "
+            for subcmd in ['version', 'config view']:
+                self.add_cmd_output('%s %s' % (kube_cmd, subcmd))
+
+            # get all namespaces in use
+            kn = self.get_command_output('%s get namespaces' % kube_cmd)
+            knsps = [n.split()[0] for n in kn['output'].splitlines()[1:] if n]
+
+            resources = [
+                'limitrange',
+                'pods',
+                'pvc',
+                'rc',
+                'resourcequota',
+                'services'
+            ]
+
+            # nodes and pvs are not namespaced, must pull separately
+            self.add_cmd_output([
+                '%s %s nodes' % (kube_cmd, kube_get_cmd),
+                '%s %s pv' % (kube_cmd, kube_get_cmd)
+            ])
+
+            for n in knsps:
+                knsp = '--namespace=%s' % n
+                k_cmd = '%s %s %s' % (kube_cmd, kube_get_cmd, knsp)
+
+                self.add_cmd_output('%s events' % k_cmd)
+
+                for res in resources:
+                    self.add_cmd_output('%s %s' % (k_cmd, res))
+
+                if self.get_option('describe'):
+                    # need to drop json formatting for this
+                    k_cmd = '%s get %s' % (kube_cmd, knsp)
+                    for res in resources:
+                        r = self.get_command_output(
+                            '%s %s' % (k_cmd, res))
+                        if r['status'] == 0:
+                            k_list = [k.split()[0] for k in
+                                      r['output'].splitlines()[1:]]
+                            for k in k_list:
+                                k_cmd = '%s %s' % (kube_cmd, knsp)
+                                self.add_cmd_output(
+                                    '%s describe %s %s' % (k_cmd, res, k))
+
+                if self.get_option('podlogs'):
+                    k_cmd = '%s %s' % (kube_cmd, knsp)
+                    r = self.get_command_output('%s get pods' % k_cmd)
+                    if r['status'] == 0:
+                        pods = [p.split()[0] for p in
+                                r['output'].splitlines()[1:]]
+                        for pod in pods:
+                            self.add_cmd_output('%s logs %s' % (k_cmd, pod))
+
+            if self.get_option('all'):
+                k_cmd = '%s get --all-namespaces=true' % kube_cmd
+                for res in resources:
+                    self.add_cmd_output('%s %s' % (k_cmd, res))
+
+    def postproc(self):
+        # First, clear sensitive data from the json output collected.
+        # This will mask values when the "name" looks susceptible of
+        # values worth obfuscating, i.e. if the name contains strings
+        # like "pass", "pwd", "key" or "token"
+        env_regexp = r'(?P<var>{\s*"name":\s*[^,]*' \
+            r'(pass|pwd|key|token|cred|PASS|PWD|KEY)[^,]*,\s*"value":)[^}]*'
+        self.do_cmd_output_sub('kubectl', env_regexp,
+                               r'\g<var> "********"')
+
+        # Next, we need to handle the private keys and certs in some
+        # output that is not hit by the previous iteration.
+        self.do_cmd_private_sub('kubectl')
 
 # vim: et ts=5 sw=4


### PR DESCRIPTION
This is a replacement PR for #718 - I realize this may be considered bad form, but with the huge amount of rework the original PR needed and the rebasing required, this way was just much easier for me.

This expands on #718 by also making the plugin namespace aware, and adds `do_cmd_private_sub()` to `Plugin` which will scrub certificates and keys from collected output. It is modeled heavily on `do_cmd_output_sub()` but does not take a regexp or substituting string, as in my opinion the resulting "----- SCRUBBED `thing` -----" single line approach is the best one to take. 

Tested on vanilla kubernetes and OSE 3.1 on RHEL 7. OSE will likely still need a separate plugin for the bits that are not shared between OSE and vanilla kube (e.g. routes). 