### PR TITLE
[openstack_sahara] capture all sahara* sudoers files

### DIFF
--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -76,7 +76,7 @@ class RedHatSahara(OpenStackSahara, RedHatPlugin):
 
     def setup(self):
         super(RedHatSahara, self).setup()
-        self.add_copy_spec("/etc/sudoers.d/sahara")
+        self.add_copy_spec("/etc/sudoers.d/sahara*")
 
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
It seems that nowadays the file is /etc/sudoers.d/sahara-rootwrap.