### PR TITLE
[block] Add the output of 'lsblk -t'

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -26,6 +26,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_cmd_output([
             "lsblk",
+            "lsblk -t",
             "blkid -c /dev/null",
             "blockdev --report",
             "ls -lanR /dev",


### PR DESCRIPTION
The output of 'lsblk -t' provides very useful information
about the device's topology, like alignment offset,
minimum io size, optimal io size, and others. It is
equivalent to running lsblk with options:

-o NAME,ALIGNMENT,MIN-IO,OPT-IO,PHY-SEC,LOG-SEC,ROTA,SCHED,
RQ-SIZE,WSAME

With this improvement to the block plugin  we can see at one
glance data available in different places like sysfs,
fdisk and/or parted, as well as data not available in the
sosreport nowadays, like
/sys/block/<device>/queue/rotational .

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
