### PR TITLE
[sosreport] Fix debian policy PackageManager misusage.

### DIFF
--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -10,8 +10,9 @@ class DebianPolicy(LinuxPolicy):
     vendor_url = "http://www.debian.org/"
     report_name = ""
     ticket_number = ""
-    package_manager = PackageManager(
-        "dpkg-query -W -f='${Package}|${Version}\\n'")
+    _debq_cmd = "dpkg-query -W -f='${Package}|${Version}\\n'"
+    _debv_cmd = "dpkg --verify"
+    _debv_filter = ""
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin"
@@ -20,8 +21,11 @@ class DebianPolicy(LinuxPolicy):
         super(DebianPolicy, self).__init__(sysroot=sysroot)
         self.report_name = ""
         self.ticket_number = ""
-        self.package_manager = PackageManager(
-            "dpkg-query -W -f='${Package}|${Version}\\n'")
+        self.package_manager = PackageManager(query_command=self._debq_cmd,
+                                              verify_command=self._debv_cmd,
+                                              verify_filter=self._debv_filter,
+                                              chroot=sysroot)
+
         self.valid_subclasses = [DebianPlugin]
 
     @classmethod


### PR DESCRIPTION
Python does not impose any kind of ordering on keyword args,
but if the keywords are missing it will still attempt to honour
the call by mapping positional call arguments to corresponding
keywords in the declaration.

In this case the Debian policy invokes the PackageManager call
as though it only uses positional arguments. This is undoubtedly
wrong.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
