### PR TITLE
[plugins] Handle stat errors on missing files

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -537,7 +537,10 @@ class Plugin(object):
             _file = None
 
             for _file in files:
-                current_size += os.stat(_file)[stat.ST_SIZE]
+                try:
+                    current_size += os.stat(_file)[stat.ST_SIZE]
+                except (OSError, FileNotFoundError):
+                    self._log_info("failed to stat '%s'" % _file)
                 if sizelimit and current_size > sizelimit:
                     limit_reached = True
                     break


### PR DESCRIPTION
When the stat is done on a broken symlink, it will return either OSError
or FileNotFoundError. Handle these and report accordingly.

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>