### PR TITLE
[filesys] call df commands with autofs excluded

### DIFF
--- a/sos/plugins/filesys.py
+++ b/sos/plugins/filesys.py
@@ -36,9 +36,9 @@ class Filesys(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/mounts"
         ])
         self.add_cmd_output("mount -l", root_symlink="mount")
-        self.add_cmd_output("df -al", root_symlink="df")
+        self.add_cmd_output("df -al -x autofs", root_symlink="df")
         self.add_cmd_output([
-            "df -ali",
+            "df -ali -x autofs",
             "findmnt"
         ])
 


### PR DESCRIPTION
To prevent timeouts of "df" commands when using a huge amount of
direct mappings on autofs.

Resolves: #1093

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
