### PR TITLE
[Plugin] Do not run verify on empty package list

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -161,7 +161,7 @@ class PackageManager(object):
             return None
 
         by_regex = self.all_pkgs_by_name_regex
-        verify_list = map(by_regex, packages)
+        verify_list = filter(None, map(by_regex, packages))
 
         # No packages after regex match?
         if not verify_list:


### PR DESCRIPTION
In some instances, the regex match in all_pkgs_by_name_regex() was
returning an empty list when no match was made. This in turn caused sos
to run an empty verify command, e.g. 'rpm -V '.

By filtering the list of packages to verify, we can remove these empty
lists and avoid the empty verify command.

Closes: #1304

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
