### PR TITLE
[sosreport] Fix --threads having no effect

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -48,7 +48,7 @@ _arg_names = [
     'enableplugins', 'experimental', 'label', 'list_plugins', 'list_presets',
     'list_profiles', 'log_size', 'noplugins', 'noreport', 'note',
     'onlyplugins', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
-    'tmp_dir', 'verbosity', 'verify'
+    'threads', 'tmp_dir', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values


### PR DESCRIPTION
The threads option was missing from the _arg_names list which meant it
could not actually be changed by the command line option. Add threads to
this list so the number of threads is user-controllable.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
