### PR TITLE
[autofs] service status shouldnt rely on init.d

### DIFF
--- a/sos/plugins/autofs.py
+++ b/sos/plugins/autofs.py
@@ -49,7 +49,7 @@ class Autofs(Plugin):
 
     def setup(self):
         self.add_copy_spec("/etc/auto*")
-        self.add_cmd_output("/etc/init.d/autofs status")
+        self.add_cmd_output("service autofs status")
         self.add_cmd_output("automount -m")
         if self.checkdebug():
             self.add_copy_spec(self.getdaemondebug())


### PR DESCRIPTION
Replace init.d call by more generic "service" command applicable also
to systemd.

Resolves: #1183

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
