### PR TITLE
[kernel] Disable gathering /proc/timer* statistics by default

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -27,6 +27,10 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     sys_module = '/sys/module'
 
+    option_list = [
+        ("with-timer", "gather /proc/timer* statistics", "slow", False)
+    ]
+
     def setup(self):
         # compat
         self.add_cmd_output("uname -a", root_symlink="uname")
@@ -83,7 +87,6 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/driver",
             "/proc/sys/kernel/tainted",
             "/proc/softirqs",
-            "/proc/timer*",
             "/proc/lock*",
             "/proc/misc",
             "/var/log/dmesg",
@@ -91,5 +94,10 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             clocksource_path + "available_clocksource",
             clocksource_path + "current_clocksource"
         ])
+
+        if self.get_option("with-timer"):
+            # This can be very slow, depending on the number of timers,
+            # and may also cause softlockups
+            self.add_copy_spec("/proc/timer*")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Disable gathering `/proc/timer*` statistics by default, a new option 'kernel.with-timer' enables gathering these.

If `/proc/timer_list` is huge, then kernel will experience issues with processing all the timers since it needs to spin in a tight loop inside the kernel.

We have tried to fix it from kernel side, added `touch_nmi_watchdog()` to silence softlockups, `cond_resched()` to fix RCU stall issue but with such huge number of timers the RHEL7 kernel is still hangs.
It can reproduced somehow on upstream kernel (however, there will be workqueue lockups).

We came to conclusion that reading `/proc/timer_list` should be disabled in sosreport.
Since `/proc/timer_stats` is tight to `/proc/timer_list`, both are disabled at the same time.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
