### PR TITLE
[plugins] add method to check process list for a named process

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1026,6 +1026,22 @@ class Plugin(object):
         else:
             return html
 
+    def check_process_by_name(self, process):
+        """Checks if a named process is found in /proc/[0-9]*/cmdline.
+        Returns either True or False."""
+        status = False
+        cmd_line_glob = "/proc/[0-9]*/cmdline"
+        try:
+            cmd_line_paths = glob.glob(cmd_line_glob)
+            for path in cmd_line_paths:
+                f = open(path, 'r')
+                cmd_line = f.read().strip()
+                if process in cmd_line:
+                    status = True
+        except IOError as e:
+            return False
+        return status
+
 
 class RedHatPlugin(object):
     """Tagging class for Red Hat's Linux distributions"""


### PR DESCRIPTION
In openstack plugins we collect data depending if processes with
different names are there. This introduces a check_process_by_name
Plugin method to have a consistent way to do this from any plugin
where needed.

Signed-off-by: Martin Schuppert mschuppe@redhat.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
