### PR TITLE
[ovirt] Obfuscate passwords in backup config files.

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -48,7 +48,7 @@ class Ovirt(Plugin, RedHatPlugin):
         /etc/
         (rhevm|ovirt-engine|ovirt-engine-dwh)/
         (engine.conf|ovirt-engine-dwhd.conf)
-        (\.d/.+.conf)?
+        (\.d/.+.conf.*?)?
         $
         """
     )


### PR DESCRIPTION
Previously, backup copies of config files under /etc/ovirt-engine would
not be obfuscated properly. This patch corrects this by also matching
any string following '.conf' in the file name.

Resolves #1074

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
