### PR TITLE
[libvirt] Include '/etc/libvirt/qemu.conf'

### DIFF
--- a/sos/plugins/libvirt.py
+++ b/sos/plugins/libvirt.py
@@ -34,6 +34,7 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         self.add_copy_spec([
             "/etc/libvirt/libvirt.conf",
             "/etc/libvirt/libvirtd.conf",
+            "/etc/libvirt/qemu.conf",
             "/etc/libvirt/lxc.conf",
             "/etc/libvirt/nwfilter/*.xml",
             "/etc/libvirt/qemu/*.xml",
@@ -69,5 +70,11 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                     r"(\s*passwd=\s*')([^']*)('.*)",
                     r"\1******\3"
                 )
+
+        self.do_file_sub(
+            "/etc/libvirt/qemu.conf",
+            r"(\w+_password[\s]+=)(.*)",
+            r"\1*****"
+        )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Parameter such as "security_driver"(included in this conf
file) is responsible to enable SElinux on qemu instances.
One such case was observed when live migration failed as
the driver was set to "none" which was hard to debug as
this file was not included in soseport.

Closes-Bug: #903