### PR TITLE
[networking] collect socket stat from each namespace

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -290,7 +290,8 @@ class Networking(Plugin):
                 self.add_cmd_output([
                     cmd_prefix + namespace + " ip address show",
                     cmd_prefix + namespace + " ip route show table all",
-                    cmd_prefix + namespace + " iptables-save"
+                    cmd_prefix + namespace + " iptables-save",
+                    cmd_prefix + namespace + " ss -lnp"
                 ])
 
             # Devices that exist in a namespace use less ethtool


### PR DESCRIPTION
added command to collect 'ss -lnp' within each namespace

Signed-off-by: Martin Schuppert <mschuppert@redhat.com>