### PR TITLE
[tripleo] Add ui logs

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -75,6 +75,9 @@ class OpenStackInstack(Plugin):
                             deployment + ".log",
                             timeout=600)
 
+            self.add_cmd_output("openstack object save "
+                                "tripleo-ui-logs tripleo-ui.logs --file -")
+
     def postproc(self):
         protected_keys = [
             "UNDERCLOUD_TUSKAR_PASSWORD", "UNDERCLOUD_ADMIN_PASSWORD",


### PR DESCRIPTION
This is attempt number two to add the tripleo-ui logs. The first one is #1042. The stdout streaming for `openstack object save` has been [merged](https://review.openstack.org/#/c/476199/) upstream.

We're using the "openstack" command to stream the ui log file to stdout.

Signed-off-by: Honza Pokorny <honza@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
