### PR TITLE
[openstack_ironic] update to cover recent features

### DIFF
--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -82,8 +82,10 @@ class OpenStackIronic(Plugin):
                                 "the environment file for the user intended "
                                 "to connect to the OpenStack environment.")
         else:
+            self.add_cmd_output("openstack baremetal driver list --long")
             self.add_cmd_output("openstack baremetal node list --long")
-            self.add_cmd_output("openstack baremetal port list")
+            self.add_cmd_output("openstack baremetal port list --long")
+            self.add_cmd_output("openstack baremetal port group list --long")
 
     def postproc(self):
         protect_keys = [

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -63,10 +63,9 @@ class OpenStackIronic(Plugin):
                 "/var/log/containers/httpd/ironic-api/*log"
             ], sizelimit=self.limit)
 
-        self.add_cmd_output('ls -laRt /var/lib/ironic/')
-        self.add_cmd_output(
-            'ls -laRt ' + self.var_puppet_gen + '/var/lib/ironic/'
-        )
+        for path in ['/var/lib/ironic', '/httpboot', '/tftpboot']:
+            self.add_cmd_output('ls -laRt %s' % path)
+            self.add_cmd_output('ls -laRt %s' % (self.var_puppet_gen + path))
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))


### PR DESCRIPTION
* ironic-discoverd was renamed to ironic-inspector in Liberty release
* collect port groups list, driver list and detailed port list
* collect introspection statuses list
* optionally collect introspection data from all nodes

Signed-off-by: Dmitry Tantsur <divius.inside@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?