### PR TITLE
[dnf] Traceback when dnf history is empty

### DIFF
--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -63,7 +63,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
 
         if self.get_option("history-info"):
             history = self.call_ext_prog("dnf history")
-            transactions = None
+            transactions = -1
             if history['output']:
                 for line in history['output'].splitlines():
                     try:


### PR DESCRIPTION
Set transactions = -1 to skip for loop when dnf history is empty.

Resolves: #969

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>