### PR TITLE
[pcp] really apply sizelimit to logs collected

### DIFF
--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -122,7 +122,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
         if self.pcp_hostname != '':
             for pmdir in ('pmlogger', 'pmmgr'):
                 path = os.path.join(self.pcp_log_dir, pmdir,
-                                    self.pcp_hostname)
+                                    self.pcp_hostname, '*')
                 self.add_copy_spec(path, sizelimit=self.limit)
 
         self.add_copy_spec([


### PR DESCRIPTION
add_copy_spec must be called to files and not dirs, to apply sizelimit

Resolves: #1187

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
