### PR TITLE
[atomichost] Move the split() into each line of output

### DIFF
--- a/sos/plugins/atomichost.py
+++ b/sos/plugins/atomichost.py
@@ -35,8 +35,8 @@ class AtomicHost(Plugin, RedHatPlugin):
 
         if self.get_option('info'):
             # images output may have trailing whitespace
-            images = self.get_command_output("docker images -q").strip()
-            for image in set(images['output'].splitlines()):
+            images = self.get_command_output("docker images -q")
+            for image in set(images['output'].strip().splitlines()):
                 self.add_cmd_output("atomic info {0}".format(image))
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Previously, an attempt was made to split() on the images dict itself.
This has been moved to each line of the output.