### PR TITLE
[docker] Collect daemon.json for all OSes

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -36,6 +36,7 @@ class Docker(Plugin):
 
     def setup(self):
         self.add_copy_spec([
+            "/etc/docker/daemon.json",
             "/var/lib/docker/repositories-*"
         ])
 
@@ -126,7 +127,6 @@ class UbuntuDocker(Docker, UbuntuPlugin):
         super(UbuntuDocker, self).setup()
         self.add_copy_spec([
             "/etc/default/docker",
-            "/etc/docker/daemon.json",
             "/var/run/docker/libcontainerd/containerd/events.log"
         ])
 


### PR DESCRIPTION
The Red Hat packaging of docker now also supports using
/etc/docker/daemon.json for configuring docker.

This moves collect of daemon.json from being Ubuntu-only to being for
any OS installation.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
