### PR TITLE
[openstack plugins+logrotate] Tripleo additional directories - patch2

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -49,13 +49,15 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/gnocchi/*",
-                "/var/log/containers/gnocchi/*"],
+                "/var/log/containers/gnocchi/*",
+                "/var/log/containers/httpd/gnocchi-api/*"],
                 sizelimit=self.limit
             )
         else:
             self.add_copy_spec([
                 "/var/log/gnocchi/*.log",
-                "/var/log/containers/gnocchi/*.log"],
+                "/var/log/containers/gnocchi/*.log",
+                "/var/log/containers/httpd/gnocchi-api/*log"],
                 sizelimit=self.limit
             )
 

--- a/sos/plugins/logrotate.py
+++ b/sos/plugins/logrotate.py
@@ -22,12 +22,16 @@ class LogRotate(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     plugin_name = 'logrotate'
     profiles = ('system',)
 
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/crond"
+
     def setup(self):
         self.add_cmd_output("logrotate --debug /etc/logrotate.conf",
                             suggest_filename="logrotate_debug")
         self.add_copy_spec([
             "/etc/logrotate*",
-            "/var/lib/logrotate.status"
+            "/var/lib/logrotate.status",
+            self.var_puppet_gen + "/etc/logrotate-crond.conf",
+            self.var_puppet_gen + "/var/spool/cron/root"
         ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_aodh.py
+++ b/sos/plugins/openstack_aodh.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2017 Red Hat, Inc., Sachin Patil <psachin@redhat.com>
+# Copyright (C) 2017 Red Hat, Inc., Martin Schuppert <mschuppert@redhat.com>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,16 +34,31 @@ class OpenStackAodh(Plugin, RedHatPlugin):
 
     requires_root = False
 
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/aodh"
+
     def setup(self):
-        self.add_copy_spec("/etc/aodh/")
+        self.add_copy_spec([
+            "/etc/aodh/",
+            self.var_puppet_gen + "/etc/aodh/*",
+            self.var_puppet_gen + "/etc/httpd/conf/*",
+            self.var_puppet_gen + "/etc/httpd/conf.d/*",
+            self.var_puppet_gen + "/etc/httpd/conf.modules.d/wsgi.conf",
+            self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
+        ])
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/aodh/",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/aodh/*",
+                "/var/log/containers/aodh/*",
+                "/var/log/containers/httpd/aodh-api/*"
+            ], sizelimit=self.limit)
         else:
-            self.add_copy_spec("/var/log/aodh/*.log",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/aodh/*.log",
+                "/var/log/containers/aodh/*.log",
+                "/var/log/containers/httpd/aodh-api/*log"
+            ], sizelimit=self.limit)
 
         vars_all = [p in os.environ for p in [
             'OS_USERNAME', 'OS_PASSWORD', 'OS_AUTH_TYPE'
@@ -72,8 +88,21 @@ class OpenStackAodh(Plugin, RedHatPlugin):
 
         self.do_file_sub(
             "/etc/aodh/aodh.conf",
-            r"(auth_url[\t\ ]*=[\t\ ]*)(.+)",
+            r"(rabbit_password[\t\ ]*=[\t\ ]*)(.+)",
             r"\1********",
         )
+
+        self.do_file_sub(
+            self.var_puppet_gen + "/etc/aodh/aodh.conf",
+            r"(password[\t\ ]*=[\t\ ]*)(.+)",
+            r"\1********"
+        )
+
+        self.do_file_sub(
+            self.var_puppet_gen + "/etc/aodh/aodh.conf",
+            r"(rabbit_password[\t\ ]*=[\t\ ]*)(.+)",
+            r"\1********",
+        )
+
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -41,12 +41,14 @@ class OpenStackGlance(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/glance/",
-                "/var/log/containers/glance/"
+                "/var/log/containers/glance/",
+                "/var/log/containers/httpd/glance-api/"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/glance/*.log",
-                "/var/log/containers/glance/*.log"
+                "/var/log/containers/glance/*.log",
+                "/var/log/containers/httpd/glance-api/*log"
             ], sizelimit=self.limit)
 
         self.add_copy_spec([

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -52,12 +52,16 @@ class OpenStackHeat(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/heat/",
-                "/var/log/containers/heat/"
+                "/var/log/containers/heat/",
+                "/var/log/containers/httpd/heat-api/",
+                "/var/log/containers/httpd/heat-api-cfn"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/heat/*.log",
-                "/var/log/containers/heat/*.log"
+                "/var/log/containers/heat/*.log",
+                "/var/log/containers/httpd/heat-api/*log",
+                "/var/log/containers/httpd/heat-api-cfn/*log"
             ], sizelimit=self.limit)
 
         self.add_copy_spec([

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -35,12 +35,14 @@ class OpenStackHorizon(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/horizon/",
-                "/var/log/containers/horizon/"
+                "/var/log/containers/horizon/",
+                "/var/log/containers/httpd/horizon/"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/horizon/*.log",
-                "/var/log/containers/horizon/*.log"
+                "/var/log/containers/horizon/*.log",
+                "/var/log/containers/httpd/horizon/*log"
             ], sizelimit=self.limit)
 
         self.add_copy_spec([

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -25,21 +25,48 @@ class OpenStackIronic(Plugin):
     plugin_name = "openstack_ironic"
     profiles = ('openstack', 'openstack_undercloud')
 
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/ironic"
+
     def setup(self):
-        self.conf_list = ['/etc/ironic/*']
-        self.add_copy_spec('/etc/ironic/')
+        self.conf_list = [
+            "/etc/ironic/*",
+            self.var_puppet_gen + "/etc/ironic/*",
+            self.var_puppet_gen + "_api/etc/ironic/*"
+        ]
+        self.add_copy_spec([
+            "/etc/ironic/",
+            self.var_puppet_gen + "/etc/xinetd.conf",
+            self.var_puppet_gen + "/etc/xinetd.d/",
+            self.var_puppet_gen + "/etc/ironic/",
+            self.var_puppet_gen + "/etc/httpd/conf/",
+            self.var_puppet_gen + "/etc/httpd/conf.d/",
+            self.var_puppet_gen + "/etc/httpd/conf.modules.d/*.conf",
+            self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf",
+            self.var_puppet_gen + "_api/etc/ironic/",
+            self.var_puppet_gen + "_api/etc/httpd/conf/",
+            self.var_puppet_gen + "_api/etc/httpd/conf.d/",
+            self.var_puppet_gen + "_api/etc/httpd/conf.modules.d/*.conf",
+            self.var_puppet_gen + "_api/etc/my.cnf.d/tripleo.cnf"
+        ])
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec(["/var/log/ironic/",
-                                "/var/log/containers/ironic/"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/ironic/",
+                "/var/log/containers/ironic/",
+                "/var/log/containers/httpd/ironic-api/"
+            ], sizelimit=self.limit)
         else:
-            self.add_copy_spec(["/var/log/ironic/*.log",
-                                "/var/log/containers/ironic/*.log"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/ironic/*.log",
+                "/var/log/containers/ironic/*.log",
+                "/var/log/containers/httpd/ironic-api/*log"
+            ], sizelimit=self.limit)
 
         self.add_cmd_output('ls -laRt /var/lib/ironic/')
+        self.add_cmd_output(
+            'ls -laRt ' + self.var_puppet_gen + '/var/lib/ironic/'
+        )
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -47,12 +47,14 @@ class OpenStackKeystone(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/keystone/",
-                "/var/log/containers/keystone/"
+                "/var/log/containers/keystone/",
+                "/var/log/containers/httpd/keystone/"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/keystone/*.log",
-                "/var/log/containers/keystone/*.log"
+                "/var/log/containers/keystone/*.log",
+                "/var/log/containers/httpd/keystone/*log"
             ], sizelimit=self.limit)
 
         if self.get_option("verify"):

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -29,19 +29,25 @@ class OpenStackManila(Plugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/manila/",
-            self.var_puppet_gen + "/etc/manila/"
+            self.var_puppet_gen + "/etc/manila/",
+            self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf",
+            self.var_puppet_gen + "/etc/httpd/conf/",
+            self.var_puppet_gen + "/etc/httpd/conf.d/",
+            self.var_puppet_gen + "/etc/httpd/conf.modules.d/*.conf",
         ])
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/manila/*",
-                "/var/log/containers/manila/*"
+                "/var/log/containers/manila/*",
+                "/var/log/containers/httpd/manila-api/*"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/manila/*.log",
-                "/var/log/containers/manila/*.log"
+                "/var/log/containers/manila/*.log",
+                "/var/log/containers/httpd/manila-api/*log"
             ], sizelimit=self.limit)
 
     def postproc(self):

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -33,17 +33,21 @@ class OpenStackNeutron(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/neutron/",
-                "/var/log/containers/neutron/"
+                "/var/log/containers/neutron/",
+                "/var/log/containers/httpd/neutron-api/"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/neutron/*.log",
-                "/var/log/containers/neutron/*.log"
+                "/var/log/containers/neutron/*.log",
+                "/var/log/containers/httpd/neutron-api/*log"
             ], sizelimit=self.limit)
 
         self.add_copy_spec([
             "/etc/neutron/",
-            self.var_puppet_gen + "/etc/neutron/"
+            self.var_puppet_gen + "/etc/neutron/",
+            self.var_puppet_gen + "/etc/default/neutron-server",
+            self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
         ])
         self.add_copy_spec("/var/lib/neutron/")
         if self.get_option("verify"):

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -71,12 +71,16 @@ class OpenStackNova(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/nova/",
-                "/var/log/containers/nova/"
+                "/var/log/containers/nova/",
+                "/var/log/containers/httpd/nova-api/",
+                "/var/log/containers/httpd/nova-placement/"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/nova/*.log",
-                "/var/log/containers/nova/*.log"
+                "/var/log/containers/nova/*.log",
+                "/var/log/containers/httpd/nova-api/*log",
+                "/var/log/containers/httpd/nova-placement/*log"
             ], sizelimit=self.limit)
 
         self.add_copy_spec([
@@ -89,7 +93,12 @@ class OpenStackNova(Plugin):
             self.var_puppet_gen + "_placement/etc/httpd/conf.d/",
             self.var_puppet_gen + "_placement/etc/httpd/conf.modules.d/*.conf",
             self.var_puppet_gen + "_placement/etc/my.cnf.d/tripleo.cnf",
-            self.var_puppet_gen + "/../memcached/etc/sysconfig/memcached"
+            self.var_puppet_gen + "/../memcached/etc/sysconfig/memcached",
+            self.var_puppet_gen + "_libvirt/etc/libvirt/",
+            self.var_puppet_gen + "_libvirt/etc/my.cnf.d/tripleo.cnf",
+            self.var_puppet_gen + "_libvirt/etc/nova/migration/"
+            "authorized_keys",
+            self.var_puppet_gen + "_libvirt/var/lib/nova/.ssh/config",
         ])
 
         if self.get_option("verify"):
@@ -113,6 +122,10 @@ class OpenStackNova(Plugin):
         )
         self.do_path_regex_sub(
             self.var_puppet_gen + "_placement/etc/nova/*",
+            regexp, r"\1*********"
+        )
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "_libvirt/etc/nova/*",
             regexp, r"\1*********"
         )
 

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -35,12 +35,14 @@ class OpenStackSwift(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/swift/",
-                "/var/log/containers/swift/"
+                "/var/log/containers/swift/",
+                "/var/log/containers/httpd/swift-proxy/"
             ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/swift/*.log",
-                "/var/log/containers/swift/*.log"
+                "/var/log/containers/swift/*.log",
+                "/var/log/containers/httpd/swift-proxy/*log"
             ], sizelimit=self.limit)
 
         self.add_copy_spec([


### PR DESCRIPTION
Tripleo Pike opinionated config+log paths to be collected
for services, when running in containers.

This is an addition to #1054 where a couple of things got missed

Signed-off-by: Martin Schuppert <mschuppe@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
