### PR TITLE
[policies] stop execution on Ctrl+C during user input

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -432,7 +432,7 @@ class LinuxPolicy(Policy):
                                        "that you are generating this "
                                        "report for [%s]: ") % caseid)
                 self._print()
-            except:
+            except Exception:
                 self._print()
                 self.report_name = localname
 


### PR DESCRIPTION
When pressing Ctrl+C during user input (name and case id), sosreport
treats that as an empty string and starts to collect data. It must
terminate instead.

It is sufficient to not catch BaseException in the relevant try block.

Resolves: #1094

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
