### PR TITLE
[openvswitch] get specific flow version commands

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -83,6 +83,29 @@ class OpenVSwitch(Plugin):
                     "ovs-ofctl show %s" % br
                 ])
 
+                # Flow protocols currently supported
+                flow_versions = ["OpenFlow10",
+                                 "OpenFlow11",
+                                 "OpenFlow12",
+                                 "OpenFlow13"]
+
+                # List protocols currently in use, if any
+                br_info_file = self.get_cmd_output_now(
+                                   "ovs-vsctl list bridge %s" % br)
+                br_info = open(br_info_file).read()
+                for line in br_info.splitlines():
+                    if "protocols" in line:
+                        br_protos_ln = line[line.find("[")+1:line.find("]")]
+                        br_protos = br_protos_ln.replace('"', '').split(", ")
+
+                # Collect flow information for relevant protocol versions only
+                for flow in flow_versions:
+                    if flow in br_protos:
+                        self.add_cmd_output([
+                            "ovs-ofctl -O %s dump-flows %s" % (flow, br),
+                            "ovs-ofctl -O %s dump-ports-desc %s" % (flow, br)
+                        ])
+
 
 class RedHatOpenVSwitch(OpenVSwitch, RedHatPlugin):
 


### PR DESCRIPTION
The output of ovs-ofctl varies depending on the version of OpenFlow you
query it with.  Using the currently supported versions, retrieve
ovs-ofctl output for each ovs-bridge depending on which specified
versions of OpenFlow are in use.

Signed-off-by: Robb Manes <rmanes@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

This is a continuation of the discussion [here](https://github.com/sosreport/sos/pull/1039), where we need this information when troubleshooting origin issues.  However, it was discussed that collection of OpenFlow-specific version information probably is better suited in the general OpenVSwitch plugin rather than one-off collecting it in origin.  This should meet that need and negate PR#1039.

The above patch has been tested under load in OSE and regular vswitch environments and does not appear to show any regression.  Tests passed locally, including pep8 as well.