### PR TITLE
[fibrechannel] proper fix of test dir when missing

### DIFF
--- a/sos/plugins/fibrechannel.py
+++ b/sos/plugins/fibrechannel.py
@@ -29,8 +29,8 @@ class Fibrechannel(Plugin, RedHatPlugin):
         ]
 
         for loc in dirs:
-            devs.extend([loc + device for device in os.listdir(loc)
-                         if os.path.isdir(loc)])
+            if os.path.isdir(loc):
+                devs.extend([loc + device for device in os.listdir(loc)])
 
         if devs:
             self.add_udev_info(devs, attrs=True)


### PR DESCRIPTION
The if clause inside for cycle is evaluated after the os.listdir.

Resolves: #1341

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
