### PR TITLE
[foreman] increase timeout of foreman-debug to 15minutes

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -30,6 +30,6 @@ class Foreman(Plugin, RedHatPlugin):
 
         path = self.get_cmd_output_path(name="foreman-debug")
         self.add_cmd_output("%s -g -q -a -d %s" % (cmd, path),
-                            chroot=self.tmp_in_sysroot())
+                            chroot=self.tmp_in_sysroot(), timeout=900)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
foreman-debug (collecting lots of log files and mainly katello task
export) often runs longer than the default 5 minutes timeout.

Closes: #888.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>