### PR TITLE
[systemd] Add configuration files of systemd-modules-load.service

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -58,6 +58,7 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/lib/systemd/system",
             "/lib/systemd/user",
             "/etc/vconsole.conf",
+            "/etc/modules-load.d/*.conf",
             "/etc/yum/protected.d/systemd.conf"
         ])
 


### PR DESCRIPTION
It is possible to load kernel modules during boot in a static list
as mentioned under /etc/modules-load.d/*.conf. These files are used
by systemd-modules-load.service. Collect this information using
kernel plugin.

Signed-off-by: Akhil John <ajohn@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
