### PR TITLE
[Ubuntu] Add ubuntu-advantage status and change u-s-s to better default

### DIFF
--- a/sos/plugins/ubuntu.py
+++ b/sos/plugins/ubuntu.py
@@ -16,16 +16,9 @@ class Ubuntu(Plugin, UbuntuPlugin):
     plugin_name = 'ubuntu'
     profiles = ('system',)
 
-    option_list = [
-        ('support-show-all',
-         'Show all packages with their status', '', False),
-    ]
-
     def setup(self):
-        cmd = ["ubuntu-support-status"]
-
-        if self.get_option('support-show-all'):
-            cmd.append("--show-all")
-
-        self.add_cmd_output(" ".join(cmd),
-                            suggest_filename='ubuntu-support-status.txt')
+        self.add_cmd_output([
+            "ubuntu-support-status --show-all",
+            "hwe-support-status --verbose",
+            "ubuntu-advantage status"
+        ])


### PR DESCRIPTION
Add ubuntu-advantage status which is installed by default on Ubuntu and
shows when various UA items are enabled - esm, fips, and livepatch.

Switch ubuntu-support-status to always --show-all. It takes exactly
the same amount of time to run (in both cases it's relatively slow at
3 seconds), and only adds 30k uncompressed/12k compressed.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
