### PR TITLE
[ipa] collect more logs and httpd alias configs

### DIFF
--- a/sos/plugins/ipa.py
+++ b/sos/plugins/ipa.py
@@ -53,6 +53,7 @@ class Ipa(Plugin, RedHatPlugin):
                "/var/log/pki/pki-tomcat/ca/debug",
                "/var/log/pki/pki-tomcat/ca/system",
                "/var/log/pki/pki-tomcat/ca/transactions",
+               "/var/log/pki/pki-tomcat/ca/selftests.log",
                "/var/log/pki/pki-tomcat/catalina.*",
                "/var/log/pki/pki-ca-spawn.*",
                "/var/log/pki/pki-tomcat/kra/debug",
@@ -65,6 +66,7 @@ class Ipa(Plugin, RedHatPlugin):
                "/var/log/pki-ca/debug",
                "/var/log/pki-ca/system",
                "/var/log/pki-ca/transactions",
+               "/var/log/pki-ca/selftests.log",
                "/var/log/pki-ca/catalina.*",
                "/var/log/pki/pki-ca-spawn.*"
             ])
@@ -105,11 +107,16 @@ class Ipa(Plugin, RedHatPlugin):
             "/etc/dirsrv/slapd-*/dse.ldif",
             "/etc/dirsrv/slapd-*/schema/99user.ldif",
             "/etc/hosts",
+            "/etc/httpd/alias/*",
             "/etc/named.*",
             "/etc/ipa/ca.crt",
             "/etc/ipa/default.conf",
+            "/root/.ipa/log/cli.log",
             "/var/lib/certmonger/requests/[0-9]*",
-            "/var/lib/certmonger/cas/[0-9]*"
+            "/var/lib/certmonger/cas/[0-9]*",
+            "/var/lib/ipa/ra-agent.pem",
+            "/var/kerberos/krb5kdc/kdc.crt",
+            "/var/lib/ipa/sysrestore/sysrestore.state"
         ])
 
         #  Make sure to use the right PKI config and NSS DB folders
@@ -128,6 +135,10 @@ class Ipa(Plugin, RedHatPlugin):
             "/etc/dirsrv/slapd-*/key*",
             "/etc/dirsrv/slapd-*/pin.txt",
             "/etc/dirsrv/slapd-*/pwdfile.txt",
+            "/etc/httpd/alias/ipasession.key",
+            "/etc/httpd/alias/key*",
+            "/etc/httpd/alias/pin.txt",
+            "/etc/httpd/alias/pwdfile.txt",
             "/etc/named.keytab",
             "%s/alias/key*" % self.pki_tomcat_dir,
             "%s/flatfile.txt" % self.pki_tomcat_conf_dir,
@@ -138,6 +149,8 @@ class Ipa(Plugin, RedHatPlugin):
             "ls -la /etc/dirsrv/slapd-*/schema/",
             "getcert list",
             "certutil -L -d /etc/httpd/alias/",
+            "pki-server cert-find --show-all",
+            "pki-server subsystem-cert-validate ca",
             "klist -ket /etc/dirsrv/ds.keytab",
             "klist -ket /etc/httpd/conf/ipa.keytab",
             "klist -ket /var/lib/ipa/gssproxy/http.keytab"


### PR DESCRIPTION
Improvements and one correction:

 - Include IPA CLI log
 - Include Dogtag system certificate verification log 
 - Include Apache NSS database under `/etc/httpd/alias`
   - Add exclusions for the Apache NSS database key database and PIN/password files
 - Include RA agent and KDC certificates (>= IPA v4.5)
 - Include IPA sysrestore state file
 - Run command `pki-server cert-find --show-all` to obtain copies of Dogtag CA system certificates
 - Run command `pki-server subsystem-cert-validate ca` to obtain validation status for Dogtag CA system certificates

Resolves: #1346

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
