### PR TITLE
[kubernetes] Collect metrics from master

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -83,10 +83,12 @@ class kubernetes(Plugin, RedHatPlugin):
                 'services'
             ]
 
-            # nodes and pvs are not namespaced, must pull separately
+            # nodes and pvs are not namespaced, must pull separately.
+            # Also collect master metrics
             self.add_cmd_output([
                 "{} get -o json nodes".format(kube_cmd),
-                "{} get -o json pv".format(kube_cmd)
+                "{} get -o json pv".format(kube_cmd),
+                "{} get --raw /metrics".format(kube_cmd)
             ])
 
             for n in knsps:


### PR DESCRIPTION
Add an invocation to `kubectl get --raw /metrics` to obtain metrics from the kubernetes master.

This is related to/inspired from #1076 but does not collect metrics from nodes, only from the master. Collecting information from nodes is more involved as we'd need to process the node list - and also I'm not sure if we want to always want to collect that from all nodes.

This PR is a much simpler addition that collects master's metrics, which are useful on their own.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
