### PR TITLE
[mongodb] Collect size of dbs from FS point of view

### DIFF
--- a/sos/plugins/mongodb.py
+++ b/sos/plugins/mongodb.py
@@ -40,6 +40,7 @@ class MongoDb(Plugin, DebianPlugin, UbuntuPlugin):
             "/var/log/mongodb/mongodb.log",
             "/var/log/containers/mongodb/mongodb.log"
         ])
+        self.add_cmd_output("du -s /var/lib/mongodb/")
 
     def postproc(self):
         self.do_file_sub(


### PR DESCRIPTION
This patch gathers the size of the content in
/var/lib/mongodb/ , which can be useful in some
cases to see if a db is growing out of control.

Closes: #1233.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
