### PR TITLE
[systemd] Collect also output of systemd-cgls

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -44,6 +44,7 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "systemctl show-environment",
             "systemd-delta",
             "systemd-analyze",
+            "systemd-cgls",
             "journalctl --list-boots",
             "ls -lR /lib/systemd",
             "timedatectl"


### PR DESCRIPTION
systemd-cgls is a tool that reports current content of cgroup
tree. Output of the tool is very useful for figuring out in which
cgroup given process runs. Process cgroup placement may have
implications on process lifetime, e.g. user sessions are terminated
early on shutdown, before "normal" system services.