### PR TITLE
[ovirt_provider_ovn] fix typo in provider file/config variable name

### DIFF
--- a/sos/plugins/ovirt_provider_ovn.py
+++ b/sos/plugins/ovirt_provider_ovn.py
@@ -22,7 +22,7 @@ class OvirtProviderOvn(Plugin, RedHatPlugin):
     provider_conf = '/etc/ovirt-provider-ovn/ovirt-provider-ovn.conf'
 
     def setup(self):
-        self.add_copy_spec(self.provider_file)
+        self.add_copy_spec(self.provider_conf)
         self.add_copy_spec('/etc/ovirt-provider-ovn/conf.d/*')
 
         spec = '/var/log/ovirt-provider-ovn.log'


### PR DESCRIPTION
Resolves: #1343

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
