### PR TITLE
[plugins] add unpackaged plugin

### DIFF
--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -73,3 +73,5 @@ class Unpackaged(Plugin, RedHatPlugin):
         not_packaged = [x for x in all_fsystem if x not in all_frpm]
         not_packaged_expanded = format_output(not_packaged)
         self.add_string_as_file('\n'.join(not_packaged_expanded), 'unpackaged')
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -43,7 +43,8 @@ class Unpackaged(Plugin, RedHatPlugin):
 
             for root, dirs, files in os.walk(path, topdown=True):
                 if exclude:
-                    dirs[:] = [d for d in dirs if dirs not in exclude]
+                    for e in exclude:
+                        dirs[:] = [d for d in dirs if d not in e]
                 for name in files:
                     file_list.append(os.path.join(root, name))
                 for name in dirs:

--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -66,8 +66,8 @@ class Unpackaged(Plugin, RedHatPlugin):
             return expanded
 
         all_fsystem = []
-        all_frpm = set(self.policy().mangle_package_path(
-                       self.policy().package_manager.files))
+        all_frpm = set(self.policy.mangle_package_path(
+                       self.policy.package_manager.files))
         for d in get_env_path_list():
             all_fsystem += all_files_system(d)
         not_packaged = [x for x in all_fsystem if x not in all_frpm]

--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -1,0 +1,75 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+import os
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class Unpackaged(Plugin, RedHatPlugin):
+    '''
+    Collects a list of files that are not handled by the package
+    manager
+    '''
+
+    def setup(self):
+
+        def get_env_path_list():
+            """
+            It returns a list of directories contained in the $PATH var
+            """
+            return os.environ['PATH'].split(':')
+
+        def all_files_system(path, exclude=None):
+            """
+            path: string
+            exclude: list
+
+            It returns a list of all files installed on a system.
+            It excludes all the files in the directories listed in 'exclude'
+            """
+            file_list = []
+
+            for root, dirs, files in os.walk(path, topdown=True):
+                if exclude:
+                    dirs[:] = [d for d in dirs if dirs not in exclude]
+                for name in files:
+                    file_list.append(os.path.join(root, name))
+                for name in dirs:
+                    file_list.append(os.path.join(root, name))
+
+            return file_list
+
+        def format_output(files):
+            """
+            files: list
+
+            It returns a better formatted string in case we have symlinks
+            """
+            expanded = []
+            for f in files:
+                if os.path.islink(f):
+                    expanded.append("{} -> {}".format(f, os.readlink(f)))
+                else:
+                    expanded.append(f)
+            return expanded
+
+        all_fsystem = []
+        all_frpm = set(self.policy().mangle_package_path(
+                       self.policy().package_manager.files))
+        for d in get_env_path_list():
+            all_fsystem += all_files_system(d)
+        not_packaged = [x for x in all_fsystem if x not in all_frpm]
+        not_packaged_expanded = format_output(not_packaged)
+        self.add_string_as_file('\n'.join(not_packaged_expanded), 'unpackaged')

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -62,12 +62,15 @@ class PackageManager(object):
     chroot = None
 
     def __init__(self, chroot=None, query_command=None,
-                 verify_command=None, verify_filter=None):
+                 verify_command=None, verify_filter=None,
+                 grab_files=None):
         self.packages = {}
+        self.files = []
 
         self.query_command = query_command if query_command else None
         self.verify_command = verify_command if verify_command else None
         self.verify_filter = verify_filter if verify_filter else None
+        self.grab_files = grab_files if grab_files else None
 
         if chroot:
             self.chroot = chroot
@@ -139,6 +142,17 @@ class PackageManager(object):
         version, release, arch = fields[-3:]
         name = "-".join(fields[:-3])
         return (name, version, release, arch)
+
+    def all_files(self):
+        """
+        Returns a list of files known by the package manager
+        """
+        if self.grab_files:
+            cmd = self.grab_files
+            self.files = shell_out(
+                cmd, timeout=0, chroot=self.chroot
+            )['output'].splitlines()
+        return self.files
 
     def build_verify_command(self, packages):
         """build_verify_command(self, packages) -> str

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -151,7 +151,7 @@ class PackageManager(object):
             cmd = self.grab_files
             self.files = shell_out(
                 cmd, timeout=0, chroot=self.chroot
-            )['output'].splitlines()
+            ).splitlines()
         return self.files
 
     def build_verify_command(self, packages):


### PR DESCRIPTION
This adds a plugin named 'unpackaged'.
It collects a list of files that are not handled by the package manager (it support for now only RHEL
and Fedora distros).
If a file is a link, it will be listed as 'link -> target'.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
