### PR TITLE
[docker] Collect new registry config location

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -105,7 +105,8 @@ class RedHatDocker(Docker, RedHatPlugin):
         super(RedHatDocker, self).setup()
 
         self.add_copy_spec([
-            "/etc/udev/rules.d/80-docker.rules"
+            "/etc/udev/rules.d/80-docker.rules",
+            "/etc/containers/"
         ])
 
 


### PR DESCRIPTION
For the Red Hat release of docker, registries are now configured in
/etc/containers/registries.conf instead of /etc/sysconfig/docker.

This patch adds collection of /etc/containers to collect registry
configuration files. /etc/sysconfig/docker can still be used for daemon
configuration, so that is still collected.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
