### PR TITLE
Samba improvements

### DIFF
--- a/sos/plugins/samba.py
+++ b/sos/plugins/samba.py
@@ -34,6 +34,14 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                                  sizelimit=self.limit)
         self.add_copy_spec_limit("/var/log/samba/log.nmbd",
                                  sizelimit=self.limit)
+        self.add_copy_spec_limit("/var/log/samba/log.winbindd",
+                                 sizelimit=self.limit)
+        self.add_copy_spec_limit("/var/log/samba/log.winbindd-idmap",
+                                 sizelimit=self.limit)
+        self.add_copy_spec_limit("/var/log/samba/log.winbindd-dc-connet",
+                                 sizelimit=self.limit)
+        self.add_copy_spec_limit("/var/log/samba/log.wb-*",
+                                 sizelimit=self.limit)
 
         self.add_cmd_output([
             "wbinfo --domain='.' -g",

--- a/sos/plugins/samba.py
+++ b/sos/plugins/samba.py
@@ -23,12 +23,18 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     profiles = ('services',)
 
     def setup(self):
+        self.limit = self.get_option("log_size")
+
         self.add_copy_spec([
             "/etc/samba/smb.conf",
             "/etc/samba/lmhosts",
-            "/var/log/samba/log.smbd",
-            "/var/log/samba/log.nmbd"
         ])
+
+        self.add_copy_spec_limit("/var/log/samba/log.smbd",
+                                 sizelimit=self.limit)
+        self.add_copy_spec_limit("/var/log/samba/log.nmbd",
+                                 sizelimit=self.limit)
+
         self.add_cmd_output([
             "wbinfo --domain='.' -g",
             "wbinfo --domain='.' -u",

--- a/sos/plugins/samba.py
+++ b/sos/plugins/samba.py
@@ -32,7 +32,7 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "wbinfo --domain='.' -g",
             "wbinfo --domain='.' -u",
-            "testparm -s -v"
+            "testparm -s",
         ])
 
 

--- a/sos/plugins/samba.py
+++ b/sos/plugins/samba.py
@@ -43,6 +43,9 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec_limit("/var/log/samba/log.wb-*",
                                  sizelimit=self.limit)
 
+        if self.get_option("all_logs"):
+            self.add_copy_spec_limit("/var/log/samba/", sizelimit=self.limit)
+
         self.add_cmd_output([
             "wbinfo --domain='.' -g",
             "wbinfo --domain='.' -u",


### PR DESCRIPTION
- add output of "testparm -s" (without -v)
- collect winbind log files by default
- collect all logs if --all-logs are given