### PR TITLE
[gnocchi] Fixed missing 'os' module in gnocchi plugin

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
+import os
 from sos.plugins import Plugin, RedHatPlugin
 
 


### PR DESCRIPTION
Missing 'os' module in gnocchi plugin.

Signed-off-by: Sachin <psachin@redhat.com>