### PR TITLE
[sosreport] Allow policies to change report name generation

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -11,7 +11,7 @@ sosreport \- Collect and package diagnostic and support data
           [-k plug.opt|--plugin-option plug.opt]\fR
           [--no-report] [--config-file conf]\fR
           [--batch] [--build] [--debug]\fR
-          [--name name] [--case-id id] [--ticket-number nr]
+          [--label label] [--case-id id] [--ticket-number nr]
           [-s|--sysroot SYSROOT]\fR
           [-c|--chroot {auto|always|never}\fR
           [--tmp-dir directory]\fR
@@ -124,7 +124,12 @@ Override the default compression type specified by the active policy.
 Generate archive without prompting for interactive input.
 .TP
 .B \--name NAME
-Specify a name to be used for the archive.
+Deprecated. See \--label
+.TP
+.B \--label LABEL
+Specify an arbitrary identifier to associate with the archive.
+Labels will be appended after the system's short hostname and may container
+alphanumeric characters.
 .TP
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -8,7 +8,6 @@ class DebianPolicy(LinuxPolicy):
     distro = "Debian"
     vendor = "the Debian project"
     vendor_url = "http://www.debian.org/"
-    report_name = ""
     ticket_number = ""
     package_manager = PackageManager(
         "dpkg-query -W -f='${Package}|${Version}\\n'")
@@ -18,7 +17,6 @@ class DebianPolicy(LinuxPolicy):
 
     def __init__(self, sysroot=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot)
-        self.report_name = ""
         self.ticket_number = ""
         self.package_manager = PackageManager(
             "dpkg-query -W -f='${Package}|${Version}\\n'")

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -45,10 +45,10 @@ class RedHatPolicy(LinuxPolicy):
     _in_container = False
     _host_sysroot = '/'
     default_scl_prefix = '/opt/rh'
+    name_pattern = 'friendly'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)
-        self.report_name = ""
         self.ticket_number = ""
         # need to set _host_sysroot before PackageManager()
         if sysroot:

--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -31,7 +31,6 @@ class SuSEPolicy(LinuxPolicy):
 
     def __init__(self, sysroot=None):
         super(SuSEPolicy, self).__init__()
-        self.report_name = ""
         self.ticket_number = ""
         self.package_manager = PackageManager(
             'rpm -qa --queryformat "%{NAME}|%{VERSION}\\n"')

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -248,7 +248,7 @@ class SoSOptions(object):
     _quiet = False
     _debug = False
     _case_id = ""
-    _customer_name = ""
+    _label = ""
     _profiles = deque()
     _list_profiles = False
     _config_file = ""
@@ -470,15 +470,15 @@ class SoSOptions(object):
         self._case_id = value
 
     @property
-    def customer_name(self):
+    def label(self):
         if self._options is not None:
-            return self._options.customer_name
-        return self._customer_name
+            return self._options.label
+        return self._label
 
-    @customer_name.setter
-    def customer_name(self, value):
+    @label.setter
+    def label(self, value):
         self._check_options_initialized()
-        self._customer_name = value
+        self._label = value
 
     @property
     def profiles(self):
@@ -641,9 +641,8 @@ class SoSOptions(object):
                           dest="list_profiles", default=False,
                           help="display a list of available profiles and "
                                "plugins that they include")
-        parser.add_option("--name", action="store",
-                          dest="customer_name",
-                          help="specify report name")
+        parser.add_option("--label", "--name", action="store", dest="label",
+                          help="specify an additional report label")
         parser.add_option("--config-file", action="store",
                           dest="config_file",
                           help="specify alternate configuration file")


### PR DESCRIPTION
Previously, sosreport tarball names consisted of a very long date
string that was not pleasant to read, especially when dealing with
multiple sosreports for an ongoing issue.

This allows policies to determine how the report name should be
formatted by adding a 'name_scheme' attribute to the policies. By
default, this is set to 'legacy' and will result in names that are
unchanged - E.G this will give tarball names like
'sosreport-tux.123456-20170120185433'.

Additionally, there is a new 'friendly' name scheme that results in
tarball names like 'sosreport-tux-123456-2017-12-24-ezcfcop.tar.xz'.

A policy may also set name_scheme to 'custom' and provide it's own
pattern by setting the 'name_scheme_string' to a format() parsable
string.

This also sets the Red Hat policy to use the new 'friendly' pattern.

Resolves: #469

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
