### PR TITLE
[archive] warn with errmsg if compress fails

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1507,7 +1507,10 @@ class SoSReport(object):
             # compute and store the archive checksum
             hash_name = self.policy.get_preferred_hash_name()
             checksum = self._create_checksum(archive, hash_name)
-            self._write_checksum(archive, hash_name, checksum)
+            try:
+                self._write_checksum(archive, hash_name, checksum)
+            except (OSError, IOError):
+                print(_("Error writing checksum for file: %s" % archive))
 
             # output filename is in the private tmpdir - move it to the
             # containing directory.
@@ -1540,7 +1543,6 @@ class SoSReport(object):
                     os.rename(archive_hash, final_hash)
             except (OSError, IOError):
                     print(_("Error moving checksum file: %s" % archive_hash))
-                    return False
 
         self.policy.display_results(archive, directory, checksum)
 


### PR DESCRIPTION
Include stderr of compression command and warn instead of
info so user sees RC immediately.

Signed-off-by: Filip Krska <fkrska@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
