### PR TITLE
[ceph] exclude temporary mounts at /var/lib/ceph/tmp/*mnt*

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -81,6 +81,13 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
         self.add_forbidden_path("/var/lib/ceph/*/*/*keyring*")
         self.add_forbidden_path("/var/lib/ceph/osd/*")
         self.add_forbidden_path("/var/lib/ceph/mon/*")
+
+# Excludes temporary ceph-osd mount location like
+# /var/lib/ceph/tmp/mnt.XXXX from sos collection.
+# In the /var/lib/ceph/tmp/ can still other files of potential
+# interest exists, so exclude only known temporary mount locations.
+
+        self.add_forbidden_path("/var/lib/ceph/tmp/*mnt*")
         self.add_forbidden_path("/etc/ceph/*bindpass*")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
[ceph] Excludes temporary ceph-osd mount location like /var/lib/ceph/tmp/mnt.XXXX from sos collection.
In the /var/lib/ceph/tmp/ can still other files of potential interest exists, so exclude only known temporary mount locations.

Resolves #1006

Signed-off-by: Tomas Petr <tpetr@redhat.com>