### PR TITLE
Support iproute2 ns list output

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -76,7 +76,7 @@ class Networking(Plugin):
                or line.isspace() \
                or line[:1].isspace():
                 return out
-            out.append(line)
+            out.append(line.partition(' ')[0])
         return out
 
     def get_netns_devs(self, namespace):


### PR DESCRIPTION
iproute2 now prints an id after namespace names
when listing with e.g. ip netns. This breaks the
sosreport get_ip_netns() function.

Fixes #948