### PR TITLE
[openstack_horizon] fix regex in postproc method

### DIFF
--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -48,7 +48,8 @@ class OpenStackHorizon(Plugin):
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
         self.do_path_regex_sub("/etc/openstack-dashboard/.*\.json",
                                regexp, r"\1*********")
-        self.do_path_regex_sub("/etc/openstack-dashboard/local_settings",
+        self.do_path_regex_sub("/etc/openstack-dashboard/local_settings/ + \
+                               .*\.conf.*",
                                regexp, r"\1*********")
 
 


### PR DESCRIPTION
"The regex needs to handle in openstack_horizon:
currently the configurations are listed by
"/etc/openstack-dashboard/local_settings"
causing below errors:

regex substitution failed for '/etc/openstack-dashboard/local_settings.d/_11_rcue_theme.pyc'

Purposing a fix by changing the regex to match only intended configuration
files (_.conf_) in this directory.

Signed-off-by: Poornima M. Kshirsagar pkshiras@redhat.com
