### PR TITLE
[mysql] Add 'du' output from the mysql database path

### DIFF
--- a/sos/plugins/mysql.py
+++ b/sos/plugins/mysql.py
@@ -79,6 +79,8 @@ class Mysql(Plugin):
             name = "mysqldump_--all-databases"
             self.add_cmd_output("mysqldump %s" % opts, suggest_filename=name)
 
+        self.add_cmd_output("du -s /var/lib/mysql/*")
+
 
 class RedHatMysql(Mysql, RedHatPlugin):
 


### PR DESCRIPTION
This patch gathers the size of the content in
var/lib/mysql , which can be useful in some
cases to see if a db is growing out of control
(for example keystones tokens or another).

Closes: #1144

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
