### PR TITLE
[filesys] Add permission and selinux check for /tmp

### DIFF
--- a/sos/plugins/filesys.py
+++ b/sos/plugins/filesys.py
@@ -9,7 +9,7 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Filesys(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Filesys(Plugin, DebianPlugin, UbuntuPlugin):
     """Local file systems
     """
 
@@ -68,5 +68,12 @@ class Filesys(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                  "Output information may be incomplete.)\n")
 
         self.do_cmd_output_sub("lsof", regex, '')
+
+
+class RedHatFilesys(Filesys, RedHatPlugin):
+
+    def setup(self):
+        super(RedHatFilesys, self).setup()
+        self.add_cmd_output("ls -ltradZ /tmp")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a check for the /tmp directory for permissions and selinux
context. If either of these are incorrect, the system in question can
exhibit strange behavior and otherwise be difficult for support teams to
detect.

On systems where SELinux is disabled, the permission check is still
relevant and the command still produces useful output with the -Z
option.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
