### PR TITLE
[block] collect whole /sys/block

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -28,7 +28,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_cmd_output([
             "lsblk",
-            "lsblk -t",
+            "lsblk -tD",
             "blkid -c /dev/null",
             "blockdev --report",
             "ls -lanR /dev",


### PR DESCRIPTION
To collect block devices information like iostats, geometry or alignment

Closes: #889.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>