### PR TITLE
[openstack_horizon] fix password obfuscate in local_settings

### DIFF
--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -74,11 +74,11 @@ class OpenStackHorizon(Plugin):
             regexp, r"\1*********"
         )
         self.do_path_regex_sub(
-            "/etc/openstack-dashboard/local_settings/.*\.conf.*",
+            "/etc/openstack-dashboard/local_settings$",
             regexp, r"\1*********"
         )
         self.do_path_regex_sub(
-            var_puppet_gen + "/etc/openstack-dashboard/.*\.conf.*",
+            var_puppet_gen + "/etc/openstack-dashboard/local_settings$",
             regexp, r"\1*********"
         )
 


### PR DESCRIPTION
commit d0bcd552f4bc2119afd2a835f4e5ec1107421f40 broke the
replacement of the protect_keys for the main local_settings
config file.

Signed-off-by: Martin Schuppert mschuppe@redhat.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
