### PR TITLE
[ceph] missing coma when adding /etc/calamari

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -50,7 +50,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.add_copy_spec([
             "/etc/ceph/",
-            "/etc/calamari/"
+            "/etc/calamari/",
             "/var/lib/ceph/",
             "/var/run/ceph/"
         ])


### PR DESCRIPTION
(regression introduced in 6b2e85b)

Resolves: #987

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>