### PR TITLE
[general] Fix Permission Denied backtrace on _copy_dir()

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -360,6 +360,10 @@ class Plugin(object):
                 msg = "Too many levels of symbolic links copying"
                 self._log_error("_copy_dir: %s '%s'" % (msg, srcpath))
                 return
+            if e.errno == errno.EACCES:
+                msg = "Permission Denied"
+                self._log_error("_copy_dir: %s '%s'" % (msg, srcpath))
+                return
             raise e
 
     def _get_dest_for_srcpath(self, srcpath):


### PR DESCRIPTION
_copy_dir() assumes that root can read all files which can be false,
which is the case with LXC containers where some files in /sys are
protected from access by cgroups. This fix will display an error but
avoid a backtrace if it happens.

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>