### PR TITLE
[process] Replace stime option to lstart option

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -27,7 +27,7 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         # process group and thread options
         ps_group_opts = "pid,ppid,user,group,lwp,nlwp,start_time,comm,cgroup"
         ps_sched_opts = "flags,state,uid,pid,ppid,pgid,sid,cls,pri,addr,sz,"
-        ps_sched_opts += "wchan,stime,tty,time,cmd"
+        ps_sched_opts += "wchan,tty,lstart,time,cmd"
         self.add_copy_spec("/proc/sched_debug")
         self.add_cmd_output("ps auxwww", root_symlink="ps")
         self.add_cmd_output("pstree", root_symlink="pstree")


### PR DESCRIPTION
stime option doesn't provide consistent formatted data and the granularity of time scale differs from time to date order.
lstart option provides consistent date/time format and it is easy to find out when the process starts.

Signed-off-by: Keigo Noha <knoha@redhat.com>