### PR TITLE
[postgresql] Run on -common package being present too

### DIFF
--- a/sos/plugins/postgresql.py
+++ b/sos/plugins/postgresql.py
@@ -30,7 +30,7 @@ class PostgreSQL(Plugin):
     plugin_name = "postgresql"
     profiles = ('services',)
 
-    packages = ('postgresql',)
+    packages = ('postgresql', 'postgresql-common')
 
     tmp_dir = None
 


### PR DESCRIPTION
On Ubuntu and Debian the postgresql package is a meta
package pointing to the latest postgresql package. It's
not required to be installed to have postgresql.

This adds checking for postgresql-common package which has
to be installed if they are running a server.

Closes: #1103

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
