### PR TITLE
[sosreport] Correct verbosity level when -v is not specified

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -605,7 +605,7 @@ class SoSOptions(object):
                             dest="build", default=False,
                             help="preserve the temporary directory and do not "
                                  "package results")
-        parser.add_argument("-v", "--verbose", action="count",
+        parser.add_argument("-v", "--verbose", action="count", default=0,
                             dest="verbosity", help="increase verbosity")
         parser.add_argument("--verify", action="store_true",
                             dest="verify", default=False,
@@ -1358,7 +1358,7 @@ class SoSReport(object):
             self.handle_exception(plugname, "collect")
 
     def ui_progress(self, status_line):
-        if self.opts.verbosity == 0:
+        if self.opts.verbosity == 0 and not self.opts.batch:
             status_line = "\r%s" % status_line.ljust(90)
         else:
             status_line = "%s\n" % status_line


### PR DESCRIPTION
Fixes an issue where verbosity would be set to 'None' rather than 0 in
the event that a sosreport was run with options, when those options did
not include -v at all. This meant that if any options were specified, a
newline would be printed for each started plugin when instead we should
still have been refreshing a single line.

Related to this, the previous newline behavior was beneficial when
running with --batch, so that behavior is maintained if --batch is
specified.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
