### PR TITLE
[Plugin] Fix string decoding for debug log output

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -709,12 +709,10 @@ class Plugin(object):
     def add_string_as_file(self, content, filename):
         """Add a string to the archive as a file named `filename`"""
         self.copy_strings.append((content, filename))
-        if isinstance(content, six.string_types):
-            content = "..." + content.splitlines()[0]
-        else:
-            content = ("..." +
-                       (content.splitlines()[0]).decode('utf8', 'ignore'))
-        self._log_debug("added string '%s' as '%s'" % (content, filename))
+        content = content.splitlines()[0]
+        if not isinstance(content, six.string_types):
+            content = content.decode('utf8', 'ignore')
+        self._log_debug("added string ...'%s' as '%s'" % (content, filename))
 
     def get_cmd_output_now(self, exe, suggest_filename=None,
                            root_symlink=False, timeout=300, stderr=True,
@@ -863,13 +861,10 @@ class Plugin(object):
 
     def _collect_strings(self):
         for string, file_name in self.copy_strings:
-            content = "..."
-            if isinstance(string, six.string_types):
-                content = "..." + content.splitlines()[0]
-            else:
-                content = ("..." +
-                           (content.splitlines()[0]).decode('utf8', 'ignore'))
-            self._log_info("collecting string '%s' as '%s'"
+            content = string.splitlines()[0]
+            if not isinstance(content, six.string_types):
+                content = content.decode('utf8', 'ignore')
+            self._log_info("collecting string ...'%s' as '%s'"
                            % (content, file_name))
             try:
                 self.archive.add_string(string,


### PR DESCRIPTION
In add_string_as_file and _collect_strings, the first line of each string
is printed to debug log, however there is a bug in _collect_strings that
tries to decode the first line of '...' instead of the actual string;
this causes a error like:

  File "/usr/share/sosreport/sos/sosreport.py", line 1300, in collect
    plug.collect()
  File "/usr/share/sosreport/sos/plugins/__init__.py", line 877, in collect
    self._collect_strings()
  File "/usr/share/sosreport/sos/plugins/__init__.py", line 860, in _collect_strings
    (content.splitlines()[0]).decode('utf8', 'ignore'))
AttributeError: 'str' object has no attribute 'decode'

This simplifies the (string or bytearray)-to-first-line-string of both
functions, which also fixes the bug using the wrong variable to decode.

Fixes: 7ba2fb47d05b608f3863fda9271894e38b43937a
Signed-off-by: Dan Streetman <ddstreet@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

Note - commit msg is line-split and wrapped at 72 chars, except for the python backtrace.  I edited the checklist to indicate all X's, since I assume the python backtrace is exempted from the 72-char line limit