### PR TITLE
[xfs] Remove logprint and add xfs stats

### DIFF
--- a/sos/plugins/xfs.py
+++ b/sos/plugins/xfs.py
@@ -23,8 +23,6 @@ class Xfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     plugin_name = 'xfs'
     profiles = ('storage',)
 
-    option_list = [("logprint", 'gathers the log information', 'slow', False)]
-
     def setup(self):
         mounts = '/proc/mounts'
         ext_fs_regex = r"^(/dev/.+).+xfs\s+"
@@ -33,10 +31,6 @@ class Xfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                 parts = e.split(' ')
                 self.add_cmd_output("xfs_info %s" % (parts[1]))
 
-        if self.get_option('logprint'):
-            for dev in zip(self.do_regex_find_all(ext_fs_regex, mounts)):
-                for e in dev:
-                    parts = e.split(' ')
-                    self.add_cmd_output("xfs_logprint -c %s" % (parts[0]))
+        self.add_copy_spec('/proc/fs/xfs')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Removes the logprint option which wasn't particularly useful for sos to
capture, reference Red Hat Bugzilla 1250035.

Adds collection of /proc/fs/xfs which has useful xfs statistics.

Resolves #621

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
