### PR TITLE
[plugins] Tripleo specific containerized services logs

### DIFF
--- a/sos/plugins/mongodb.py
+++ b/sos/plugins/mongodb.py
@@ -30,7 +30,8 @@ class MongoDb(Plugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/mongodb.conf",
-            "/var/log/mongodb/mongodb.log"
+            "/var/log/mongodb/mongodb.log",
+            "/var/log/containers/mongodb/mongodb.log"
         ])
 
     def postproc(self):

--- a/sos/plugins/mysql.py
+++ b/sos/plugins/mysql.py
@@ -40,12 +40,14 @@ class Mysql(Plugin):
             # Required for MariaDB under pacemaker (MariaDB-Galera)
             "/var/log/mysqld.log",
             "/var/log/mysql/mysqld.log",
+            "/var/log/containers/mysql/mysqld.log",
             "/var/log/mariadb/mariadb.log",
         ])
 
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/mysql*",
+                "/var/log/containers/mysql*",
                 "/var/log/mariadb*"
             ])
 

--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -32,9 +32,12 @@ class OpenStackCeilometer(Plugin):
         # Ceilometer
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/ceilometer/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/ceilometer/",
+                                "/var/log/containers/ceilometer/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/ceilometer/*.log",
+            self.add_copy_spec(["/var/log/ceilometer/*.log",
+                                "/var/log/containers/ceilometer/*.log"],
                                sizelimit=self.limit)
         self.add_copy_spec("/etc/ceilometer/")
         if self.get_option("verify"):

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -40,9 +40,13 @@ class OpenStackCinder(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/cinder/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/cinder/",
+                                "/var/log/containers/cinder/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/cinder/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/cinder/*.log",
+                                "/var/log/containers/cinder/*.log"],
+                               sizelimit=self.limit)
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -38,9 +38,13 @@ class OpenStackGlance(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/glance/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/glance/",
+                                "/var/log/containers/glance/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/glance/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/glance/*.log",
+                                "/var/log/containers/glance/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec("/etc/glance/")
 

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -45,9 +45,13 @@ class OpenStackHeat(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/heat/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/heat/",
+                                "/var/log/containers/heat/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/heat/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/heat/*.log",
+                                "/var/log/containers/heat/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec("/etc/heat/")
 

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -32,9 +32,13 @@ class OpenStackHorizon(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/horizon/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/horizon/",
+                                "/var/log/containers/horizon/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/horizon/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/horizon/*.log",
+                                "/var/log/containers/horizon/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec("/etc/openstack-dashboard/")
         self.add_forbidden_path("*.py[co]")

--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -34,14 +34,18 @@ class OpenStackInstack(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/mistral/",
+            self.add_copy_spec(["/var/log/mistral/",
+                                "/var/log/containers/mistral/"],
                                sizelimit=self.limit)
-            self.add_copy_spec("/var/log/zaqar/",
+            self.add_copy_spec(["/var/log/zaqar/",
+                                "/var/log/containers/zaqar/"],
                                sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/mistral/*.log",
+            self.add_copy_spec(["/var/log/mistral/*.log",
+                                "/var/log/containers/mistral/*.log"],
                                sizelimit=self.limit)
-            self.add_copy_spec("/var/log/zaqar/*.log",
+            self.add_copy_spec(["/var/log/zaqar/*.log",
+                                "/var/log/containers/zaqar/*.log"],
                                sizelimit=self.limit)
 
         vars = [p in os.environ for p in [

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -31,9 +31,13 @@ class OpenStackIronic(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/ironic/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/ironic/",
+                                "/var/log/containers/ironic/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/ironic/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/ironic/*.log",
+                                "/var/log/containers/ironic/*.log"],
+                               sizelimit=self.limit)
 
         self.add_cmd_output('ls -laRt /var/lib/ironic/')
 

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -37,9 +37,13 @@ class OpenStackKeystone(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/keystone/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/keystone/",
+                                "/var/log/containers/keystone/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/keystone/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/keystone/*.log",
+                                "/var/log/containers/keystone/*.log"],
+                               sizelimit=self.limit)
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -29,10 +29,12 @@ class OpenStackManila(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/manila/*",
+            self.add_copy_spec(["/var/log/manila/*",
+                                "/var/log/containers/manila/*"],
                                sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/manila/*.log",
+            self.add_copy_spec(["/var/log/manila/*.log",
+                                "/var/log/containers/manila/*.log"],
                                sizelimit=self.limit)
 
     def postproc(self):

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -29,9 +29,13 @@ class OpenStackNeutron(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/neutron/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/neutron/",
+                                "/var/log/containers/neutron/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/neutron/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/neutron/*.log",
+                                "/var/log/containers/neutron/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec("/etc/neutron/")
         self.add_copy_spec("/var/lib/neutron/")

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -63,9 +63,13 @@ class OpenStackNova(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/nova/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/nova/",
+                                "/var/log/containers/nova/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/nova/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/nova/*.log",
+                                "/var/log/containers/nova/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec("/etc/nova/")
 

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -32,9 +32,13 @@ class OpenStackSahara(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/sahara/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/sahara/",
+                                "/var/log/containers/sahara/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/sahara/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/sahara/*.log",
+                                "/var/log/containers/sahara/*.log"],
+                               sizelimit=self.limit)
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -31,9 +31,13 @@ class OpenStackSwift(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/swift/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/swift/",
+                                "/var/log/containers/swift/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/swift/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/swift/*.log",
+                                "/var/log/containers/swift/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec("/etc/swift/")
 

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -30,9 +30,13 @@ class OpenStackTrove(Plugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/trove/", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/trove/",
+                                "/var/log/containers/trove/"],
+                               sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/trove/*.log", sizelimit=self.limit)
+            self.add_copy_spec(["/var/log/trove/*.log",
+                                "/var/log/containers/trove/*.log"],
+                               sizelimit=self.limit)
 
         self.add_copy_spec('/etc/trove/')
 

--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -36,7 +36,8 @@ class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
             "/var/lib/pacemaker/cib/cib.xml",
             self.defaults,
             "/var/log/pacemaker.log",
-            "/var/log/pcsd/pcsd.log"
+            "/var/log/pcsd/pcsd.log",
+            "/var/log/pacemaker/bundles/*/",
         ])
         self.add_cmd_output([
             "crm_mon -1 -A -n -r -t",

--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -29,6 +29,7 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output("rabbitmqctl list_policies")
 
         self.add_copy_spec("/etc/rabbitmq/*")
-        self.add_copy_spec("/var/log/rabbitmq/*",
+        self.add_copy_spec(["/var/log/rabbitmq/*",
+                            "/var/log/containers/rabbitmq/*"],
                            sizelimit=self.get_option('log_size'))
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/redis.py
+++ b/sos/plugins/redis.py
@@ -32,10 +32,12 @@ class Redis(Plugin, RedHatPlugin):
         self.limit = self.get_option("log_size")
         self.add_cmd_output("redis-cli info")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/redis/redis.log*",
+            self.add_copy_spec(["/var/log/redis/redis.log*",
+                                "/var/log/containers/redis/redis.log*"],
                                sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/redis/redis.log",
+            self.add_copy_spec(["/var/log/redis/redis.log",
+                                "/var/log/containers/redis/redis.log"],
                                sizelimit=self.limit)
 
     def postproc(self):


### PR DESCRIPTION
Add Tripleo Pike opinionated logs paths to be collected
for services, when running in containers. This is a temporary
and will be reworked for Queens, like switching those to syslog
or fluentd shipping logs to Elasticsearch cluster.

Partial bug: https://bugs.launchpad.net/tripleo/+bug/1700909
Related blueprint: https://review.openstack.org/#/c/462900

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
