### PR TITLE
[ceph] skip collecting of all keyring files

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -59,11 +59,12 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph report"
         ])
 
-        self.add_forbidden_path("/etc/ceph/*keyring")
-        self.add_forbidden_path("/var/lib/ceph/*keyring")
-        self.add_forbidden_path("/var/lib/ceph/*/*keyring")
-        self.add_forbidden_path("/var/lib/ceph/*/*/*keyring")
+        self.add_forbidden_path("/etc/ceph/*keyring*")
+        self.add_forbidden_path("/var/lib/ceph/*keyring*")
+        self.add_forbidden_path("/var/lib/ceph/*/*keyring*")
+        self.add_forbidden_path("/var/lib/ceph/*/*/*keyring*")
         self.add_forbidden_path("/var/lib/ceph/osd/*")
         self.add_forbidden_path("/var/lib/ceph/osd/mon/*")
+        self.add_forbidden_path("/etc/ceph/*bindpass*")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Do not collect any keyring files - expand the add_forbidden_path
regular expressions accordingly to cover there filenames like:

/var/lib/ceph/tmp/keyring.mon.magna055

Resolves: #861

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>