### PR TITLE
[openstack_instack] Collect undercloud debug information

### DIFF
--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2012 Rackspace US, Inc.,
 #                    Justin Shepherd <jshepher@rackspace.com>
 # Copyright (C) 2009 Red Hat, Inc., Joey Boggs <jboggs@redhat.com>
+# Copyright (C) 2017 Red Hat, Inc., Martin Schuppert <mschuppert@redhat.com>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +19,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import os
 
 
 class OpenStackGlance(Plugin):
@@ -43,6 +45,15 @@ class OpenStackGlance(Plugin):
                                      sizelimit=self.limit)
 
         self.add_copy_spec("/etc/glance/")
+
+        vars = [p in os.environ for p in [
+                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
+        if not all(vars):
+            self.soslog.warning("Not all environment variables set. Source "
+                                "the environment file for the user intended "
+                                "to connect to the OpenStack environment.")
+        else:
+            self.add_cmd_output("openstack image list --long")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2013 Red Hat, Inc.
+# Copyright (C) 2017 Red Hat, Inc., Martin Schuppert <mschuppert@redhat.com>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +16,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import os
 
 
 class OpenStackHeat(Plugin):
@@ -31,6 +33,15 @@ class OpenStackHeat(Plugin):
             "heat-manage db_version",
             suggest_filename="heat_db_version"
         )
+
+        vars = [p in os.environ for p in [
+                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
+        if not all(vars):
+            self.soslog.warning("Not all environment variables set. Source "
+                                "the environment file for the user intended "
+                                "to connect to the OpenStack environment.")
+        else:
+            self.add_cmd_output("openstack stack list")
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015 Red Hat, Inc., Lee Yarwood <lyarwood@redhat.com>
+# Copyright (C) 2017 Red Hat, Inc., Martin Schuppert <mschuppert@redhat.com>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +16,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import os
 
 
 class OpenStackIronic(Plugin):
@@ -36,6 +38,16 @@ class OpenStackIronic(Plugin):
                                      sizelimit=self.limit)
 
         self.add_cmd_output('ls -laRt /var/lib/ironic/')
+
+        vars = [p in os.environ for p in [
+                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
+        if not all(vars):
+            self.soslog.warning("Not all environment variables set. Source "
+                                "the environment file for the user intended "
+                                "to connect to the OpenStack environment.")
+        else:
+            self.add_cmd_output("openstack baremetal node list --long")
+            self.add_cmd_output("openstack baremetal port list")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2013 Red Hat, Inc., Jeremy Agee <jagee@redhat.com>
+# Copyright (C) 2017 Red Hat, Inc., Martin Schuppert <mschuppert@redhat.com>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +16,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import os
 
 
 class OpenStackKeystone(Plugin):
@@ -40,6 +42,16 @@ class OpenStackKeystone(Plugin):
         else:
             self.add_copy_spec_limit("/var/log/keystone/*.log",
                                      sizelimit=self.limit)
+
+        vars = [p in os.environ for p in [
+                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
+        if not all(vars):
+            self.soslog.warning("Not all environment variables set. Source "
+                                "the environment file for the user intended "
+                                "to connect to the OpenStack environment.")
+        else:
+            self.add_cmd_output("openstack endpoint list")
+            self.add_cmd_output("openstack catalog list")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2013 Red Hat, Inc., Brent Eagles <beagles@redhat.com>
+# Copyright (C) 2017 Red Hat, Inc., Martin Schuppert <mschuppert@redhat.com>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +16,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import os
 
 
 class OpenStackNeutron(Plugin):
@@ -35,6 +37,18 @@ class OpenStackNeutron(Plugin):
 
         self.add_copy_spec("/etc/neutron/")
         self.add_copy_spec("/var/lib/neutron/")
+
+        vars = [p in os.environ for p in [
+                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
+        if not all(vars):
+            self.soslog.warning("Not all environment variables set. Source "
+                                "the environment file for the user intended "
+                                "to connect to the OpenStack environment.")
+        else:
+            self.add_cmd_output("openstack subnet list")
+            self.add_cmd_output("openstack port list")
+            self.add_cmd_output("openstack router list")
+            self.add_cmd_output("openstack network agent list")
 
     def postproc(self):
         protect_keys = [


### PR DESCRIPTION
If auth information got sourced before sosreport run
(OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME) collect
information from nova, neutron, keystone, glance, ironic
and heat.
Only undercloud specific heat information is collected in
instack plugin.

Signed-off-by: Martin Schuppert <mschuppe@redhat.com>