### PR TITLE
[pacemaker] Clean up Pacemaker plugin and grab new log locations

### DIFF
--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -36,11 +36,19 @@ class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         self.add_copy_spec([
+            # Pacemaker cluster configuration file
             "/var/lib/pacemaker/cib/cib.xml",
-            self.defaults,
+
+            # Pacemaker 2.x default log locations
+            "/var/log/cluster/pacemaker.log",
+            "/var/log/cluster/bundles/*/",
+
+            # Pacemaker 1.x default log locations
             "/var/log/pacemaker.log",
-            "/var/log/pcsd/pcsd.log",
             "/var/log/pacemaker/bundles/*/",
+
+            self.defaults,
+            "/var/log/pcsd/pcsd.log",
         ])
         self.add_cmd_output([
             "crm_mon -1 -A -n -r -t",
@@ -76,9 +84,9 @@ class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
                             (crm_scrub, crm_dest, crm_from),
                             chroot=self.tmp_in_sysroot())
 
-        # collect user-defined logfiles, matching pattern:
-        # PCMK_loggfile=filename
-        # specified in the pacemaker defaults file.
+        # collect user-defined logfiles, matching a shell-style syntax:
+        #   PCMK_logfile=filename
+        # specified in the pacemaker start-up environment file.
         pattern = '^\s*PCMK_logfile=[\'\"]?(\S+)[\'\"]?\s*(\s#.*)?$'
         if os.path.isfile(self.defaults):
             with open(self.defaults) as f:

--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -74,12 +74,16 @@ class Pacemaker(Plugin):
             "/var/lib/pacemaker/cib/cib.xml",
 
             # Pacemaker 2.x default log locations
-            "/var/log/cluster/pacemaker.log",
-            "/var/log/cluster/bundles/*/",
+            "/var/log/pacemaker/pacemaker.log",
+            "/var/log/pacemaker/bundles/*/",
 
             # Pacemaker 1.x default log locations
             "/var/log/pacemaker.log",
             "/var/log/pacemaker/bundles/*/",
+
+            # Common user-specified locations
+            "/var/log/cluster/pacemaker.log",
+            "/var/log/cluster/bundles/*/",
         ])
 
         self.setup_crm_mon()

--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -23,7 +23,10 @@ class Pacemaker(Plugin, DebianPlugin, UbuntuPlugin):
 
     plugin_name = "pacemaker"
     profiles = ("cluster", )
-    packages = ["pacemaker"]
+    packages = (
+        "pacemaker",
+        "pacemaker-remote",
+    )
     defaults = "/etc/default/pacemaker"
 
     option_list = [


### PR DESCRIPTION
Pacemaker upstream is planning to change the default log location with its 2.0 release, so prepare for that now. Also clean up a few minor issues with the plugin.
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
