### PR TITLE
[plugins] Check read access before trying to list a dir

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -431,7 +431,7 @@ class Plugin(object):
             self._copy_symlink(srcpath)
             return
         else:
-            if stat.S_ISDIR(st.st_mode):
+            if stat.S_ISDIR(st.st_mode) and os.access(srcpath, os.R_OK):
                 self._copy_dir(srcpath)
                 return
 


### PR DESCRIPTION
I found a permission error when trying to copy /sys/fs/pstore when
running on LXD containers.  Adding a permission check first allows
it to skip folders it can't list.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
