### PR TITLE
[ipa] fix implicit concatenation in one copy_spec

### DIFF
--- a/sos/plugins/ipa.py
+++ b/sos/plugins/ipa.py
@@ -59,7 +59,7 @@ class Ipa(Plugin, RedHatPlugin):
                "/var/log/pki/pki-tomcat/ca/system",
                "/var/log/pki/pki-tomcat/ca/transactions",
                "/var/log/pki/pki-tomcat/catalina.*",
-               "/var/log/pki/pki-ca-spawn.*"
+               "/var/log/pki/pki-ca-spawn.*",
                "/var/log/pki/pki-tomcat/kra/debug",
                "/var/log/pki/pki-tomcat/kra/system",
                "/var/log/pki/pki-tomcat/kra/transactions",


### PR DESCRIPTION
Missing comma between "/var/log/pki/pki-ca-spawn.*"
and "/var/log/pki/pki-tomcat/kra/debug"

Resolves: #1195

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
