### PR TITLE
[libraries] collect standard library paths

### DIFF
--- a/sos/plugins/libraries.py
+++ b/sos/plugins/libraries.py
@@ -26,4 +26,16 @@ class Libraries(Plugin, RedHatPlugin, UbuntuPlugin):
             self.add_cmd_output("ldconfig -v -N -X")
         self.add_cmd_output("ldconfig -p -N -X")
 
+        # Collect library directories from ldconfig's cache
+        cmd = self.get_command_output("ldconfig -p -N -X")
+        dirs = set()
+        if cmd['status'] == 0:
+            for l in cmd['output'].splitlines():
+                s = l.split(" => ", 2)
+                if len(s) != 2:
+                    continue
+                dirs.add(s[1].rsplit('/', 1)[0])
+        self.add_cmd_output("ls -lanH %s" % " ".join(dirs),
+                            suggest_filename="ld_so_cache")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

This PR proposes to collect the list of libraries found in lib and usr/lib (respectively lib64 and usr/lib64).
This may be useful to detect non-standard libraries pointing to some outside place.