### PR TITLE
[policies/debian] Remove glob that causes directories to be queried.

### DIFF
--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -11,7 +11,7 @@ class DebianPolicy(LinuxPolicy):
     report_name = ""
     ticket_number = ""
     package_manager = PackageManager(
-        "dpkg-query -W -f='${Package}|${Version}\\n' \*")
+        "dpkg-query -W -f='${Package}|${Version}\\n'")
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin"
@@ -21,7 +21,7 @@ class DebianPolicy(LinuxPolicy):
         self.report_name = ""
         self.ticket_number = ""
         self.package_manager = PackageManager(
-            "dpkg-query -W -f='${Package}|${Version}\\n' \*")
+            "dpkg-query -W -f='${Package}|${Version}\\n'")
         self.valid_subclasses = [DebianPlugin]
 
     @classmethod


### PR DESCRIPTION
The change in how commands are parsed was introduced in commit
04d412816de2e4053f43956adf536272a2ddc19c.  This caused our old dpkg parsing
to not work.  Whatever the reason for the \* in the command it doesn't appear to
be needed now anyway so removing it.

Resolves: #935

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>