### PR TITLE
[archive] Handle error when adding /dev/null as a node

### DIFF
--- a/tests/archive_tests.py
+++ b/tests/archive_tests.py
@@ -39,6 +39,12 @@ class TarFileArchiveTest(unittest.TestCase):
 
         self.check_for_file('test/tests/ziptest')
 
+    def test_add_node_dev_null(self):
+        st = os.lstat('/dev/null')
+        dev_maj = os.major(st.st_rdev)
+        dev_min = os.minor(st.st_rdev)
+        self.tf.add_node('/dev/null', st.st_mode, os.makedev(dev_maj, dev_min))
+
     # when the string comes from tail() output
     def test_add_string_from_file(self):
         self.copy_strings = []


### PR DESCRIPTION
Adding /dev/null as a node will trigger EPERM. This can happen namely
when masking systemd units which symlinks to /dev/null. This fix will
avoid a stacktrace and will generate a INFO message about it.

Test for that situation is also included.

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>