### PR TITLE
[plugins] prevent collecting some key[3-4].db private keys

### DIFF
--- a/sos/plugins/cman.py
+++ b/sos/plugins/cman.py
@@ -26,7 +26,6 @@ class Cman(Plugin, RedHatPlugin):
 
     packages = [
         "luci",
-        "ricci",
         "cman",
         "clusterlib",
     ]
@@ -45,7 +44,6 @@ class Cman(Plugin, RedHatPlugin):
             "/etc/sysconfig/cman",
             "/var/log/cluster",
             "/etc/fence_virt.conf",
-            "/var/lib/ricci",
             "/var/lib/luci/data/luci.db",
             "/var/lib/luci/etc",
             "/var/log/luci"

--- a/sos/plugins/ds.py
+++ b/sos/plugins/ds.py
@@ -43,7 +43,7 @@ class DirectoryServer(Plugin, RedHatPlugin):
         self.add_forbidden_path("/etc/dirsrv/slapd*/key3.db")
         self.add_forbidden_path("/etc/dirsrv/slapd*/pwfile.txt")
         self.add_forbidden_path("/etc/dirsrv/slapd*/*passw*")
-        self.add_forbidden_path("/etc/dirsrv/admin-serv/key3.db")
+        self.add_forbidden_path("/etc/dirsrv/admin-serv/key[3-4].db")
         self.add_forbidden_path("/etc/dirsrv/admin-serv/admpw")
         self.add_forbidden_path("/etc/dirsrv/admin-serv/password.conf")
         try:

--- a/sos/plugins/openswan.py
+++ b/sos/plugins/openswan.py
@@ -42,4 +42,6 @@ class Openswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         if self.get_option("ipsec-barf"):
             self.add_cmd_output("ipsec barf")
 
+        self.add_forbidden_path("/etc/ipsec.d/key[3-4].db")
+
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/smartcard.py
+++ b/sos/plugins/smartcard.py
@@ -37,5 +37,6 @@ class Smartcard(Plugin, RedHatPlugin):
             "pklogin_finder debug",
             "ls -nl /usr/lib*/pam_pkcs11/"
         ])
+        self.add_forbidden_path("/etc/pam_pkcs11/nssdb/key[3-4].db")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Stop collecting:
/etc/dirsrv/admin-serv/key4.db
/etc/pam_pkcs11/nssdb/key[3-4].db
/etc/ipsec.d/key[3-4].db

Further drop ricci from cman as obsolete, to stop potential collecting several private keys.

Resolves: #964

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>