### PR TITLE
[ipa] set ipa_version variable before referencing it

### DIFF
--- a/sos/plugins/ipa.py
+++ b/sos/plugins/ipa.py
@@ -86,6 +86,8 @@ class Ipa(Plugin, RedHatPlugin):
         self.pki_tomcat_conf_dir_v4 = "/etc/pki/pki-tomcat/ca"
         self.pki_tomcat_conf_dir_v3 = "/etc/pki-ca"
 
+        ipa_version = None
+
         if self.ipa_server_installed():
             self._log_debug("IPA server install detected")
 


### PR DESCRIPTION
In case neither IPA v3 or v4 is installed, ipa_version remains
uninitialized before referencing it.

Resolves: #1214

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
