### PR TITLE
[rpm] Collect package-cleanup and add option for rpm DB

### DIFF
--- a/sos/plugins/rpm.py
+++ b/sos/plugins/rpm.py
@@ -13,6 +13,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from sos.plugins import Plugin, RedHatPlugin
+from sos.utilities import is_executable
 
 
 class Rpm(Plugin, RedHatPlugin):
@@ -24,12 +25,18 @@ class Rpm(Plugin, RedHatPlugin):
 
     option_list = [("rpmq", "queries for package information via rpm -q",
                     "fast", True),
-                   ("rpmva", "runs a verify on all packages", "slow", False)]
+                   ("rpmva", "runs a verify on all packages", "slow", False),
+                   ("rpmdb", "collect /var/lib/rpm", "slow", False)]
 
     verify_packages = ('rpm',)
 
     def setup(self):
         self.add_copy_spec("/var/log/rpmpkgs")
+        if is_executable('package-cleanup'):
+            self.add_cmd_output([
+                'package-cleanup --problems',
+                'package-cleanup --dupes'
+            ])
 
         def add_rpm_cmd(query_fmt, filter_cmd, symlink, suggest):
             rpmq_cmd = 'rpm --nodigest -qa --qf=%s' % query_fmt
@@ -60,5 +67,10 @@ class Rpm(Plugin, RedHatPlugin):
         if self.get_option("rpmva"):
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",
                                 timeout=180)
+
+        if self.get_option("rpmdb"):
+            self.add_cmd_output("lsof +D /var/lib/rpm",
+                                suggest_filename='lsof_D_var_lib_rpm')
+            self.add_copy_spec("/var/lib/rpm")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of package-cleanup output if the package-cleanup command
is available on the system.

Adds the rpmdb option, disabled by default, to collect the contents of
/var/lib/rpm to diagnose RPM DB problems. Users should note that use of
this option will typically significantly increase the size of the final
sosreport archive.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
