### PR TITLE
[networking] plugin tracebacks when net-tools not installed

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -322,8 +322,8 @@ class RedHatNetworking(Networking, RedHatPlugin):
 
     def setup(self):
         # Handle change from -T to -W in Red Hat netstat 2.0 and greater.
-        netstat_pkg = self.policy().package_manager.all_pkgs()['net-tools']
         try:
+            netstat_pkg = self.policy().package_manager.all_pkgs()['net-tools']
             # major version
             if int(netstat_pkg['version'][0]) < 2:
                 self.ns_wide = "-T"


### PR DESCRIPTION
Move netstat_pkg assignment grepping for net-tools version into try
block.

It can be put to the existing block that will catch the exception
since it does not matter what parameter to be used with netstat
command that isn't present.

Resolves: #876.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>