### PR TITLE
[systemd] collect additional useful information

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -45,10 +45,14 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "systemd-delta",
             "systemd-analyze",
             "systemd-analyze blame",
+            "systemd-analyze dump",
             "journalctl --list-boots",
             "ls -lR /lib/systemd",
             "timedatectl"
         ])
+
+        self.add_cmd_output("systemd-analyze plot",
+                            suggest_filename="systemd-analyze_plot.svg")
 
         if self.get_option("verify"):
             self.add_cmd_output("journalctl --verify")
@@ -58,7 +62,12 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/lib/systemd/system",
             "/lib/systemd/user",
             "/etc/vconsole.conf",
-            "/etc/yum/protected.d/systemd.conf"
+            "/etc/yum/protected.d/systemd.conf",
+            "/run/systemd/generator*",
+            "/run/systemd/seats",
+            "/run/systemd/sessions",
+            "/run/systemd/system",
+            "/run/systemd/users"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

- Including `/run/systemd` directory enables to debug generated units, which is useful when customization are made by the customer, or when session leaks occur.
- `systemd-analyze dump` and `systemd-analyze plot` enable to understand the dynamic of the boot (`dump` has the raw data, `plot` is nice in a browser)