### PR TITLE
[sosreport] clarify in man and help that --logsize is in MB

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -107,7 +107,7 @@ testing or other plugin defined behaviour. Use of \--verify may cause
 the time taken to generate a report to be considerably longer.
 .TP
 .B \--log-size
-Places a global limit on the size of any collected set of logs. The
+Places a global limit on the size (in MiB) of any collected set of logs. The
 limit is applied separately for each set of logs collected by any
 plugin.
 .TP

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -599,7 +599,7 @@ class SoSOptions(object):
                           default=deque())
         parser.add_option("--log-size", action="store",
                           dest="log_size", default=10, type="int",
-                          help="set a limit on the size of collected logs")
+                          help="set a limit on the size of collected logs (in MiB)")
         parser.add_option("-a", "--alloptions", action="store_true",
                           dest="usealloptions", default=False,
                           help="enable all options for loaded plugins")


### PR DESCRIPTION
Neither sosreport --help or man pages specify the units of
--logsize parameter. Let it clarify.

Resolves: #916

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>