### PR TITLE
[systemd] Removed `systemctl show-environment`

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -41,7 +41,6 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "systemctl list-units",
             "systemctl list-units --failed",
             "systemctl list-unit-files",
-            "systemctl show-environment",
             "systemd-delta",
             "systemd-analyze",
             "journalctl --list-boots",


### PR DESCRIPTION
The environment variables LANG and PATH are captured in `systemctl
show --all` anyways.

Signed-off-by: Sachin Patil <psachin@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
