### PR TITLE
Make add_copy_spec_limit understand lists of copyspecs

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -555,8 +555,8 @@ class Plugin(object):
                                          self.name(), strfile)
                 self.archive.add_link(link_path, _file)
 
-    def add_copy_spec(self, copyspecs):
-        self.add_copy_spec_limit(copyspecs)
+    def add_copy_spec(self, copyspecs, sizelimit=None, tailit=True):
+        self.add_copy_spec_limit(copyspecs, sizelimit, tailit)
 
     def get_command_output(self, prog, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None):

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -556,20 +556,7 @@ class Plugin(object):
                 self.archive.add_link(link_path, _file)
 
     def add_copy_spec(self, copyspecs):
-        """Add a file specification (can be file, dir,or shell glob) to be
-        copied into the sosreport by this module.
-        """
-        if isinstance(copyspecs, six.string_types):
-            copyspecs = [copyspecs]
-        for copyspec in copyspecs:
-            if self.use_sysroot():
-                copyspec = self.join_sysroot(copyspec)
-            if not (copyspec and len(copyspec)):
-                self._log_warn("added null or empty copy spec")
-                return False
-            copy_paths = self._expand_copy_spec(copyspec)
-            self._add_copy_paths(copy_paths)
-            self._log_info("added copyspec '%s'" % copy_paths)
+        self.add_copy_spec_limit(copyspecs)
 
     def get_command_output(self, prog, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None):

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -505,7 +505,7 @@ class Plugin(object):
     def _add_copy_paths(self, copy_paths):
         self.copy_paths.update(copy_paths)
 
