### PR TITLE
openvswitch additional information collection

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -36,6 +36,8 @@ class OpenVSwitch(Plugin):
             # The '-s' option enables dumping of packet counters on the
             # ports.
             "ovs-dpctl -s show",
+            # Capture the in-kernel flow information if it exists
+            "ovs-dpctl dump-flows -m",
             # The '-t 5' adds an upper bound on how long to wait to connect
             # to the Open vSwitch server, avoiding hangs when running sos.
             "ovs-vsctl -t 5 show",

--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -45,6 +45,9 @@ class OpenVSwitch(Plugin):
             "ls -laZ /var/run/openvswitch",
             # List devices and their drivers
             "dpdk_nic_bind --status",
+            "dpdk_devbind.py --status",
+            "driverctl list-devices",
+            "driverctl list-overrides",
             # Capture a list of all bond devices
             "ovs-appctl bond/list",
             # Capture more details from bond devices


### PR DESCRIPTION
Following commits modify the information collection to use additional programs to collect the list of dpdk overrides as well as capturing the in-kernel datapath flow information.
