### PR TITLE
[policies] Reset to expected variable order for packagemanager

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -59,8 +59,8 @@ class PackageManager(object):
     verify_filter = None
     chroot = None
 
-    def __init__(self, chroot=None, query_command=None,
-                 verify_command=None, verify_filter=None):
+    def __init__(self,  query_command=None, verify_command=None,
+                 verify_filter=None, chroot=None,):
         self.packages = {}
 
         self.query_command = query_command if query_command else None


### PR DESCRIPTION
Commit 82e4ee2 changed the order of variables in packagemanager
to what none of the policies expected.  This sets it back so
query is always first.  Red Hat policy is the only one that
uses more than one variable for it.

Closes: #1155 

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
