### PR TITLE
[abrt] Add config files to sosreport

### DIFF
--- a/sos/plugins/abrt.py
+++ b/sos/plugins/abrt.py
@@ -41,4 +41,9 @@ class Abrt(Plugin, RedHatPlugin):
         if self.get_option('detailed') and list_file:
             self.info_detailed(list_file)
 
+        self.add_copy_spec([
+            "/etc/abrt/abrt.conf",
+            "/etc/abrt/abrt-action-save-package-data.conf",
+            "/etc/abrt/plugins"
+        ])
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch adds the configuration files /etc/abrt/abrt.conf and 
/etc/abrt/abrt-action-save-package-data.conf that were not collected
 in the abrt plugin.

Resolves: #1251

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
