### PR TITLE
[man/sosreport] fix typo in chroot description

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -82,7 +82,7 @@ reports from containers and images.
 Set the chroot mode. When \--sysroot is used commands default to
 executing with SYSROOT as the root directory (unless disabled by
 a specific plugin). This can be overriden by setting \--chroot to
-"always" (alwyas chroot) or "never" (always run in the host
+"always" (always chroot) or "never" (always run in the host
 namespace).
 .TP
 .B \--tmp-dir DIRECTORY


### PR DESCRIPTION
Fix small typo in the chroot section of the man page (alwyas -> always)

Fixes #1035

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>