### PR TITLE
[yum] Capture installed list

### DIFF
--- a/sos/plugins/yum.py
+++ b/sos/plugins/yum.py
@@ -52,7 +52,10 @@ class Yum(Plugin, RedHatPlugin):
             "/etc/pki/consumer/cert.pem",
             "/etc/pki/entitlement/*.pem"
         ])
-        self.add_cmd_output("yum history")
+        self.add_cmd_output([
+            "yum history",
+            "yum list installed"
+        ])
 
         # packages installed/erased/updated per transaction
         if self.get_option("yum-history-info"):


### PR DESCRIPTION
Adds collection of 'yum list installed' to the yum plugin. The system management support team told me this would help a decent percentage of their cases move faster and asked that it be a default action.

I think this should be safe to run by default, testing on a RHEL 7 system with 66 repos enabled this took 1m10s to run. I can't think of any realistic scenarios aside from a pulp/satellite deployment where a system would have anywhere near that many repos enabled. With the other performance enhancements we're picking up (especially if #1199 makes 3.6) this should be acceptable since the rest of the plugin wouldn't add much longer to the run time, unless `yumlist` was specified to grab the larger list of all available *and* installed packages.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
