### PR TITLE
[openstack_cinder] check for api service running via cinder_wsgi

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1026,6 +1026,17 @@ class Plugin(object):
         else:
             return html
 
+    def check_process_by_name(self, pr):
+        """Checks if a named process is listed in ps -ef output."""
+        ps = self.get_command_output("ps -ef")
+        status = False
+        if ps['status'] == 0:
+            for line in ps['output'].splitlines():
+                if pr in line:
+                    status = True
+                    break
+        return status
+
 
 class RedHatPlugin(object):
     """Tagging class for Red Hat's Linux distributions"""


### PR DESCRIPTION
With OSP11 cinder api changed to run via https wsgi. To check for
running cinder-manage command we also need to take this situation.
The change checks for cinder_wsgi process.

Signed-off-by: Martin Schuppert <mschuppert@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
