### PR TITLE
[openstack_glance|heat|nova] fix api container names

### DIFF
--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -64,7 +64,7 @@ class OpenStackGlance(Plugin):
         in_container = False
         if container_status['status'] == 0:
             for line in container_status['output'].splitlines():
-                if line.endswith("cinder_api"):
+                if line.endswith("glance_api"):
                     in_container = True
 
         if (service_status['status'] == 0) or in_container:

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -40,7 +40,7 @@ class OpenStackHeat(Plugin):
         in_container = False
         if container_status['status'] == 0:
             for line in container_status['output'].splitlines():
-                if line.endswith("cinder_api"):
+                if line.endswith("heat_api"):
                     in_container = True
 
         if (service_status['status'] == 0) or in_container:

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -43,7 +43,7 @@ class OpenStackNova(Plugin):
         in_container = False
         if container_status['status'] == 0:
             for line in container_status['output'].splitlines():
-                if line.endswith("cinder_api"):
+                if line.endswith("nova_api"):
                     in_container = True
 
         if (service_status['status'] == 0) or in_container:


### PR DESCRIPTION
Container names of glance, heat and nova api was not correct
when verify if a the container is running.

Signed-off-by: Martin Schuppert <mschuppe@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
