### PR TITLE
[gnocchi] Missing "packages = .." causes plugins runs everytime

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -21,6 +21,9 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
     """Gnocchi - Metric as a service"""
     plugin_name = "openstack_gnocchi"
     profiles = ('openstack', 'openstack_controller')
+    packages = ('openstack-gnocchi-metricd', 'openstack-gnocchi-common',
+                'openstack-gnocchi-statsd', 'openstack-gnocchi-api',
+                'openstack-gnocchi-carbonara')
     requires_root = False
 
     def setup(self):


### PR DESCRIPTION
Specify packages plugin variable to run the plugin only on systems
with gnocchi installed.

Resolves: #977

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>