### PR TITLE
[openstack plugins] Tripleo specific containerized services configs

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -33,8 +33,17 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
 
     requires_root = False
 
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/gnocchi"
+
     def setup(self):
-        self.add_copy_spec("/etc/gnocchi/")
+        self.add_copy_spec([
+            "/etc/gnocchi/*",
+            self.var_puppet_gen + "/etc/gnocchi/*",
+            self.var_puppet_gen + "/etc/httpd/conf/*",
+            self.var_puppet_gen + "/etc/httpd/conf.d/*",
+            self.var_puppet_gen + "/etc/httpd/conf.modules.d/wsgi.conf",
+            self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
+        ])
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
@@ -70,5 +79,12 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
             r"password=(.*)",
             r"password=*****",
         )
+        self.do_file_sub(
+            self.var_puppet_gen + "/etc/gnocchi/"
+            "gnocchi.conf",
+            r"password=(.*)",
+            r"password=*****",
+        )
+
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/haproxy.py
+++ b/sos/plugins/haproxy.py
@@ -27,7 +27,11 @@ class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
     packages = ('haproxy',)
 
     def setup(self):
-        self.add_copy_spec("/etc/haproxy/haproxy.cfg")
+        var_puppet_gen = "/var/lib/config-data/puppet-generated/haproxy"
+        self.add_copy_spec([
+            "/etc/haproxy/haproxy.cfg",
+            var_puppet_gen + "/etc/haproxy/haproxy.cfg"
+        ])
         self.add_copy_spec("/etc/haproxy/conf.d/*")
         self.add_cmd_output("haproxy -f /etc/haproxy/haproxy.cfg -c")
 

--- a/sos/plugins/iscsi.py
+++ b/sos/plugins/iscsi.py
@@ -25,9 +25,11 @@ class Iscsi(Plugin):
     profiles = ('storage',)
 
     def setup(self):
