### PR TITLE
[utilities] Allow size limits for command output

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -606,7 +606,7 @@ class Plugin(object):
 
     def get_command_output(self, prog, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None,
-                           binary=False):
+                           binary=False, sizelimit=None):
         if chroot or self.commons['cmdlineopts'].chroot == 'always':
             root = self.sysroot
         else:
@@ -614,7 +614,8 @@ class Plugin(object):
 
         result = sos_get_command_output(prog, timeout=timeout, stderr=stderr,
                                         chroot=root, chdir=runat,
-                                        env=env, binary=binary)
+                                        env=env, binary=binary,
+                                        sizelimit=sizelimit)
 
         if result['status'] == 124:
             self._log_warn("command '%s' timed out after %ds"
@@ -652,14 +653,16 @@ class Plugin(object):
 
     def _add_cmd_output(self, cmd, suggest_filename=None,
                         root_symlink=None, timeout=300, stderr=True,
-                        chroot=True, runat=None, env=None, binary=False):
+                        chroot=True, runat=None, env=None, binary=False,
+                        sizelimit=None):
         """Internal helper to add a single command to the collection list."""
         cmdt = (
             cmd, suggest_filename,
             root_symlink, timeout, stderr,
-            chroot, runat, env, binary
+            chroot, runat, env, binary, sizelimit
         )
-        _tuplefmt = "('%s', '%s', '%s', %s, '%s', '%s', '%s', '%s', '%s')"
+        _tuplefmt = ("('%s', '%s', '%s', %s, '%s', '%s', '%s', '%s', '%s', "
+                     "'%s')")
         _logstr = "packed command tuple: " + _tuplefmt
         self._log_debug(_logstr % cmdt)
         self.collect_cmds.append(cmdt)
@@ -667,8 +670,12 @@ class Plugin(object):
 
     def add_cmd_output(self, cmds, suggest_filename=None,
                        root_symlink=None, timeout=300, stderr=True,
-                       chroot=True, runat=None, env=None, binary=False):
+                       chroot=True, runat=None, env=None, binary=False,
+                       sizelimit=None):
         """Run a program or a list of programs and collect the output"""
+        if sizelimit is None:
+            sizelimit = int(self.get_option('log_size'))
+
         if isinstance(cmds, six.string_types):
             cmds = [cmds]
         if len(cmds) > 1 and (suggest_filename or root_symlink):
@@ -676,7 +683,7 @@ class Plugin(object):
         for cmd in cmds:
             self._add_cmd_output(cmd, suggest_filename,
                                  root_symlink, timeout, stderr,
-                                 chroot, runat, env, binary)
+                                 chroot, runat, env, binary, sizelimit)
 
     def get_cmd_output_path(self, name=None, make=True):
         """Return a path into which this module should store collected
@@ -733,14 +740,15 @@ class Plugin(object):
     def get_cmd_output_now(self, exe, suggest_filename=None,
                            root_symlink=False, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None,
-                           binary=False):
+                           binary=False, sizelimit=None):
         """Execute a command and save the output to a file for inclusion in the
         report.
         """
         start = time()
         result = self.get_command_output(exe, timeout=timeout, stderr=stderr,
                                          chroot=chroot, runat=runat,
-                                         env=env, binary=binary)
+                                         env=env, binary=binary,
+                                         sizelimit=sizelimit)
         self._log_debug("collected output of '%s' in %s"
                         % (exe.split()[0], time() - start))
 
@@ -789,7 +797,7 @@ class Plugin(object):
 
     def add_journal(self, units=None, boot=None, since=None, until=None,
                     lines=None, allfields=False, output=None, timeout=None,
-                    identifier=None, catalog=None):
+                    identifier=None, catalog=None, sizelimit=None):
         """ Collect journald logs from one of more units.
 
         Keyword arguments:
@@ -811,6 +819,8 @@ class Plugin(object):
         identifier -- an optional message identifier.
         catalog    -- If True, augment lines with descriptions from the
                    system catalog.
