### PR TITLE
[kernel] Add collection of tracing information

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -57,6 +57,18 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
 
         clocksource_path = "/sys/devices/system/clocksource/clocksource0/"
+
+        forbids = [
+            'trace_pipe',
+            'README',
+            'trace_stat/*',
+            'per_cpu/*',
+            'events/*'
+        ]
+
+        for forbid in forbids:
+            self.add_forbidden_path('/sys/kernel/debug/tracing/%s' % forbid)
+
         self.add_copy_spec([
             "/proc/modules",
             "/proc/sys/kernel/random/boot_id",
@@ -65,6 +77,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/sys/module/*/refcnt",
             "/sys/module/*/taint",
             "/sys/firmware/acpi/*",
+            "/sys/kernel/debug/tracing/*",
             "/proc/kallsyms",
             "/proc/buddyinfo",
             "/proc/slabinfo",


### PR DESCRIPTION
Adds collection of /sys/kernel/debug/tracing and /sys/kernel/debug/sunrpc information to the kernel plugin.

Skips items like `trace_pipe` and `per_cpu/*` that would cause either sos to hang or a potential load spike.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
