### PR TITLE
[rabbitmq] Mask default password in rabbitmq.conf

### DIFF
--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -60,5 +60,8 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/var/log/containers/rabbitmq/*"
         ], sizelimit=self.get_option('log_size'))
 
+    def postproc(self):
+        self.do_file_sub("/etc/rabbitmq/rabbitmq.conf",
+                         r"(\s*default_pass\s*,\s*)\S+", r"\1<<***>>},")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Use do_file_sub() to mask the default password in
the config file /etc/rabbitmq/rabbitmq.conf, to resolve
 #840.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
