### PR TITLE
[origin] fix typo in oc adm diagnostics --prevent-modification

### DIFF
--- a/sos/plugins/origin.py
+++ b/sos/plugins/origin.py
@@ -48,7 +48,7 @@ class OpenShiftOrigin(Plugin):
     option_list = [
         ("diag", "run 'oc adm diagnostics' to collect its output",
          'fast', True),
-        ("diag-prevent", "set --prevent-modifications on 'oc adm diagnostics'",
+        ("diag-prevent", "set --prevent-modification on 'oc adm diagnostics'",
          'fast', False),
     ]
 
@@ -137,7 +137,7 @@ class OpenShiftOrigin(Plugin):
             if self.get_option('diag'):
                 diag_cmd = "%s adm diagnostics -l 0" % self.oc_cmd_admin
                 if self.get_option('diag-prevent'):
-                    diag_cmd += " --prevent-modifications=true"
+                    diag_cmd += " --prevent-modification=true"
                 self.add_cmd_output(diag_cmd)
             self.add_journal(units=["atomic-openshift-master",
                                     "atomic-openshift-master-api",


### PR DESCRIPTION
The argument is singular --prevent-modification .

Resolves: #1150

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
