### PR TITLE
[etcd] dont traceback when etcd package isnt installed

### DIFF
--- a/sos/plugins/etcd.py
+++ b/sos/plugins/etcd.py
@@ -61,11 +61,16 @@ class etcd(Plugin, RedHatPlugin):
                         return line.split('=')[1].replace('"', '').strip()
         # If we can't read etcd.conf, assume defaults by etcd version
         except:
-            ver = self.policy().package_manager.get_pkg_list()['etcd']
-            ver = ver['version'][0]
-            if ver == '2':
-                return 'http://localhost:4001'
-            if ver == '3':
-                return 'http://localhost:2379'
+            # assume v3 is the default
+            url = 'http://localhost:2379'
+            try:
+                ver = self.policy().package_manager.get_pkg_list()['etcd']
+                ver = ver['version'][0]
+                if ver == '2':
+                    url = 'http://localhost:4001'
+            except:
+                # fallback when etcd is not installed
+                pass
+            return url
 
 # vim: et ts=5 sw=4


### PR DESCRIPTION
catch exception when etcd package isnt installed and we inspect its
version

Resolves: #1159

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
