### PR TITLE
[sosreport] call traceback.print_exc without arguments

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1228,10 +1228,9 @@ class SoSReport(object):
             else:
                 raise e
         except Exception as e:
-            import traceback
             self.ui_log.error("")
             self.ui_log.error(" Unexpected exception setting up archive:")
-            traceback.print_exc(e)
+            traceback.print_exc()
             self.ui_log.error(e)
         self._exit(1)
 


### PR DESCRIPTION
to prevent uncaught exception on py3

Resolves: #1349

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
