### PR TITLE
[plugins] allow add_cmd_output to collect binary output

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -85,6 +85,9 @@ class Archive(object):
     def add_string(self, content, dest):
         raise NotImplementedError
 
+    def add_binary(self, content, dest):
+        raise NotImplementedError
+
     def add_link(self, source, link_name):
         raise NotImplementedError
 
@@ -214,6 +217,14 @@ class FileCacheArchive(Archive):
                     "Unable to add '%s' to FileCacheArchive: %s" % (dest, e))
         self.log_debug("added string at '%s' to FileCacheArchive '%s'"
                        % (src, self._archive_root))
+
+    def add_binary(self, content, dest):
+        dest = self.dest_path(dest)
+        self._check_path(dest)
+        f = codecs.open(dest, 'wb', encoding=None)
+        f.write(content)
+        self.log_debug("added binary content at '%s' to FileCacheArchive '%s'"
+                       % (dest, self._archive_root))
 
     def add_link(self, source, link_name):
         dest = self.dest_path(link_name)

--- a/sos/plugins/postgresql.py
+++ b/sos/plugins/postgresql.py
@@ -69,7 +69,9 @@ class PostgreSQL(Plugin):
 
                 if scl is not None:
                     cmd = self.convert_cmd_scl(scl, cmd)
-                self.add_cmd_output(cmd, suggest_filename=filename)
+                self.add_cmd_output(cmd, suggest_filename=filename,
+                                    binary=True)
+
             else:  # no password in env or options
                 self.soslog.warning(
                     "password must be supplied to dump a database."

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -110,7 +110,8 @@ def is_executable(command):
 
 
 def sos_get_command_output(command, timeout=300, stderr=False,
-                           chroot=None, chdir=None, env=None):
+                           chroot=None, chdir=None, env=None,
+                           binary=False):
     """Execute a command and return a dictionary of status and output,
     optionally changing root or current working directory before
     executing command.
@@ -164,7 +165,7 @@ def sos_get_command_output(command, timeout=300, stderr=False,
 
     return {
         'status': p.returncode,
-        'output': stdout.decode('utf-8', 'ignore')
+        'output': stdout if binary else stdout.decode('utf-8', 'ignore')
     }
 
 


### PR DESCRIPTION
If a command output is a true binary data, allow add_cmd_output to
collect the raw content and dont try to decode it as UTF-8.

Resolves: #1169

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
