### PR TITLE
 Increase the timeout when calling spacewalk-debug

### DIFF
--- a/sos/plugins/satellite.py
+++ b/sos/plugins/satellite.py
@@ -81,7 +81,8 @@ class Satellite(Plugin, RedHatPlugin):
             ])
             self.add_cmd_output(
                 "spacewalk-debug --dir %s"
-                % self.get_cmd_output_path(name="spacewalk-debug"))
+                % self.get_cmd_output_path(name="spacewalk-debug"),
+                timeout=900)
 
         if self.proxy:
             self.add_copy_spec(["/etc/squid", "/var/log/squid"])


### PR DESCRIPTION
This PR increases the timeout when calling spacewalk-debug. 
```bash
$ sosreport
sosreport (version 3.2)

[..SNIP..]

 Setting up archive ...
 Setting up plugins ...
dbname must be supplied to dump a database.
 Running plugins. Please wait ...

  Running 10/92: boot...

[..SNIP..]

  Running 70/92: satellite...        [plugin:satellite] command 'spacewalk-debug --dir /tmp/sos.PKdPAS/sosreport-rhn-support-redhat-20170405132739/sos_commands/satellite/spacewalk-debug' timed out after 300s

[..SNIP..]

Creating compressed archive...
Traceback (most recent call last):
  File "/usr/sbin/sosreport", line 25, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1520, in main
    sos.execute()
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1499, in execute
    return self.final_work()
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1411, in final_work
    checksum = self._create_checksum(archive, hash_name)
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1349, in _create_checksum
    archive_fp = open(archive, 'rb')
IOError: [Errno 2] No such file or directory: '/tmp/sos.PKdPAS/sosreport-rhn-support-redhat-20170405132739.tar.xz'

real    60m6.624s
user    12m25.001s
sys     10m39.263s
```
I also submitted a PR that enhances the `spacewalk-debug` performance.  (see https://github.com/spacewalkproject/spacewalk/pull/532)