### PR TITLE
[autofs] Pull autofs maps

### DIFF
--- a/sos/plugins/autofs.py
+++ b/sos/plugins/autofs.py
@@ -50,6 +50,7 @@ class Autofs(Plugin):
     def setup(self):
         self.add_copy_spec("/etc/auto*")
         self.add_cmd_output("/etc/init.d/autofs status")
+        self.add_cmd_output("automount -m")
         if self.checkdebug():
             self.add_copy_spec(self.getdaemondebug())
 


### PR DESCRIPTION
Add `automount -m` output, as it is useful when debugging
autofs issues.

Signed-off-by: Thiago Rafael Becker <thiago.becker@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
