### PR TITLE
[sosreport] add command line presets

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -45,9 +45,9 @@ _sos = _default
 _arg_names = [
     'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
     'config_file', 'debug', 'enableplugins', 'experimental', 'label',
-    'list_plugins', 'list_profiles', 'log_size', 'noplugins', 'noreport',
-    'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
-    'tmp_dir', 'usealloptions', 'verbosity', 'verify'
+    'list_plugins', 'list_presets', 'list_profiles', 'log_size', 'noplugins',
+    'noreport', 'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet',
+    'sysroot', 'tmp_dir', 'usealloptions', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -72,6 +72,7 @@ class SoSOptions(object):
     experimental = False
     label = ""
     list_plugins = False
+    list_presets = False
     list_profiles = False
     log_size = _arg_defaults["log_size"]
     noplugins = []

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -16,7 +16,6 @@ gettext to internationalize messages.
 """
 
 import gettext
-from collections import deque
 
 __version__ = "3.5"
 
@@ -171,5 +170,20 @@ class SoSOptions(object):
             else:
                 if replace or not getattr(self, arg):
                     self._copy_opt(arg, src)
+
+    def dict(self):
+        """Return this ``SoSOptions`` option values as a dictionary of
+            argument name to value mappings.
+
+            :returns: a name:value dictionary of option values.
+        """
+        odict = {}
+        for arg in _arg_names:
+            value = getattr(self, arg)
+            # Do not attempt to store --add-preset <name> in presets
+            if arg == 'add_preset':
+                value = None
+            odict[arg] = value
+        return odict
 
 # vim: set et ts=4 sw=4 :

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -16,6 +16,7 @@ gettext to internationalize messages.
 """
 
 import gettext
+import six
 
 __version__ = "3.5"
 
@@ -123,19 +124,23 @@ class SoSOptions(object):
             :param suffix: arbitrary suffix string
             :param literal: print values as Python literals
         """
-        fmt = prefix
-        arg_fmt = "=%s" if not quote else "='%s'"
+        args = prefix
+        arg_fmt = "=%s"
         for arg in _arg_names:
-            fmt += arg + arg_fmt + sep
-        fmt.strip(sep)
-        fmt += suffix
+            args += arg + arg_fmt + sep
+        args.strip(sep)
 
+        vals = [getattr(self, arg) for arg in _arg_names]
         if not quote:
             # Convert Python source notation for sequences into plain strings
-            args = [getattr(self, arg) for arg in _arg_names]
-            args = [",".join(a) if _is_seq(a) else a for a in args]
+            vals = [",".join(v) if _is_seq(v) else v for v in vals]
+        else:
+            def is_string(val):
+                return isinstance(val, six.string_types)
+            # Only quote strings if quote=False
+            vals = ["'%s'" % v if is_string(v) else v for v in vals]
 
-        return fmt % tuple(args)
+        return (args % tuple(vals)).strip(sep) + suffix
 
     def __str__(self):
         return self.__str()

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -55,6 +55,7 @@ _arg_defaults = {
     "log_size": 10,
     "chroot": "auto",
     "compression_type": "auto",
+    "preset": "auto"
 }
 
 

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -42,11 +42,12 @@ _sos = _default
 
 #: Names of all arguments
 _arg_names = [
-    'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
-    'config_file', 'debug', 'enableplugins', 'experimental', 'label',
-    'list_plugins', 'list_presets', 'list_profiles', 'log_size', 'noplugins',
-    'noreport', 'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet',
-    'sysroot', 'tmp_dir', 'usealloptions', 'verbosity', 'verify'
+    'add_preset', 'all_logs', 'batch', 'build', 'case_id', 'chroot',
+    'compression_type', 'config_file', 'debug', 'del_preset', 'enableplugins',
+    'experimental', 'label', 'list_plugins', 'list_presets', 'list_profiles',
+    'log_size', 'noplugins', 'noreport', 'onlyplugins', 'plugopts', 'preset',
+    'profiles', 'quiet', 'sysroot', 'tmp_dir', 'usealloptions', 'verbosity',
+    'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -59,6 +60,7 @@ _arg_defaults = {
 
 
 class SoSOptions(object):
+    add_preset = ""
     all_logs = False
     batch = False
     build = False
@@ -67,6 +69,7 @@ class SoSOptions(object):
     compression_type = _arg_defaults["compression_type"]
     config_file = ""
     debug = False
+    del_preset = ""
     enableplugins = []
     experimental = False
     label = ""

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -185,8 +185,8 @@ class SoSOptions(object):
         odict = {}
         for arg in _arg_names:
             value = getattr(self, arg)
-            # Do not attempt to store --add-preset <name> in presets
-            if arg == 'add_preset':
+            # Do not attempt to store preset option values in presets
+            if arg in ('add_preset', 'del_preset', 'desc', 'note'):
                 value = None
             odict[arg] = value
         return odict

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -46,8 +46,8 @@ _arg_names = [
     'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
     'config_file', 'debug', 'enableplugins', 'experimental', 'label',
     'list_plugins', 'list_profiles', 'log_size', 'noplugins', 'noreport',
-    'onlyplugins', 'plugopts', 'profiles', 'quiet', 'sysroot', 'tmp_dir',
-    'usealloptions', 'verbosity', 'verify'
+    'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
+    'tmp_dir', 'usealloptions', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -77,6 +77,7 @@ class SoSOptions(object):
     noreport = False
     onlyplugins = []
     plugopts = []
+    preset = ""
     profiles = []
     quiet = False
     sysroot = None
@@ -114,7 +115,7 @@ class SoSOptions(object):
                       self.debug, self.enableplugins, self.experimental,
                       self.label, self.list_plugins, self.list_profiles,
                       self.log_size, self.noplugins, self.noreport,
-                      self.onlyplugins, self.plugopts, self.product,
+                      self.onlyplugins, self.plugopts, self.preset,
                       self.profiles, self.quiet, self.sysroot, self.tmp_dir,
                       self.usealloptions, self.verbosity, self.verify)
 

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -77,7 +77,7 @@ class SoSOptions(object):
     noreport = False
     onlyplugins = []
     plugopts = []
-    profiles = deque()
+    profiles = []
     quiet = False
     sysroot = None
     threads = 4

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -59,32 +59,32 @@ _arg_defaults = {
 
 
 class SoSOptions(object):
-    list_plugins = False
-    noplugins = []
-    enableplugins = []
-    onlyplugins = []
-    plugopts = []
-    usealloptions = False
     all_logs = False
-    log_size = _arg_defaults["log_size"]
     batch = False
     build = False
-    verbosity = 0
-    verify = False
-    quiet = False
-    debug = False
     case_id = ""
-    label = ""
-    profiles = deque()
-    list_profiles = False
-    config_file = ""
-    tmp_dir = ""
-    noreport = False
-    sysroot = None
     chroot = _arg_defaults["chroot"]
     compression_type = _arg_defaults["compression_type"]
+    config_file = ""
+    debug = False
+    enableplugins = []
     experimental = False
+    label = ""
+    list_plugins = False
+    list_profiles = False
+    log_size = _arg_defaults["log_size"]
+    noplugins = []
+    noreport = False
+    onlyplugins = []
+    plugopts = []
+    profiles = deque()
+    quiet = False
+    sysroot = None
     threads = 4
+    tmp_dir = ""
+    usealloptions = False
+    verbosity = 0
+    verify = False
 
     def _copy_opt(self, opt, src):
         if hasattr(src, opt):

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -42,12 +42,12 @@ _sos = _default
 
 #: Names of all arguments
 _arg_names = [
-    'add_preset', 'all_logs', 'batch', 'build', 'case_id', 'chroot',
-    'compression_type', 'config_file', 'desc', 'debug', 'del_preset',
+    'add_preset', 'alloptions', 'all_logs', 'batch', 'build', 'case_id',
+    'chroot', 'compression_type', 'config_file', 'desc', 'debug', 'del_preset',
     'enableplugins', 'experimental', 'label', 'list_plugins', 'list_presets',
     'list_profiles', 'log_size', 'noplugins', 'noreport', 'note',
     'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
-    'tmp_dir', 'usealloptions', 'verbosity', 'verify'
+    'tmp_dir', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -61,6 +61,7 @@ _arg_defaults = {
 
 class SoSOptions(object):
     add_preset = ""
+    alloptions = False
     all_logs = False
     batch = False
     build = False
@@ -89,7 +90,6 @@ class SoSOptions(object):
     sysroot = None
     threads = 4
     tmp_dir = ""
-    usealloptions = False
     verbosity = 0
     verify = False
 

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -112,14 +112,7 @@ class SoSOptions(object):
             fmt += arg + arg_fmt + sep
         fmt.strip(sep)
         fmt += suffix
-        return fmt % (self.all_logs, self.batch, self.build, self.case_id,
-                      self.chroot, self.compression_type, self.config_file,
-                      self.debug, self.enableplugins, self.experimental,
-                      self.label, self.list_plugins, self.list_profiles,
-                      self.log_size, self.noplugins, self.noreport,
-                      self.onlyplugins, self.plugopts, self.preset,
-                      self.profiles, self.quiet, self.sysroot, self.tmp_dir,
-                      self.usealloptions, self.verbosity, self.verify)
+        return fmt % tuple([getattr(self, arg) for arg in _arg_names])
 
     def __str__(self):
         return self.__str()

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -94,6 +94,37 @@ class SoSOptions(object):
         for arg in _arg_names:
             self._copy_opt(arg, src)
 
+    def __str(self, quote=False, sep=" ", prefix="", suffix=""):
+        """Format a SoSOptions object as a human or machine readable string.
+
+            :param quote: quote option values
+            :param sep: list separator string
+            :param prefix: arbitrary prefix string
+            :param suffix: arbitrary suffix string
+            :param literal: print values as Python literals
+        """
+        fmt = prefix
+        arg_fmt = "=%s" if not quote else "='%s'"
+        for arg in _arg_names:
+            fmt += arg + arg_fmt + sep
+        fmt.strip(sep)
+        fmt += suffix
+        return fmt % (self.all_logs, self.batch, self.build, self.case_id,
+                      self.chroot, self.compression_type, self.config_file,
+                      self.debug, self.enableplugins, self.experimental,
+                      self.label, self.list_plugins, self.list_profiles,
+                      self.log_size, self.noplugins, self.noreport,
+                      self.onlyplugins, self.plugopts, self.product,
+                      self.profiles, self.quiet, self.sysroot, self.tmp_dir,
+                      self.usealloptions, self.verbosity, self.verify)
+
+    def __str__(self):
+        return self.__str()
+
+    def __repr__(self):
+        return self.__str(quote=True, sep=", ", prefix="SoSOptions(",
+                          suffix=")")
+
     def __init__(self, **kwargs):
         """Initialise a new ``SoSOptions`` object from keyword arguments.
 
@@ -135,7 +166,6 @@ class SoSOptions(object):
             :param replace: ``True`` if non-default values should be
                             overwritten.
         """
-
         for arg in _arg_names:
             if not hasattr(src, arg):
                 continue

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -16,6 +16,7 @@ gettext to internationalize messages.
 """
 
 import gettext
+from collections import deque
 
 __version__ = "3.5"
 
@@ -30,3 +31,119 @@ def _default(msg):
 
 
 _sos = _default
+
+# Global option definitions
+# These must be in the module itself in order to be available to both
+# the sosreport and policy module (and to avoid recursive import errors).
+#
+# FIXME: these definitions make our main module a bit more bulky: the
+# alternative is to place these in a new sos.options module. This may
+# prove to be the best route long-term (as it could also contain an
+# exported parsing routine, and all the command-line definitions).
+
+#: Names of all arguments
+_arg_names = [
+    'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
+    'config_file', 'debug', 'enableplugins', 'experimental', 'label',
+    'list_plugins', 'list_profiles', 'log_size', 'noplugins', 'noreport',
+    'onlyplugins', 'plugopts', 'profiles', 'quiet', 'sysroot', 'tmp_dir',
+    'usealloptions', 'verbosity', 'verify'
+]
+
+#: Arguments with non-zero default values
+_arg_defaults = {
+    "log_size": 10,
+    "chroot": "auto",
+    "compression_type": "auto",
+}
+
+
+class SoSOptions(object):
+    list_plugins = False
+    noplugins = []
+    enableplugins = []
+    onlyplugins = []
+    plugopts = []
+    usealloptions = False
+    all_logs = False
+    log_size = _arg_defaults["log_size"]
+    batch = False
+    build = False
+    verbosity = 0
+    verify = False
+    quiet = False
+    debug = False
+    case_id = ""
+    label = ""
+    profiles = deque()
+    list_profiles = False
+    config_file = ""
+    tmp_dir = ""
+    noreport = False
+    sysroot = None
+    chroot = _arg_defaults["chroot"]
+    compression_type = _arg_defaults["compression_type"]
+    experimental = False
+    threads = 4
+
+    def _copy_opt(self, opt, src):
+        if hasattr(src, opt):
+            setattr(self, opt, getattr(src, opt))
+
+    def _copy_opts(self, src):
+        for arg in _arg_names:
+            self._copy_opt(arg, src)
+
+    def __init__(self, **kwargs):
+        """Initialise a new ``SoSOptions`` object from keyword arguments.
+
+            Initialises the new object with values taken from keyword
+            arguments matching the names of ``SoSOptions`` attributes.
+
+            A ``ValueError`` is raised is any of the supplied keyword
+            arguments does not correspond to a known ``SoSOptions`
+            attribute name.
+
+            :param *kwargs: a list of ``SoSOptions`` keyword args.
+            :returns: the new ``SoSOptions`` object.
+        """
+        for arg in kwargs.keys():
+            if arg not in _arg_names:
+                raise ValueError("Unknown SoSOptions attribute: %s" % arg)
+            setattr(self, arg, kwargs[arg])
+
+    @classmethod
+    def from_args(cls, args):
+        """Initialise a new SoSOptions object from a ``Namespace``
+            obtained by parsing command line arguments.
+
+            :param args: parsed command line arguments
+            :returns: an initialised SoSOptions object
+            :returntype: SoSOptions
+        """
+        opts = SoSOptions()
+        opts._copy_opts(args)
+        return opts
+
+    def merge(self, src, replace=False):
+        """Merge another set of ``SoSOptions`` into this object.
+
+            Merge two ``SoSOptions`` objects by setting unset or default
+            values to their value in the ``src`` object.
+
+            :param src: the ``SoSOptions`` object to copy from
+            :param replace: ``True`` if non-default values should be
+                            overwritten.
+        """
+
+        for arg in _arg_names:
+            if not hasattr(src, arg):
+                continue
+            if arg in _arg_defaults.keys():
+                if replace or getattr(self, arg) == _arg_defaults[arg]:
+                    self._copy_opt(arg, src)
+            else:
+                if replace or not getattr(self, arg):
+                    self._copy_opt(arg, src)
+
+# vim: set et ts=4 sw=4 :

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -53,10 +53,13 @@ _arg_names = [
 
 #: Arguments with non-zero default values
 _arg_defaults = {
-    "log_size": 10,
     "chroot": "auto",
     "compression_type": "auto",
-    "preset": "auto"
+    "log_size": 10,
+    "preset": "auto",
+    # Verbosity has an explicit zero default since the ArgumentParser
+    # count action default is None.
+    "verbosity": 0
 }
 
 

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -55,7 +55,7 @@ _arg_names = [
 _arg_defaults = {
     "chroot": "auto",
     "compression_type": "auto",
-    "log_size": 10,
+    "log_size": 25,
     "preset": "auto",
     # Verbosity has an explicit zero default since the ArgumentParser
     # count action default is None.

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -116,7 +116,19 @@ class SoSOptions(object):
             fmt += arg + arg_fmt + sep
         fmt.strip(sep)
         fmt += suffix
-        return fmt % tuple([getattr(self, arg) for arg in _arg_names])
+
+        def is_seq(val):
+            """Return true if val is an instance of a known sequence type.
+            """
+            val_type = type(val)
+            return val_type is list or val_type is tuple
+
+        if not quote:
+            # Convert Python source notation for sequences into plain strings
+            args = [getattr(self, arg) for arg in _arg_names]
+            args = [",".join(a) if is_seq(a) else a for a in args]
+
+        return fmt % tuple(args)
 
     def __str__(self):
         return self.__str()

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -188,11 +188,12 @@ class SoSOptions(object):
         for arg in _arg_names:
             if not hasattr(src, arg):
                 continue
+            if _is_seq(getattr(self, arg)):
+                self._merge_opt(arg, src, replace)
+                continue
             if arg in _arg_defaults.keys():
                 if replace or getattr(self, arg) == _arg_defaults[arg]:
                     self._merge_opt(arg, src, replace)
-            elif _is_seq(getattr(self, arg)):
-                self._merge_opt(arg, src, replace)
             else:
                 if replace or not getattr(self, arg):
                     self._merge_opt(arg, src, replace)

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -43,11 +43,11 @@ _sos = _default
 #: Names of all arguments
 _arg_names = [
     'add_preset', 'all_logs', 'batch', 'build', 'case_id', 'chroot',
-    'compression_type', 'config_file', 'debug', 'del_preset', 'enableplugins',
-    'experimental', 'label', 'list_plugins', 'list_presets', 'list_profiles',
-    'log_size', 'noplugins', 'noreport', 'onlyplugins', 'plugopts', 'preset',
-    'profiles', 'quiet', 'sysroot', 'tmp_dir', 'usealloptions', 'verbosity',
-    'verify'
+    'compression_type', 'config_file', 'desc', 'debug', 'del_preset',
+    'enableplugins', 'experimental', 'label', 'list_plugins', 'list_presets',
+    'list_profiles', 'log_size', 'noplugins', 'noreport', 'note',
+    'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
+    'tmp_dir', 'usealloptions', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -70,6 +70,7 @@ class SoSOptions(object):
     config_file = ""
     debug = False
     del_preset = ""
+    desc = ""
     enableplugins = []
     experimental = False
     label = ""
@@ -79,6 +80,7 @@ class SoSOptions(object):
     log_size = _arg_defaults["log_size"]
     noplugins = []
     noreport = False
+    note = ""
     onlyplugins = []
     plugopts = []
     preset = ""

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -571,8 +571,7 @@ No changes will be made to system configuration.
             if match == preset:
                 return self.presets[match]
 
-        # Return default preset
-        return self.presets[""]
+        return None
 
     def probe_preset(self):
         """Return a ``PresetDefaults`` object matching the runing host.

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -625,6 +625,7 @@ No changes will be made to system configuration.
             raise ValueError("A preset with name '%s' already exists" % name)
 
         preset = PresetDefaults(name=name, desc=desc, note=note, opts=opts)
+        preset.builtin = False
         self.presets[preset.name] = preset
         preset.write(presets_path)
 

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -517,7 +517,7 @@ No changes will be made to system configuration.
         """Find a preset profile matching the specified preset string.
 
             :param preset: a string containing a preset profile name.
-            :returns: a matching ProductProfile.
+            :returns: a matching PresetProfile.
         """
         # FIXME: allow fuzzy matching?
         for match in self.presets.keys():
@@ -525,6 +525,15 @@ No changes will be made to system configuration.
                 return self.presets[match]
 
         # Return default preset
+        return self.presets[""]
+
+    def probe_preset(self):
+        """Return a ``PresetDefaults`` object matching the runing host.
+
+            Stub method to be implemented by derived policy classes.
+
+            :returns: a ``PresetDefaults`` object.
+        """
         return self.presets[""]
 
 

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -31,8 +31,9 @@ rh_presets = {
     "": PresetDefaults(name="rhel"),
     "rhel7": PresetDefaults(name="rhel7"),
     "rhosp": PresetDefaults(name="rhosp", opts=SoSOptions(all_logs=True)),
-    "rhv": PresetDefaults(name="rhv",
-                          opts=SoSOptions(all_logs=True, verify=True))
+    "ocp": PresetDefaults(name="ocp",
+                          opts=SoSOptions(all_logs=True, verify=True)),
+    "rhv": PresetDefaults(name="rhv", opts=SoSOptions(verify=True))
 }
 
 OS_RELEASE = "/etc/os-release"

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -92,6 +92,7 @@ class RedHatPolicy(LinuxPolicy):
         self.PATH += os.pathsep + "/usr/local/bin"
         self.PATH += os.pathsep + "/usr/local/sbin"
         self.set_exec_path()
+        self.load_presets()
 
     @classmethod
     def check(cls):
@@ -210,7 +211,7 @@ No changes will be made to system configuration.
 
     def __init__(self, sysroot=None):
         super(RHELPolicy, self).__init__(sysroot=sysroot)
-        self.presets.update(rhel_presets)
+        self.register_presets(rhel_presets)
 
     @classmethod
     def check(cls):

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -34,6 +34,7 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError
 
 from sos import _sos as _
 from sos import __version__
+from sos import _arg_names, _arg_defaults, SoSOptions
 import sos.policies
 from sos.archive import TarFileArchive
 from sos.reporting import (Report, Section, Command, CopiedFile, CreatedFile,
@@ -199,22 +200,6 @@ class XmlReport(object):
 # valid modes for --chroot
 chroot_modes = ["auto", "always", "never"]
 
-#: Names of all arguments
-_arg_names = [
-    'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
-    'config_file', 'debug', 'enableplugins', 'experimental', 'label',
-    'list_plugins', 'list_profiles', 'log_size', 'noplugins', 'noreport',
-    'onlyplugins', 'plugopts', 'profiles', 'quiet', 'sysroot', 'tmp_dir',
-    'usealloptions', 'verbosity', 'verify'
-]
-
-#: Arguments with non-zero default values
-_arg_defaults = {
-    "log_size": 10,
-    "chroot": "auto",
-    "compression_type": "auto",
-}
-
 
 def _parse_args(args):
     """ Parse command line options and arguments"""
@@ -318,77 +303,6 @@ def _parse_args(args):
                         " (default=4)", default=4, type=int)
 
     return parser.parse_args(args)
-
-
-class SoSOptions(object):
-    list_plugins = False
-    noplugins = []
-    enableplugins = []
-    onlyplugins = []
-    plugopts = []
-    usealloptions = False
-    all_logs = False
-    log_size = 10
-    batch = False
-    build = False
-    verbosity = 0
-    verify = False
-    quiet = False
-    debug = False
-    case_id = ""
-    label = ""
-    profiles = deque()
-    list_profiles = False
-    config_file = ""
-    tmp_dir = ""
-    noreport = False
-    sysroot = None
-    chroot = 'auto'
-    compression_type = 'auto'
-    experimental = False
-    threads = 4
-
-    def _copy_opt(self, opt, src):
-        if hasattr(src, opt):
-            setattr(self, opt, getattr(src, opt))
-
-    def _copy_opts(self, src):
-        for arg in _arg_names:
-            self._copy_opt(arg, src)
-
-    @classmethod
-    def from_args(cls, args):
-        """Initialise a new SoSOptions object from a ``Namespace``
-            obtained by parsing command line arguments.
-
-            :param args: parsed command line arguments
-            :returns: an initialised SoSOptions object
-            :returntype: SoSOptions
-        """
-        opts = SoSOptions()
-        opts._copy_opts(args)
-        return opts
-
-    def merge(self, src, replace=False):
-        """Merge another set of ``SoSOptions`` into this object.
-
-            Merge two ``SoSOptions`` objects by setting unset or default
-            values to their value in the ``src`` object.
-
-            :param src: the ``SoSOptions`` object to copy from
-            :param replace: ``True`` if non-default values should be
-                            overwritten.
-        """
-
-        for arg in _arg_names:
-            if not hasattr(src, arg):
-                continue
-            if arg in _arg_defaults.keys():
-                if replace or getattr(self, arg) == _arg_defaults[arg]:
-                    self._copy_opt(arg, src)
-            else:
-                if replace or not getattr(self, arg):
-                    self._copy_opt(arg, src)
 
 
 class SoSReport(object):

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -273,6 +273,8 @@ def _parse_args(args):
     parser.add_argument("-o", "--only-plugins", action="extend",
                         dest="onlyplugins", type=str,
                         help="enable these plugins only", default=deque())
+    parser.add_argument("--preset", action="store", type=str,
+                        help="A preset identifier")
     parser.add_argument("-p", "--profile", action="extend",
                         dest="profiles", type=str, default=deque(),
                         help="enable plugins used by the given profiles")

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -295,8 +295,9 @@ def _parse_args(args):
                         dest="tmp_dir",
                         help="specify alternate temporary directory",
                         default=None)
-    parser.add_argument("-v", "--verbose", action="count", default=0,
-                        dest="verbosity", help="increase verbosity")
+    parser.add_argument("-v", "--verbose", action="count", dest="verbosity",
+                        default=_arg_defaults["verbosity"],
+                        help="increase verbosity"),
     parser.add_argument("--verify", action="store_true",
                         dest="verify", default=False,
                         help="perform data verification during collection")

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -354,11 +354,18 @@ class SoSReport(object):
 
         self._is_root = self.policy.is_root()
 
-        # Apply per-preset command line defaults
+        # user specified command line preset
         if cmd_args.preset != _arg_defaults["preset"]:
             self.preset = self.policy.find_preset(cmd_args.preset)
-        else:
+            if not self.preset:
+                sys.stderr.write("Unknown preset: '%s'\n" % cmd_args.preset)
+                self.preset = self.policy.probe_preset()
+                self.opts.list_presets = True
+
+        # --preset=auto
+        if not self.preset:
             self.preset = self.policy.probe_preset()
+
         self.opts.merge(self.preset.opts)
 
         # system temporary directory to use

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -865,7 +865,15 @@ class SoSReport(object):
             if preset.note:
                 self.ui_log.info("%-15s (%s)" % ("", preset.note))
             if self.opts.verbosity > 0:
+                # Filter out options that do not make sense in presets
+                def filter_opt(opt):
+                    if opt.startswith("add_preset"):
+                        return False
+                    if opt.startswith("del_preset"):
+                        return False
+                    return True
                 opts = str(preset.opts).split()
+                opts = [opt for opt in opts if filter_opt(opt)]
                 lines = _format_list("%-15s" % "options: ", opts, indent=True)
                 for line in lines:
                     self.ui_log.info(line)

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -323,6 +323,7 @@ class SoSReport(object):
         self.sysroot = "/"
         self.sys_tmp = None
         self.exit_process = False
+        self.preset = None
 
         try:
             import signal
@@ -341,6 +342,9 @@ class SoSReport(object):
             self._exit(0)
 
         self._is_root = self.policy.is_root()
+
+        self.preset = self.policy.find_preset(cmd_args.preset)
+        self.opts.merge(self.preset.opts)
 
         # system temporary directory to use
         tmp = os.path.abspath(self.policy.get_tmp_dir(self.opts.tmp_dir))
@@ -888,8 +892,19 @@ class SoSReport(object):
         self._exit(1)
 
     def setup(self):
+        # Log command line options
         msg = "[%s:%s] executing 'sosreport %s'"
         self.soslog.info(msg % (__name__, "setup", " ".join(self._args)))
+
+        # Log active preset defaults
+        msg = ("[%s:%s] using '%s' preset defaults" %
+               (__name__, "setup", self.preset.name))
+        self.soslog.info(msg)
+
+        # Log effective options after applying preset defaults
+        self.soslog.info("[%s:%s] effective options now: %s" %
+                         (__name__, "steup", str(self.opts)))
+
         self.ui_log.info(_(" Setting up plugins ..."))
         for plugname, plug in self.loaded_plugins:
             try:

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -213,30 +213,6 @@ def _parse_args(args):
 
     parser = ArgumentParser(usage=usage_string)
     parser.register('action', 'extend', SosListOption)
-    parser.add_argument("-l", "--list-plugins", action="store_true",
-                        dest="list_plugins", default=False,
-                        help="list plugins and available plugin options")
-    parser.add_argument("-n", "--skip-plugins", action="extend",
-                        dest="noplugins", type=str,
-                        help="disable these plugins", default=deque())
-    parser.add_argument("--experimental", action="store_true",
-                        dest="experimental", default=False,
-                        help="enable experimental plugins")
-    parser.add_argument("-e", "--enable-plugins", action="extend",
-                        dest="enableplugins", type=str,
-                        help="enable these plugins", default=deque())
-    parser.add_argument("-o", "--only-plugins", action="extend",
-                        dest="onlyplugins", type=str,
-                        help="enable these plugins only", default=deque())
-    parser.add_argument("-k", "--plugin-option", action="extend",
-                        dest="plugopts", type=str,
-                        help="plugin options in plugname.option=value "
-                             "format (see -l)",
-                        default=deque())
-    parser.add_argument("--log-size", action="store",
-                        dest="log_size", default=25, type=int,
-                        help="set a limit on the size of collected logs "
-                             "(in MiB)")
     parser.add_argument("-a", "--alloptions", action="store_true",
                         dest="usealloptions", default=False,
                         help="enable all options for loaded plugins")
@@ -251,50 +227,74 @@ def _parse_args(args):
                         dest="build", default=False,
                         help="preserve the temporary directory and do not "
                              "package results")
+    parser.add_argument("--case-id", action="store",
+                        dest="case_id",
+                        help="specify case identifier")
+    parser.add_argument("-c", "--chroot", action="store", dest="chroot",
+                        help="chroot executed commands to SYSROOT "
+                             "[auto, always, never] (default=auto)",
+                        default="auto")
+    parser.add_argument("--config-file", action="store",
+                        dest="config_file",
+                        help="specify alternate configuration file")
+    parser.add_argument("--debug", action="count",
+                        dest="debug",
+                        help="enable interactive debugging using the "
+                             "python debugger")
+    parser.add_argument("--experimental", action="store_true",
+                        dest="experimental", default=False,
+                        help="enable experimental plugins")
+    parser.add_argument("-e", "--enable-plugins", action="extend",
+                        dest="enableplugins", type=str,
+                        help="enable these plugins", default=deque())
+    parser.add_argument("-k", "--plugin-option", action="extend",
+                        dest="plugopts", type=str,
+                        help="plugin options in plugname.option=value "
+                             "format (see -l)",
+                        default=deque())
+    parser.add_argument("--label", "--name", action="store", dest="label",
+                        help="specify an additional report label")
+    parser.add_argument("-l", "--list-plugins", action="store_true",
+                        dest="list_plugins", default=False,
+                        help="list plugins and available plugin options")
+    parser.add_argument("--list-profiles", action="store_true",
+                        dest="list_profiles", default=False,
+                        help="display a list of available profiles and "
+                             "plugins that they include")
+    parser.add_argument("--log-size", action="store",
+                        dest="log_size", default=25, type=int,
+                        help="set a limit on the size of collected logs "
+                             "(in MiB)")
+    parser.add_argument("-n", "--skip-plugins", action="extend",
+                        dest="noplugins", type=str,
+                        help="disable these plugins", default=deque())
+    parser.add_argument("--no-report", action="store_true",
+                        dest="noreport",
+                        help="disable HTML/XML reporting", default=False)
+    parser.add_argument("-o", "--only-plugins", action="extend",
+                        dest="onlyplugins", type=str,
+                        help="enable these plugins only", default=deque())
+    parser.add_argument("-p", "--profile", action="extend",
+                        dest="profiles", type=str, default=deque(),
+                        help="enable plugins used by the given profiles")
+    parser.add_argument("--quiet", action="store_true",
+                        dest="quiet", default=False,
+                        help="only print fatal errors")
+    parser.add_argument("-s", "--sysroot", action="store", dest="sysroot",
+                        help="system root directory path (default='/')",
+                        default=None)
+    parser.add_argument("--ticket-number", action="store",
+                        dest="case_id",
+                        help="specify ticket number")
+    parser.add_argument("--tmp-dir", action="store",
+                        dest="tmp_dir",
+                        help="specify alternate temporary directory",
+                        default=None)
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         dest="verbosity", help="increase verbosity")
     parser.add_argument("--verify", action="store_true",
                         dest="verify", default=False,
                         help="perform data verification during collection")
-    parser.add_argument("--quiet", action="store_true",
-                        dest="quiet", default=False,
-                        help="only print fatal errors")
-    parser.add_argument("--debug", action="count",
-                        dest="debug",
-                        help="enable interactive debugging using the "
-                             "python debugger")
-    parser.add_argument("--ticket-number", action="store",
-                        dest="case_id",
-                        help="specify ticket number")
-    parser.add_argument("--case-id", action="store",
-                        dest="case_id",
-                        help="specify case identifier")
-    parser.add_argument("-p", "--profile", action="extend",
-                        dest="profiles", type=str, default=deque(),
-                        help="enable plugins used by the given profiles")
-    parser.add_argument("--list-profiles", action="store_true",
-                        dest="list_profiles", default=False,
-                        help="display a list of available profiles and "
-                             "plugins that they include")
-    parser.add_argument("--label", "--name", action="store", dest="label",
-                        help="specify an additional report label")
-    parser.add_argument("--config-file", action="store",
-                        dest="config_file",
-                        help="specify alternate configuration file")
-    parser.add_argument("--tmp-dir", action="store",
-                        dest="tmp_dir",
-                        help="specify alternate temporary directory",
-                        default=None)
-    parser.add_argument("--no-report", action="store_true",
-                        dest="noreport",
-                        help="disable HTML/XML reporting", default=False)
-    parser.add_argument("-s", "--sysroot", action="store", dest="sysroot",
-                        help="system root directory path (default='/')",
-                        default=None)
-    parser.add_argument("-c", "--chroot", action="store", dest="chroot",
-                        help="chroot executed commands to SYSROOT "
-                             "[auto, always, never] (default=auto)",
-                        default="auto")
     parser.add_argument("-z", "--compression-type",
                         dest="compression_type", default="auto",
                         help="compression technology to use [auto, "

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -887,7 +887,7 @@ class SoSReport(object):
             :returns: True on success or False otherwise
         """
         policy = self.policy
-        if policy.find_preset(name).name is not "":
+        if policy.find_preset(name):
             self.ui_log.error("A preset named '%s' already exists" % name)
             return False
 
@@ -915,7 +915,7 @@ class SoSReport(object):
             :returns: True on success or False otherwise
         """
         policy = self.policy
-        if policy.find_preset(name).name is "":
+        if not policy.find_preset(name):
             self.ui_log.error("Preset '%s' not found" % name)
             return False
 

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -199,6 +199,22 @@ class XmlReport(object):
 # valid modes for --chroot
 chroot_modes = ["auto", "always", "never"]
 
+#: Names of all arguments
+_arg_names = [
+    'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
+    'config_file', 'debug', 'enableplugins', 'experimental', 'label',
+    'list_plugins', 'list_profiles', 'log_size', 'noplugins', 'noreport',
+    'onlyplugins', 'plugopts', 'profiles', 'quiet', 'sysroot', 'tmp_dir',
+    'usealloptions', 'verbosity', 'verify'
+]
+
+#: Arguments with non-zero default values
+_arg_defaults = {
+    "log_size": 10,
+    "chroot": "auto",
+    "compression_type": "auto",
+}
+
 
 def _parse_args(args):
     """ Parse command line options and arguments"""
@@ -233,7 +249,7 @@ def _parse_args(args):
     parser.add_argument("-c", "--chroot", action="store", dest="chroot",
                         help="chroot executed commands to SYSROOT "
                              "[auto, always, never] (default=auto)",
-                        default="auto")
+                        default=_arg_defaults["chroot"])
     parser.add_argument("--config-file", action="store",
                         dest="config_file",
                         help="specify alternate configuration file")
@@ -260,10 +276,9 @@ def _parse_args(args):
                         dest="list_profiles", default=False,
                         help="display a list of available profiles and "
                              "plugins that they include")
-    parser.add_argument("--log-size", action="store",
-                        dest="log_size", default=25, type=int,
-                        help="set a limit on the size of collected logs "
-                             "(in MiB)")
+    parser.add_argument("--log-size", action="store", dest="log_size",
+                        type=int, default=_arg_defaults["log_size"],
+                        help="limit the size of collected logs (in MiB)")
     parser.add_argument("-n", "--skip-plugins", action="extend",
                         dest="noplugins", type=str,
                         help="disable these plugins", default=deque())
@@ -294,8 +309,8 @@ def _parse_args(args):
     parser.add_argument("--verify", action="store_true",
                         dest="verify", default=False,
                         help="perform data verification during collection")
-    parser.add_argument("-z", "--compression-type",
-                        dest="compression_type", default="auto",
+    parser.add_argument("-z", "--compression-type", dest="compression_type",
+                        default=_arg_defaults["compression_type"],
                         help="compression technology to use [auto, "
                              "gzip, bzip2, xz] (default=auto)")
     parser.add_argument("-t", "--threads", action="store", dest="threads",
@@ -303,15 +318,6 @@ def _parse_args(args):
                         " (default=4)", default=4, type=int)
 
     return parser.parse_args(args)
-
-
-_arg_names = [
-    'all_logs', 'batch', 'build', 'case_id', 'chroot', 'compression_type',
-    'config_file', 'debug', 'enableplugins', 'experimental', 'label',
-    'list_plugins', 'list_profiles', 'log_size', 'noplugins', 'noreport',
-    'onlyplugins', 'plugopts', 'profiles', 'quiet', 'sysroot', 'tmp_dir',
-    'usealloptions', 'verbosity', 'verify'
-]
 
 
 class SoSOptions(object):

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -348,6 +348,14 @@ class SoSOptions(object):
     experimental = False
     threads = 4
 
+    def _copy_opt(self, opt, src):
+        if hasattr(src, opt):
+            setattr(self, opt, getattr(src, opt))
+
+    def _copy_opts(self, src):
+        for arg in _arg_names:
+            self._copy_opt(arg, src)
+
     @classmethod
     def from_args(cls, args):
         """Initialise a new SoSOptions object from a ``Namespace``
@@ -358,10 +366,29 @@ class SoSOptions(object):
             :returntype: SoSOptions
         """
         opts = SoSOptions()
-        for arg in _arg_names:
-            if hasattr(args, arg):
-                setattr(opts, arg, getattr(args, arg))
+        opts._copy_opts(args)
         return opts
+
+    def merge(self, src, replace=False):
+        """Merge another set of ``SoSOptions`` into this object.
+
+            Merge two ``SoSOptions`` objects by setting unset or default
+            values to their value in the ``src`` object.
+
+            :param src: the ``SoSOptions`` object to copy from
+            :param replace: ``True`` if non-default values should be
+                            overwritten.
+        """
+
+        for arg in _arg_names:
+            if not hasattr(src, arg):
+                continue
+            if arg in _arg_defaults.keys():
+                if replace or getattr(self, arg) == _arg_defaults[arg]:
+                    self._copy_opt(arg, src)
+            else:
+                if replace or not getattr(self, arg):
+                    self._copy_opt(arg, src)
 
 
 class SoSReport(object):

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -215,7 +215,7 @@ def _parse_args(args):
     parser = ArgumentParser(usage=usage_string)
     parser.register('action', 'extend', SosListOption)
     parser.add_argument("-a", "--alloptions", action="store_true",
-                        dest="usealloptions", default=False,
+                        dest="alloptions", default=False,
                         help="enable all options for loaded plugins")
     parser.add_argument("--all-logs", action="store_true",
                         dest="all_logs", default=False,
@@ -691,7 +691,7 @@ class SoSReport(object):
             self._exit(1)
 
     def _set_all_options(self):
-        if self.opts.usealloptions:
+        if self.opts.alloptions:
             for plugname, plug in self.loaded_plugins:
                 for name, parms in zip(plug.opt_names, plug.opt_parms):
                     if type(parms["enabled"]) == bool:

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -870,46 +870,9 @@ class SoSReport(object):
             self.ui_log.info("%14s %s" % ("description:", preset.desc))
             if preset.note:
                 self.ui_log.info("%14s %s" % ("note:", preset.note))
+
             if self.opts.verbosity > 0:
-                def filter_opt(opt):
-                    """ Filter out preset options.
-                    """
-                    opt = opt.split("=")[0]
-                    if opt in ("add_preset", "del_preset", "desc", "note"):
-                        return False
-                    return True
-
-                def argify(opt):
-                    """ Convert sos option notation to command line arguments.
-                    """
-                    # Handle --verbosity specially
-                    if opt.startswith("verbosity"):
-                        (arg, value) = opt.split("=")
-                        arg = "-" + int(value) * "v"
-                        return arg
-
-                    # Convert "a_name=value" to "--a-name=value" and
-                    # "name=True" to "--name"
-                    arg = "--" + opt if len(opt) > 1 else "-" + opt
-                    arg = arg.replace("_", "-")
-                    arg = arg[:-len("=True")] if arg.endswith("=True") else arg
-                    return arg
-
-                def has_value(opt):
-                    """ Test for null option values.
-                    """
-                    null_values = ("False", "None", "[]", '""', "''", "0")
-                    (opt_name, opt_value) = opt.split("=")
-                    if opt_name in _arg_defaults:
-                        if opt_value == str(_arg_defaults[opt_name]):
-                            return False
-                    if not opt_value or opt_value in null_values:
-                        return False
-                    return True
-
-                opts = str(preset.opts).split()
-                opts = [opt for opt in opts if filter_opt(opt)]
-                args = [argify(opt) for opt in opts if has_value(opt)]
+                args = preset.opts.to_args()
                 options_str = "%14s " % "options:"
                 lines = _format_list(options_str, args, indent=True, sep=' ')
                 for line in lines:

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -26,7 +26,6 @@ from sos.plugins import import_plugin
 from sos.utilities import ImporterHelper
 from stat import ST_UID, ST_GID, ST_MODE, ST_CTIME, ST_ATIME, ST_MTIME, S_IMODE
 from time import strftime, localtime
-from collections import deque
 from shutil import rmtree
 import tempfile
 import hashlib
@@ -248,12 +247,11 @@ def _parse_args(args):
                         help="enable experimental plugins")
     parser.add_argument("-e", "--enable-plugins", action="extend",
                         dest="enableplugins", type=str,
-                        help="enable these plugins", default=deque())
+                        help="enable these plugins", default=[])
     parser.add_argument("-k", "--plugin-option", action="extend",
                         dest="plugopts", type=str,
                         help="plugin options in plugname.option=value "
-                             "format (see -l)",
-                        default=deque())
+                             "format (see -l)", default=[])
     parser.add_argument("--label", "--name", action="store", dest="label",
                         help="specify an additional report label")
     parser.add_argument("-l", "--list-plugins", action="store_true",
@@ -270,7 +268,7 @@ def _parse_args(args):
                         help="limit the size of collected logs (in MiB)")
     parser.add_argument("-n", "--skip-plugins", action="extend",
                         dest="noplugins", type=str,
-                        help="disable these plugins", default=deque())
+                        help="disable these plugins", default=[])
     parser.add_argument("--no-report", action="store_true",
                         dest="noreport",
                         help="disable HTML/XML reporting", default=False)
@@ -278,11 +276,11 @@ def _parse_args(args):
                         help="Behaviour notes for new preset")
     parser.add_argument("-o", "--only-plugins", action="extend",
                         dest="onlyplugins", type=str,
-                        help="enable these plugins only", default=deque())
+                        help="enable these plugins only", default=[])
     parser.add_argument("--preset", action="store", type=str,
                         help="A preset identifier", default="auto")
     parser.add_argument("-p", "--profile", action="extend",
-                        dest="profiles", type=str, default=deque(),
+                        dest="profiles", type=str, default=[],
                         help="enable plugins used by the given profiles")
     parser.add_argument("--quiet", action="store_true",
                         dest="quiet", default=False,
@@ -325,9 +323,9 @@ class SoSReport(object):
     """The main sosreport class"""
 
     def __init__(self, args):
-        self.loaded_plugins = deque()
-        self.skipped_plugins = deque()
-        self.all_options = deque()
+        self.loaded_plugins = []
+        self.skipped_plugins = []
+        self.all_options = []
         self.xml_report = XmlReport()
         self.global_plugin_options = {}
         self.archive = None
@@ -609,7 +607,7 @@ class SoSReport(object):
         import sos.plugins
         helper = ImporterHelper(sos.plugins)
         plugins = helper.get_modules()
-        self.plugin_names = deque()
+        self.plugin_names = []
         self.profiles = set()
         using_profiles = len(self.opts.profiles)
         policy_classes = self.policy.valid_subclasses
@@ -700,7 +698,7 @@ class SoSReport(object):
     def _set_tunables(self):
         if self.config.has_section("tunables"):
             if not self.opts.plugopts:
-                self.opts.plugopts = deque()
+                self.opts.plugopts = []
 
             for opt, val in self.config.items("tunables"):
                 if not opt.split('.')[0] in self._get_disabled_plugins():
@@ -733,7 +731,7 @@ class SoSReport(object):
                 try:
                     opts[plug]
                 except KeyError:
-                    opts[plug] = deque()
+                    opts[plug] = []
                 opts[plug].append((opt, val))
 
             for plugname, plug in self.loaded_plugins:
@@ -1235,8 +1233,8 @@ class SoSReport(object):
         """)
 
         # Make a pass to gather Alerts and a list of module names
-        allAlerts = deque()
-        plugNames = deque()
+        allAlerts = []
+        plugNames = []
         for plugname, plug in self.loaded_plugins:
             for alert in plug.alerts:
                 allAlerts.append('<a href="#%s">%s</a>: %s' % (plugname,

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -257,6 +257,8 @@ def _parse_args(args):
     parser.add_argument("-l", "--list-plugins", action="store_true",
                         dest="list_plugins", default=False,
                         help="list plugins and available plugin options")
+    parser.add_argument("--list-presets", action="store_true",
+                        help="display a list of available presets")
     parser.add_argument("--list-profiles", action="store_true",
                         dest="list_profiles", default=False,
                         help="display a list of available profiles and "
@@ -837,6 +839,27 @@ class SoSReport(object):
                 self.ui_log.info(" %s" % line)
         self._report_profiles_and_plugins()
 
+    def list_presets(self):
+        if not self.policy.presets:
+            self.soslog.fatal(_("no valid presets found"))
+            return
+        self.ui_log.info(_("The following presets are available:"))
+        self.ui_log.info("")
+
+        for preset in self.policy.presets.keys():
+            if not preset:
+                continue
+            preset = self.policy.presets[preset]
+            self.ui_log.info("%-15s %s" % (preset.name, preset.desc))
+            if preset.note:
+                self.ui_log.info("%-15s (%s)" % ("", preset.note))
+            if self.opts.verbosity > 0:
+                opts = str(preset.opts).split()
+                lines = _format_list("%-15s" % "options: ", opts, indent=True)
+                for line in lines:
+                    self.ui_log.info(line)
+            self.ui_log.info("")
+
     def batch(self):
         if self.opts.batch:
             self.ui_log.info(self.policy.get_msg())
@@ -1333,6 +1356,9 @@ class SoSReport(object):
                 return True
             if self.opts.list_profiles:
                 self.list_profiles()
+                return True
+            if self.opts.list_presets:
+                self.list_presets()
                 return True
 
             # verify that at least one plug-in is enabled

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -882,9 +882,17 @@ class SoSReport(object):
                 def argify(opt):
                     """ Convert sos option notation to command line arguments.
                     """
-                    arg = "--" + opt
+                    # Handle --verbosity specially
+                    if opt.startswith("verbosity"):
+                        (arg, value) = opt.split("=")
+                        arg = "-" + int(value) * "v"
+                        return arg
+
+                    # Convert "a_name=value" to "--a-name=value" and
+                    # "name=True" to "--name"
+                    arg = "--" + opt if len(opt) > 1 else "-" + opt
                     arg = arg.replace("_", "-")
-                    arg = arg.strip("=True")
+                    arg = arg[:-len("=True")] if arg.endswith("=True") else arg
                     return arg
 
                 def has_value(opt):

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -237,8 +237,7 @@ def _parse_args(args):
     parser.add_argument("--config-file", action="store",
                         dest="config_file",
                         help="specify alternate configuration file")
-    parser.add_argument("--debug", action="count",
-                        dest="debug",
+    parser.add_argument("--debug", action="store_true", dest="debug",
                         help="enable interactive debugging using the "
                              "python debugger")
     parser.add_argument("--experimental", action="store_true",

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -274,7 +274,7 @@ def _parse_args(args):
                         dest="onlyplugins", type=str,
                         help="enable these plugins only", default=deque())
     parser.add_argument("--preset", action="store", type=str,
-                        help="A preset identifier")
+                        help="A preset identifier", default="auto")
     parser.add_argument("-p", "--profile", action="extend",
                         dest="profiles", type=str, default=deque(),
                         help="enable plugins used by the given profiles")
@@ -343,7 +343,11 @@ class SoSReport(object):
 
         self._is_root = self.policy.is_root()
 
-        self.preset = self.policy.find_preset(cmd_args.preset)
+        # Apply per-preset command line defaults
+        if cmd_args.preset != _arg_defaults["preset"]:
+            self.preset = self.policy.find_preset(cmd_args.preset)
+        else:
+            self.preset = self.policy.probe_preset()
         self.opts.merge(self.preset.opts)
 
         # system temporary directory to use

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -867,9 +867,8 @@ class SoSReport(object):
             if self.opts.verbosity > 0:
                 # Filter out options that do not make sense in presets
                 def filter_opt(opt):
-                    if opt.startswith("add_preset"):
-                        return False
-                    if opt.startswith("del_preset"):
+                    opt = opt.split("=")[0]
+                    if opt in ("add_preset", "del_preset", "desc", "note"):
                         return False
                     return True
                 opts = str(preset.opts).split()


### PR DESCRIPTION
This isn't completely ready to be merged as yet, but it's a big series and starting to come together: it should be in fairly solid testable shape and I wanted to start getting feedback on the general idea as well as the code.

This branch adds a command line preset facility to `sos`: a preset is a named collection of command line argument values that can be applied either by user action (`--preset=`), or by auto-detection through the system policy. This is intended to save support users and customers time, by quickly recalling commonly-used configurations that will collect the right data for a given situation.

This enables different products, or different types of case within a product, to use separate command line defaults: for e.g. presets can enable options like `--all-logs` that are normally disabled by default, enable or disable plugins, and adjust the temporary directory and other options. These can be shipped as product defaults, or be added by the user later.

Values entered on the command line will take precedence over preset values for all atomic valued arguments. Arguments accepting a list (`--onlyplugins`, `--profiles`, etc.) are merged with the user-specified values (so it is possible to extend a list of preset-defined plugins or profiles etc.).

Presets are displayed by running `sosreport --list-presets`:
```
[root@bmr-rhel7-vm1 tmp]# sosreport --list-presets

sosreport (version 3.5)

The following presets are available:

         name: rhosp
  description: Red Hat OpenStack Platform
         note: This preset may increase report size

         name: satellite
  description: Red Hat Satellite
         note: This preset may increase report size and run time

         name: rhel
  description: Red Hat Enterprise Linux

         name: logs-only
  description: 

         name: rhv
  description: Red Hat Virtualization
         note: This preset may increase report run time

```

With `--verbose` the preset arguments are displayed:

```
[root@bmr-rhel7-vm1 tmp]# sosreport --list-presets -v

sosreport (version 3.5)

The following presets are available:

         name: rhosp
  description: Red Hat OpenStack Platform
         note: This preset may increase report size
      options: --all-logs

         name: satellite
  description: Red Hat Satellite
         note: This preset may increase report size and run time
      options: --all-logs --verify

         name: rhel
  description: Red Hat Enterprise Linux
      options:

         name: logs-only
  description: 
      options: --all-logs --batch --onlyplugins=logs --verbosity=3

         name: rhv
  description: Red Hat Virtualization
         note: This preset may increase report run time
      options: --all-logs --verify

```

Presets can be defined by both policies and the user: policy presets are defined in the respective policy class source and are registered with the policy core at runtime. User defined presets are added and removed with the `--add-preset` and `--del-preset` options and are stored as JSON files (one preset per file, although the format can represent any number) by default at `/var/lib/sos/presets` (note: the build scripts have not yet been updated to create this directory automatically: it must be created manually before using presets). Preset files can also be copied into the directory by hand (e.g. from product support downloads).

To add a preset, type the `sosreport` command line as normal, but add `--add-preset <name>`. Presets are removed with `sosreport --del-preset <name>`. Built-in presets cannot be deleted by the user.

```
[root@bmr-rhel7-vm1 tmp]# sosreport -vvv --batch --debug --profile system --add-preset qux
set sysroot to '/' (default)

sosreport (version 3.5)

Added preset 'qux' with options -vvv --batch --debug --profile system

[root@bmr-rhel7-vm1 tmp]# sosreport --del-preset qux

sosreport (version 3.5)

Deleted preset 'qux'

# Adding a description and note
[root@bmr-rhel7-vm1 tmp]# sosreport -vvv --batch --debug --profile system --add-preset qux --desc "Debugging preset" --note "Traps to pdb"
set sysroot to '/' (default)

sosreport (version 3.5)

Added preset 'qux' with options -vvv --batch --debug --profile system --desc Debugging preset --note Traps to pdb

[root@bmr-rhel7-vm1 tmp]# sosreport --list-presets -v

sosreport (version 3.5)

The following presets are available:

[...]
         name: qux
  description: Debugging preset
         note: Traps to pdb
      options: --batch --debug=1 --profiles=system --verbosity=3
[...]

```
Policies that have not opted-in to the presets framework will continue to use the same command line defaults as before and these are now defined in a single location in the source.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