+        sizelimit  -- Limit to the size of output returned in MB. Defaults
+                      to --log-size
         """
         journal_cmd = "journalctl --no-pager "
         unit_opt = " --unit %s"
@@ -857,8 +867,13 @@ class Plugin(object):
         if output:
             journal_cmd += output_opt % output
 
+        if sizelimit is None:
+            sizelimit = max(100, int(self.get_option('log_size')))
+
         self._log_debug("collecting journal: %s" % journal_cmd)
-        self._add_cmd_output(journal_cmd, None, None, timeout)
+        self._add_cmd_output(journal_cmd, None, None, timeout,
+                             sizelimit=sizelimit
+                             )
 
     def _expand_copy_spec(self, copyspec):
         return glob.glob(copyspec)
@@ -876,16 +891,18 @@ class Plugin(object):
                 timeout,
                 stderr,
                 chroot, runat,
-                env, binary
+                env, binary,
+                sizelimit
             ) = progs[0]
             self._log_debug(("unpacked command tuple: " +
                              "('%s', '%s', '%s', %s, '%s', '%s', '%s', '%s'," +
-                             "'%s')") % progs[0])
+                             "'%s %s')") % progs[0])
             self._log_info("collecting output of '%s'" % prog)
             self.get_cmd_output_now(prog, suggest_filename=suggest_filename,
                                     root_symlink=root_symlink, timeout=timeout,
                                     stderr=stderr, chroot=chroot, runat=runat,
-                                    env=env, binary=binary)
+                                    env=env, binary=binary,
+                                    sizelimit=sizelimit)
 
     def _collect_strings(self):
         for string, file_name in self.copy_strings:

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -23,8 +23,10 @@ import fnmatch
 import errno
 import shlex
 import glob
+import threading
 
 from contextlib import closing
+from collections import deque
 
 # PYCOMPAT
 import six
@@ -111,7 +113,7 @@ def is_executable(command):
 
 def sos_get_command_output(command, timeout=300, stderr=False,
                            chroot=None, chdir=None, env=None,
-                           binary=False):
+                           binary=False, sizelimit=None):
     """Execute a command and return a dictionary of status and output,
     optionally changing root or current working directory before
     executing command.
@@ -153,7 +155,11 @@ def sos_get_command_output(command, timeout=300, stderr=False,
                   stderr=STDOUT if stderr else PIPE,
                   bufsize=-1, env=cmd_env, close_fds=True,
                   preexec_fn=_child_prep_fn)
-        stdout, stderr = p.communicate()
+
+        reader = AsyncReader(p.stdout, sizelimit, binary)
+        stdout = reader.get_contents()
+        p.poll()
+
     except OSError as e:
         if e.errno == errno.ENOENT:
             return {'status': 127, 'output': ""}
