### PR TITLE
[docker] Enable log timestamp in docker logs

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -99,7 +99,7 @@ class Docker(Plugin):
             if self.get_option('logs'):
                 for container in insp:
                     self.add_cmd_output(
-                        "{0} logs {1}".format(
+                        "{0} logs -t {1}".format(
                             self.docker_cmd,
                             container
                         )


### PR DESCRIPTION
To make container troubleshooting easier. Container logs sometimes have different TZ timestapms without TZ info or no timestamps at all.