### PR TITLE
[systemd] collect unit paths

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -44,6 +44,8 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "systemctl show-environment",
             "systemd-delta",
             "systemd-analyze",
+            "systemd-analyze dump",
+            "systemd-analyze plot",
             "journalctl --list-boots",
             "ls -lR /lib/systemd",
             "timedatectl"
@@ -57,7 +59,8 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/lib/systemd/system",
             "/lib/systemd/user",
             "/etc/vconsole.conf",
-            "/etc/yum/protected.d/systemd.conf"
+            "/etc/yum/protected.d/systemd.conf",
+            "/run/systemd"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

This PR proposes to collect unit file names found in standard systemd paths. It will enable to find out unwanted customizations, such as creating a symlink to some outside place.