### PR TITLE
[filesys] Clean lsof output, capture lslocks and mountinfo for pids

### DIFF
--- a/sos/plugins/filesys.py
+++ b/sos/plugins/filesys.py
@@ -33,13 +33,15 @@ class Filesys(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/self/mounts",
             "/proc/self/mountinfo",
             "/proc/self/mountstats",
+            "/proc/[0-9]*/mountinfo",
             "/proc/mounts"
         ])
         self.add_cmd_output("mount -l", root_symlink="mount")
         self.add_cmd_output("df -al -x autofs", root_symlink="df")
         self.add_cmd_output([
             "df -ali -x autofs",
-            "findmnt"
+            "findmnt",
+            "lslocks"
         ])
 
         if self.get_option('lsof'):
@@ -59,5 +61,12 @@ class Filesys(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             r"(password=)[^\s]*",
             r"\1********"
         )
+
+        # remove expected errors from lsof due to command formatting, but still
+        # keep stderr so other errors are reported
+        regex = (r"(lsof: (avoiding (.*?)|WARNING: can't stat\(\) (.*?))|"
+                 "Output information may be incomplete.)\n")
+
+        self.do_cmd_output_sub("lsof", regex, '')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Cleans the output of lsof, removing errors and warnings that are
expected due to the lsof command that is being run. Other errors that
lsof might produce to stderr are still preserved.

Additionally, capture lslocks output and /proc/pid/mountinfo for each
pid.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
