### PR TITLE
[Plugins] Add new add_udev_info() method

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -860,6 +860,26 @@ class Plugin(object):
         self._log_debug("collecting journal: %s" % journal_cmd)
         self._add_cmd_output(journal_cmd, None, None, timeout)
 
+    def add_udev_info(self, device, attrs=False):
+        """Collect udevadm info output for a given device
+
+        Arguments:
+        device      - A string or list of strings of device names or sysfs
+                      paths. E.G. either '/dev/sda' or
+                      '/sys/class/scsi_host/host0' is valid.
+        attrs       - If True, run udevadm with the --attribute-walk option.
+        """
+        udev_cmd = 'udevadm info'
+        if attrs:
+            udev_cmd += ' -a'
+
+        if isinstance(device, six.string_types):
+            device = [device]
+
+        for dev in device:
+            self._log_debug("collecting udev info for: %s" % dev)
+            self._add_cmd_output('%s %s' % (udev_cmd, dev))
+
     def _expand_copy_spec(self, copyspec):
         return glob.glob(copyspec)
 


### PR DESCRIPTION
Adds a new collection method add_udev_info() which will collect 'udevadm
info' output for a given device or list of devices.

An optional 'attrs' boolean will, if True, have udevadm perform an
attribute-walk of the device's sysfs attributes.

This method can take either device names such as '/dev/sda' or sysfs
paths such as '/sys/class/scsi_host/host0' and these styles may be
freely interchanged in a list given to a single call.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
