### PR TITLE
[plugins] Don't tail gzipped files when reaching sizelimit

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -81,6 +81,15 @@ def _node_type(st):
             return t[1]
 
 
+def _file_is_archive(_file):
+    """ check if the file is an archive - used to decide if we can tail it or
+    skip if sizelimit is reached.
+    The check is done heuristically just by comparing file suffix against four
+    most often used archive algorithms.
+    """
+    return _file.endswith(('.gz', '.xz', '.bz', '.bz2'))
+
+
 class Plugin(object):
     """ This is the base class for sosreport plugins. Plugins should subclass
     this and set the class variables where applicable.
@@ -555,7 +564,7 @@ class Plugin(object):
                     break
                 self._add_copy_paths([_file])
 
-            if limit_reached and tailit:
+            if limit_reached and tailit and not _file_is_archive(_file):
                 file_name = _file
 
                 if file_name[0] == os.sep:

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -517,6 +517,9 @@ class Plugin(object):
         file in a glob is too large it will be tailed to meet the sizelimit.
         """
 
+        if self.get_option('all_logs'):
+            sizelimit = None
+
         if sizelimit:
             sizelimit *= 1024 * 1024  # in MB
 

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -90,7 +90,7 @@ class EnablerPlugin(Plugin):
 
 
 class MockOptions(object):
-    pass
+    all_logs = False
 
 
 class PluginToolTests(unittest.TestCase):


### PR DESCRIPTION
In case sizelimit in add_copy_spec is reached and tailit=True, we shall
skip tailing a gzip archive that would be collected as damaged.
    
Resolves: #907
    
Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
