### PR TITLE
[scsi]  scsi address mapping with scsi device name

### DIFF
--- a/sos/plugins/scsi.py
+++ b/sos/plugins/scsi.py
@@ -35,7 +35,7 @@ class Scsi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
         self.add_cmd_output([
             "lsscsi",
-            "sg_map"
+            "sg_map -x"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
 Collect scsi device name mapping with scsi "H C T L" address. Currently sg_map collect mapping information about sg device name and scsi address. "sg_map -x" collect scsi device name mapping with sg device name and scsi address.

Signed-off-by: RanjithML  <ranjithml@gmail.com>
