### PR TITLE
[kernel] Just use modinfo as filename

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -34,7 +34,8 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         try:
             modules = os.listdir(self.sys_module)
-            self.add_cmd_output("modinfo " + " ".join(modules))
+            self.add_cmd_output("modinfo " + " ".join(modules),
+                                suggest_filename="modinfo_ALL_MODULES")
         except OSError:
             self._log_warn("could not list %s" % self.sys_module)
 
@@ -63,6 +64,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/sys/module/*/initstate",
             "/sys/module/*/refcnt",
             "/sys/module/*/taint",
+            "/sys/module/*/version",
             "/sys/firmware/acpi/*",
             "/proc/kallsyms",
             "/proc/buddyinfo",


### PR DESCRIPTION
We've found the modinfo autogenerated name ends up being too long
for some filesystems (specifically ecryptfs).  This just changes
the name to modinfo.  It used to be something like:
modinfo_cpuidle_pcie_aspm_ccp_kernel_pstore_edac_core_pci_hotplug_
rcupdate_mousedev_vt_x_tables_processor_lp_r8169_8250_snd_hda_
intel_xen_netfront_crypto_simd_efivars_i2c_piix4_sysimgblt
_pciehp_macvlan_i2c_designware_core_gpio_generic_uvcvideo_usbhid_ther

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
 [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
 [x] Is the subject and message clear and concise?
 [x] Does the subject start with [plugin_name] if submitting a plugin patch or a [section_name] if part of the core sosreport code?
 [x] Does the commit contain a Signed-off-by: First Lastname email@example.com?
