### PR TITLE
[etcd] Do not collect private etcd keys

### DIFF
--- a/sos/plugins/etcd.py
+++ b/sos/plugins/etcd.py
@@ -31,6 +31,7 @@ class etcd(Plugin, RedHatPlugin):
     def setup(self):
         etcd_url = self.get_etcd_url()
 
+        self.add_forbidden_path('/etc/etcd/ca')
         self.add_copy_spec('/etc/etcd')
 
         subcmds = [


### PR DESCRIPTION
Prevents sos from capturing the /etc/etcd/ca directory and its contents,
which is primarily private keys and the like.

Confirmed there is nothing of actual value for sos in the ca directory.

Resolves: #1193 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
