### PR TITLE
[firewalld] collect *.xml configs

### DIFF
--- a/sos/plugins/firewalld.py
+++ b/sos/plugins/firewalld.py
@@ -28,7 +28,8 @@ class FirewallD(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/etc/firewalld/*.conf",
+            "/etc/firewalld/firewalld.conf",
+            "/etc/firewalld/*.xml",
             "/etc/firewalld/icmptypes/*.xml",
             "/etc/firewalld/services/*.xml",
             "/etc/firewalld/zones/*.xml",


### PR DESCRIPTION
Collect /etc/firewalld/*.xml (and firewalld.conf) instead of *conf.

Issue #854 has a typo talking about *.conf instead of *.xml.

Resolves #933

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>