### PR TITLE
[sssd] Retrieve SSSD created krb5 snippets

### DIFF
--- a/sos/plugins/sssd.py
+++ b/sos/plugins/sssd.py
@@ -29,6 +29,7 @@ class Sssd(Plugin):
         self.add_copy_spec([
             "/etc/sssd/sssd.conf",
             "/var/log/sssd/*",
+            "/var/lib/sss/pubconf/krb5.include.d/*",
             # SSSD 1.14
             "/etc/sssd/conf.d/*.conf"
         ])


### PR DESCRIPTION
Obtain SSSD automatically-generated krb5 snippet configuration files
for localauth plugin, domain_realm mapping, and libdefaults additions.
These files are pulled in by libkrb5 with an 'includedir' line in
/etc/krb5.conf.

Signed-off-by: Justin Stephenson <jstephen@redhat.com>