### PR TITLE
[sos] Fix version string in sos/__init__.py

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -23,7 +23,7 @@ gettext to internationalize messages.
 
 import gettext
 
-__version__ = "3.2"
+__version__ = "3.3"
 
 gettext_dir = "/usr/share/locale"
 gettext_app = "sos"


### PR DESCRIPTION
sosreport still report 3.2 when running

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>