### PR TITLE
[openvswitch] verbose tunnel port output

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -71,7 +71,7 @@ class OpenVSwitch(Plugin):
             # Capture tnl arp table"
             "ovs-appctl tnl/arp/show",
             # Capture a list of listening ports"
-            "ovs-appctl tnl/ports/show",
+            "ovs-appctl tnl/ports/show -v",
             # Capture upcall information
             "ovs-appctl upcall/show",
             # Capture DPDK and other parameters


### PR DESCRIPTION
Run the command "ovs-appctl tnl/ports/show" with verbose output.
Leave the non verbose output as well, as the output differs.

Signed-off-by: Matteo Croce <mcroce@redhat.com>

---
Please place an 'X' inside each '[X]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
