### PR TITLE
[snappy] new plugin to show snappy info

### DIFF
--- a/sos/plugins/snappy.py
+++ b/sos/plugins/snappy.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2017 Bryan Quigley <bryan.quigley@canonical.com>
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+from sos.plugins import Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin
+
+
+class Snappy(Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin):
+    """Snap packages
+    """
+
+    plugin_name = 'snappy'
+    profiles = ('system', 'sysmgmt', 'packagemanager')
+    files = ('/usr/bin/snap')
+
+    def setup(self):
+        self.add_cmd_output([
+            "systemctl status snapd.service",
+            "snap list --all",
+            "snap --version",
+            "snap changes"
+        ])
+        self.add_journal(units="snapd")
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a new plugin that lists information about snappy, including:
 * all installed snaps with version info (snap list --all)
 * Snappy's own version info (snap --version)
 * status info and logs for the snapd daemon
 * List snappy system changes (snap changes)

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>