### PR TITLE
[plugins] dont catch FileNotFoundError specifically

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -556,7 +556,7 @@ class Plugin(object):
             def getmtime(path):
                 try:
                     return os.path.getmtime(path)
-                except (OSError, FileNotFoundError):
+                except OSError:
                     return 0
 
             files.sort(key=getmtime, reverse=True)
@@ -567,7 +567,7 @@ class Plugin(object):
             for _file in files:
                 try:
                     current_size += os.stat(_file)[stat.ST_SIZE]
-                except (OSError, FileNotFoundError):
+                except OSError:
                     self._log_info("failed to stat '%s'" % _file)
                 if sizelimit and current_size > sizelimit:
                     limit_reached = True


### PR DESCRIPTION
.. since it doesnt exist in py2, while parent class OSError does

Resolves: #1230

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
