### PR TITLE
[sosreport] Increase default log size to 25MB

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -581,7 +581,7 @@ class SoSOptions(object):
                                  "format (see -l)",
                             default=deque())
         parser.add_argument("--log-size", action="store",
-                            dest="log_size", default=10, type=int,
+                            dest="log_size", default=25, type=int,
                             help="set a limit on the size of collected logs "
                                  "(in MiB)")
         parser.add_argument("-a", "--alloptions", action="store_true",


### PR DESCRIPTION
Increases the default log_size option to 25MB, as 10MB may be too low
and miss pertinent information in places like /var/log/messages.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
