### PR TITLE
[chrony] add and modify chronyc commands

### DIFF
--- a/sos/plugins/chrony.py
+++ b/sos/plugins/chrony.py
@@ -36,7 +36,7 @@ class Chrony(Plugin, RedHatPlugin):
             "chronyc sourcestats",
             "chronyc serverstats",
             "chronyc ntpdata",
-            "chronyc clients"
+            "chronyc -n clients"
         ])
         self.add_journal(units="chronyd")
 

--- a/sos/plugins/chrony.py
+++ b/sos/plugins/chrony.py
@@ -30,9 +30,12 @@ class Chrony(Plugin, RedHatPlugin):
             "/var/lib/chrony/drift"
         ])
         self.add_cmd_output([
+            "chronyc activity",
             "chronyc tracking",
             "chronyc sources",
             "chronyc sourcestats",
+            "chronyc serverstats",
+            "chronyc ntpdata",
             "chronyc clients"
         ])
         self.add_journal(units="chronyd")


### PR DESCRIPTION
This adds few more chronyc commands to the plugin, which can be very useful in debugging. It also adds the -n option to the chronyc clients command to avoid a significant slowdown with a large number of clients.

---

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
