### PR TITLE
[logs] rework: collect journalctl verbosed logs with --all-logs only

### DIFF
--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -29,9 +29,7 @@ class Logs(Plugin):
         self.add_copy_spec("/var/log/boot.log", sizelimit=self.limit)
         self.add_copy_spec("/var/log/cloud-init*", sizelimit=self.limit)
         self.add_journal(boot="this", catalog=True)
-        self.add_journal(boot="this", allfields=True, output="verbose")
         self.add_journal(boot="last", catalog=True)
-        self.add_journal(boot="last", allfields=True, output="verbose")
         self.add_cmd_output("journalctl --disk-usage")
 
         confs = ['/etc/syslog.conf', '/etc/rsyslog.conf']
@@ -57,6 +55,7 @@ class Logs(Plugin):
 
         if self.get_option('all_logs'):
             self.add_journal(boot="this", allfields=True, output="verbose")
+            self.add_journal(boot="last", allfields=True, output="verbose")
 
     def postproc(self):
         self.do_path_regex_sub(


### PR DESCRIPTION
commit 7bc90f618f0549279544d26effae2e5197d85e2b ("[logs] collect
journalctl verbosed logs with --all-logs only") did not suppress
the journalctl verbosed logs by default.  Let's rework it.

Resolves: #1225

Signed-off-by: Kazuhito Hagio <k-hagio@ab.jp.nec.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
