### PR TITLE
[plugins] Collect cmd-output before copy-specs

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -840,8 +840,8 @@ class Plugin(object):
     def collect(self):
         """Collect the data for a plugin."""
         start = time()
-        self._collect_copy_specs()
         self._collect_cmd_output()
+        self._collect_copy_specs()
         self._collect_strings()
         fields = (self.name(), time() - start)
         self._log_debug("collected plugin '%s' in %s" % fields)


### PR DESCRIPTION
This patch changes the plugin.collect method to reverse call order of
_collect_copy_specs and _collect_cmd_output, so that latter is called
first.

This makes it easier for plugins to implement a collect-sequence where
a command execution generates some output files that can then be
collected in sos-report as copy-specs together with the command
output.

A hypothetical example would be of a plugin that uses gdb to analyze
a process core-dump and report stack contents. The plugin would
generate a gdb-command script that uses log redirection to dump stack
contents to a file which is then added to the sos-report together with
output of the gdb command. Below is a rough outline of this
hypothetical plugin:

```
class MyBinaryStackDump(Plugin):
...
    def setup(self):
        .. Generate GDB init Script gdb.sh to log stack to stack.txt ..
        self.add_cmd_output("gdb mybinary core-file -batch -x gdb.sh")
        self.add_copy_spec("stack.txt")

    def postproc(self):
        .. unlink gdb.sh and stack.txt temp files ..
```
Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>