### PR TITLE
[networking] Add /etc/netplan/*.yaml collection for Ubuntu.

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -375,7 +375,8 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/etc/network/interfaces.d",
             "/etc/ufw",
             "/var/log/ufw.Log",
-            "/etc/resolv.conf"
+            "/etc/resolv.conf",
+            "/etc/netplan/*.yaml"
         ])
         self.add_cmd_output([
             "/usr/sbin/ufw status",

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -10,8 +10,9 @@ class DebianPolicy(LinuxPolicy):
     vendor_url = "http://www.debian.org/"
     report_name = ""
     ticket_number = ""
-    package_manager = PackageManager(
-        "dpkg-query -W -f='${Package}|${Version}\\n'")
+    _debq_cmd = "dpkg-query -W -f='${Package}|${Version}\\n'"
+    _debv_cmd = "dpkg --verify"
+    _debv_filter = ""
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin"
@@ -20,8 +21,10 @@ class DebianPolicy(LinuxPolicy):
         super(DebianPolicy, self).__init__(sysroot=sysroot)
         self.report_name = ""
         self.ticket_number = ""
-        self.package_manager = PackageManager(
-            "dpkg-query -W -f='${Package}|${Version}\\n'")
+        self.package_manager = PackageManager(query_command=self._debq_cmd,
+                                              verify_command=self._debv_cmd,
+                                              verify_filter=self._debv_filter,
+                                              chroot=sysroot)
         self.valid_subclasses = [DebianPlugin]
 
     @classmethod


### PR DESCRIPTION
Netplan is a YAML network configuration abstraction for various
backends (NetworkManager, networkd). It reads network configuration
from /etc/netplan/*.yaml.

Related documents:
https://wiki.ubuntu.com/Netplan
https://wiki.ubuntu.com/Netplan/Design

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
