### PR TITLE
[sas3ircu] add missing description

### DIFF
--- a/sos/plugins/sas3ircu.py
+++ b/sos/plugins/sas3ircu.py
@@ -20,6 +20,8 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class SAS3ircu(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """SAS-3 Integrated RAID adapter information
+    """
 
     plugin_name = "sas3ircu"
     commands = ("sas3ircu",)


### PR DESCRIPTION
I found that `sosreport --list-plugins` unexpectedly shows the docstring of the `Plugin` class for `sas3ircu` plugin.
```
# sosreport --list-plugins
...
 sas3ircu             inactive       This is the base class for sosreport plugins. Plugins should subclass
    this and set the class variables where applicable.
...
```
But I'm not sure whether the description of this patch is the most suitable for it.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
