### PR TITLE
[smartcard] Stop collecting pkcs11_inspect debug

### DIFF
--- a/sos/plugins/smartcard.py
+++ b/sos/plugins/smartcard.py
@@ -33,7 +33,6 @@ class Smartcard(Plugin, RedHatPlugin):
             "/etc/reader.conf.d/",
             "/etc/pam_pkcs11/"])
         self.add_cmd_output([
-            "pkcs11_inspect debug",
             "pklogin_finder debug",
             "ls -nl /usr/lib*/pam_pkcs11/"
         ])


### PR DESCRIPTION
The tool always requires PIN to be entered manually. That contradicts the aim
of sosreport to collect data as automatically as possible.

Once smartcar community allows providing the PIN e.g. via an env.variable,
we can add the command back.

Resolves: #1045

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
