### PR TITLE
[landscape] add /sys/class/dmi/id/sys_vendor

### DIFF
--- a/sos/plugins/landscape.py
+++ b/sos/plugins/landscape.py
@@ -30,6 +30,7 @@ class Landscape(Plugin, UbuntuPlugin):
         self.add_copy_spec("/etc/landscape/service.conf")
         self.add_copy_spec("/etc/landscape/service.conf.old")
         self.add_copy_spec("/etc/default/landscape-server")
+        self.add_copy_spec("/sys/class/dmi/id/sys_vendor")
         if not self.get_option("all_logs"):
             limit = self.get_option("log_size")
             self.add_copy_spec("/var/log/landscape/*.log", sizelimit=limit)


### PR DESCRIPTION
The get_vm_info and _get_vm_by_vendor functions in the Landscape
client's vm_info.py script rely on /sys/class/dmi/id/sys_vendor
for VM type detection.

Sometimes Landscape doesn't detect the VM type, because of an
unknown string in that file. Adding this file will help us
understand why Landscape didn't detect the computer as a VM.

The data included in this file is only a few characters long and
will not have an impact on the time or size of the report.

Signed-off-by: David Coronel <david.coronel@canonical.com>