### PR TITLE
[apache|logs|nscd] honour --all-logs

### DIFF
--- a/sos/plugins/apache.py
+++ b/sos/plugins/apache.py
@@ -55,22 +55,25 @@ class RedHatApache(Apache, RedHatPlugin):
 
         self.add_forbidden_path("/etc/httpd/conf/password.conf")
 
+        # determine how much logs to collect
+        self.limit = None if self.get_option("all_logs") else 5
+
         # collect only the current log set by default
-        self.add_copy_spec("/var/log/httpd/access_log", 5)
-        self.add_copy_spec("/var/log/httpd/error_log", 5)
-        self.add_copy_spec("/var/log/httpd/ssl_access_log", 5)
-        self.add_copy_spec("/var/log/httpd/ssl_error_log", 5)
+        self.add_copy_spec("/var/log/httpd/access_log", self.limit)
+        self.add_copy_spec("/var/log/httpd/error_log", self.limit)
+        self.add_copy_spec("/var/log/httpd/ssl_access_log", self.limit)
+        self.add_copy_spec("/var/log/httpd/ssl_error_log", self.limit)
         # JBoss Enterprise Web Server 2.x
-        self.add_copy_spec("/var/log/httpd22/access_log", 5)
-        self.add_copy_spec("/var/log/httpd22/error_log", 5)
-        self.add_copy_spec("/var/log/httpd22/ssl_access_log", 5)
-        self.add_copy_spec("/var/log/httpd22/ssl_error_log", 5)
+        self.add_copy_spec("/var/log/httpd22/access_log", self.limit)
+        self.add_copy_spec("/var/log/httpd22/error_log", self.limit)
+        self.add_copy_spec("/var/log/httpd22/ssl_access_log", self.limit)
+        self.add_copy_spec("/var/log/httpd22/ssl_error_log", self.limit)
         # Red Hat JBoss Web Server 3.x
-        self.add_copy_spec("/var/log/httpd24/access_log", 5)
-        self.add_copy_spec("/var/log/httpd24/error_log", 5)
-        self.add_copy_spec("/var/log/httpd24/ssl_access_log", 5)
-        self.add_copy_spec("/var/log/httpd24/ssl_error_log", 5)
-        if self.get_option("log"):
+        self.add_copy_spec("/var/log/httpd24/access_log", self.limit)
+        self.add_copy_spec("/var/log/httpd24/error_log", self.limit)
+        self.add_copy_spec("/var/log/httpd24/ssl_access_log", self.limit)
+        self.add_copy_spec("/var/log/httpd24/ssl_error_log", self.limit)
+        if self.get_option("log") or self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/httpd/*",
                 # JBoss Enterprise Web Server 2.x
@@ -90,10 +93,13 @@ class DebianApache(Apache, DebianPlugin, UbuntuPlugin):
             "/etc/default/apache2"
         ])
 
+        # determine how much logs to collect
+        self.limit = None if self.get_option("all_logs") else 15
+
         # collect only the current log set by default
-        self.add_copy_spec("/var/log/apache2/access_log", 15)
-        self.add_copy_spec("/var/log/apache2/error_log", 15)
-        if self.get_option("log"):
+        self.add_copy_spec("/var/log/apache2/access_log", self.limit)
+        self.add_copy_spec("/var/log/apache2/error_log", self.limit)
+        if self.get_option("log") or self.get_option("all_logs"):
             self.add_copy_spec("/var/log/apache2/*")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -29,7 +29,8 @@ class Logs(Plugin):
             "/etc/rsyslog.d"
         ])
 
-        self.limit = self.get_option("log_size")
+        self.limit = (None if self.get_option("all_logs")
+                      else self.get_option("log_size"))
         self.add_copy_spec("/var/log/boot.log", sizelimit=self.limit)
         self.add_copy_spec("/var/log/cloud-init*", sizelimit=self.limit)
         self.add_journal(boot="this")

--- a/sos/plugins/nscd.py
+++ b/sos/plugins/nscd.py
@@ -30,10 +30,12 @@ class Nscd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_copy_spec("/etc/nscd.conf")
 
+        self.limit = (None if self.get_option("all_logs")
+                      else self.get_option("log_size"))
         opt = self.file_grep(r"^\s*logfile", "/etc/nscd.conf")
         if (len(opt) > 0):
             for o in opt:
                 f = o.split()
-                self.add_copy_spec(f[1], sizelimit=self.get_option("log_size"))
+                self.add_copy_spec(f[1], sizelimit=self.limit)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The three plug-ins partially or completely ignore --all-logs option. This PR applies the option completely to the plug-ins.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
