### PR TITLE
[vdo] collect proper sys paths

### DIFF
--- a/sos/plugins/vdo.py
+++ b/sos/plugins/vdo.py
@@ -27,8 +27,8 @@ class Vdo(Plugin, RedHatPlugin):
     profiles = ('storage',)
     packages = ('vdo',)
     files = (
-        '/sys/vdo',
-        '/sys/albireo',
+        '/sys/kvdo',
+        '/sys/uds',
         '/etc/vdoconf.yml',
         '/etc/vdoconf.xml'
     )


### PR DESCRIPTION
VDO plugin shall collect /sys/kvdo and /sys/uds
instead of original /sys/vdo and /sys/albireo

Resolves: #1134

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
