### PR TITLE
[sosreport] Fix finished running plugins report

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1344,7 +1344,7 @@ class SoSReport(object):
                     " ",
                     "[Running: %s]" % (' '.join(p for p in self.running_plugs))
                 )
-            if not self.running_plugs:
+            if not self.running_plugs and not self.pluglist:
                 status = "\n  Finished running plugins"
             if status:
                 self.ui_progress(status)


### PR DESCRIPTION
Adds the condition that no more plugins are supposed to run when there
are no plugins running to report that sosreport has finished running
plugins.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
