### PR TITLE
[openstack plugins] run openstack command when correct ENV is set

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -44,9 +44,13 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
             self.add_copy_spec("/var/log/gnocchi/*.log",
                                sizelimit=self.limit)
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -47,9 +47,13 @@ class OpenStackGlance(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -34,9 +34,13 @@ class OpenStackHeat(Plugin):
             suggest_filename="heat_db_version"
         )
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -44,9 +44,13 @@ class OpenStackInstack(Plugin):
             self.add_copy_spec("/var/log/zaqar/*.log",
                                sizelimit=self.limit)
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -40,9 +40,13 @@ class OpenStackIronic(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -44,9 +44,13 @@ class OpenStackKeystone(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -38,9 +38,13 @@ class OpenStackNeutron(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -35,9 +35,13 @@ class OpenStackNova(Plugin):
         self.add_cmd_output("nova-manage fixed list")
         self.add_cmd_output("nova-manage floating list")
 
-        vars = [p in os.environ for p in [
-                'OS_USERNAME', 'OS_PASSWORD', 'OS_TENANT_NAME']]
-        if not all(vars):
+        vars_all = [p in os.environ for p in [
+                    'OS_USERNAME', 'OS_PASSWORD']]
+
+        vars_any = [p in os.environ for p in [
+                    'OS_TENANT_NAME', 'OS_PROJECT_NAME']]
+
+        if not (all(vars_all) and any(vars_any)):
             self.soslog.warning("Not all environment variables set. Source "
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")


### PR DESCRIPTION
With Tripleo Pike the default ENV changed from OS_TENANT_NAME to
OS_PROJECT_NAME. The commands of the openstack plugins against
the env should run when either OSP_TENANT_NAME or OS_PROJECT_NAME
is set.

Signed-off-by: Martin Schuppert mschuppe@redhat.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
