### PR TITLE
[lustre] make the join call py3 compatible

### DIFF
--- a/sos/plugins/lustre.py
+++ b/sos/plugins/lustre.py
@@ -9,7 +9,6 @@
 # GNU General Public License for more details.
 
 from sos.plugins import Plugin, RedHatPlugin
-from string import join
 
 
 class Lustre(Plugin, RedHatPlugin):
@@ -24,7 +23,7 @@ class Lustre(Plugin, RedHatPlugin):
             file.
 
         '''
-        self.add_cmd_output("lctl get_param %s" % join(param_list, " "),
+        self.add_cmd_output("lctl get_param %s" % " ".join(param_list),
                             suggest_filename="params-%s" % name,
                             stderr=False)
 


### PR DESCRIPTION
python3 fails with "cannot import name 'join'" error otherwise

Resolves: #1297

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
