### PR TITLE
[nfs] Add nfs.conf

### DIFF
--- a/sos/plugins/nfs.py
+++ b/sos/plugins/nfs.py
@@ -26,6 +26,7 @@ class Nfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec([
             "/etc/nfsmount.conf",
             "/etc/idmapd.conf",
+            "/etc/nfs.conf",
             "/proc/fs/nfsfs/servers",
             "/proc/fs/nfsfs/volumes"
         ])


### PR DESCRIPTION
Many NFS (and other related programs) options can now be set
through the config file /etc/nfs.conf.
Collect this from the 'nfs' plugin.

Signed-off-by: Pierguido Lambri <plambri@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
