### PR TITLE
[etcd] Add available port check to get information correctly.

### DIFF
--- a/sos/plugins/etcd.py
+++ b/sos/plugins/etcd.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from sos.plugins import Plugin, RedHatPlugin
+import socket
 
 
 class etcd(Plugin, RedHatPlugin):
@@ -23,14 +24,31 @@ class etcd(Plugin, RedHatPlugin):
     """etcd plugin
     """
 
+    def port_report(self):
+        """ Until etcd v2, the daemon listens on port 4001 for backward
+        compatibility of v2.0 eariler. But etcd v3 no loger litens on 
+        port 4001 and it listens on port 2379 only. 
+        To collect information in any version, this plugin should check 
+        which port is available.
+        """
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            self.sock.connect(("localhost", 2379))
+        except socket.error, msg:
+            self.sock.close()
+            return "4001"
+        self.sock.close()
+        return "2379"
+
     def setup(self):
         self.add_copy_spec("/etc/etcd")
 
-        self.add_cmd_output("curl http://localhost:4001/version")
-        self.add_cmd_output("curl http://localhost:4001/v2/members")
-        self.add_cmd_output("curl http://localhost:4001/v2/stats/leader")
-        self.add_cmd_output("curl http://localhost:4001/v2/stats/self")
-        self.add_cmd_output("curl http://localhost:4001/v2/stats/store")
+        curl_command = "curl -s http://localhost:" + str(self.port_report())
+        self.add_cmd_output(str(curl_command) + "/version")
+        self.add_cmd_output(str(curl_command) + "/v2/members")
+        self.add_cmd_output(str(curl_command) + "/v2/stats/leader")
+        self.add_cmd_output(str(curl_command) + "/v2/stats/self")
+        self.add_cmd_output(str(curl_command) + "/v2/stats/store")
         self.add_cmd_output("ls -lR /var/lib/etcd/")
 
 


### PR DESCRIPTION
etcd v3 no longer listens on port 4001 for backward compatibility of etc
d v2.0 earlier. To collect information, the plugin should check which
port is available to the running etcd. In this patch, etcd plugin will
run port check then curl commands will access to the available port.

Signed-off-by: Keigo Noha <knoha@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
