### PR TITLE
[networking] Add ss socket output

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -155,6 +155,7 @@ class Networking(Plugin):
         self.add_cmd_output([
             "netstat -s",
             "netstat %s -agn" % self.ns_wide,
+            "ss -peaonmi",
             "ip route show table all",
             "ip -6 route show table all",
             "ip -4 rule",


### PR DESCRIPTION
Adds the following to the networking plugin:

	$ ss -peaonmi

The ss tool provides much more detailed socket information than netstat
and is almost guaranteed to be available while netstat not always so.

ss provides some very useful extra TCP socket information such as memory
allocations, the congestion window size, window scaling factor, segments
sent/received, outstanding data, etc, etc. It also provides the socket
address for every known socket type listed.

The net-tools package is not part of the default package set for some
minimal EL installs so it is not always available. ss is part of the
more-modern iproute suite so is more likely to always be available.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>