### PR TITLE
[haproxy] Fix py2 specific import syntax for urlparse

### DIFF
--- a/sos/plugins/haproxy.py
+++ b/sos/plugins/haproxy.py
@@ -15,8 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin
-from urlparse import urlparse
 from re import match
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 
 class HAProxy(Plugin, RedHatPlugin, DebianPlugin):


### PR DESCRIPTION
urlparse is now part of urllib in python3. Make sure that
the proxy behaves correctly on both versions.
(Closes: #1137)

Signed-off-by: Louis Bouchard <louis@ubuntu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
