### PR TITLE
[block] Use add_udev_info for block devices

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -44,8 +44,9 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                 if disk.startswith("ram"):
                     continue
                 disk_path = os.path.join('/dev/', disk)
+                self.add_udev_info(disk_path)
+                self.add_udev_info(disk_path, attrs=True)
                 self.add_cmd_output([
-                    "udevadm info -ap /sys/block/%s" % (disk),
                     "parted -s %s unit s print" % (disk_path),
                     "fdisk -l %s" % disk_path
                 ])


### PR DESCRIPTION
Updates the block plugin to use the new add_udev_info() method, once
with an attribute walk and once without.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