-    def add_copy_spec_limit(self, copyspecs, sizelimit=None, tailit=True):
+    def add_copy_spec(self, copyspecs, sizelimit=None, tailit=True):
         """Add a file or glob but limit it to sizelimit megabytes. If fname is
         a single file the file will be tailed to meet sizelimit. If the first
         file in a glob is too large it will be tailed to meet the sizelimit.
@@ -554,9 +554,6 @@ class Plugin(object):
                 link_path = os.path.join(rel_path, 'sos_strings',
                                          self.name(), strfile)
                 self.archive.add_link(link_path, _file)
-
-    def add_copy_spec(self, copyspecs, sizelimit=None, tailit=True):
-        self.add_copy_spec_limit(copyspecs, sizelimit, tailit)
 
     def get_command_output(self, prog, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None):

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -527,7 +527,7 @@ class Plugin(object):
             if self.use_sysroot():
                 copyspec = self.join_sysroot(copyspec)
 
-            files = glob.glob(copyspec)
+            files = self._expand_copy_spec(copyspec)
             files.sort()
             if len(files) == 0:
                 continue

--- a/sos/plugins/apache.py
+++ b/sos/plugins/apache.py
@@ -56,20 +56,20 @@ class RedHatApache(Apache, RedHatPlugin):
         self.add_forbidden_path("/etc/httpd/conf/password.conf")
 
         # collect only the current log set by default
-        self.add_copy_spec_limit("/var/log/httpd/access_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd/error_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd/ssl_access_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd/ssl_error_log", 5)
+        self.add_copy_spec("/var/log/httpd/access_log", 5)
+        self.add_copy_spec("/var/log/httpd/error_log", 5)
+        self.add_copy_spec("/var/log/httpd/ssl_access_log", 5)
+        self.add_copy_spec("/var/log/httpd/ssl_error_log", 5)
         # JBoss Enterprise Web Server 2.x
-        self.add_copy_spec_limit("/var/log/httpd22/access_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd22/error_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd22/ssl_access_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd22/ssl_error_log", 5)
+        self.add_copy_spec("/var/log/httpd22/access_log", 5)
+        self.add_copy_spec("/var/log/httpd22/error_log", 5)
+        self.add_copy_spec("/var/log/httpd22/ssl_access_log", 5)
+        self.add_copy_spec("/var/log/httpd22/ssl_error_log", 5)
         # Red Hat JBoss Web Server 3.x
-        self.add_copy_spec_limit("/var/log/httpd24/access_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd24/error_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd24/ssl_access_log", 5)
-        self.add_copy_spec_limit("/var/log/httpd24/ssl_error_log", 5)
+        self.add_copy_spec("/var/log/httpd24/access_log", 5)
+        self.add_copy_spec("/var/log/httpd24/error_log", 5)
+        self.add_copy_spec("/var/log/httpd24/ssl_access_log", 5)
+        self.add_copy_spec("/var/log/httpd24/ssl_error_log", 5)
         if self.get_option("log"):
             self.add_copy_spec([
                 "/var/log/httpd/*",
@@ -91,8 +91,8 @@ class DebianApache(Apache, DebianPlugin, UbuntuPlugin):
         ])
 
         # collect only the current log set by default
-        self.add_copy_spec_limit("/var/log/apache2/access_log", 15)
-        self.add_copy_spec_limit("/var/log/apache2/error_log", 15)
+        self.add_copy_spec("/var/log/apache2/access_log", 15)
+        self.add_copy_spec("/var/log/apache2/error_log", 15)
         if self.get_option("log"):
             self.add_copy_spec("/var/log/apache2/*")
 

--- a/sos/plugins/apport.py
+++ b/sos/plugins/apport.py
@@ -26,10 +26,8 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/apport.log",
-                                     sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/apport.log.1",
-                                     sizelimit=limit)
+            self.add_copy_spec("/var/log/apport.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/apport.log.1", sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/apport*")
         self.add_copy_spec("/etc/apport/*")

--- a/sos/plugins/auditd.py
+++ b/sos/plugins/auditd.py
@@ -33,8 +33,7 @@ class Auditd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/audit/audit.log",
-                                     sizelimit=limit)
+            self.add_copy_spec("/var/log/audit/audit.log", sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/audit")
 

--- a/sos/plugins/cups.py
+++ b/sos/plugins/cups.py
@@ -27,11 +27,9 @@ class Cups(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/cups/access_log",
-                                     sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/cups/error_log",
-                                     sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/cups/page_log", sizelimit=limit)
+            self.add_copy_spec("/var/log/cups/access_log", sizelimit=limit)
+            self.add_copy_spec("/var/log/cups/error_log", sizelimit=limit)
+            self.add_copy_spec("/var/log/cups/page_log", sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/cups")
 

--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -38,15 +38,12 @@ class DNFPlugin(Plugin, RedHatPlugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/dnf.*",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/dnf.*", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/dnf.log",
-                                     sizelimit=self.limit)
-            self.add_copy_spec_limit("/var/log/dnf.librepo.log",
-                                     sizelimit=self.limit)
-            self.add_copy_spec_limit("/var/log/dnf.rpm.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/dnf.log", sizelimit=self.limit)
+            self.add_copy_spec("/var/log/dnf.librepo.log",
+                               sizelimit=self.limit)
+            self.add_copy_spec("/var/log/dnf.rpm.log", sizelimit=self.limit)
 
         self.add_cmd_output("dnf --version",
                             suggest_filename="dnf_version")

--- a/sos/plugins/dpkg.py
+++ b/sos/plugins/dpkg.py
@@ -34,8 +34,7 @@ class Dpkg(Plugin, DebianPlugin, UbuntuPlugin):
         ])
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/dpkg.log",
-                                     sizelimit=limit)
+            self.add_copy_spec("/var/log/dpkg.log", sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/dpkg.log*")
 

--- a/sos/plugins/gluster.py
+++ b/sos/plugins/gluster.py
@@ -105,7 +105,7 @@ class Gluster(Plugin, RedHatPlugin):
             for f in (glob.glob("/var/log/glusterfs/*log") +
                       glob.glob("/var/log/glusterfs/*/*log") +
                       glob.glob("/var/log/glusterfs/geo-replication/*/*log")):
-                self.add_copy_spec_limit(f, limit)
+                self.add_copy_spec(f, limit)
         else:
             self.add_copy_spec("/var/log/glusterfs")
 

--- a/sos/plugins/infiniband.py
+++ b/sos/plugins/infiniband.py
@@ -32,8 +32,8 @@ class Infiniband(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/rdma"
         ])
 
-        self.add_copy_spec_limit("/var/log/opensm*",
-                                 sizelimit=self.get_option("log_size"))
+        self.add_copy_spec("/var/log/opensm*",
+                           sizelimit=self.get_option("log_size"))
 
         self.add_cmd_output([
             "ibv_devices",

--- a/sos/plugins/insights.py
+++ b/sos/plugins/insights.py
@@ -27,11 +27,11 @@ class RedHatInsights(Plugin, RedHatPlugin):
         self.add_copy_spec(self.conf_file)
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/redhat-access-insights/*.log*",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/redhat-access-insights/*.log*",
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/redhat-access-insights/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/redhat-access-insights/*.log",
+                               sizelimit=self.limit)
 
     def postproc(self):
         self.do_file_sub(

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -78,10 +78,8 @@ class Juju(Plugin, UbuntuPlugin):
 
     def setup(self):
         limit = self.get_option("log_size")
-        self.add_copy_spec_limit("/var/log/upstart/juju-db.log",
-                                 sizelimit=limit)
-        self.add_copy_spec_limit("/var/log/upstart/juju-db.log.1",
-                                 sizelimit=limit)
+        self.add_copy_spec("/var/log/upstart/juju-db.log", sizelimit=limit)
+        self.add_copy_spec("/var/log/upstart/juju-db.log.1", sizelimit=limit)
         if not self.get_option("all_logs"):
             # We need this because we want to collect to the limit of all
             # *.logs in the directory.
@@ -89,7 +87,7 @@ class Juju(Plugin, UbuntuPlugin):
                 for filename in os.listdir("/var/log/juju/"):
                     if filename.endswith(".log"):
                         fullname = os.path.join("/var/log/juju/" + filename)
-                        self.add_copy_spec_limit(fullname, sizelimit=limit)
+                        self.add_copy_spec(fullname, sizelimit=limit)
             self.add_cmd_output('ls -alRh /var/log/juju*')
             self.add_cmd_output('ls -alRh /var/lib/juju/*')
 

--- a/sos/plugins/kimchi.py
+++ b/sos/plugins/kimchi.py
@@ -28,12 +28,10 @@ class Kimchi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         log_limit = self.get_option('log_size')
         self.add_copy_spec('/etc/kimchi/')
         if not self.get_option('all_logs'):
-            self.add_copy_spec_limit('/var/log/kimchi/*.log',
-                                     sizelimit=log_limit)
-            self.add_copy_spec_limit('/etc/kimchi/kimchi*',
-                                     sizelimit=log_limit)
-            self.add_copy_spec_limit('/etc/kimchi/distros.d/*.json',
-                                     sizelimit=log_limit)
+            self.add_copy_spec('/var/log/kimchi/*.log', sizelimit=log_limit)
+            self.add_copy_spec('/etc/kimchi/kimchi*', sizelimit=log_limit)
+            self.add_copy_spec('/etc/kimchi/distros.d/*.json',
+                               sizelimit=log_limit)
         else:
             self.add_copy_spec('/var/log/kimchi/')
 

--- a/sos/plugins/landscape.py
+++ b/sos/plugins/landscape.py
@@ -32,10 +32,9 @@ class Landscape(Plugin, UbuntuPlugin):
         self.add_copy_spec("/etc/default/landscape-server")
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/landscape/*.log",
-                                     sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/landscape-server/*.log",
-                                     sizelimit=limit)
+            self.add_copy_spec("/var/log/landscape/*.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/landscape-server/*.log",
+                               sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/landscape")
             self.add_copy_spec("/var/log/landscape-server")

--- a/sos/plugins/libvirt.py
+++ b/sos/plugins/libvirt.py
@@ -47,12 +47,10 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         ])
 
         if not self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/libvirt/libvirtd.log",
-                                     sizelimit=5)
-            self.add_copy_spec_limit("/var/log/libvirt/qemu/*.log",
-                                     sizelimit=5)
-            self.add_copy_spec_limit("/var/log/libvirt/lxc/*.log", sizelimit=5)
-            self.add_copy_spec_limit("/var/log/libvirt/uml/*.log", sizelimit=5)
+            self.add_copy_spec("/var/log/libvirt/libvirtd.log", sizelimit=5)
+            self.add_copy_spec("/var/log/libvirt/qemu/*.log", sizelimit=5)
+            self.add_copy_spec("/var/log/libvirt/lxc/*.log", sizelimit=5)
+            self.add_copy_spec("/var/log/libvirt/uml/*.log", sizelimit=5)
         else:
             self.add_copy_spec("/var/log/libvirt")
 

--- a/sos/plugins/lightdm.py
+++ b/sos/plugins/lightdm.py
@@ -33,12 +33,10 @@ class LightDm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/lightdm/lightdm.log",
-                                     sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/lightdm/x-0-greeter.log",
-                                     sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/lightdm/x-0.log",
-                                     sizelimit=limit)
+            self.add_copy_spec("/var/log/lightdm/lightdm.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/lightdm/x-0-greeter.log",
+                               sizelimit=limit)
+            self.add_copy_spec("/var/log/lightdm/x-0.log", sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/lightdm")
 

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -30,8 +30,8 @@ class Logs(Plugin):
         ])
 
         self.limit = self.get_option("log_size")
-        self.add_copy_spec_limit("/var/log/boot.log", sizelimit=self.limit)
-        self.add_copy_spec_limit("/var/log/cloud-init*", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/boot.log", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/cloud-init*", sizelimit=self.limit)
         self.add_journal(boot="this")
         self.add_journal(boot="this", allfields=True, output="verbose")
         self.add_cmd_output("journalctl --disk-usage")
@@ -48,7 +48,7 @@ class Logs(Plugin):
                 if i.startswith("-"):
                     i = i[1:]
                 if os.path.isfile(i):
-                    self.add_copy_spec_limit(i, sizelimit=self.limit)
+                    self.add_copy_spec(i, sizelimit=self.limit)
 
     def postproc(self):
         self.do_path_regex_sub(
@@ -72,8 +72,8 @@ class RedHatLogs(Logs, RedHatPlugin):
     def setup(self):
         super(RedHatLogs, self).setup()
         messages = "/var/log/messages"
-        self.add_copy_spec_limit("/var/log/secure*", sizelimit=self.limit)
-        self.add_copy_spec_limit(messages + "*", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/secure*", sizelimit=self.limit)
+        self.add_copy_spec(messages + "*", sizelimit=self.limit)
         # collect three days worth of logs by default if the system is
         # configured to use the journal and not /var/log/messages
         if not os.path.exists(messages) and self.is_installed("systemd"):
@@ -94,15 +94,14 @@ class DebianLogs(Logs, DebianPlugin, UbuntuPlugin):
         super(DebianLogs, self).setup()
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
-            self.add_copy_spec_limit("/var/log/syslog", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/syslog.1", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/kern.log", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/kern.log.1", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/udev", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/dist-upgrade", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/installer", sizelimit=limit)
-            self.add_copy_spec_limit("/var/log/unattended-upgrades",
-                                     sizelimit=limit)
+            self.add_copy_spec("/var/log/syslog", sizelimit=limit)
+            self.add_copy_spec("/var/log/syslog.1", sizelimit=limit)
+            self.add_copy_spec("/var/log/kern.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/kern.log.1", sizelimit=limit)
+            self.add_copy_spec("/var/log/udev", sizelimit=limit)
+            self.add_copy_spec("/var/log/dist-upgrade", sizelimit=limit)
+            self.add_copy_spec("/var/log/installer", sizelimit=limit)
+            self.add_copy_spec("/var/log/unattended-upgrades", sizelimit=limit)
             self.add_cmd_output('ls -alRh /var/log/')
         else:
             self.add_copy_spec("/var/log/")

--- a/sos/plugins/lxd.py
+++ b/sos/plugins/lxd.py
@@ -28,8 +28,8 @@ class LXD(Plugin, UbuntuPlugin):
             "/etc/default/lxc-bridge",
         ])
 
-        self.add_copy_spec_limit("/var/log/lxd*",
-                                 sizelimit=self.get_option("log_size"))
+        self.add_copy_spec("/var/log/lxd*",
+                           sizelimit=self.get_option("log_size"))
 
         # List of containers available on the machine
         self.add_cmd_output([

--- a/sos/plugins/nscd.py
+++ b/sos/plugins/nscd.py
@@ -34,7 +34,6 @@ class Nscd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         if (len(opt) > 0):
             for o in opt:
                 f = o.split()
-                self.add_copy_spec_limit(f[1],
-                                         sizelimit=self.get_option("log_size"))
+                self.add_copy_spec(f[1], sizelimit=self.get_option("log_size"))
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/numa.py
+++ b/sos/plugins/numa.py
@@ -30,7 +30,7 @@ class Numa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/numad.conf",
             "/etc/logrotate.d/numad"
         ])
-        self.add_copy_spec_limit(
+        self.add_copy_spec(
             "/var/log/numad.log*",
             sizelimit=self.get_option("log_size")
         )

--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -32,11 +32,10 @@ class OpenStackCeilometer(Plugin):
         # Ceilometer
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/ceilometer/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/ceilometer/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/ceilometer/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/ceilometer/*.log",
+                               sizelimit=self.limit)
         self.add_copy_spec("/etc/ceilometer/")
 
     def postproc(self):

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -40,11 +40,9 @@ class OpenStackCinder(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/cinder/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/cinder/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/cinder/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/cinder/*.log", sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -36,11 +36,9 @@ class OpenStackGlance(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/glance/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/glance/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/glance/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/glance/*.log", sizelimit=self.limit)
 
         self.add_copy_spec("/etc/glance/")
 

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -34,11 +34,9 @@ class OpenStackHeat(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/heat/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/heat/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/heat/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/heat/*.log", sizelimit=self.limit)
 
         self.add_copy_spec("/etc/heat/")
 

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -32,11 +32,9 @@ class OpenStackHorizon(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/horizon/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/horizon/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/horizon/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/horizon/*.log", sizelimit=self.limit)
 
         self.add_copy_spec("/etc/openstack-dashboard/")
 

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -29,11 +29,9 @@ class OpenStackIronic(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/ironic/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/ironic/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/ironic/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/ironic/*.log", sizelimit=self.limit)
 
         self.add_cmd_output('ls -laRt /var/lib/ironic/')
 

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -35,11 +35,9 @@ class OpenStackKeystone(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/keystone/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/keystone/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/keystone/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/keystone/*.log", sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -27,11 +27,9 @@ class OpenStackNeutron(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/neutron/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/neutron/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/neutron/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/neutron/*.log", sizelimit=self.limit)
 
         self.add_copy_spec("/etc/neutron/")
         self.add_copy_spec("/var/lib/neutron/")

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -69,11 +69,9 @@ class OpenStackNova(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/nova/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/nova/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/nova/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/nova/*.log", sizelimit=self.limit)
 
         self.add_copy_spec("/etc/nova/")
 

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -32,11 +32,9 @@ class OpenStackSahara(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/sahara/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/sahara/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/sahara/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/sahara/*.log", sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -31,11 +31,9 @@ class OpenStackSwift(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/swift/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/swift/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/swift/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/swift/*.log", sizelimit=self.limit)
 
         self.add_copy_spec("/etc/swift/")
 

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -30,11 +30,9 @@ class OpenStackTrove(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/trove/",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/trove/", sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/trove/*.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/trove/*.log", sizelimit=self.limit)
 
         self.add_copy_spec('/etc/trove/')
 

--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -61,7 +61,7 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
             self.add_copy_spec(all_setup_logs[0])
         # Add older ovirt-hosted-engine-setup log files only if requested
         if self.get_option('all_logs'):
-            self.add_copy_spec_limit(
+            self.add_copy_spec(
                 self.SETUP_LOG_GLOB,
                 sizelimit=self.limit
             )
@@ -72,7 +72,7 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
         ])
         # Add older ovirt-hosted-engine-ha log files only if requested
         if self.get_option('all_logs'):
-            self.add_copy_spec_limit(
+            self.add_copy_spec(
                 self.HA_LOG_GLOB,
                 sizelimit=self.limit,
             )

--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -113,7 +113,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
         # As a default strategy, collect PCP_LOG_DIR/pmlogger/* only if the
         # total size is moderately small: < 100MB. Override is possible via
         # the 'all_pcplogs' option.
-        # FIXME: Doing a recursive size check because add_copy_spec_limit
+        # FIXME: Doing a recursive size check because add_copy_spec
         # won't work for directory trees. I.e. we can't say fetch /foo/bar/
         # only if it is < 100MB. To be killed once the Plugin base class will
         # add a method for this use case via issue #281

--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -29,6 +29,6 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output("rabbitmqctl list_policies")
 
         self.add_copy_spec("/etc/rabbitmq/*")
-        self.add_copy_spec_limit("/var/log/rabbitmq/*",
-                                 sizelimit=self.get_option('log_size'))
+        self.add_copy_spec("/var/log/rabbitmq/*",
+                           sizelimit=self.get_option('log_size'))
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/redis.py
+++ b/sos/plugins/redis.py
@@ -32,11 +32,11 @@ class Redis(Plugin, RedHatPlugin):
         self.limit = self.get_option("log_size")
         self.add_cmd_output("redis-cli info")
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/redis/redis.log*",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/redis/redis.log*",
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec_limit("/var/log/redis/redis.log",
-                                     sizelimit=self.limit)
+            self.add_copy_spec("/var/log/redis/redis.log",
+                               sizelimit=self.limit)
 
     def postproc(self):
         self.do_file_sub(

--- a/sos/plugins/samba.py
+++ b/sos/plugins/samba.py
@@ -30,21 +30,17 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/samba/lmhosts",
         ])
 
-        self.add_copy_spec_limit("/var/log/samba/log.smbd",
-                                 sizelimit=self.limit)
-        self.add_copy_spec_limit("/var/log/samba/log.nmbd",
-                                 sizelimit=self.limit)
-        self.add_copy_spec_limit("/var/log/samba/log.winbindd",
-                                 sizelimit=self.limit)
-        self.add_copy_spec_limit("/var/log/samba/log.winbindd-idmap",
-                                 sizelimit=self.limit)
-        self.add_copy_spec_limit("/var/log/samba/log.winbindd-dc-connet",
-                                 sizelimit=self.limit)
-        self.add_copy_spec_limit("/var/log/samba/log.wb-*",
-                                 sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.smbd", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.nmbd", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.winbindd", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.winbindd-idmap",
+                           sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.winbindd-dc-connet",
+                           sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.wb-*", sizelimit=self.limit)
 
         if self.get_option("all_logs"):
-            self.add_copy_spec_limit("/var/log/samba/", sizelimit=self.limit)
+            self.add_copy_spec("/var/log/samba/", sizelimit=self.limit)
 
         self.add_cmd_output([
             "wbinfo --domain='.' -g",

--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -38,11 +38,11 @@ class Sar(Plugin,):
         # Copy all sa??, sar??, sa??.* and sar??.* files, which will net
         # compressed and uncompressed versions, typically.
         for suffix in ('', '.*'):
-            self.add_copy_spec_limit(
+            self.add_copy_spec(
                 os.path.join(self.sa_path, "sa[0-3][0-9]" + suffix),
                 sizelimit=self.sa_size, tailit=False
             )
-            self.add_copy_spec_limit(
+            self.add_copy_spec(
                 os.path.join(self.sa_path, "sar[0-3][0-9]" + suffix),
                 sizelimit=self.sa_size, tailit=False
             )

--- a/sos/plugins/squid.py
+++ b/sos/plugins/squid.py
@@ -32,9 +32,9 @@ class RedHatSquid(Squid, RedHatPlugin):
         log_size = self.get_option('log_size')
         log_path = "/var/log/squid/"
         self.add_copy_spec("/etc/squid/squid.conf")
-        self.add_copy_spec_limit(log_path + "access.log", sizelimit=log_size)
-        self.add_copy_spec_limit(log_path + "cache.log", sizelimit=log_size)
-        self.add_copy_spec_limit(log_path + "squid.out", sizelimit=log_size)
+        self.add_copy_spec(log_path + "access.log", sizelimit=log_size)
+        self.add_copy_spec(log_path + "cache.log", sizelimit=log_size)
+        self.add_copy_spec(log_path + "squid.out", sizelimit=log_size)
 
 
 class DebianSquid(Squid, DebianPlugin, UbuntuPlugin):
@@ -44,11 +44,11 @@ class DebianSquid(Squid, DebianPlugin, UbuntuPlugin):
     packages = ('squid3',)
 
     def setup(self):
-        self.add_copy_spec_limit("/etc/squid3/squid.conf",
-                                 sizelimit=self.get_option('log_size'))
-        self.add_copy_spec_limit("/var/log/squid3/*",
-                                 sizelimit=self.get_option('log_size'))
+        self.add_copy_spec("/etc/squid3/squid.conf",
+                           sizelimit=self.get_option('log_size'))
+        self.add_copy_spec("/var/log/squid3/*",
+                           sizelimit=self.get_option('log_size'))
         self.add_copy_spec(['/etc/squid-deb-proxy'])
-        self.add_copy_spec_limit("/var/log/squid-deb-proxy/*",
-                                 sizelimit=self.get_option('log_size'))
+        self.add_copy_spec("/var/log/squid-deb-proxy/*",
+                           sizelimit=self.get_option('log_size'))
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/tomcat.py
+++ b/sos/plugins/tomcat.py
@@ -37,13 +37,13 @@ class Tomcat(Plugin, RedHatPlugin):
 
         if not self.get_option("all_logs"):
             log_glob = "/var/log/tomcat*/catalina.out"
-            self.add_copy_spec_limit(log_glob, sizelimit=limit)
+            self.add_copy_spec(log_glob, sizelimit=limit)
 
             # get today's date in iso format so that days/months below 10
             # prepend 0
             today = datetime.date(datetime.now()).isoformat()
             log_glob = "/var/log/tomcat*/catalina.%s.log" % today
-            self.add_copy_spec_limit(log_glob, sizelimit=limit)
+            self.add_copy_spec(log_glob, sizelimit=limit)
         else:
             self.add_copy_spec("/var/log/tomcat*/*")
 

--- a/sos/plugins/upstart.py
+++ b/sos/plugins/upstart.py
@@ -44,8 +44,8 @@ class Upstart(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec('/var/log/upstart/upstart.state')
 
         # Log files
-        self.add_copy_spec_limit('/var/log/upstart/*',
-                                 sizelimit=self.get_option('log_size'))
+        self.add_copy_spec('/var/log/upstart/*',
+                           sizelimit=self.get_option('log_size'))
         # Session Jobs (running Upstart as a Session Init)
         self.add_copy_spec('/usr/share/upstart/')
 

--- a/sos/plugins/virsh.py
+++ b/sos/plugins/virsh.py
@@ -29,7 +29,7 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     def setup(self):
         # virt-manager logs
         if not self.get_option("all_logs"):
-            self.add_copy_spec_limit("/root/.virt-manager/*", sizelimit=5)
+            self.add_copy_spec("/root/.virt-manager/*", sizelimit=5)
         else:
             self.add_copy_spec("/root/.virt-manager/*")
 

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -242,6 +242,7 @@ class AddCopySpecTests(unittest.TestCase):
     def test_single_file(self):
         self.mp.add_copy_spec('tests/tail_test.txt')
         self.assert_expect_paths()
+
     def test_glob_file(self):
         self.mp.add_copy_spec('tests/tail_test.*')
         self.assert_expect_paths()

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -247,11 +247,11 @@ class AddCopySpecTests(unittest.TestCase):
         self.mp.add_copy_spec('tests/tail_test.*')
         self.assert_expect_paths()
 
+    # add_copy_spec_limit()
+
     def test_single_file_under_limit(self):
         self.mp.add_copy_spec_limit("tests/tail_test.txt", 1)
         self.assert_expect_paths()
-
-    # add_copy_spec_limit()
 
     def test_single_file_over_limit(self):
         self.mp.sysroot = '/'

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -253,6 +253,10 @@ class AddCopySpecTests(unittest.TestCase):
 
     # add_copy_spec_limit()
 
+    def test_single_file_no_limit(self):
+        self.mp.add_copy_spec_limit("tests/tail_test.txt")
+        self.assert_expect_paths()
+
     def test_single_file_under_limit(self):
         self.mp.add_copy_spec_limit("tests/tail_test.txt", 1)
         self.assert_expect_paths()
@@ -272,6 +276,15 @@ class AddCopySpecTests(unittest.TestCase):
         self.mp.sysroot = '/'
         self.assertFalse(self.mp.add_copy_spec_limit('', 1))
         self.assertFalse(self.mp.add_copy_spec_limit(None, 1))
+
+    def test_glob_file_limit_no_limit(self):
+        self.mp.sysroot = '/'
+        tmpdir = tempfile.mkdtemp()
+        fn = create_file(2, dir=tmpdir)
+        fn2 = create_file(2, dir=tmpdir)
+        self.mp.add_copy_spec_limit(tmpdir + "/*")
+        self.assertEquals(len(self.mp.copy_paths), 2)
+        shutil.rmtree(tmpdir)
 
     def test_glob_file_over_limit(self):
         self.mp.sysroot = '/'

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -237,21 +237,10 @@ class AddCopySpecTests(unittest.TestCase):
         expected_paths = set(map(pathmunge, self.expect_paths))
         self.assertEquals(self.mp.copy_paths, expected_paths)
 
-    # add_copy_spec()
-
-    def test_single_file(self):
-        self.mp.add_copy_spec('tests/tail_test.txt')
-        self.assert_expect_paths()
-
     def test_glob_file(self):
         self.mp.add_copy_spec('tests/tail_test.*')
         self.assert_expect_paths()
 
-    def test_multiple_files(self):
-        self.mp.add_copy_spec(['tests/tail_test.txt', 'tests/test.txt'])
-        self.assertEquals(len(self.mp.copy_paths), 2)
-
-    # add_copy_spec_limit()
 
     def test_single_file_no_limit(self):
         self.mp.add_copy_spec("tests/tail_test.txt")

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -18,8 +18,8 @@ PATH = os.path.dirname(__file__)
 def j(filename):
     return os.path.join(PATH, filename)
 
-def create_file(size):
-   f = tempfile.NamedTemporaryFile(delete=False)
+def create_file(size, dir=None):
+   f = tempfile.NamedTemporaryFile(delete=False, dir=dir)
    f.write(six.b("*" * size * 1024 * 1024))
    f.flush()
    f.close()

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -254,17 +254,17 @@ class AddCopySpecTests(unittest.TestCase):
     # add_copy_spec_limit()
 
     def test_single_file_no_limit(self):
-        self.mp.add_copy_spec_limit("tests/tail_test.txt")
+        self.mp.add_copy_spec("tests/tail_test.txt")
         self.assert_expect_paths()
 
     def test_single_file_under_limit(self):
-        self.mp.add_copy_spec_limit("tests/tail_test.txt", 1)
+        self.mp.add_copy_spec("tests/tail_test.txt", 1)
         self.assert_expect_paths()
 
     def test_single_file_over_limit(self):
         self.mp.sysroot = '/'
         fn = create_file(2) # create 2MB file, consider a context manager
-        self.mp.add_copy_spec_limit(fn, 1)
+        self.mp.add_copy_spec(fn, 1)
         content, fname = self.mp.copy_strings[0]
         self.assertTrue("tailed" in fname)
         self.assertTrue("tmp" in fname)
@@ -274,15 +274,15 @@ class AddCopySpecTests(unittest.TestCase):
 
     def test_bad_filename(self):
         self.mp.sysroot = '/'
-        self.assertFalse(self.mp.add_copy_spec_limit('', 1))
-        self.assertFalse(self.mp.add_copy_spec_limit(None, 1))
+        self.assertFalse(self.mp.add_copy_spec('', 1))
+        self.assertFalse(self.mp.add_copy_spec(None, 1))
 
     def test_glob_file_limit_no_limit(self):
         self.mp.sysroot = '/'
         tmpdir = tempfile.mkdtemp()
         fn = create_file(2, dir=tmpdir)
         fn2 = create_file(2, dir=tmpdir)
-        self.mp.add_copy_spec_limit(tmpdir + "/*")
+        self.mp.add_copy_spec(tmpdir + "/*")
         self.assertEquals(len(self.mp.copy_paths), 2)
         shutil.rmtree(tmpdir)
 
@@ -291,7 +291,7 @@ class AddCopySpecTests(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         fn = create_file(2, dir=tmpdir)
         fn2 = create_file(2, dir=tmpdir)
-        self.mp.add_copy_spec_limit(tmpdir + "/*", 1)
+        self.mp.add_copy_spec(tmpdir + "/*", 1)
         self.assertEquals(len(self.mp.copy_strings), 1)
         content, fname = self.mp.copy_strings[0]
         self.assertTrue("tailed" in fname)
@@ -299,11 +299,11 @@ class AddCopySpecTests(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
     def test_multiple_files_no_limit(self):
-        self.mp.add_copy_spec_limit(['tests/tail_test.txt', 'tests/test.txt'])
+        self.mp.add_copy_spec(['tests/tail_test.txt', 'tests/test.txt'])
         self.assertEquals(len(self.mp.copy_paths), 2)
 
     def test_multiple_files_under_limit(self):
-        self.mp.add_copy_spec_limit(['tests/tail_test.txt', 'tests/test.txt'], 1)
+        self.mp.add_copy_spec(['tests/tail_test.txt', 'tests/test.txt'], 1)
         self.assertEquals(len(self.mp.copy_paths), 2)
 
 

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -298,6 +298,14 @@ class AddCopySpecTests(unittest.TestCase):
         self.assertEquals(1024 * 1024, len(content))
         shutil.rmtree(tmpdir)
 
+    def test_multiple_files_no_limit(self):
+        self.mp.add_copy_spec_limit(['tests/tail_test.txt', 'tests/test.txt'])
+        self.assertEquals(len(self.mp.copy_paths), 2)
+
+    def test_multiple_files_under_limit(self):
+        self.mp.add_copy_spec_limit(['tests/tail_test.txt', 'tests/test.txt'], 1)
+        self.assertEquals(len(self.mp.copy_paths), 2)
+
 
 class CheckEnabledTests(unittest.TestCase):
 

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -237,10 +237,6 @@ class AddCopySpecTests(unittest.TestCase):
         expected_paths = set(map(pathmunge, self.expect_paths))
         self.assertEquals(self.mp.copy_paths, expected_paths)
 
-    def test_glob_file(self):
-        self.mp.add_copy_spec('tests/tail_test.*')
-        self.assert_expect_paths()
-
 
     def test_single_file_no_limit(self):
         self.mp.add_copy_spec("tests/tail_test.txt")
@@ -265,6 +261,10 @@ class AddCopySpecTests(unittest.TestCase):
         self.mp.sysroot = '/'
         self.assertFalse(self.mp.add_copy_spec('', 1))
         self.assertFalse(self.mp.add_copy_spec(None, 1))
+
+    def test_glob_file(self):
+        self.mp.add_copy_spec('tests/tail_test.*')
+        self.assert_expect_paths()
 
     def test_glob_file_limit_no_limit(self):
         self.mp.sysroot = '/'

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -247,6 +247,10 @@ class AddCopySpecTests(unittest.TestCase):
         self.mp.add_copy_spec('tests/tail_test.*')
         self.assert_expect_paths()
 
+    def test_multiple_files(self):
+        self.mp.add_copy_spec(['tests/tail_test.txt', 'tests/test.txt'])
+        self.assertEquals(len(self.mp.copy_paths), 2)
+
     # add_copy_spec_limit()
 
     def test_single_file_under_limit(self):

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -236,7 +236,7 @@ class AddCopySpecTests(unittest.TestCase):
             return os.path.join(self.mp.sysroot, path)
         expected_paths = set(map(pathmunge, self.expect_paths))
         self.assertEquals(self.mp.copy_paths, expected_paths)
-        
+
     # add_copy_spec()
 
     def test_single_file(self):

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import tempfile
+import shutil
 
 # PYCOMPAT
 import six
@@ -269,16 +270,15 @@ class AddCopySpecTests(unittest.TestCase):
 
     def test_glob_file_over_limit(self):
         self.mp.sysroot = '/'
-        # assume these are in /tmp
-        fn = create_file(2)
-        fn2 = create_file(2)
-        self.mp.add_copy_spec_limit("/tmp/tmp*", 1)
+        tmpdir = tempfile.mkdtemp()
+        fn = create_file(2, dir=tmpdir)
+        fn2 = create_file(2, dir=tmpdir)
+        self.mp.add_copy_spec_limit(tmpdir + "/*", 1)
         self.assertEquals(len(self.mp.copy_strings), 1)
         content, fname = self.mp.copy_strings[0]
         self.assertTrue("tailed" in fname)
         self.assertEquals(1024 * 1024, len(content))
-        os.unlink(fn)
-        os.unlink(fn2)
+        shutil.rmtree(tmpdir)
 
 
 class CheckEnabledTests(unittest.TestCase):

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -1,0 +1,1 @@
+content


### PR DESCRIPTION
This is  substituting add_copy_spec with add_copy_spec_limit. Steps:

- a few cleanups and improvements of existing plugin tests
- teach add_copy_spec_limit() to understand lists of copyspecs
- add tests for the new mode of add_copy_spec_limit
- let add_copy_spec be implemented by calling add_copy_spec_limit()
- change all plugins to use add_copy_spec_only
- change tests to use add_copy_spec only and remove redundant tests
- remove add_copy_spec_limit()
