### PR TITLE
[nis] enable plugin also when package or config file present

### DIFF
--- a/sos/plugins/nis.py
+++ b/sos/plugins/nis.py
@@ -22,7 +22,9 @@ class Nis(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     plugin_name = 'nis'
     profiles = ('identity', 'services')
 
-    files = ('/var/yp',)
+    files = ('/var/yp', '/etc/ypserv.conf')
+
+    packages = ('ypserv')
 
     def setup(self):
         self.add_copy_spec([


### PR DESCRIPTION
Enable nis plugin also when ypserv package is installed or
if /etc/ypserv.conf exists.

Resolves: #1180

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
