### PR TITLE
[policies] use py3-compliant string.ascii_lowercase

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -294,7 +294,7 @@ No changes will be made to system configuration.
         name = self.get_local_name().split('.')[0]
         case = self.case_id
         label = self.commons['cmdlineopts'].label
-        rand = ''.join(random.choice(string.lowercase) for x in range(7))
+        rand = ''.join(random.choice(string.ascii_lowercase) for x in range(7))
 
         if self.name_pattern == 'legacy':
             nstr = "sosreport-{name}{case}{date}"


### PR DESCRIPTION
string.lowercase works in python2 only, use equivalent
string.ascii_lowercase in either python 2 or 3

Resolves: #1296

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
