### PR TITLE
[archive] switch compression preset from -1 to -2

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -449,7 +449,7 @@ class TarFileArchive(FileCacheArchive):
             suffix = "." + cmd.replace('ip', '')
             # use fast compression if using xz or bz2
             if cmd != "gzip":
-                cmd = "%s -1" % cmd
+                cmd = "%s -2" % cmd
             try:
                 r = sos_get_command_output("%s %s" % (cmd, self.name()),
                                            timeout=0)


### PR DESCRIPTION
I've noted an uptick of users recompressing sosreports to get a
better compression rate for uploading over slow links. My tests
indicate that -2 is a better default and should remove any benefit
of compressing again.

In tested cases -2 does not cause any significant CPU increase
and always has shown an improvment - sometimes substancial.  The
worst was 3seconds more for a 15MB savings.  I would generally
expect to see similar percentage savings as sosreports get bigger.

-3 and higher were evaluated but had diminshing returns that
didn't seem worth it.

Tests results:
NVMe drive
xz -a --batch
-1 5.9M 30.766s
-2 5.7M 30.673s
-3 5.6M 30.101s
-4 5.5M 35.882s

bz2
bz2 -a --batch
-1 11M 36.675s
-2 8.3M 38.792s

xz -a --all-logs --batch
-1 87M 1m8.994s
-2 72M 1m11.926s
-3 69M 1m18.210s
-4 70M 2m33.930s

Old hard drive
-a --batch
-1 5.3M 14.935s
-2 5.2M 15.611s

-a --batch --all-logs
-1 35M 38.881s
-2 26M 38.337s

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
