### PR TITLE
Use ip -s -s neigh show for displaying L2 addresses

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -177,7 +177,7 @@ class Networking(Plugin):
             "ifenslave -a",
             "ip mroute show",
             "ip maddr show",
-            "ip neigh show",
+            "ip -s -s neigh show",
             "ip neigh show nud noarp",
             "biosdevname -d",
             "tc -s qdisc show",


### PR DESCRIPTION
Currently we do this:
$ ip neigh show
172.16.16.254 dev wlp3s0 lladdr 00:0d:b9:37:2e:71 STALE
172.16.11.5 dev enp0s25 lladdr d0:50:99:19:29:eb REACHABLE
172.16.15.254 dev enp0s25 lladdr 00:0d:b9:37:2e:70 REACHABLE
172.16.11.113 dev enp0s25  FAILED

It is often quite useful to understand what the lifetime of those
L2 addresses are:
$ ip -s -s neigh show
172.16.16.254 dev wlp3s0 lladdr 00:0d:b9:37:2e:71 used 179/174/54 probes 1 STALE
172.16.11.5 dev enp0s25 lladdr d0:50:99:19:29:eb ref 1 used 22/22/22 probes 1 REACHABLE
172.16.15.254 dev enp0s25 lladdr 00:0d:b9:37:2e:70 ref 1 used 32571/1/0 probes 4 REACHABLE
172.16.11.113 dev enp0s25  used 18194/18284/18192 probes 6 FAILED

Signed-Off-By: Michele Baldessari <michele@acksyn.org>