### PR TITLE
[powerpath] Check for kernel module to enable plugin

### DIFF
--- a/sos/plugins/powerpath.py
+++ b/sos/plugins/powerpath.py
@@ -23,7 +23,15 @@ class PowerPath(Plugin, RedHatPlugin):
 
     plugin_name = 'powerpath'
     profiles = ('storage', 'hardware')
-    packages = ('EMCpower',)
+
+    def check_enabled(self):
+        mods = ['emcp', 'emcpdm', 'emcpgpx', 'emcpmpx']
+        res = self.get_command_output('lsmod')
+        if res['status'] == 0:
+            loaded = [l.split()[0] for l in mods['output'].split('\n')]
+            if any(mod in loaded for mod in mods):
+                return True
+        return self.is_installed('EMCpower')
 
     def get_pp_files(self):
         """ EMC PowerPath specific information - files


### PR DESCRIPTION
Changes the enablement for the powerpath plugin to first check for any
of the EMC kernel modules associated with powerpath. If none are
present, still check for the presence of the EMCpower package.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
