### PR TITLE
[etcd] fix typo in etcdctl subcmds

### DIFF
--- a/sos/plugins/etcd.py
+++ b/sos/plugins/etcd.py
@@ -40,7 +40,7 @@ class etcd(Plugin, RedHatPlugin):
            'ls --recursive',
         ]
 
-        self.add_cmd_output(['%s %s' % (self.cmd, sub) for sub in subcmd])
+        self.add_cmd_output(['%s %s' % (self.cmd, sub) for sub in subcmds])
 
         urls = [
             '/v2/stats/leader',


### PR DESCRIPTION
subcmds variable set while "subcmd" referred instead.

Resolves: #1141

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
