### PR TITLE
[networking] Add netplan data collection for Ubuntu.

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -375,7 +375,10 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/etc/network/interfaces.d",
             "/etc/ufw",
             "/var/log/ufw.Log",
-            "/etc/resolv.conf"
+            "/etc/resolv.conf",
+            "/etc/netplan/*.yaml",
+            "/run/NetworkManager",
+            "/run/systemd/network"
         ])
         self.add_cmd_output([
             "/usr/sbin/ufw status",


### PR DESCRIPTION
Netplan is a YAML network configuration abstraction for various
backends (NetworkManager, networkd). It reads network configuration
from /etc/netplan/*.yaml.

Related documents:
https://wiki.ubuntu.com/Netplan
https://wiki.ubuntu.com/Netplan/Design

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
