### PR TITLE
[kernel] add /sys/fs/pstore collection for all platforms

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -84,6 +84,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/lock*",
             "/proc/misc",
             "/var/log/dmesg",
+            "/sys/fs/pstore",
             clocksource_path + "available_clocksource",
             clocksource_path + "current_clocksource"
         ])

--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -48,8 +48,7 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                 "/proc/swaps",
                 "/proc/version",
                 "/dev/nvram",
-                "/var/lib/lsvpd/",
-                "/sys/fs/pstore/"
+                "/var/lib/lsvpd/"
             ])
             self.add_cmd_output([
                 "ppc64_cpu --smt",


### PR DESCRIPTION
The pstore data should be collected upon sosreport run for all
architecture (currently only enabled in powerpc.py) because the
data there will include any past oops event and/or panic events.
This data would assist diagnosing panics with little other data
available.

Also, the data included is a few kb in size, so it will not add
much size to the output of the report.

Collection of /sys/fs/pstore was previously in plugins/powerpc.py.
I moved it to plugins/kernel.py in order to have it collect for all architectures.

I also opened the Launchpad bug for Ubuntu, but figured I would 
suggest the changes here to help speed up the process.

https://bugs.launchpad.net/ubuntu/+source/sosreport/+bug/1687126

Signed-off-by: Chris Newcomer <chris@thenewcomers.org>