### PR TITLE
[workflow] Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+---
+Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)
+
+[] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
+[] Is the subject and message clear and concise?
+[] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
+[] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?


### PR DESCRIPTION
This includes information for users wishing to submit PR's and is visible during
their creation of the PR. This allows them to validate that they are providing
all necessary requirements prior to submitting and should reduce the amount of
back and forth we do asking users to follow our guidelines.

Fixes #1021

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>