### PR TITLE
[block] Gather information about discards via lsblk

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -29,6 +29,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "lsblk",
             "lsblk -t",
+            "lsblk -D",
             "blkid -c /dev/null",
             "blockdev --report",
             "ls -lanR /dev",


### PR DESCRIPTION
This patch adds the output of 'lsblk -D' to the
block plugin, so we can gather some useful information
about discarding capabilities for each device.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
