### PR TITLE
set proper PATH for SCL commands & call pg_dump from SCL properly

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -194,6 +194,7 @@ No changes will be made to system configuration.
     vendor_url = "http://www.example.com/"
     vendor_text = ""
     PATH = ""
+    default_scl_prefix = ""
 
     _in_container = False
     _host_sysroot = '/'
@@ -270,6 +271,9 @@ No changes will be made to system configuration.
         if not opt_tmp_dir:
             return tempfile.gettempdir()
         return opt_tmp_dir
+
+    def get_default_scl_prefix(self):
+        return self.default_scl_prefix
 
     def match_plugin(self, plugin_classes):
         if len(plugin_classes) > 1:

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -44,6 +44,7 @@ class RedHatPolicy(LinuxPolicy):
     _rpmv_filter = ["debuginfo", "-devel"]
     _in_container = False
     _host_sysroot = '/'
+    default_scl_prefix = '/opt/rh'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)


### PR DESCRIPTION
pg_dump called from SCL needs to have proper PATH reflecting where SCL deploys its binaries.

Also the destination filename of the dump should match the non-SCL dump to simplify work of tools further manipulating with the dump(s).

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
