### PR TITLE
[dnf] collect installed modules and info about them

### DIFF
--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -30,6 +30,21 @@ class DNFPlugin(Plugin, RedHatPlugin):
         ("history-info", "detailed transaction history", "slow", False),
     ]
 
+    def get_modules_info(self, module_file):
+        if module_file:
+            try:
+                module_out = open(module_file).read()
+            except:
+                self._log_warn("could not read module list file")
+                return
+            # take just lines with the module names, i.e. containing "[i]" and
+            # not the "Hint: [d]efault, [e]nabled, [i]nstalled,.."
+            for line in module_out.splitlines():
+                if "[i]" in line:
+                    module = line.split()[0]
+                    if module != "Hint:":
+                        self.add_cmd_output("dnf module info "+module)
+
     def setup(self):
         self.add_copy_spec([
             "/etc/dnf/dnf.conf",
@@ -69,5 +84,9 @@ class DNFPlugin(Plugin, RedHatPlugin):
                         pass
             for tr_id in range(1, transactions+1):
                 self.add_cmd_output("dnf history info %d" % tr_id)
+
+        # Get list of dnf installed modules and their details.
+        module_file = self.get_cmd_output_now("dnf module list --installed")
+        self.get_modules_info(module_file)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
collect "dnf module list --installed" and for each module,
get info about it

Resolves: #1292

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
