### PR TITLE
[cups] collect logs also via journalctl

### DIFF
--- a/sos/plugins/cups.py
+++ b/sos/plugins/cups.py
@@ -46,4 +46,6 @@ class Cups(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "lpstat -d"
         ])
 
+        self.add_journal(units="cups")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
cups has options to log to logfiles or via journald, thus sosreport
should collect both.

Resolves: #1142

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
