### PR TITLE
Plugins: Add NFSGanesha file server support

### DIFF
--- a/sos/plugins/gluster.py
+++ b/sos/plugins/gluster.py
@@ -91,7 +91,9 @@ class Gluster(Plugin, RedHatPlugin):
             "/etc/glusterd.rpmsave",
             # common to all versions
             "/etc/glusterfs",
-            "/var/lib/glusterd/"
+            "/var/lib/glusterd/",
+            # collect nfs-ganesha related configuration
+            "/var/run/gluster/shared_storage/nfs-ganesha/"
         ] + glob.glob('/var/run/gluster/*tier-dht/*'))
 
         # collect logs - apply log_size for any individual file

--- a/sos/plugins/nfsganesha.py
+++ b/sos/plugins/nfsganesha.py
@@ -1,0 +1,44 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """NFS-Ganesha file server information
+    """
+    plugin_name = 'nfsganesha'
+    profiles = ('storage', 'network', 'nfs')
+    packages = ('nfs-ganesha')
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/ganesha",
+            "/etc/sysconfig/ganesha",
+            "/var/run/sysconfig/ganesha",
+            "/var/log/ganesha.log",
+            "/var/log/ganesha-gfapi.log"
+        ])
+
+        self.add_cmd_output([
+            "dbus-send --type=method_call --print-reply"
+            " --system --dest=org.ganesha.nfsd "
+            "/org/ganesha/nfsd/ExportMgr "
+            "org.ganesha.nfsd.exportmgr.ShowExports"
+        ])
+
+        return
+
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Included a plugin to collect the below information about
NFS-Ganesha file server provided nfs-ganesha package is installed.

Configuration files:
"/etc/ganesha/ganesha.conf"
"/etc/sysconfig/ganesha"
"/var/run/sysconfig/ganesha"

Log files:
"/var/log/ganesha.log"

Output of below commands:
 -"rpcinfo -p localhost"
 -"showmount -e localhost"
 -"dbus-send --type=method_call --print-reply"
        " --system --dest=org.ganesha.nfsd "
        "/org/ganesha/nfsd/ExportMgr "
        "org.ganesha.nfsd.exportmgr.ShowExports"

Below files are used by FSAL_GLUSTER which are optional.
Since sos silently skips the files if not present, it seemed
safe to add them.

Log files:
"/var/log/ganesha-gfapi.log"

Configurations files:
"/etc/ganesha/exports/*"

Signed-off-by: Soumya Koduri skoduri@redhat.com
