### PR TITLE
[policies] get package list without a timeout

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -55,7 +55,6 @@ class PackageManager(object):
     """
 
     query_command = None
-    timeout = 30
     chroot = None
 
     def __init__(self, query_command=None, chroot=None):
@@ -99,7 +98,7 @@ class PackageManager(object):
         if self.query_command:
             cmd = self.query_command
             pkg_list = shell_out(
-                cmd, timeout=self.timeout, chroot=self.chroot
+                cmd, timeout=0, chroot=self.chroot
             ).splitlines()
 
             for pkg in pkg_list:


### PR DESCRIPTION
Package list shall never timeout, otherwise pkgs gets empty, causing
KeyError later on.

Resolves: #942

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>