### PR TITLE
[ipa] Correct dogtag logs retrieval

### DIFF
--- a/sos/plugins/ipa.py
+++ b/sos/plugins/ipa.py
@@ -48,10 +48,11 @@ class Ipa(Plugin, RedHatPlugin):
         self.add_copy_spec([
             "/var/log/ipaupgrade.log",
             "/var/log/krb5kdc.log",
-            "/var/log/pki-ca/debug",
-            "/var/log/pki-ca/catalina.out",
-            "/var/log/pki-ca/system",
-            "/var/log/pki-ca/transactions",
+            "/var/log/pki/pki-tomcat/ca/debug",
+            "/var/log/pki/pki-tomcat/ca/system",
+            "/var/log/pki/pki-tomcat/ca/transactions",
+            "/var/log/pki/pki-tomcat/catalina.*"
+            "/var/log/pki/pki-ca-spawn.*"
             "/var/log/dirsrv/slapd-*/logs/access",
             "/var/log/dirsrv/slapd-*/logs/errors",
             "/etc/dirsrv/slapd-*/dse.ldif",


### PR DESCRIPTION
PKI services provided in IPAv4 changed the default location of
Dogtag log files. Useful log files now located in various /var/log/pki/
subdirectories should be retrieved by sosreport.

Signed-off-by: Justin Stephenson <jstephen@redhat.com>