### PR TITLE
[powerpc] Capture the opal-prd log file

### DIFF
--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -83,7 +83,8 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                 "/proc/ppc64/systemcfg",
                 "/proc/ppc64/topology_updates",
                 "/sys/firmware/opal/msglog",
-                "/var/log/opal-elog/"
+                "/var/log/opal-elog/",
+                "/var/log/opal-prd"
             ])
             if os.path.isdir("/var/log/dump"):
                 self.add_cmd_output("ls -l /var/log/dump")


### PR DESCRIPTION
Opal-prd is the Processor Runtime Diagnostics daemon on Power systems
running OPAL firmware. Capture this log file with sosreport.

Signed-off-by: Ananth N Mavinakayanahalli <ananth@linux.vnet.ibm.com>
Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
