### PR TITLE
[haproxy] catch exception when parsing haproxy.cfg

### DIFF
--- a/sos/plugins/haproxy.py
+++ b/sos/plugins/haproxy.py
@@ -49,11 +49,15 @@ class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
         # from the next line
         matched = None
         provision_ip = None
-        for line in open("/etc/haproxy/haproxy.cfg").read().splitlines():
-            if matched:
-                provision_ip = line.split()[1]
-                break
-            matched = match(".*haproxy\.stats.*", line)
+        try:
+            for line in open("/etc/haproxy/haproxy.cfg").read().splitlines():
+                if matched:
+                    provision_ip = line.split()[1]
+                    break
+                matched = match(".*haproxy\.stats.*", line)
+        except:
+            # fallback when the cfg file is not accessible
+            pass
 
         if not provision_ip:
             return


### PR DESCRIPTION
catch exception when parsed haproxy.cfg file isnt accessible

Resolves: #1160

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
