### PR TITLE
 [plugin] Add polkit libvirt rules

### DIFF
--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -124,7 +124,10 @@ class DebianNova(OpenStackNova, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         super(DebianNova, self).setup()
-        self.add_copy_spec(["/etc/sudoers.d/nova_sudoers"])
+        self.add_copy_spec([
+            "/etc/sudoers.d/nova_sudoers",
+            "/usr/share/polkit-1/rules.d/60-libvirt.rules",
+        ])
 
 
 class RedHatNova(OpenStackNova, RedHatPlugin):


### PR DESCRIPTION
This commit adds the file /usr/share/polkit-1/rules.d/60-libvirt.rules
to the copy specs of the Debian plugin.

Signed-off-by: Jorge Niedbalski R. jorge.niedbalski@canonical.com