### PR TITLE
[openstack_horizon] Fix collection of horizon logs from /var/log/httpd

### DIFF
--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -49,15 +49,15 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/gnocchi/*",
-                "/var/log/containers/gnocchi/*"],
-                sizelimit=self.limit
-            )
+                "/var/log/httpd/gnocchi*",
+                "/var/log/containers/gnocchi/*"
+                ], sizelimit=self.limit)
         else:
             self.add_copy_spec([
                 "/var/log/gnocchi/*.log",
-                "/var/log/containers/gnocchi/*.log"],
-                sizelimit=self.limit
-            )
+                "/var/log/httpd/gnocchi*.log",
+                "/var/log/containers/gnocchi/*.log"
+                ], sizelimit=self.limit)
 
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]

--- a/sos/plugins/openstack_aodh.py
+++ b/sos/plugins/openstack_aodh.py
@@ -38,11 +38,16 @@ class OpenStackAodh(Plugin, RedHatPlugin):
 
         self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/aodh/",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/aodh/",
+                "/var/log/httpd/aodh*"
+            ], sizelimit=self.limit)
+
         else:
-            self.add_copy_spec("/var/log/aodh/*.log",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/aodh/*.log",
+                "/var/log/httpd/aodh*.log"
+            ], sizelimit=self.limit)
 
         vars_all = [p in os.environ for p in [
             'OS_USERNAME', 'OS_PASSWORD', 'OS_AUTH_TYPE'

--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -92,4 +92,15 @@ class RedHatCeilometer(OpenStackCeilometer, RedHatPlugin):
         'python-ceilometerclient'
     )
 
+    def setup(self):
+        super(RedHatCeilometer, self).setup()
+        if self.get_option("all_logs"):
+            self.add_copy_spec([
+                "/var/log/httpd/ceilometer*",
+            ], sizelimit=self.limit)
+        else:
+            self.add_copy_spec([
+                "/var/log/httpd/ceilometer*.log",
+            ], sizelimit=self.limit)
+
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -117,7 +117,14 @@ class RedHatHorizon(OpenStackHorizon, RedHatPlugin):
     def setup(self):
         super(RedHatHorizon, self).setup()
         self.add_copy_spec("/etc/httpd/conf.d/openstack-dashboard.conf")
-        if self.get_option("log"):
+        if self.get_option("all_logs"):
+            self.add_copy_spec([
+                "/var/log/httpd/horizon*",
+            ], sizelimit=self.limit)
+        else:
+            self.add_copy_spec([
+                "/var/log/httpd/horizon*.log"
+            ], sizelimit=self.limit)
             self.add_copy_spec("/var/log/httpd/")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -120,4 +120,16 @@ class RedHatKeystone(OpenStackKeystone, RedHatPlugin):
         'python-keystoneclient'
     )
 
+    def setup(self):
+        super(RedHatKeystone, self).setup()
+        if self.get_option("all_logs"):
+            self.add_copy_spec([
+                "/var/log/httpd/keystone*",
+            ], sizelimit=self.limit)
+        else:
+            self.add_copy_spec([
+                "/var/log/httpd/keystone*.log",
+            ], sizelimit=self.limit)
+
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Fixes : #1131

with all_logs, all logs for respective plugins are collected
from  /var/log/httpd.

without all_logs only *.log files are collected.

Signed-off-by: Shatadru Bandyopadhyay <shatadru1@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
