### PR TITLE
[archive] compress tarball without a timeout

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -412,7 +412,8 @@ class TarFileArchive(FileCacheArchive):
             if cmd != "gzip":
                 cmd = "%s -1" % cmd
             try:
-                r = sos_get_command_output("%s %s" % (cmd, self.name()))
+                r = sos_get_command_output("%s %s" % (cmd, self.name()),
+                                           timeout=0)
 
                 if r['status']:
                     self.log_info(r['output'])


### PR DESCRIPTION
Compressing tarball uses default 300s timeout, while sosreports with large data
or random content can require more time to xz/gz the tarball.

Resolves: #910

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>