### PR TITLE
[ntp] Collect hwclock and ntpq -c output

### DIFF
--- a/sos/plugins/ntp.py
+++ b/sos/plugins/ntp.py
@@ -32,8 +32,14 @@ class Ntp(Plugin):
         ])
         self.add_cmd_output([
             "ntptime",
-            "ntpq -p"
+            "ntpq -pn",
+            "ntpq -c as"
         ])
+
+        ids = self.get_command_output('ntpq -c as')
+        if ids['status'] == 0:
+            for asid in [i.split()[1] for i in ids['output'].splitlines()[3:]]:
+                self.add_cmd_output("ntpq -c 'rv %s'" % asid)
 
 
 class RedHatNtp(Ntp, RedHatPlugin):


### PR DESCRIPTION
Adds collection of hwclock, and adds -n to the ntpq -p command
collected.

Collects `ntpq -c as` output and will also iterate over all association
ids listed to collect `ntpq -c 'rv $id'`.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
