### PR TITLE
[archive] Change log level for missing compression tools

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -428,7 +428,7 @@ class TarFileArchive(FileCacheArchive):
             if is_executable(method):
                 methods.append(method)
             else:
-                self.log_error("\"%s\" command not found." % method)
+                self.log_info("\"%s\" compression method unavailable" % method)
         if self.method in methods:
             methods = [self.method]
 


### PR DESCRIPTION
Changes the log level from error to info when sos is checking for valid
compression tools (xz, bzip2, gzip) and finds that one does not exist.

The fact that one of the compression methods isn't available is not
necessarily an error depending on where sos is being run, for example in
a container that provides xz but not gzip. In this case an error is
printed saying gzip is not available, even if sos would never have used
gzip due to the presence of xz, which could cause end user confusion.

If no supported compression methods are available, then that is still
properly reported as an error.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
