### PR TITLE
[sosreport]Update ceph.py

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -81,6 +81,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
         self.add_forbidden_path("/var/lib/ceph/*/*/*keyring*")
         self.add_forbidden_path("/var/lib/ceph/osd/*")
         self.add_forbidden_path("/var/lib/ceph/mon/*")
+        self.add_forbidden_path("/var/lib/ceph/tmp/mnt*")
         self.add_forbidden_path("/etc/ceph/*bindpass*")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -15,6 +15,7 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 from datetime import datetime, timedelta
 import re
+import os.path
 
 
 class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
@@ -45,6 +46,7 @@ class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
             "pcs status",
             "pcs property list --all"
         ])
+
         # crm_report needs to be given a --from "YYYY-MM-DD HH:MM:SS" start
         # time in order to collect data.
         crm_from = (datetime.today() -
@@ -69,6 +71,21 @@ class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
                             ' --dest %s --from "%s"' %
                             (crm_scrub, crm_dest, crm_from),
                             chroot=self.tmp_in_sysroot())
+
+        # collect user-defined logfiles, matching pattern:
+        # PCMK_loggfile=filename
+        # specified in the pacemaker defaults file.
+        pattern = '^\s*PCMK_logfile=[\'\"]?(\S+)[\'\"]?\s*(\s#.*)?$'
+        if os.path.isfile(self.defaults):
+            with open(self.defaults) as f:
+                for line in f:
+                    if re.match(pattern, line):
+                        # remove trailing and leading quote marks, in case the
+                        # line is e.g. PCMK_logfile="/var/log/pacemaker.log"
+                        logfile = re.search(pattern, line).group(1)
+                        for regexp in [r'^"', r'"$', r'^\'', r'\'$']:
+                            logfile = re.sub(regexp, '', logfile)
+                        self.add_copy_spec(logfile)
 
     def postproc(self):
         self.do_cmd_output_sub(

--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -17,12 +17,13 @@ from datetime import datetime, timedelta
 import re
 
 
-class Pacemaker(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
     """HA Cluster resource manager"""
 
     plugin_name = "pacemaker"
     profiles = ("cluster", )
     packages = ["pacemaker"]
+    defaults = "/etc/default/pacemaker"
 
     option_list = [
         ("crm_from", "specify the start time for crm_report", "fast", False),
@@ -32,7 +33,7 @@ class Pacemaker(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_copy_spec([
             "/var/lib/pacemaker/cib/cib.xml",
-            "/etc/sysconfig/pacemaker",
+            self.defaults,
             "/var/log/pacemaker.log",
             "/var/log/pcsd/pcsd.log"
         ])
@@ -75,5 +76,14 @@ class Pacemaker(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             r"(passwd=|incoming_password=)\S+",
             r"\1********"
         )
+
+
+class RedHatPacemaker(Pacemaker, RedHatPlugin):
+    """ Handle alternate location of pacemaker defaults file.
+    """
+    def setup(self):
+        self.defaults = "/etc/sysconfig/pacemaker"
+        super(RedHatPacemaker, self).setup()
+
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
if the osd stays mounted on temporary mount location /var/lib/ceph/tmp/mnt.XXXX , sosreport will collect the content of the osd, which can be TB of data. this change will prevent that.

Signed-off-by: Tomas Petr <tpetr@redhat.com>