### PR TITLE
[postfix|sendmail] Add mailq output

### DIFF
--- a/sos/plugins/postfix.py
+++ b/sos/plugins/postfix.py
@@ -28,7 +28,10 @@ class Postfix(Plugin):
             "/etc/postfix/main.cf",
             "/etc/postfix/master.cf"
         ])
-        self.add_cmd_output("postconf")
+        self.add_cmd_output([
+            'postconf',
+            'mailq'
+        ])
 
 
 class RedHatPostfix(Postfix, RedHatPlugin):

--- a/sos/plugins/sendmail.py
+++ b/sos/plugins/sendmail.py
@@ -23,33 +23,31 @@ class Sendmail(Plugin):
 
     plugin_name = "sendmail"
     profiles = ('services', 'mail')
-
     packages = ('sendmail',)
+
+    def setup(self):
+        self.add_copy_spec("/etc/mail/*")
+        self.add_cmd_output([
+            'mailq',
+            'mailq -Ac'
+        ])
 
 
 class RedHatSendmail(Sendmail, RedHatPlugin):
 
     files = ('/etc/rc.d/init.d/sendmail',)
-    packages = ('sendmail',)
 
     def setup(self):
         super(RedHatSendmail, self).setup()
-        self.add_copy_spec([
-            "/etc/mail/*",
-            "/var/log/maillog"
-        ])
+        self.add_copy_spec('/var/log/maillog')
 
 
 class DebianSendmail(Sendmail, DebianPlugin, UbuntuPlugin):
 
     files = ('/etc/init.d/sendmail',)
-    packages = ('sendmail',)
 
     def setup(self):
         super(DebianSendmail, self).setup()
-        self.add_copy_spec([
-            "/etc/mail/*",
-            "/var/log/mail.*"
-        ])
+        self.add_copy_spec("/var/log/mail.*")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of mailq output to the postfix and sendmail plugins.
Sendmail also collects 'mailq -Ac'.

Additionally, cleanup redundant checks and add_copy_spec in sendmail
plugin.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
