### PR TITLE
openstack/undercloud: include /var/log/heat-launcher/*

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -29,6 +29,7 @@ class OpenStackInstack(Plugin):
         self.add_copy_spec("/home/stack/.instack/install-undercloud.log")
         self.add_copy_spec("/home/stack/instackenv.json")
         self.add_copy_spec("/home/stack/undercloud.conf")
+        self.add_copy_spec("/var/log/heat-launcher/")
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 


### PR DESCRIPTION
/var/log/heat-launcher is a new directory that contains the
heat-installer sqlite, logs and configuration.
The content is small because it's only used once and it's ephemeral
(purged everytime an operator install or upgrade an undercloud).

However, collecting these files will be useful to help customers.