### PR TITLE
[subscription_manager] collect /var/lib/rhsm/

### DIFF
--- a/sos/plugins/subscription_manager.py
+++ b/sos/plugins/subscription_manager.py
@@ -29,6 +29,7 @@ class SubscriptionManager(Plugin, RedHatPlugin):
         # rhsm config and logs
         self.add_copy_spec([
             "/etc/rhsm/",
+            "/var/lib/rhsm/",
             "/var/log/rhsm/rhsm.log",
             "/var/log/rhsm/rhsmcertd.log"])
         self.add_cmd_output([


### PR DESCRIPTION
The directory contains usefull info about subscription status and facts
the RHSM server gets from this client.

Resolves: #912

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>