### PR TITLE
[ceph_ansible] Add ceph-ansible plugin

### DIFF
--- a/sos/plugins/ceph_ansible.py
+++ b/sos/plugins/ceph_ansible.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 Red Hat, Inc., Kyle Squizzato <ksquizza@redhat.com>
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class CephAnsible(Plugin, RedHatPlugin):
+    """ceph-ansible playbooks
+    """
+
+    plugin_name = "ceph_ansible"
+    profiles = ('storage',)
+    packages = (
+        "ceph-ansible",
+    )
+    files = ('/usr/share/ceph-ansible/')
+
+    def setup(self):
+        self.add_copy_spec([
+            "/usr/share/ansible/group_vars/",
+            "/usr/share/ansible/site*.yml",
+            "/usr/share/ansible/ansible.cfg"
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This adds a plugin to retrieve specifics from Red Hat installs
of ceph-ansible.  This plugin will capture user variables and
edited site files, as well as playbook specific ansible.cfg.

Signed-off-by: Kyle Squizzato <ksquizza@redhat.com>

---

**Note:** I was unsure whether to make this just a `RedHatPlugin` as you can use `ceph-ansible` on Ubuntu/Debian as well, but there's no `ceph-ansible` specific package shipped with those distros, so it's really going to be difficult to check where users are going to be cloning the directory contents to be able to grab it with `sos` or even verify it's installed in the first place.