### PR TITLE
[Feature] Collect basic numa info from /sys by default without numad or numactl.

### DIFF
--- a/sos/plugins/numa.py
+++ b/sos/plugins/numa.py
@@ -42,4 +42,11 @@ class Numa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "numactl --hardware",
         ])
 
+        numa_path = "/sys/devices/system/node"
+        self.add_copy_spec([
+            os.path.join(numa_path, "node*/meminfo")
+            os.path.join(numa_path, "node*/cpulist")
+            os.path.join(numa_path, "node*/distance")
+        ])
+
 # vim: et ts=4 sw=4

--- a/sos/plugins/tuned.py
+++ b/sos/plugins/tuned.py
@@ -31,6 +31,10 @@ class Tuned(Plugin, RedHatPlugin):
             "tuned-adm recommend"
         ])
         self.add_copy_spec([
+            "/etc/tuned.conf",
+            "/etc/tune-profiles"
+        ])
+        self.add_copy_spec([
             "/etc/tuned",
             "/usr/lib/tuned",
             "/var/log/tuned/tuned.log"


### PR DESCRIPTION
Hi Bryn,
I know you collect the info from numad and numactl but in case you don't have it installed 
it's still good to have the basic info at least.

Lukas
