### PR TITLE
[openstack_*] obfuscate just passwords from connection URIs

### DIFF
--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -85,6 +85,13 @@ class OpenStackCinder(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
+    def apply_regex_sub(self, regexp, subst):
+        self.do_path_regex_sub("/etc/cinder/*", regexp, subst)
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/cinder/*",
+            regexp, subst
+        )
+
     def postproc(self):
         protect_keys = [
             "admin_password", "backup_tsm_password", "chap_password",
@@ -95,15 +102,19 @@ class OpenStackCinder(Plugin):
             "netapp_password", "netapp_sa_password", "nexenta_password",
             "password", "qpid_password", "rabbit_password", "san_password",
             "ssl_key_password", "vmware_host_password", "zadara_password",
-            "zfssa_initiator_password", "connection", "zfssa_target_password",
-            "os_privileged_user_password", "hmac_keys"
+            "zfssa_initiator_password", "hmac_keys", "zfssa_target_password",
+            "os_privileged_user_password"
         ]
+        connection_keys = ["connection"]
 
-        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/cinder/*", regexp, r"\1*********")
-        self.do_path_regex_sub(
-            self.var_puppet_gen + "/etc/cinder/*",
-            regexp, r"\1*********"
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"\1*********"
+        )
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*(.*)://(\w*):)(.*)(@(.*))" %
+            "|".join(connection_keys),
+            r"\1*********\6"
         )
 
 

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -93,18 +93,28 @@ class OpenStackGlance(Plugin):
             else:
                 self.add_cmd_output("openstack image list --long")
 
+    def apply_regex_sub(self, regexp, subst):
+        self.do_path_regex_sub("/etc/glance/*", regexp, subst)
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/glance/*",
+            regexp, subst
+        )
+
     def postproc(self):
         protect_keys = [
             "admin_password", "password", "qpid_password", "rabbit_password",
-            "s3_store_secret_key", "ssl_key_password", "connection",
-            "vmware_server_password"
+            "s3_store_secret_key", "ssl_key_password", "vmware_server_password"
         ]
+        connection_keys = ["connection"]
 
-        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/glance/*", regexp, r"\1*********")
-        self.do_path_regex_sub(
-            self.var_puppet_gen + "/etc/glance/*",
-            regexp, r"\1*********"
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"\1*********"
+        )
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*(.*)://(\w*):)(.*)(@(.*))" %
+            "|".join(connection_keys),
+            r"\1*********\6"
         )
 
 

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -85,16 +85,27 @@ class OpenStackIronic(Plugin):
             self.add_cmd_output("openstack baremetal node list --long")
             self.add_cmd_output("openstack baremetal port list")
 
+    def apply_regex_sub(self, regexp, subst):
+        for conf in self.conf_list:
+            self.do_path_regex_sub(conf, regexp, subst)
+
     def postproc(self):
         protect_keys = [
             "dns_passkey", "memcache_secret_key", "rabbit_password",
-            "password", "qpid_password", "connection", "sql_connection",
-            "admin_password", "ssl_key_password", "os_password"
+            "password", "qpid_password", "admin_password", "ssl_key_password",
+            "os_password"
         ]
-        regexp = r"((?m)^\s*#*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+        connection_keys = ["connection", "sql_connection"]
 
-        for conf in self.conf_list:
-            self.do_path_regex_sub(conf, regexp, r"\1*********")
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"\1*********"
+        )
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*(.*)://(\w*):)(.*)(@(.*))" %
+            "|".join(connection_keys),
+            r"\1*********\6"
+        )
 
 
 class DebianIronic(OpenStackIronic, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -50,19 +50,29 @@ class OpenStackManila(Plugin):
                 "/var/log/containers/httpd/manila-api/*log"
             ], sizelimit=self.limit)
 
+    def apply_regex_sub(self, regexp, subst):
+        self.do_path_regex_sub("/etc/manila/*", regexp, subst)
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/manila/*",
+            regexp, subst
+        )
+
     def postproc(self):
         protect_keys = [
             "nova_admin_password",  "rabbit_password",  "qpid_password",
             "password", "netapp_nas_password", "cinder_admin_password",
-            "neutron_admin_password", "service_instance_password",
-            "connection", "sql_connection"
+            "neutron_admin_password", "service_instance_password"
         ]
+        connection_keys = ["connection", "sql_connection"]
 
-        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/manila/*", regexp, r"\1*********")
-        self.do_path_regex_sub(
-            self.var_puppet_gen + "/etc/manila/*",
-            regexp, r"\1*********"
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"\1*********"
+        )
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*(.*)://(\w*):)(.*)(@(.*))" %
+            "|".join(connection_keys),
+            r"\1*********\6"
         )
 
 

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -56,19 +56,30 @@ class OpenStackSwift(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
+    def apply_regex_sub(self, regexp, subst):
+        self.do_path_regex_sub("/etc/swift/.*\.conf.*", regexp, subst)
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/swift/etc/swift/.*\.conf.*",
+            regexp, subst
+        )
+
     def postproc(self):
         protect_keys = [
             "ldap_dns_password", "neutron_admin_password", "rabbit_password",
             "qpid_password", "powervm_mgr_passwd", "virtual_power_host_pass",
             "xenapi_connection_password", "password", "host_password",
-            "vnc_password", "connection", "sql_connection", "admin_password"
+            "vnc_password", "admin_password"
         ]
+        connection_keys = ["connection", "sql_connection"]
 
-        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub("/etc/swift/.*\.conf.*", regexp, r"\1*********")
-        self.do_path_regex_sub(
-            self.var_puppet_gen + "/swift/etc/swift/.*\.conf.*",
-            regexp, r"\1*********"
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"\1*********"
+        )
+        self.apply_regex_sub(
+            r"((?m)^\s*(%s)\s*=\s*(.*)://(\w*):)(.*)(@(.*))" %
+            "|".join(connection_keys),
+            r"\1*********\6"
         )
 
 


### PR DESCRIPTION
do not obfuscate whole connection URI but just the password there

currently, for a config line:

    connection=mysql+pymysql://nova_api:tYscAjtg6FC4u8rDxDPnXAkkp@1.2.3.4/nova_api?read_default_file=/etc/my.cnf.d/tripleo.cnf&read_default_group=tripleo

sosreport obfuscates to:

    connection=*********

while it should just do:

    connection=mysql+pymysql://nova_api:*********@1.2.3.4/nova_api?read_default_file=/etc/my.cnf.d/tripleo.cnf&read_default_group=tripleo


Resolves: #1246

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
