### PR TITLE
[openstack_keystone] collect domain specific config

### DIFF
--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -45,6 +45,15 @@ class OpenStackKeystone(Plugin):
                                 "/var/log/containers/keystone/*.log"],
                                sizelimit=self.limit)
 
+        # collect domain config directory, if exists
+        self.domain_config_dir_added = False
+        self.domain_config_dir = self.get_cmd_output_now(
+                "openstack-config --get /etc/keystone/keystone.conf "
+                "identity domain_config_dir")
+        if self.domain_config_dir and os.path.isdir(self.domain_config_dir):
+            self.add_copy_spec(self.domain_config_dir)
+            self.domain_config_dir_added = True
+
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
@@ -71,6 +80,11 @@ class OpenStackKeystone(Plugin):
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
         self.do_path_regex_sub("/etc/keystone/*", regexp, r"\1*********")
+
+        # obfuscate LDAP plaintext passwords in domain config dir, if collected
+        if self.domain_config_dir_added:
+            self.do_path_regex_sub(self.domain_config_dir,
+                                   r"((?m)^\s*(%s)\s*=\s*)(.*)", r"\1********")
 
 
 class DebianKeystone(OpenStackKeystone, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Collect domain config directory if it exists.

Resolves: #1086

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
