### PR TITLE
[rpm] Fix awk string escaping

### DIFF
--- a/sos/plugins/rpm.py
+++ b/sos/plugins/rpm.py
@@ -40,7 +40,7 @@ class Rpm(Plugin, RedHatPlugin):
             query_fmt = query_fmt + '%{INSTALLTIME:date}\n"'
 
             filter_cmd = 'awk -F "~~" ' \
-                r'"{printf \\"%-59s %s\\n\\",\$1,\$2}"|sort -V'
+                r'"{printf \"%-59s %s\n\",\$1,\$2}"|sort -V'
 
             add_rpm_cmd(query_fmt, filter_cmd, "installed-rpms", None)
 


### PR DESCRIPTION
With the transition to pycodestyle, we needed to make the filter_cmd
string that defined the awk string a raw string. This in turn broke the
escaping and would result in the following for the installed-rpms file:

    awk: cmd. line:1: {printf \%-59s
    awk: cmd. line:1:         ^ syntax error

This fixes the escaping so that pycodestyle still passes the check on
the string, and that awk still accepts the string and we get the proper
output in the installed-rpms file.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
