### PR TITLE
[logs] Revert "[logs] implement --all-logs for Red Hat messages* and secure*"

### DIFF
--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -79,14 +79,8 @@ class RedHatLogs(Logs, RedHatPlugin):
     def setup(self):
         super(RedHatLogs, self).setup()
         messages = "/var/log/messages"
-        secure = "/var/log/secure"
-
-        if self.get_option("all_logs"):
-            messages += "*"
-            secure += "*"
-
-        self.add_copy_spec(secure, sizelimit=self.limit)
-        self.add_copy_spec(messages, sizelimit=self.limit)
+        self.add_copy_spec("/var/log/secure*", sizelimit=self.limit)
+        self.add_copy_spec(messages + "*", sizelimit=self.limit)
 
         # collect three days worth of logs by default if the system is
         # configured to use the journal and not /var/log/messages


### PR DESCRIPTION
```
commit 5d25dd31e731cc0d2d09a1b242803373937b4863 ("[logs] implement
--all-logs for Red Hat messages* and secure*") dropped rotated
/var/log/messages files by default.  This will make support enginners
ask their customers to collect them separately again and again because
these are the most important and the most freqently referenced files
for support engineers.  So it should be limited only with sizelimit
by default.

Also, if --all-logs is specified and the variable "messages" ends with
"*", os.path.exists(messages) always returns False, and it collects
journal unexpectedly.  So "*" should not be added to the variable
"messages" itself.

Signed-off-by: Kazuhito Hagio <k-hagio@ab.jp.nec.com>
```
I strongly recommend reverting commit 5d25dd3.
Is there any strong reason to drop rotated messages by default?

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
