### PR TITLE
[networking] collect "ip address" with all details

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -173,7 +173,7 @@ class Networking(Plugin):
             "ip -4 rule",
             "ip -6 rule",
             "ip -s -d link",
-            "ip address",
+            "ip -d address",
             "ifenslave -a",
             "ip mroute show",
             "ip maddr show",


### PR DESCRIPTION
Call "ip -d address" to collect all details instead of
"ip address" only.

Resolves: #1084

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
