### PR TITLE
[system,kernel] dont collect some empty nonreadable files

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -63,12 +63,16 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         clocksource_path = "/sys/devices/system/clocksource/clocksource0/"
 
+        # FIXME: provide a a long-term solution for #1299
         self.add_forbidden_path([
             '/sys/kernel/debug/tracing/trace_pipe',
             '/sys/kernel/debug/tracing/README',
             '/sys/kernel/debug/tracing/trace_stat/*',
             '/sys/kernel/debug/tracing/per_cpu/*',
-            '/sys/kernel/debug/tracing/events/*'
+            '/sys/kernel/debug/tracing/events/*',
+            '/sys/kernel/debug/tracing/free_buffer',
+            '/sys/kernel/debug/tracing/trace_marker',
+            '/sys/kernel/debug/tracing/trace_marker_raw'
         ])
 
         self.add_copy_spec([

--- a/sos/plugins/system.py
+++ b/sos/plugins/system.py
@@ -30,7 +30,10 @@ class System(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/default",
         ])
 
+        # FIXME: provide a a long-term solution for #1299
         self.add_forbidden_path([
+            "/proc/sys/net/ipv4/route/flush",
+            "/proc/sys/net/ipv6/route/flush",
             "/proc/sys/net/ipv6/neigh/*/retrans_time",
             "/proc/sys/net/ipv6/neigh/*/base_reachable_time"
         ])


### PR DESCRIPTION
To prevent confusing errors on stdout in py3

Resolves: #1299

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
