### PR TITLE
[plugin] Use log_size for limiting size of journal

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -875,7 +875,7 @@ class Plugin(object):
 
         self._log_debug("collecting journal: %s" % journal_cmd)
         self._add_cmd_output(journal_cmd, timeout=timeout,
-                             sizelimit=sizelimit)
+                             sizelimit=log_size)
 
     def add_udev_info(self, device, attrs=False):
         """Collect udevadm info output for a given device


### PR DESCRIPTION
Corrects the _add_cmd_output() call from add_journal() to use the
log_size determined by comparing sos options, sizelimit, and the default
journal size instead of always using sizelimit.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
