### PR TITLE
[sosreport][regression] --tmp-dir on NFS raises uncaught exception

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -83,6 +83,7 @@ class TempFileUtil(object):
 
     def new(self):
         fd, fname = tempfile.mkstemp(dir=self.tmp_dir)
+        os.close(fd)
         fobj = open(fname, 'w')
         self.files.append((fname, fobj))
         return fobj

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -882,9 +882,7 @@ class SoSReport(object):
             ui_console.setLevel(logging.INFO)
             self.ui_log.addHandler(ui_console)
 
-    def _finish_logging(self):
-        logging.shutdown()
-
+    def _add_sos_logs(self):
         # Make sure the log files are added before we remove the log
         # handlers. This prevents "No handlers could be found.." messages
         # from leaking to the console when running in --quiet mode when
@@ -1479,7 +1477,7 @@ class SoSReport(object):
         # files are closed and cleaned up at exit.
         #
         # All subsequent terminal output must use print().
-        self._finish_logging()
+        self._add_sos_logs()
 
         archive = None    # archive path
         directory = None  # report directory path (--build)
@@ -1562,6 +1560,7 @@ class SoSReport(object):
         self.policy.display_results(archive, directory, checksum)
 
         # clean up
+        logging.shutdown()
         if self.tempfile_util:
             self.tempfile_util.clean()
         if self.tmpdir:


### PR DESCRIPTION
Running sosreport `--tmp-dir` on a NFS raises uncaught exception:

    Traceback (most recent call last):
      File "./sosreport", line 25, in <module>
        main(sys.argv[1:])
      File "/root/sos-master/sos/sosreport.py", line 1633, in main
        sos.execute()
      File "/root/sos-master/sos/sosreport.py", line 1619, in execute
        self.archive.cleanup()
      File "/root/sos-master/sos/archive.py", line 241, in cleanup
        shutil.rmtree(self._archive_root)
      File "/usr/lib64/python2.7/shutil.py", line 239, in rmtree
        onerror(os.listdir, path, sys.exc_info())
      File "/usr/lib64/python2.7/shutil.py", line 237, in rmtree
        names = os.listdir(path)
    OSError: [Errno 2] No such file or directory: '/nfs_sos/sos.2A3Jdp/machine.local-20170101191654'

That is a regression caused by commit 4a9b919 .

The bug is twofold:

1) tempfiles created by `tempfile.mkstemp` call redundantly leave opened FD. We shall close it before deleting the upper directory.

2) logging needs to be shut down after archive class writes its logs during tarball creation.
