### PR TITLE
[Plugin] Make Plugin.policy an object instead of a function

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -142,6 +142,7 @@ class Plugin(object):
         self.copy_strings = []
         self.collect_cmds = []
         self.sysroot = commons['sysroot']
+        self.policy = commons['policy']
 
         self.soslog = self.commons['soslog'] if 'soslog' in self.commons \
             else logging.getLogger('sos')
@@ -176,9 +177,6 @@ class Plugin(object):
     def _log_debug(self, msg):
         self.soslog.debug(self._format_msg(msg))
 
-    def policy(self):
-        return self.commons["policy"]
-
     def join_sysroot(self, path):
         if path[0] == os.sep:
             path = path[1:]
@@ -200,7 +198,7 @@ class Plugin(object):
 
     def is_installed(self, package_name):
         '''Is the package $package_name installed?'''
-        return self.policy().pkg_by_name(package_name) is not None
+        return self.policy.pkg_by_name(package_name) is not None
 
     def do_cmd_private_sub(self, cmd):
         '''Remove certificate and key output archived by sosreport. cmd
@@ -963,7 +961,7 @@ class Plugin(object):
             else:
                 return
 
-        pm = self.policy().package_manager
+        pm = self.policy.package_manager
         verify_cmd = pm.build_verify_command(self.verify_packages)
         if verify_cmd:
             self.add_cmd_output(verify_cmd)
@@ -1070,7 +1068,7 @@ class SCLPlugin(RedHatPlugin):
         """wrapping command in "scl enable" call and adds proper PATH
         """
         # load default SCL prefix to PATH
-        prefix = self.policy().get_default_scl_prefix()
+        prefix = self.policy.get_default_scl_prefix()
         # read prefix from /etc/scl/prefixes/${scl} and strip trailing '\n'
         try:
             prefix = open('/etc/scl/prefixes/%s' % scl, 'r').read()\
@@ -1103,7 +1101,7 @@ class SCLPlugin(RedHatPlugin):
     # specific path. So we need to insert the paths after the appropriate root
     # dir.
     def convert_copyspec_scl(self, scl, copyspec):
-        scl_prefix = self.policy().get_default_scl_prefix()
+        scl_prefix = self.policy.get_default_scl_prefix()
         for rootdir in ['etc', 'var']:
             p = re.compile('^/%s/' % rootdir)
             copyspec = p.sub('/%s/%s/%s/' % (rootdir, scl_prefix, scl),

--- a/sos/plugins/atomichost.py
+++ b/sos/plugins/atomichost.py
@@ -27,7 +27,7 @@ class AtomicHost(Plugin, RedHatPlugin):
     ]
 
     def check_enabled(self):
-        return self.policy().in_container()
+        return self.policy.in_container()
 
     def setup(self):
         self.add_copy_spec("/etc/ostree/remotes.d")

--- a/sos/plugins/etcd.py
+++ b/sos/plugins/etcd.py
@@ -64,7 +64,7 @@ class etcd(Plugin, RedHatPlugin):
             # assume v3 is the default
             url = 'http://localhost:2379'
             try:
-                ver = self.policy().package_manager.get_pkg_list()['etcd']
+                ver = self.policy.package_manager.get_pkg_list()['etcd']
                 ver = ver['version'][0]
                 if ver == '2':
                     url = 'http://localhost:4001'

--- a/sos/plugins/iprconfig.py
+++ b/sos/plugins/iprconfig.py
@@ -27,7 +27,7 @@ class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     plugin_name = 'iprconfig'
 
     def check_enabled(self):
-        arch = self.policy().get_arch()
+        arch = self.policy.get_arch()
         return "ppc64" in arch and is_executable("iprconfig")
 
     def setup(self):

--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -69,7 +69,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/buddyinfo",
             "/proc/slabinfo",
             "/proc/zoneinfo",
-            "/lib/modules/%s/modules.dep" % self.policy().kernel_version(),
+            "/lib/modules/%s/modules.dep" % self.policy.kernel_version(),
             "/etc/conf.modules",
             "/etc/modules.conf",
             "/etc/modprobe.conf",

--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -352,7 +352,7 @@ class RedHatNetworking(Networking, RedHatPlugin):
     def setup(self):
         # Handle change from -T to -W in Red Hat netstat 2.0 and greater.
         try:
-            netstat_pkg = self.policy().package_manager.all_pkgs()['net-tools']
+            netstat_pkg = self.policy.package_manager.all_pkgs()['net-tools']
             # major version
             if int(netstat_pkg['version'][0]) < 2:
                 self.ns_wide = "-T"

--- a/sos/plugins/nfsserver.py
+++ b/sos/plugins/nfsserver.py
@@ -27,8 +27,8 @@ class NfsServer(Plugin, RedHatPlugin):
     profiles = ('storage', 'network', 'services', 'nfs')
 
     def check_enabled(self):
-        default_runlevel = self.policy().default_runlevel()
-        nfs_runlevels = self.policy().runlevel_by_service("nfs")
+        default_runlevel = self.policy.default_runlevel()
+        nfs_runlevels = self.policy.runlevel_by_service("nfs")
         if default_runlevel in nfs_runlevels:
             return True
 

--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -27,7 +27,7 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     profiles = ('system', 'hardware')
 
     def check_enabled(self):
-        return "ppc64" in self.policy().get_arch()
+        return "ppc64" in self.policy.get_arch()
 
     def setup(self):
         try:

--- a/sos/plugins/processor.py
+++ b/sos/plugins/processor.py
@@ -42,7 +42,7 @@ class Processor(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "turbostat --debug sleep 10"
         ])
 
-        if '86' in self.policy().get_arch():
+        if '86' in self.policy.get_arch():
             self.add_cmd_output("x86info -a")
 
 

--- a/sos/plugins/s390.py
+++ b/sos/plugins/s390.py
@@ -27,7 +27,7 @@ class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     # Check for s390 arch goes here
 
     def check_enabled(self):
-        return ("s390" in self.policy().get_arch())
+        return ("s390" in self.policy.get_arch())
 
     # Gather s390 specific information
 

--- a/sos/plugins/sunrpc.py
+++ b/sos/plugins/sunrpc.py
@@ -26,8 +26,8 @@ class SunRPC(Plugin):
     service = None
 
     def check_enabled(self):
-        if self.policy().default_runlevel() in \
-                self.policy().runlevel_by_service(self.service):
+        if self.policy.default_runlevel() in \
+                self.policy.runlevel_by_service(self.service):
             return True
         return False
 

--- a/tests/option_tests.py
+++ b/tests/option_tests.py
@@ -3,12 +3,15 @@
 import unittest
 
 from sos.plugins import Plugin
+from sos.policies import LinuxPolicy
+
 
 class GlobalOptionTest(unittest.TestCase):
 
     def setUp(self):
         self.commons = {
             'sysroot': '/',
+            'policy': LinuxPolicy(),
             'global_plugin_options': {
                 'test_option': 'foobar',
                 'baz': None,

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -12,6 +12,7 @@ except:
 
 from sos.plugins import Plugin, regex_findall, _mangle_command
 from sos.archive import TarFileArchive
+from sos.policies import LinuxPolicy
 import sos.policies
 
 PATH = os.path.dirname(__file__)
@@ -133,48 +134,55 @@ class PluginTests(unittest.TestCase):
     def setUp(self):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
+            'policy': LinuxPolicy(),
             'sysroot': self.sysroot
         })
         self.mp.archive = MockArchive()
 
     def test_plugin_default_name(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.name(), "mockplugin")
 
     def test_plugin_set_name(self):
-        p = NamedMockPlugin({'sysroot': self.sysroot})
+        p = NamedMockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy()
+        })
         self.assertEquals(p.name(), "testing")
 
     def test_plugin_no_descrip(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.get_description(), "<no description available>")
 
     def test_plugin_no_descrip(self):
-        p = NamedMockPlugin({'sysroot': self.sysroot})
+        p = NamedMockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy()
+        })
         self.assertEquals(p.get_description(), "This plugin has a description.")
 
     def test_set_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option("opt"), "testing")
 
     def test_set_nonexistant_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertFalse(p.set_option("badopt", "testing"))
 
     def test_get_nonexistant_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.get_option("badopt"), 0)
 
     def test_get_unset_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.get_option("opt"), 0)
 
     def test_get_unset_plugin_option_with_default(self):
         # this shows that even when we pass in a default to get,
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.get_option("opt", True), True)
 
     def test_get_unset_plugin_option_with_default_not_none(self):
@@ -182,20 +190,20 @@ class PluginTests(unittest.TestCase):
         # if the plugin default is not None
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.get_option("opt2", True), False)
 
     def test_get_option_as_list_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         p.set_option("opt", "one,two,three")
         self.assertEquals(p.get_option_as_list("opt"), ['one', 'two', 'three'])
 
     def test_get_option_as_list_plugin_option_default(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         self.assertEquals(p.get_option_as_list("opt", default=[]), [])
 
     def test_get_option_as_list_plugin_option_not_list(self):
-        p = MockPlugin({'sysroot': self.sysroot})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option_as_list("opt"), ['testing'])
 
@@ -210,7 +218,8 @@ class PluginTests(unittest.TestCase):
     def test_copy_dir_forbidden_path(self):
         p = ForbiddenMockPlugin({
             'cmdlineopts': MockOptions(),
-            'sysroot': self.sysroot
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy()
         })
         p.archive = MockArchive()
         p.setup()
@@ -225,6 +234,7 @@ class AddCopySpecTests(unittest.TestCase):
     def setUp(self):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
+            'policy': LinuxPolicy(),
             'sysroot': os.getcwd()
         })
         self.mp.archive = MockArchive()
@@ -328,6 +338,7 @@ class RegexSubTests(unittest.TestCase):
     def setUp(self):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
+            'policy': LinuxPolicy(),
             'sysroot': os.getcwd()
         })
         self.mp.archive = MockArchive()


### PR DESCRIPTION
Moves Plugin.policy to be an object for plugins instead of a function,
making it easier to leverage the active policy within sos plugins.

Also updates existing plugins that make use of `self.policy`.

Resolves: #763 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
