### PR TITLE
[ovirt_hosted_engine] Collect all setup logs

### DIFF
--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -32,7 +32,6 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
     plugin_name = 'ovirt_hosted_engine'
     profiles = ('virt',)
 
-    SETUP_LOG_GLOB = '/var/log/ovirt-hosted-engine-setup/*.log'
     HA_LOG_GLOB = '/var/log/ovirt-hosted-engine-ha/*.log'
 
     def setup(self):
@@ -56,19 +55,8 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
             '/var/lib/ovirt-hosted-engine-ha/broker.conf',
         ])
 
-        all_setup_logs = glob.glob(self.SETUP_LOG_GLOB)
-        all_setup_logs.sort(reverse=True)
-        if len(all_setup_logs):
-            # Add latest ovirt-hosted-engine-setup log file
-            self.add_copy_spec(all_setup_logs[0])
-        # Add older ovirt-hosted-engine-setup log files only if requested
-        if self.get_option('all_logs'):
-            self.add_copy_spec(
-                self.SETUP_LOG_GLOB,
-                sizelimit=self.limit
-            )
-
         self.add_copy_spec([
+            '/var/log/ovirt-hosted-engine-setup',
             '/var/log/ovirt-hosted-engine-ha/agent.log',
             '/var/log/ovirt-hosted-engine-ha/broker.log',
         ])


### PR DESCRIPTION
In oVirt 4.2.1 and later, setup also runs several ansible playbooks,
each logging to its own file. Collect everything.

There should not be many files usually, as if all goes well users run
setup only once. Otherwise, it is useful for debugging to get older logs
as well.

Resolves: #1243

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
