### PR TITLE
[btrfs] Add filesystem show and version

### DIFF
--- a/sos/plugins/btrfs.py
+++ b/sos/plugins/btrfs.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+
+
+class Btrfs(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+    """Btrfs filesystem
+    """
+
+    plugin_name = 'btrfs'
+    profiles = ('storage',)
+
+    packages = ('btrfs-progs', 'btrfs-tools')
+
+    def setup(self):
+        self.add_cmd_output([
+            "btrfs filesystem show",
+            "btrfs version"])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds btrfs filesystem show as that shows if there are
btrfs partitions or not.
Also show version of btrfs command.

Closes: #1112.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
