### PR TITLE
Add test for non-root runs of sosreport

### DIFF
--- a/tests/run_nonroot_tests.py
+++ b/tests/run_nonroot_tests.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+import unittest
+import tempfile
+import shutil
+import gettext
+from sos import sosreport
+from mock import patch
+
+
+class SosRunTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.workdir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.workdir)
+
+    def _get_sos_version(self):
+        '''
+        Get the main sosreport version from sos.spec.
+        This is how make updateversion sets the value
+        in sos/__init__.py
+        '''
+        with open('sos.spec') as spec:
+            lines = spec.readlines()
+        for line in lines:
+            if line.startswith('Version:'):
+                break
+        return line.strip('Version: ').strip()
+
+    @patch('sos.sosreport.logging')
+    def test_run_sosreport_nonroot(self, soserr):
+        # Use --quiet so the sosreport run doesn't botch test output
+        sosreport.main(['--batch', '--tmp-dir', '%s' % self.workdir,
+                        '--config-file', './sos.conf', '--quiet'])
+        # gettext call required to avoid error when $LANGUAGE is localised
+        soserr.getLogger().error.assert_called_once_with(
+                gettext.dgettext('sos', 'no valid plugins were enabled'))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=0)
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
This new test run sosreport as non-root user which will try to load all plugins. Verifies that no plugin is loaded.
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
