### PR TITLE
[postgresql] use a single name for the db dump file

### DIFF
--- a/sos/plugins/postgresql.py
+++ b/sos/plugins/postgresql.py
@@ -141,8 +141,7 @@ class RedHatPostgreSQL(PostgreSQL, SCLPlugin):
 
         if scl in self.scls_matched:
             self.pg_dump(
-                pg_dump_command="scl enable rh-postgresql95 -- pg_dump",
-                filename="sos_scl_pgdump.tar"
+                pg_dump_command="scl enable rh-postgresql95 -- pg_dump"
             )
 
 


### PR DESCRIPTION
Currently, there are two names for the file that contain
the postgresql db dump. The original one, which is sos_pgdump.tar
and the new one sos_scl_pgdump.tar based on postgresql95.
However, changing the name of file that contain the pgdump
because of new technologies break the tools that are
based on sos tool. This patch make sure we use the same name.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
