### PR TITLE
netplan conf files can exist in 3 locations

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -293,7 +293,9 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/etc/ufw",
             "/var/log/ufw.Log",
             "/etc/resolv.conf",
+            "/run/netplan/*.yaml",
             "/etc/netplan/*.yaml",
+            "/lib/netplan/*.yaml",
             "/run/systemd/network"
         ])
         self.add_cmd_output([


### PR DESCRIPTION
Configuration files can exist in three different locations
with the precedence from most important to least as follows:

/run/netplan/*.yaml
/etc/netplan/*.yaml
/lib/netplan/*.yaml

Alphabetically later files, no matter what directory in, will
amend keys if the key does not already exist and override previous keys if they do.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
