### PR TITLE
[nfsganesha] collect all log files related to ganesha including log rotated 

### DIFF
--- a/sos/plugins/nfsganesha.py
+++ b/sos/plugins/nfsganesha.py
@@ -27,8 +27,8 @@ class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/ganesha",
             "/etc/sysconfig/ganesha",
             "/var/run/sysconfig/ganesha",
-            "/var/log/ganesha.log",
-            "/var/log/ganesha-gfapi.log"
+            "/var/log/ganesha*log*",
+            "/var/log/ganesha-gfapi*log*"
         ])
 
         self.add_cmd_output([


### PR DESCRIPTION
Sometimes /var/log/ganesha.log and /var/log/ganesha-gfapi.log files does
not provide sufficient logs. The logs might be rotated before the
sosreport exection and nfsganesha not collecting the rotated logs.
The nfsganesha plugin should collect log rotated files for references
to older logs.

Resolves: #1016

Signed-off-by: Prashant D <pdhange@redhat.com>