### PR TITLE
[os_net_config] Capture the os-net-config run time data

### DIFF
--- a/sos/plugins/os_net_config.py
+++ b/sos/plugins/os_net_config.py
@@ -24,6 +24,7 @@ class OsNetConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     def setup(self):
         self.add_copy_spec("/etc/os-net-config")
+        self.add_copy_spec("/var/lib/os-net-config")
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
For DPDK OpenStack deployments with TripleO, os-net-config
binds the DPDK PMD driver to the interface and writes the
details in to the directory /var/lib/os-net-config. Adding
this directory for the report collection.

Signed-off-by: Saravanan KR <skramaja@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
