### PR TITLE
Collect install-undercloud.log for a containerized undercloud

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -26,7 +26,10 @@ class OpenStackInstack(Plugin):
     profiles = ('openstack', 'openstack_undercloud')
 
     def setup(self):
+        # For non-containerized undercloud
         self.add_copy_spec("/home/stack/.instack/install-undercloud.log")
+        # For containerized undercloud
+        self.add_copy_spec("/home/stack/install-undercloud.log")
         self.add_copy_spec("/home/stack/instackenv.json")
         self.add_copy_spec("/home/stack/undercloud.conf")
         if self.get_option("verify"):


### PR DESCRIPTION
When containerizing the undercloud, we're moving install-undercloud.log
into $HOME which makes it more accessible for the users, while we're
removing instack(-undercloud) bits over time.

This patch add $HOME/install-undercloud.log file and document why we're
doing this. Note that we still collect old file for previous releases.