### PR TITLE
[gnocchi] Tripleo specific containerized services logs

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -38,11 +38,17 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/gnocchi/",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/gnocchi/*",
+                "/var/log/containers/gnocchi/*"],
+                sizelimit=self.limit
+            )
         else:
-            self.add_copy_spec("/var/log/gnocchi/*.log",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/gnocchi/*.log",
+                "/var/log/containers/gnocchi/*.log"],
+                sizelimit=self.limit
+            )
 
         vars = [p in os.environ for p in [
                 'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]


### PR DESCRIPTION
This is an addition to pull request 1046 to collect gnocchi logs
correct when service is running in a container.

Signed-off-by: Martin Schuppert mschuppert@redhat.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
