### PR TITLE
[plugins] Fixed missing 'self' in function add_cmd_output_scl()

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1157,7 +1157,7 @@ class SCLPlugin(RedHatPlugin):
             cmds = [cmds]
         scl_cmds = []
         for cmd in cmds:
-            scl_cmds.append(convert_cmd_scl(scl, cmd))
+            scl_cmds.append(self.convert_cmd_scl(scl, cmd))
         self.add_cmd_output(scl_cmds, **kwargs)
 
     # config files for Software Collections are under /etc/${prefix}/${scl} and


### PR DESCRIPTION
This is a minor change.

Signed-off-by: Sachin Patil <psachin@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
