### PR TITLE
[firewalld] Collect all configs under /etc/firewalld

### DIFF
--- a/sos/plugins/firewalld.py
+++ b/sos/plugins/firewalld.py
@@ -28,7 +28,7 @@ class FirewallD(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/etc/firewalld/firewalld.conf",
+            "/etc/firewalld/*.conf",
             "/etc/firewalld/icmptypes/*.xml",
             "/etc/firewalld/services/*.xml",
             "/etc/firewalld/zones/*.xml",


### PR DESCRIPTION
Collect all /etc/firewalld/*.conf files, not only firewalld.conf

Resolves: #854

Signed-off-by: Pavel Moravec pmoravec@redhat.com
