### PR TITLE
[rpm] --verify option to check also SSL related packages

### DIFF
--- a/sos/plugins/rpm.py
+++ b/sos/plugins/rpm.py
@@ -32,6 +32,7 @@ class Rpm(Plugin, RedHatPlugin):
         'java.*', 'perl.*',
         'rpm', 'yum',
         'spacewalk.*',
+        'zlib', 'openssl.*', 'nss.*',
     ]
 
     def setup(self):


### PR DESCRIPTION
--verify option shall also check zlib, openssl* and nss* packages

Having those packages improperly installed often causes system-wide problems as well.

Resolves: #1079

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
