### PR TITLE
[networking] collect netstat for all namespaces

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -316,11 +316,15 @@ class Networking(Plugin):
         cmd_prefix = "ip netns exec "
         if ip_netns_file:
             for namespace in self.get_ip_netns(ip_netns_file):
+                ns_cmd_prefix = cmd_prefix + namespace + " "
                 self.add_cmd_output([
-                    cmd_prefix + namespace + " ip address show",
-                    cmd_prefix + namespace + " ip route show table all",
-                    cmd_prefix + namespace + " iptables-save",
-                    cmd_prefix + namespace + " ss -peaonmi"
+                    ns_cmd_prefix + "ip address show",
+                    ns_cmd_prefix + "ip route show table all",
+                    ns_cmd_prefix + "iptables-save",
+                    ns_cmd_prefix + "ss -peaonmi",
+                    ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
+                    ns_cmd_prefix + "netstat -s",
+                    ns_cmd_prefix + "netstat %s -agn" % self.ns_wide
                 ])
 
             # Devices that exist in a namespace use less ethtool


### PR DESCRIPTION
collect all netstat commands for all network namespaces

Resolves: #1261

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
