### PR TITLE
[multiple plugins] Fix package list tuples

### DIFF
--- a/sos/plugins/nfsganesha.py
+++ b/sos/plugins/nfsganesha.py
@@ -14,7 +14,7 @@ class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     """
     plugin_name = 'nfsganesha'
     profiles = ('storage', 'network', 'nfs')
-    packages = ('nfs-ganesha')
+    packages = ('nfs-ganesha',)
 
     def setup(self):
         self.add_copy_spec([

--- a/sos/plugins/nis.py
+++ b/sos/plugins/nis.py
@@ -18,7 +18,7 @@ class Nis(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     files = ('/var/yp', '/etc/ypserv.conf')
 
-    packages = ('ypserv')
+    packages = ('ypserv',)
 
     def setup(self):
         self.add_copy_spec([

--- a/sos/plugins/os_net_config.py
+++ b/sos/plugins/os_net_config.py
@@ -14,7 +14,7 @@ class OsNetConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     plugin_name = "os_net_config"
     profiles = ('openstack')
-    packages = ('os-net-config')
+    packages = ('os-net-config',)
 
     def setup(self):
         self.add_copy_spec("/etc/os-net-config")


### PR DESCRIPTION
Fixes the nis, nfsganesha, and os_net_config plugins package lists to
use a 1-tuple instead of a string that would break package verification
for those plugins.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
