### PR TITLE
[openstack_*] Allow some log files to be excluded

### DIFF
--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -26,7 +26,9 @@ class OpenStackCeilometer(Plugin):
     plugin_name = "openstack_ceilometer"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 
-    option_list = []
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         # Ceilometer
@@ -38,6 +40,9 @@ class OpenStackCeilometer(Plugin):
             self.add_copy_spec_limit("/var/log/ceilometer/*.log",
                                      sizelimit=self.limit)
         self.add_copy_spec("/etc/ceilometer/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -27,8 +27,10 @@ class OpenStackCinder(Plugin):
     plugin_name = "openstack_cinder"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("db", "gathers openstack cinder db version", "slow",
-                    False)]
+    option_list = [
+        ("db", "gathers openstack cinder db version", "slow", False),
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         if self.get_option("db"):
@@ -45,6 +47,9 @@ class OpenStackCinder(Plugin):
         else:
             self.add_copy_spec_limit("/var/log/cinder/*.log",
                                      sizelimit=self.limit)
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -25,7 +25,9 @@ class OpenStackGlance(Plugin):
     plugin_name = "openstack_glance"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = []
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         # Glance
@@ -43,6 +45,9 @@ class OpenStackGlance(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec("/etc/glance/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -23,7 +23,9 @@ class OpenStackHeat(Plugin):
     plugin_name = "openstack_heat"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = []
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         # Heat
@@ -41,6 +43,9 @@ class OpenStackHeat(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec("/etc/heat/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -26,7 +26,10 @@ class OpenStackHorizon(Plugin):
 
     plugin_name = "openstack_horizon"
     profiles = ('openstack', 'openstack_controller')
-    option_list = []
+
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
 
@@ -39,6 +42,9 @@ class OpenStackHorizon(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec("/etc/openstack-dashboard/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -23,6 +23,10 @@ class OpenStackIronic(Plugin):
     plugin_name = "openstack_ironic"
     profiles = ('openstack', 'openstack_undercloud')
 
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
+
     def setup(self):
         self.conf_list = ['/etc/ironic/*']
         self.add_copy_spec('/etc/ironic/')
@@ -34,6 +38,10 @@ class OpenStackIronic(Plugin):
         else:
             self.add_copy_spec_limit("/var/log/ironic/*.log",
                                      sizelimit=self.limit)
+
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
         self.add_cmd_output('ls -laRt /var/lib/ironic/')
 

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -23,7 +23,10 @@ class OpenStackKeystone(Plugin):
     plugin_name = "openstack_keystone"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("nopw", "dont gathers keystone passwords", "slow", True)]
+    option_list = [
+        ("nopw", "dont gathers keystone passwords", "slow", True),
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         self.add_copy_spec([
@@ -40,6 +43,9 @@ class OpenStackKeystone(Plugin):
         else:
             self.add_copy_spec_limit("/var/log/keystone/*.log",
                                      sizelimit=self.limit)
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -23,6 +23,10 @@ class OpenStackNeutron(Plugin):
     plugin_name = "openstack_neutron"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
+
     def setup(self):
 
         self.limit = self.get_option("log_size")
@@ -35,6 +39,9 @@ class OpenStackNeutron(Plugin):
 
         self.add_copy_spec("/etc/neutron/")
         self.add_copy_spec("/var/lib/neutron/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -28,7 +28,10 @@ class OpenStackNova(Plugin):
     plugin_name = "openstack_nova"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 
-    option_list = [("cmds", "gathers openstack nova commands", "slow", False)]
+    option_list = [
+        ("cmds", "gathers openstack nova commands", "slow", False),
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         if self.get_option("cmds"):
@@ -76,6 +79,9 @@ class OpenStackNova(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec("/etc/nova/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -22,7 +22,9 @@ class OpenStackSahara(Plugin):
     plugin_name = 'openstack_sahara'
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = []
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
         self.add_copy_spec("/etc/sahara/")
@@ -37,6 +39,9 @@ class OpenStackSahara(Plugin):
         else:
             self.add_copy_spec_limit("/var/log/sahara/*.log",
                                      sizelimit=self.limit)
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -25,7 +25,9 @@ class OpenStackSwift(Plugin):
     plugin_name = "openstack_swift"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = []
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
 
@@ -38,6 +40,9 @@ class OpenStackSwift(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec("/etc/swift/")
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -24,7 +24,10 @@ class OpenStackTrove(Plugin):
 
     plugin_name = "openstack_trove"
     profiles = ('openstack', 'openstack_controller')
-    option_list = []
+
+    option_list = [
+        ("exclude", "Ignore files matching this path spec", "", "")
+    ]
 
     def setup(self):
 
@@ -37,6 +40,9 @@ class OpenStackTrove(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec('/etc/trove/')
+        if self.get_option("exclude"):
+            exclude = self.get_option("exclude")
+            self.add_forbidden_path(exclude)
 
     def postproc(self):
 


### PR DESCRIPTION
OpenStack deployments can create machine readable json log files, eg:

/var/log/glance/glance-api.log
/var/log/glance/glance-api-json.log

The json logs contain information which is a duplicate of the equivalent
non-json logs. Both can be quite large.

Add an 'exclude' option to the openstack plugins which allows log files
matching a specification (eg "/var/log/glance/_json_") to be skipped.

This greatly reduces the resulting sos tar file size, the time to gather
the logs, and the amount of space in /tmp required when generating the
tar file.