+        var_puppet_gen = "/var/lib/config-data/puppet-generated/iscsid"
         self.add_copy_spec([
             "/etc/iscsi/iscsid.conf",
             "/etc/iscsi/initiatorname.iscsi",
+            var_puppet_gen + "/etc/iscsi/initiatorname.iscsi",
             "/var/lib/iscsi"
         ])
         self.add_cmd_output([

--- a/sos/plugins/mongodb.py
+++ b/sos/plugins/mongodb.py
@@ -25,11 +25,18 @@ class MongoDb(Plugin, DebianPlugin, UbuntuPlugin):
     profiles = ('services',)
 
     packages = ('mongodb-server',)
-    files = ('/etc/mongodb.conf',)
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/mongodb"
+
+    files = (
+        '/etc/mongodb.conf',
+        var_puppet_gen + '/etc/mongod.conf'
+    )
 
     def setup(self):
         self.add_copy_spec([
             "/etc/mongodb.conf",
+            self.var_puppet_gen + "/etc/",
+            self.var_puppet_gen + "/etc/systemd/system/mongod.service.d/",
             "/var/log/mongodb/mongodb.log",
             "/var/log/containers/mongodb/mongodb.log"
         ])
@@ -37,6 +44,12 @@ class MongoDb(Plugin, DebianPlugin, UbuntuPlugin):
     def postproc(self):
         self.do_file_sub(
             "/etc/mongodb.conf",
+            r"(mms-token\s*=\s*.*)",
+            r"mms-token = ********"
+        )
+
+        self.do_file_sub(
+            self.var_puppet_gen + "/etc/mongodb.conf",
             r"(mms-token\s*=\s*.*)",
             r"mms-token = ********"
         )

--- a/sos/plugins/mysql.py
+++ b/sos/plugins/mysql.py
@@ -93,9 +93,10 @@ class RedHatMysql(Mysql, RedHatPlugin):
         super(RedHatMysql, self).setup()
         self.add_copy_spec([
             "/etc/ld.so.conf.d/mysql-*.conf",
-            "/etc/ld.so.conf.d/mariadb-*.conf"
+            "/etc/ld.so.conf.d/mariadb-*.conf",
+            "/etc/my.cnf.d/*",
+            "/var/lib/config-data/puppet-generated/mysql/etc/my.cnf.d/*"
         ])
-        self.add_copy_spec("/etc/my.cnf.d/*")
 
 
 class DebianMysql(Mysql, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -24,18 +24,25 @@ class OpenStackManila(Plugin):
     profiles = ('openstack', 'openstack_controller')
     option_list = []
 
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/manila"
+
     def setup(self):
-        self.add_copy_spec("/etc/manila/")
+        self.add_copy_spec([
+            "/etc/manila/",
+            self.var_puppet_gen + "/etc/manila/"
+        ])
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec(["/var/log/manila/*",
-                                "/var/log/containers/manila/*"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/manila/*",
+                "/var/log/containers/manila/*"
+            ], sizelimit=self.limit)
         else:
-            self.add_copy_spec(["/var/log/manila/*.log",
-                                "/var/log/containers/manila/*.log"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/manila/*.log",
+                "/var/log/containers/manila/*.log"
+            ], sizelimit=self.limit)
 
     def postproc(self):
         protect_keys = [
@@ -47,6 +54,10 @@ class OpenStackManila(Plugin):
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
         self.do_path_regex_sub("/etc/manila/*", regexp, r"\1*********")
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/manila/*",
+            regexp, r"\1*********"
+        )
 
 
 class DebianManila(OpenStackManila, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -23,22 +23,28 @@ class OpenStackSahara(Plugin):
     profiles = ('openstack', 'openstack_controller')
 
     option_list = []
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/sahara"
 
     def setup(self):
-        self.add_copy_spec("/etc/sahara/")
+        self.add_copy_spec([
+            "/etc/sahara/",
+            self.var_puppet_gen + "/etc/sahara/"
+        ])
         self.add_journal(units="openstack-sahara-all")
         self.add_journal(units="openstack-sahara-api")
         self.add_journal(units="openstack-sahara-engine")
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec(["/var/log/sahara/",
-                                "/var/log/containers/sahara/"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/sahara/",
+                "/var/log/containers/sahara/"
+            ], sizelimit=self.limit)
         else:
-            self.add_copy_spec(["/var/log/sahara/*.log",
-                                "/var/log/containers/sahara/*.log"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/sahara/*.log",
+                "/var/log/containers/sahara/*.log"
+            ], sizelimit=self.limit)
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
@@ -52,6 +58,10 @@ class OpenStackSahara(Plugin):
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
         self.do_path_regex_sub("/etc/sahara/*", regexp, r"\1*********")
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/sahara/*",
+            regexp, r"\1*********"
+        )
 
 
 class DebianSahara(OpenStackSahara, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -26,19 +26,26 @@ class OpenStackTrove(Plugin):
     profiles = ('openstack', 'openstack_controller')
     option_list = []
 
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/trove"
+
     def setup(self):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec(["/var/log/trove/",
-                                "/var/log/containers/trove/"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/trove/",
+                "/var/log/containers/trove/"
+            ], sizelimit=self.limit)
         else:
-            self.add_copy_spec(["/var/log/trove/*.log",
-                                "/var/log/containers/trove/*.log"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/trove/*.log",
+                "/var/log/containers/trove/*.log"
+            ], sizelimit=self.limit)
 
-        self.add_copy_spec('/etc/trove/')
+        self.add_copy_spec([
+            '/etc/trove/',
+            self.var_puppet_gen + '/etc/trove/'
+        ])
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
@@ -53,6 +60,10 @@ class OpenStackTrove(Plugin):
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
         self.do_path_regex_sub("/etc/trove/*", regexp, r"\1*********")
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/trove/*",
+            regexp, r"\1*********"
+        )
 
 
 class DebianTrove(OpenStackTrove, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -20,7 +20,11 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     """
     plugin_name = 'rabbitmq'
     profiles = ('services',)
-    files = ('/etc/rabbitmq/rabbitmq.conf',)
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/rabbitmq"
+    files = (
+        '/etc/rabbitmq/rabbitmq.conf',
+        var_puppet_gen + '/etc/rabbitmq/rabbitmq.config'
+    )
     packages = ('rabbitmq-server',)
 
     def setup(self):
@@ -28,8 +32,16 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output("rabbitmqctl cluster_status")
         self.add_cmd_output("rabbitmqctl list_policies")
 
-        self.add_copy_spec("/etc/rabbitmq/*")
-        self.add_copy_spec(["/var/log/rabbitmq/*",
-                            "/var/log/containers/rabbitmq/*"],
-                           sizelimit=self.get_option('log_size'))
+        self.add_copy_spec([
+            "/etc/rabbitmq/*",
+            self.var_puppet_gen + "/etc/rabbitmq/*",
+            self.var_puppet_gen + "/etc/security/limits.d/",
+            self.var_puppet_gen + "/etc/systemd/"
+        ])
+        self.add_copy_spec([
+            "/var/log/rabbitmq/*",
+            "/var/log/containers/rabbitmq/*"
+        ], sizelimit=self.get_option('log_size'))
+
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add Tripleo Pike opinionated config paths to be collected
for services, when running in containers. Each service has a
config dir in /var/lib/config-data on the host which gets bind
mounted read only into the container.

Signed-off-by: Martin Schuppert <mschuppe@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
