### PR TITLE
[kernel] Avoid capturing blanket 'find -ls'

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -54,11 +54,13 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         for pattern in extra_mod_patterns:
             extra_mod_paths.extend(glob.glob(pattern))
 
+        if extra_mod_paths:
+            self.add_cmd_output("find %s -ls" % " ".join(extra_mod_paths))
+
         self.add_cmd_output([
             "dmesg",
             "sysctl -a",
-            "dkms status",
-            "find %s -ls" % " ".join(extra_mod_paths)
+            "dkms status"
         ])
 
         clocksource_path = "/sys/devices/system/clocksource/clocksource0/"


### PR DESCRIPTION
Previously, if sos was run in an environment where '/lib/modules/*' did
not exist, the kernel plugin would pass an empty extra_mod_paths list to
'find -ls', which would in turn cause sos to execute 'find -ls' on the
entire filesystem.

While this situation may seem rare, this is a possiblity whenever sos is
run in a container that does not have the proper environment variable
set that indicates to the active policy that sos is in fact in  a
container. On top of generating a sosreport with little to useful
information in this case, the generated sosreport could potentially be
very large due to the collection of a blanket 'find -ls'.

This prevents this from occuring, by not running 'find -ls' if the
extra_mod_paths list is empty.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
