### PR TITLE
[logs] Add gathering of systemd journal from previous boot

### DIFF
--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -34,6 +34,8 @@ class Logs(Plugin):
         self.add_copy_spec("/var/log/cloud-init*", sizelimit=self.limit)
         self.add_journal(boot="this")
         self.add_journal(boot="this", allfields=True, output="verbose")
+        self.add_journal(boot="last")
+        self.add_journal(boot="last", allfields=True, output="verbose")
         self.add_cmd_output("journalctl --disk-usage")
 
         if self.get_option('all_logs'):


### PR DESCRIPTION
As a support engineer, having the journal from previous boot helps debugging issues happening during shutdown.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
