### PR TITLE
[process] inhibit lsof's thread information by default

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -22,6 +22,11 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     plugin_name = 'process'
     profiles = ('system',)
 
+    option_list = [
+        ("lsof-threads", "gathers threads' open file info if supported",
+         "slow", False)
+    ]
+
     def setup(self):
         ps_axo = "ps axo"
         # process group and thread options
@@ -31,7 +36,9 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec("/proc/sched_debug")
         self.add_cmd_output("ps auxwww", root_symlink="ps")
         self.add_cmd_output("pstree", root_symlink="pstree")
-        self.add_cmd_output("lsof -b +M -n -l", root_symlink="lsof")
+        self.add_cmd_output("lsof -b +M -n -l -c ''", root_symlink="lsof")
+        if self.get_option("lsof-threads") or self.get_option("all_logs"):
+            self.add_cmd_output("lsof -b +M -n -l")
         self.add_cmd_output([
             "ps auxwwwm",
             "ps alxwww",


### PR DESCRIPTION
Current lsof lists not only processes' open file information but also all threads' one by default. But when a heavily-multithreaded process exists, this behavior takes several minutes and consumes huge CPU time. Moreover, if it takes more than 300 seconds, lsof executed by sosreport times out with no useful information.
```
  # ./pthread 12000 &
  # time lsof -b +M -n -l >/dev/null
  ...
  real    4m57.620s
  user    1m13.004s
  sys     3m44.350s
```
This patch inhibits lsof's thread information with its -c option below to reduce CPU time significantly and adds an option to gather it if needed.
```
  # time lsof -b +M -n -l -c '' >/dev/null
  ...
  real    0m22.451s
  user    0m0.062s
  sys     0m22.057s
```
As a support engineer I think that lsof's thread infomation is very rarely needed, because generally thread's open files are inherited from the process and same as its one. At least I have not ever used the information for several years.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
