### PR TITLE
[hardware] add /sys/class/dmi/id/*

### DIFF
--- a/sos/plugins/hardware.py
+++ b/sos/plugins/hardware.py
@@ -29,7 +29,8 @@ class Hardware(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/dma",
             "/proc/devices",
             "/proc/rtc",
-            "/var/log/mcelog"
+            "/var/log/mcelog",
+            "/sys/class/dmi/id/*"
         ])
 
         self.add_cmd_output("dmidecode", root_symlink="dmidecode")


### PR DESCRIPTION
Collect the entire /sys/class/dmi/id/ directory from the
hardware plugin. Today, this is really the "native" format for
this information, as far as Linux is concerned. The dmidecode
program (which historically at least read the data directly
from firmware tables, as no proc or sysfs interface existed) is
a legacy formatting of this information which we are
unfortunately obliged to keep around a little longer yet, as
many users have grown dependencies on its format.

The data included in this directory is small (about 500 bytes
on my system) and will not have an impact on the time or size
of the report.

Original discussion at:
https://github.com/sosreport/sos/pull/1034

Signed-off-by: David Coronel <david.coronel@canonical.com>