### PR TITLE
[sosreport] --batch option does not display results

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1612,8 +1612,7 @@ class SoSReport(object):
                 except (OSError, IOError):
                     print(_("Error moving checksum file: %s" % archive_hash))
 
-        if archive and checksum:
-            self.policy.display_results(archive, directory, checksum)
+        self.policy.display_results(archive, directory, checksum)
 
         # clean up
         logging.shutdown()


### PR DESCRIPTION
Fixing a regression caused by 8e69d36 .

Resolves: #1337

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
