### PR TITLE
[networking] call iptables -L only when iptable_filter module is loaded

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -182,9 +182,15 @@ class Networking(Plugin):
             "biosdevname -d",
             "tc -s qdisc show",
             "ip -s macsec show",
-            "iptables -vnxL",
-            "ip6tables -vnxL"
         ])
+
+        # When iptables is called it will load the modules
+        # iptables and iptables_filter if they are not loaded.
+        # The same goes for ipv6.
+        if self.check_ext_prog("grep -q iptable_filter /proc/modules"):
+            self.add_cmd_output("iptables -vnxL")
+        if self.check_ext_prog("grep -q ip6table_filter /proc/modules"):
+            self.add_cmd_output("ip6tables -vnxL")
 
         # There are some incompatible changes in nmcli since
         # the release of NetworkManager >= 0.9.9. In addition,


### PR DESCRIPTION
If iptables_filter kernel module isn't loaded, dont call
"iptables -vnxL" that would load that plugin.

The same applies to ip6tables as well.

Kudos to @sbradley7777 to identify the cause and to provide the patch.

Resolves: #1095

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
