### PR TITLE
[memory] Change swapon arguments to be compatible with wider range of OS/release.

### DIFF
--- a/sos/plugins/memory.py
+++ b/sos/plugins/memory.py
@@ -37,7 +37,7 @@ class Memory(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output("free", root_symlink="free")
         self.add_cmd_output([
             "free -m",
-            "swapon --bytes --show"
+            "swapon --summary --verbose"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Change swapon arguments to be compatible with a wider range of OS/release where arguments --bytes & --show aren't implemented yet.
