### PR TITLE
xfs: Add xfs_admin information

### DIFF
--- a/sos/plugins/cifs.py
+++ b/sos/plugins/cifs.py
@@ -1,0 +1,30 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class Cifs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """Cifs filesystem
+    """
+    packages = ('cifs-utils',)
+    plugin_name = "cifs"
+    profiles = ('storage',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/proc/fs/cifs"
+        ])
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/xfs.py
+++ b/sos/plugins/xfs.py
@@ -32,6 +32,7 @@ class Xfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             for e in dev:
                 parts = e.split(' ')
                 self.add_cmd_output("xfs_info %s" % (parts[1]))
+                self.add_cmd_output("xfs_admin -l -u %s" % (parts[1]))
 
         if self.get_option('logprint'):
             for dev in zip(self.do_regex_find_all(ext_fs_regex, mounts)):


### PR DESCRIPTION
Some information about xfs volumes is unavailable when using
xfs_info, namely UUId an label of the volume. This information
is sometimes needed to debug other facilities.

Signed-off-by: Thiago Rafael Becker <thiago.becker@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
