### PR TITLE
[sosreport] Fix exit status propagation

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -33,6 +33,12 @@ import errno
 import six
 from six.moves import zip, filter
 
+# FileNotFoundError does not exist in 2.7, so map it to IOError
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 def _to_u(s):
     if not isinstance(s, six.text_type):

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -808,8 +808,7 @@ class SoSReport(object):
             pdb.pm()
 
     def _exit(self, error=0):
-        raise SystemExit()
-#        sys.exit(error)
+        raise SystemExit(error)
 
     def get_exit_handler(self):
         def exit_handler(signum, frame):
@@ -1195,9 +1194,9 @@ class SoSReport(object):
             msg += _("Press ENTER to continue, or CTRL-C to quit.\n")
             try:
                 input(msg)
-            except:
+            except Exception as err:
                 self.ui_log.info("")
-                self._exit()
+                self._exit(err)
 
     def _log_plugin_exception(self, plugin, method):
         trace = traceback.format_exc()
@@ -1610,7 +1609,7 @@ class SoSReport(object):
 
             return self.final_work()
 
-        except (OSError, SystemExit, KeyboardInterrupt):
+        except (OSError, SystemExit, KeyboardInterrupt) as to_be_raised:
             try:
                 # archive and tempfile cleanup may fail due to a fatal
                 # OSError exception (ENOSPC, EROFS etc.).
@@ -1622,6 +1621,8 @@ class SoSReport(object):
                     rmtree(self.tmpdir)
             except:
                 raise
+
+            self._exit(to_be_raised)
 
         return False
 


### PR DESCRIPTION
This fixes exit status propagation so that sos will now properly exit
with a non-zero exit code when appropriate, such as when a keyboard
interrupt is issued.

Additionally, this fixes an issue when a NameError would be hit when
using --debug due to FileNotFoundError not existing in python 2.7.

Resolves #672

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