@@ -165,7 +171,7 @@ def sos_get_command_output(command, timeout=300, stderr=False,
 
     return {
         'status': p.returncode,
-        'output': stdout if binary else stdout.decode('utf-8', 'ignore')
+        'output': stdout
     }
 
 
@@ -191,6 +197,55 @@ def shell_out(cmd, timeout=30, chroot=None, runat=None):
     """
     return sos_get_command_output(cmd, timeout=timeout,
                                   chroot=chroot, chdir=runat)['output']
+
+
+class AsyncReader(threading.Thread):
+    '''Used to limit command output to a given size without deadlocking
+    sos.
+
+    Takes a sizelimit value in MB, and will compile stdout from Popen into a
+    string that is limited to the given sizelimit.
+    '''
+
+    def __init__(self, channel, sizelimit, binary):
+        super(AsyncReader, self).__init__()
+        self.chan = channel
+        self.binary = binary
+        self.chunksize = 2048
+        slots = None
+        if sizelimit:
+            sizelimit = sizelimit * 1048576  # convert to bytes
+            slots = sizelimit / self.chunksize
+        self.deque = deque(maxlen=slots)
+        self.start()
+        self.join()
+
+    def run(self):
+        '''Reads from the channel (pipe) that is the output pipe for a
+        called Popen. As we are reading from the pipe, the output is added
+        to a deque. After the size of the deque exceeds the sizelimit
+        earlier (older) entries are removed.
+
+        This means the returned output is chunksize-sensitive, but is not
+        really byte-sensitive.
+        '''
+        try:
+            while True:
+                line = self.chan.read(self.chunksize)
+                if not line:
+                    # Pipe can remain open after output has completed
+                    break
+                self.deque.append(line)
+        except (ValueError, IOError):
+            # pipe has closed, meaning command output is done
+            pass
+
+    def get_contents(self):
+        '''Returns the contents of the deque as a string'''
+        if not self.binary:
+            return ''.join(ln.decode('utf-8', 'ignore') for ln in self.deque)
+        else:
+            return b''.join(ln for ln in self.deque)
 
 
 class ImporterHelper(object):


### PR DESCRIPTION
As mentioned by @bmr-cymru  in #1119 I have been working on a size limitation for command and journal output. I believe this is now in a good state for review, as it is functional and is exposed in the proper places (that I can think of at least).

This patch adds a size_limit option to `add_cmd_output()` and `add_journal()` which defaults to using `--log-size` (which itself currently defaults to 10MB).

This changes the way command execution is handled by handing the output channel to a new thread (only way I could avoid deadlocks) that reads the output line by line, and adds it to a deque. As the output is added, the deque's size will be checked against the given `size_limit` and if the deque is larger, the oldest (LRU) line in the deque will be removed. This technically means the size_limit is line sensitive, not byte sensitive, however I believe this is a close enough approximation. If `size_limit` is set to `0`, then output will not be limited (so, how it currently works) - using `None` produces the default behavior.

Running a few tests on some RHEL boxes, one very small and one decently sized, I have seen a massive reduction in the amount of memory used. The max memory reading below is from zsh's `time` which includes memory statistics:

```
RHEL 7.4, sos 3.4, 2GB memory system - journal on disk is 300mb - verbose journal failed to collect
sosreport --batch   223.05s  user 69.98s system 46% cpu 10:31.42 total
max memory:                1375 MB


RHEL 7.4, sos 3.4 with patch, same node as above, verbose journal was collected
sosreport --batch   260.02s  user 38.55s system 80% cpu 6:09.75 total
max memory:                641 MB



RHEL 7.3, sos 3.4, 48GB memory kube node with ~20 pods. journal on disk is 2.2G
sosreport --batch   371.95s  user 93.11s system 85% cpu 9:04.12 total
max memory:                13525 MB <==== !!!!



RHEL 7.3, sos 3.4 with patch, same node as above
sosreport --batch   393.94s  user 61.12s system 111% cpu 6:46.73 total
max memory:                449 MB

RHEL 7.3, same as above but with --log-size=100
sosreport --batch --log-size=100   392.64s  user 64.53s system 108% cpu 7:00.91 total
max memory:                885 MB
```

Note that while in the first test this patch does increase run time it is mostly because of the fact that sos hit a `Memory Error` while running the `logs` plugin. In the second test the run time still increases somewhat, but to a lesser extent.

I feel that the trade off of run time here is well worth the gains. As it stands, a low memory system will likely fail to collect a number of important items - taking an extra 20 seconds versus not getting output is preferable in my mind. Similarly on larger systems, the significantly reduced memory load is still a large benefit so that running sos is far less likely to affect other running processes. It also does not appear that the run time increase gets larger as the log-size gets larger - in other words this looks like a static increase in run time.

The other major benefit to this is that sosreports will no longer collect (by default at least) absurdly large journals and in addition the larger verbose journals as in #1029 

The one main point I am unsure of for this change is the default setting of `size_limit` for `add_journal()`. Right now it will also default to `--log-size` however as a support engineer I personally think 10MB is too small for a collected journal. I would venture that a 100MB default would be sufficient, but I am open to other suggestions.

Resolves: #1029 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
