### PR TITLE
[plugins] Remove unnecessary sizelimits

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -2,7 +2,7 @@
 
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
-Version: 3.5
+Version: 3.6
 Release: 1%{?dist}
 Group: Applications/System
 Source0: http://people.redhat.com/breeves/sos/releases/sos-%{version}.tar.gz

--- a/sos/plugins/apport.py
+++ b/sos/plugins/apport.py
@@ -20,9 +20,10 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-            self.add_copy_spec("/var/log/apport.log", sizelimit=limit)
-            self.add_copy_spec("/var/log/apport.log.1", sizelimit=limit)
+            self.add_copy_spec([
+                "/var/log/apport.log",
+                "/var/log/apport.log.1"
+            ])
         else:
             self.add_copy_spec("/var/log/apport*")
         self.add_copy_spec("/etc/apport/*")

--- a/sos/plugins/auditd.py
+++ b/sos/plugins/auditd.py
@@ -30,8 +30,7 @@ class Auditd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
 
         if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-            self.add_copy_spec("/var/log/audit/audit.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/audit/audit.log")
         else:
             self.add_copy_spec("/var/log/audit")
 

--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -28,20 +28,19 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
 
     def setup(self):
         all_logs = self.get_option("all_logs")
-        limit = self.get_option("log_size")
 
         if not all_logs:
             self.add_copy_spec([
                 "/var/log/ceph/*.log",
                 "/var/log/radosgw/*.log",
                 "/var/log/calamari/*.log"
-            ], sizelimit=limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/ceph/",
                 "/var/log/calamari",
                 "/var/log/radosgw"
-            ], sizelimit=limit)
+            ])
 
         self.add_copy_spec([
             "/etc/ceph/",

--- a/sos/plugins/cups.py
+++ b/sos/plugins/cups.py
@@ -20,10 +20,9 @@ class Cups(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-            self.add_copy_spec("/var/log/cups/access_log", sizelimit=limit)
-            self.add_copy_spec("/var/log/cups/error_log", sizelimit=limit)
-            self.add_copy_spec("/var/log/cups/page_log", sizelimit=limit)
+            self.add_copy_spec("/var/log/cups/access_log")
+            self.add_copy_spec("/var/log/cups/error_log")
+            self.add_copy_spec("/var/log/cups/page_log")
         else:
             self.add_copy_spec("/var/log/cups")
 

--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -46,14 +46,12 @@ class DNFPlugin(Plugin, RedHatPlugin):
             "/etc/dnf/protected.d/*",
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/dnf.*", sizelimit=self.limit)
+            self.add_copy_spec("/var/log/dnf.*")
         else:
-            self.add_copy_spec("/var/log/dnf.log", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/dnf.librepo.log",
-                               sizelimit=self.limit)
-            self.add_copy_spec("/var/log/dnf.rpm.log", sizelimit=self.limit)
+            self.add_copy_spec("/var/log/dnf.log")
+            self.add_copy_spec("/var/log/dnf.librepo.log")
+            self.add_copy_spec("/var/log/dnf.rpm.log")
 
         self.add_cmd_output([
             "dnf --version",

--- a/sos/plugins/dpkg.py
+++ b/sos/plugins/dpkg.py
@@ -28,8 +28,7 @@ class Dpkg(Plugin, DebianPlugin, UbuntuPlugin):
             "/etc/debconf.conf"
         ])
         if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-            self.add_copy_spec("/var/log/dpkg.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/dpkg.log")
         else:
             self.add_copy_spec("/var/log/dpkg.log*")
 

--- a/sos/plugins/elastic.py
+++ b/sos/plugins/elastic.py
@@ -43,13 +43,10 @@ class Elastic(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         els_config_file = "/etc/elasticsearch/elasticsearch.yml"
         self.add_copy_spec(els_config_file)
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/elasticsearch/*",
-                               sizelimit=self.limit)
+            self.add_copy_spec("/var/log/elasticsearch/*")
         else:
-            self.add_copy_spec("/var/log/elasticsearch/elasticsearch.log",
-                               sizelimit=self.limit)
+            self.add_copy_spec("/var/log/elasticsearch/elasticsearch.log")
 
         host, port = self.get_hostname_port(els_config_file)
         endpoint = host + ":" + port

--- a/sos/plugins/gnocchi.py
+++ b/sos/plugins/gnocchi.py
@@ -39,21 +39,20 @@ class GnocchiPlugin(Plugin, RedHatPlugin):
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/gnocchi/*",
                 "/var/log/httpd/gnocchi*",
                 "/var/log/containers/gnocchi/*",
                 "/var/log/containers/httpd/gnocchi-api/*"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/gnocchi/*.log",
                 "/var/log/httpd/gnocchi*.log",
                 "/var/log/containers/gnocchi/*.log",
                 "/var/log/containers/httpd/gnocchi-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]

--- a/sos/plugins/grafana.py
+++ b/sos/plugins/grafana.py
@@ -21,11 +21,9 @@ class Grafana(Plugin, RedHatPlugin):
 
     def setup(self):
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/grafana/*.log",
-                               sizelimit=self.get_option("log_size"))
+            self.add_copy_spec("/var/log/grafana/*.log")
         else:
-            self.add_copy_spec("/var/log/grafana/*.log",
-                               sizelimit=self.get_option("log_size"))
+            self.add_copy_spec("/var/log/grafana/*.log")
 
         self.add_cmd_output([
             "grafana-cli plugins ls",

--- a/sos/plugins/infiniband.py
+++ b/sos/plugins/infiniband.py
@@ -27,8 +27,7 @@ class Infiniband(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/rdma"
         ])
 
-        self.add_copy_spec("/var/log/opensm*",
-                           sizelimit=self.get_option("log_size"))
+        self.add_copy_spec("/var/log/opensm*")
 
         self.add_cmd_output([
             "ibv_devices",

--- a/sos/plugins/insights.py
+++ b/sos/plugins/insights.py
@@ -19,13 +19,10 @@ class RedHatInsights(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec(self.conf_file)
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/redhat-access-insights/*.log*",
-                               sizelimit=self.limit)
+            self.add_copy_spec("/var/log/redhat-access-insights/*.log*")
         else:
-            self.add_copy_spec("/var/log/redhat-access-insights/*.log",
-                               sizelimit=self.limit)
+            self.add_copy_spec("/var/log/redhat-access-insights/*.log")
 
     def postproc(self):
         self.do_file_sub(

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -71,9 +71,8 @@ class Juju(Plugin, UbuntuPlugin):
                 suggest_filename="{}.json".format(collection))
 
     def setup(self):
-        limit = self.get_option("log_size")
-        self.add_copy_spec("/var/log/upstart/juju-db.log", sizelimit=limit)
-        self.add_copy_spec("/var/log/upstart/juju-db.log.1", sizelimit=limit)
+        self.add_copy_spec("/var/log/upstart/juju-db.log")
+        self.add_copy_spec("/var/log/upstart/juju-db.log.1")
         if not self.get_option("all_logs"):
             # We need this because we want to collect to the limit of all
             # *.logs in the directory.
@@ -81,7 +80,7 @@ class Juju(Plugin, UbuntuPlugin):
                 for filename in os.listdir("/var/log/juju/"):
                     if filename.endswith(".log"):
                         fullname = os.path.join("/var/log/juju/" + filename)
-                        self.add_copy_spec(fullname, sizelimit=limit)
+                        self.add_copy_spec(fullname)
             self.add_cmd_output('ls -alRh /var/log/juju*')
             self.add_cmd_output('ls -alRh /var/lib/juju/*')
 

--- a/sos/plugins/kimchi.py
+++ b/sos/plugins/kimchi.py
@@ -22,10 +22,9 @@ class Kimchi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         log_limit = self.get_option('log_size')
         self.add_copy_spec('/etc/kimchi/')
         if not self.get_option('all_logs'):
-            self.add_copy_spec('/var/log/kimchi/*.log', sizelimit=log_limit)
-            self.add_copy_spec('/etc/kimchi/kimchi*', sizelimit=log_limit)
-            self.add_copy_spec('/etc/kimchi/distros.d/*.json',
-                               sizelimit=log_limit)
+            self.add_copy_spec('/var/log/kimchi/*.log')
+            self.add_copy_spec('/etc/kimchi/kimchi*')
+            self.add_copy_spec('/etc/kimchi/distros.d/*.json')
         else:
             self.add_copy_spec('/var/log/kimchi/')
 

--- a/sos/plugins/landscape.py
+++ b/sos/plugins/landscape.py
@@ -25,10 +25,8 @@ class Landscape(Plugin, UbuntuPlugin):
         self.add_copy_spec("/etc/landscape/service.conf.old")
         self.add_copy_spec("/etc/default/landscape-server")
         if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-            self.add_copy_spec("/var/log/landscape/*.log", sizelimit=limit)
-            self.add_copy_spec("/var/log/landscape-server/*.log",
-                               sizelimit=limit)
+            self.add_copy_spec("/var/log/landscape/*.log")
+            self.add_copy_spec("/var/log/landscape-server/*.log")
         else:
             self.add_copy_spec("/var/log/landscape")
             self.add_copy_spec("/var/log/landscape-server")

--- a/sos/plugins/lightdm.py
+++ b/sos/plugins/lightdm.py
@@ -26,11 +26,9 @@ class LightDm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/lightdm/users.conf"
         ])
         if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-            self.add_copy_spec("/var/log/lightdm/lightdm.log", sizelimit=limit)
-            self.add_copy_spec("/var/log/lightdm/x-0-greeter.log",
-                               sizelimit=limit)
-            self.add_copy_spec("/var/log/lightdm/x-0.log", sizelimit=limit)
+            self.add_copy_spec("/var/log/lightdm/lightdm.log")
+            self.add_copy_spec("/var/log/lightdm/x-0-greeter.log")
+            self.add_copy_spec("/var/log/lightdm/x-0.log")
         else:
             self.add_copy_spec("/var/log/lightdm")
 

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -24,10 +24,8 @@ class Logs(Plugin):
             "/etc/rsyslog.d"
         ])
 
-        self.limit = (None if self.get_option("all_logs")
-                      else self.get_option("log_size"))
-        self.add_copy_spec("/var/log/boot.log", sizelimit=self.limit)
-        self.add_copy_spec("/var/log/cloud-init*", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/boot.log")
+        self.add_copy_spec("/var/log/cloud-init*")
         self.add_journal(boot="this", catalog=True)
         self.add_journal(boot="last", catalog=True)
         self.add_cmd_output("journalctl --disk-usage")
@@ -51,7 +49,7 @@ class Logs(Plugin):
             if i.startswith("-"):
                 i = i[1:]
             if os.path.isfile(i):
-                self.add_copy_spec(i, sizelimit=self.limit)
+                self.add_copy_spec(i)
 
         if self.get_option('all_logs'):
             self.add_journal(boot="this", allfields=True, output="verbose")
@@ -87,8 +85,8 @@ class RedHatLogs(Logs, RedHatPlugin):
 
         have_messages = os.path.exists(messages)
 
-        self.add_copy_spec(secure + "*", sizelimit=self.limit)
-        self.add_copy_spec(messages + "*", sizelimit=self.limit)
+        self.add_copy_spec(secure + "*")
+        self.add_copy_spec(messages + "*")
 
         # collect three days worth of logs by default if the system is
         # configured to use the journal and not /var/log/messages
@@ -109,15 +107,16 @@ class DebianLogs(Logs, DebianPlugin, UbuntuPlugin):
     def setup(self):
         super(DebianLogs, self).setup()
         if not self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/syslog", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/syslog.1", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/kern.log", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/kern.log.1", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/udev", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/dist-upgrade", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/installer", sizelimit=self.limit)
-            self.add_copy_spec("/var/log/unattended-upgrades",
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/syslog",
+                "/var/log/syslog.1",
+                "/var/log/kern.log",
+                "/var/log/kern.log.1",
+                "/var/log/udev",
+                "/var/log/dist-upgrade",
+                "/var/log/installer",
+                "/var/log/unattended-upgrades"
+            ])
             self.add_cmd_output('ls -alRh /var/log/')
         else:
             self.add_copy_spec("/var/log/")

--- a/sos/plugins/lxd.py
+++ b/sos/plugins/lxd.py
@@ -24,8 +24,7 @@ class LXD(Plugin, UbuntuPlugin):
             "/etc/default/lxc-bridge",
         ])
 
-        self.add_copy_spec("/var/log/lxd*",
-                           sizelimit=self.get_option("log_size"))
+        self.add_copy_spec("/var/log/lxd*")
 
         # List of containers available on the machine
         self.add_cmd_output([

--- a/sos/plugins/mssql.py
+++ b/sos/plugins/mssql.py
@@ -80,9 +80,8 @@ class MsSQL(Plugin, RedHatPlugin):
         ])
 
         if not self.get_option('all_logs'):
-            limit = self.get_option('log_size')
-            self.add_copy_spec(errorlogfile + '/*', sizelimit=limit)
-            self.add_copy_spec(sqlagent_errorlogfile, sizelimit=limit)
+            self.add_copy_spec(errorlogfile + '/*')
+            self.add_copy_spec(sqlagent_errorlogfile)
         else:
             self.add_copy_spec(errorlogfile + '/*')
             self.add_copy_spec(sqlagent_errorlogfile)

--- a/sos/plugins/nscd.py
+++ b/sos/plugins/nscd.py
@@ -24,12 +24,10 @@ class Nscd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
         self.add_copy_spec("/etc/nscd.conf")
 
-        self.limit = (None if self.get_option("all_logs")
-                      else self.get_option("log_size"))
         opt = self.file_grep(r"^\s*logfile", "/etc/nscd.conf")
         if (len(opt) > 0):
             for o in opt:
                 f = o.split()
-                self.add_copy_spec(f[1], sizelimit=self.limit)
+                self.add_copy_spec(f[1])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/numa.py
+++ b/sos/plugins/numa.py
@@ -26,10 +26,7 @@ class Numa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/numad.conf",
             "/etc/logrotate.d/numad"
         ])
-        self.add_copy_spec(
-            "/var/log/numad.log*",
-            sizelimit=self.get_option("log_size")
-        )
+        self.add_copy_spec("/var/log/numad.log*")
         self.add_cmd_output([
             "numastat",
             "numastat -m",

--- a/sos/plugins/opendaylight.py
+++ b/sos/plugins/opendaylight.py
@@ -26,17 +26,16 @@ class OpenDaylight(Plugin, RedHatPlugin):
             self.var_puppet_gen + "/opt/opendaylight/etc/",
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/opt/opendaylight/data/log/",
                 "/var/log/containers/opendaylight/",
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/opt/opendaylight/data/log/*.log*",
                 "/var/log/containers/opendaylight/*.log*",
-            ], sizelimit=self.limit)
+            ])
 
         self.add_cmd_output("docker logs opendaylight_api")
 

--- a/sos/plugins/openstack_aodh.py
+++ b/sos/plugins/openstack_aodh.py
@@ -40,21 +40,20 @@ class OpenStackAodh(Plugin, RedHatPlugin):
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/aodh/*",
                 "/var/log/httpd/aodh*",
                 "/var/log/containers/aodh/*",
                 "/var/log/containers/httpd/aodh-api/*"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/aodh/*.log",
                 "/var/log/httpd/aodh*.log",
                 "/var/log/containers/aodh/*.log",
                 "/var/log/containers/httpd/aodh-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
         vars_all = [p in os.environ for p in [
             'OS_USERNAME', 'OS_PASSWORD', 'OS_AUTH_TYPE'

--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -25,17 +25,16 @@ class OpenStackCeilometer(Plugin):
 
     def setup(self):
         # Ceilometer
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/ceilometer/*",
                 "/var/log/containers/ceilometer/*"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/ceilometer/*.log",
                 "/var/log/containers/ceilometer/*.log"
-            ], sizelimit=self.limit)
+            ])
         self.add_copy_spec([
             "/etc/ceilometer/*",
             self.var_puppet_gen + "/etc/ceilometer/*"
@@ -101,10 +100,10 @@ class RedHatCeilometer(OpenStackCeilometer, RedHatPlugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/httpd/ceilometer*",
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/httpd/ceilometer*.log",
-            ], sizelimit=self.limit)
+            ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -63,21 +63,20 @@ class OpenStackCinder(Plugin):
             self.var_puppet_gen + "/etc/sysconfig/",
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/cinder/",
                 "/var/log/httpd/cinder*",
                 "/var/log/containers/cinder/",
                 "/var/log/containers/httpd/cinder-api/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/cinder/*.log",
                 "/var/log/httpd/cinder*.log",
                 "/var/log/containers/cinder/*.log",
                 "/var/log/containers/httpd/cinder-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -25,19 +25,18 @@ class OpenStackGlance(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated/glance_api"
 
     def setup(self):
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/glance/",
                 "/var/log/containers/glance/",
                 "/var/log/containers/httpd/glance-api/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/glance/*.log",
                 "/var/log/containers/glance/*.log",
                 "/var/log/containers/httpd/glance-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             "/etc/glance/",

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -63,21 +63,20 @@ class OpenStackHeat(Plugin):
             else:
                 self.add_cmd_output("openstack stack list")
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/heat/",
                 "/var/log/containers/heat/",
                 "/var/log/containers/httpd/heat-api/",
                 "/var/log/containers/httpd/heat-api-cfn"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/heat/*.log",
                 "/var/log/containers/heat/*.log",
                 "/var/log/containers/httpd/heat-api/*log",
                 "/var/log/containers/httpd/heat-api-cfn/*log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             "/etc/heat/",

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -24,20 +24,18 @@ class OpenStackHorizon(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated"
 
     def setup(self):
-
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/horizon/",
                 "/var/log/containers/horizon/",
                 "/var/log/containers/httpd/horizon/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/horizon/*.log",
                 "/var/log/containers/horizon/*.log",
                 "/var/log/containers/httpd/horizon/*log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             "/etc/openstack-dashboard/",
@@ -114,13 +112,11 @@ class RedHatHorizon(OpenStackHorizon, RedHatPlugin):
         super(RedHatHorizon, self).setup()
         self.add_copy_spec("/etc/httpd/conf.d/openstack-dashboard.conf")
         if self.get_option("all_logs"):
-            self.add_copy_spec([
-                "/var/log/httpd/horizon*",
-            ], sizelimit=self.limit)
+            self.add_copy_spec("/var/log/httpd/horizon*")
         else:
             self.add_copy_spec([
                 "/var/log/httpd/horizon*.log"
-            ], sizelimit=self.limit)
-            self.add_copy_spec("/var/log/httpd/")
+                "/var/log/httpd/"
+            ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -36,21 +36,20 @@ class OpenStackInstack(Plugin):
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
-            self.add_copy_spec(["/var/log/mistral/",
-                                "/var/log/containers/mistral/"],
-                               sizelimit=self.limit)
-            self.add_copy_spec(["/var/log/zaqar/",
-                                "/var/log/containers/zaqar/"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/mistral/",
+                "/var/log/containers/mistral/",
+                "/var/log/zaqar/",
+                "/var/log/containers/zaqar/"
+            ])
         else:
-            self.add_copy_spec(["/var/log/mistral/*.log",
-                                "/var/log/containers/mistral/*.log"],
-                               sizelimit=self.limit)
-            self.add_copy_spec(["/var/log/zaqar/*.log",
-                                "/var/log/containers/zaqar/*.log"],
-                               sizelimit=self.limit)
+            self.add_copy_spec([
+                "/var/log/mistral/*.log",
+                "/var/log/containers/mistral/*.log",
+                "/var/log/zaqar/*.log",
+                "/var/log/containers/zaqar/*.log"
+            ])
 
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -43,19 +43,18 @@ class OpenStackIronic(Plugin):
             self.var_puppet_gen + "_api/etc/my.cnf.d/tripleo.cnf"
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/ironic/",
                 "/var/log/containers/ironic/",
                 "/var/log/containers/httpd/ironic-api/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/ironic/*.log",
                 "/var/log/containers/ironic/*.log",
                 "/var/log/containers/httpd/ironic-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
         for path in ['/var/lib/ironic', '/httpboot', '/tftpboot']:
             self.add_cmd_output('ls -laRt %s' % path)

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -37,19 +37,18 @@ class OpenStackKeystone(Plugin):
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/keystone/",
                 "/var/log/containers/keystone/",
                 "/var/log/containers/httpd/keystone/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/keystone/*.log",
                 "/var/log/containers/keystone/*.log",
                 "/var/log/containers/httpd/keystone/*log"
-            ], sizelimit=self.limit)
+            ])
 
         # collect domain config directory, if specified
         # if not, collect default /etc/keystone/domains
@@ -129,13 +128,9 @@ class RedHatKeystone(OpenStackKeystone, RedHatPlugin):
     def setup(self):
         super(RedHatKeystone, self).setup()
         if self.get_option("all_logs"):
-            self.add_copy_spec([
-                "/var/log/httpd/keystone*",
-            ], sizelimit=self.limit)
+            self.add_copy_spec("/var/log/httpd/keystone*")
         else:
-            self.add_copy_spec([
-                "/var/log/httpd/keystone*.log",
-            ], sizelimit=self.limit)
+            self.add_copy_spec("/var/log/httpd/keystone*.log")
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -30,19 +30,18 @@ class OpenStackManila(Plugin):
             self.var_puppet_gen + "/etc/httpd/conf.modules.d/*.conf",
         ])
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/manila/*",
                 "/var/log/containers/manila/*",
                 "/var/log/containers/httpd/manila-api/*"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/manila/*.log",
                 "/var/log/containers/manila/*.log",
                 "/var/log/containers/httpd/manila-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/manila/*", regexp, subst)

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -22,20 +22,18 @@ class OpenStackNeutron(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated/neutron"
 
     def setup(self):
-
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/neutron/",
                 "/var/log/containers/neutron/",
                 "/var/log/containers/httpd/neutron-api/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/neutron/*.log",
                 "/var/log/containers/neutron/*.log",
                 "/var/log/containers/httpd/neutron-api/*log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             "/etc/neutron/",

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -91,21 +91,20 @@ class OpenStackNova(Plugin):
                         cmd,
                         suggest_filename="instance-" + instance + ".log")
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/nova/",
                 "/var/log/containers/nova/",
                 "/var/log/containers/httpd/nova-api/",
                 "/var/log/containers/httpd/nova-placement/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/nova/*.log",
                 "/var/log/containers/nova/*.log",
                 "/var/log/containers/httpd/nova-api/*log",
                 "/var/log/containers/httpd/nova-placement/*log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             "/etc/nova/",

--- a/sos/plugins/openstack_octavia.py
+++ b/sos/plugins/openstack_octavia.py
@@ -34,19 +34,18 @@ class OpenStackOctavia(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_forbidden_path("/etc/octavia/certs/")
 
         # logs
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/containers/httpd/octavia-api/*",
                 "/var/log/containers/octavia/*",
                 "/var/log/octavia/*",
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/containers/httpd/octavia-api/*.log",
                 "/var/log/containers/octavia/*.log",
                 "/var/log/octavia/*.log",
-            ], sizelimit=self.limit)
+            ])
 
         # commands
         self.add_cmd_output([

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -28,17 +28,16 @@ class OpenStackSahara(Plugin):
         self.add_journal(units="openstack-sahara-api")
         self.add_journal(units="openstack-sahara-engine")
 
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/sahara/",
                 "/var/log/containers/sahara/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/sahara/*.log",
                 "/var/log/containers/sahara/*.log"
-            ], sizelimit=self.limit)
+            ])
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -24,20 +24,18 @@ class OpenStackSwift(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated"
 
     def setup(self):
-
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/swift/",
                 "/var/log/containers/swift/",
                 "/var/log/containers/httpd/swift-proxy/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/swift/*.log",
                 "/var/log/containers/swift/*.log",
                 "/var/log/containers/httpd/swift-proxy/*log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             "/etc/swift/",

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -23,18 +23,16 @@ class OpenStackTrove(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated/trove"
 
     def setup(self):
-
-        self.limit = self.get_option("log_size")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/trove/",
                 "/var/log/containers/trove/"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/trove/*.log",
                 "/var/log/containers/trove/*.log"
-            ], sizelimit=self.limit)
+            ])
 
         self.add_copy_spec([
             '/etc/trove/',

--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -23,7 +23,6 @@ class OpenVSwitch(Plugin):
     def setup(self):
 
         all_logs = self.get_option("all_logs")
-        limit = self.get_option("log_size")
 
         log_dirs = [
             '/var/log/containers/openvswitch/',
@@ -35,12 +34,9 @@ class OpenVSwitch(Plugin):
             log_dirs.append(environ.get('OVS_LOGDIR'))
 
         if not all_logs:
-            self.add_copy_spec([path_join(ld, '*.log') for ld in log_dirs],
-                               sizelimit=limit)
-            self.add_copy_spec([path_join(ld, '*.log') for ld in log_dirs],
-                               sizelimit=limit)
+            self.add_copy_spec([path_join(ld, '*.log') for ld in log_dirs])
         else:
-            self.add_copy_spec(log_dirs, sizelimit=limit)
+            self.add_copy_spec(log_dirs)
 
         self.add_copy_spec([
             "/var/run/openvswitch/ovsdb-server.pid",

--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -29,8 +29,6 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
     HA_LOG_GLOB = '/var/log/ovirt-hosted-engine-ha/*.log'
 
     def setup(self):
-        self.limit = self.get_option('log_size')
-
         # Add configuration files
         # Collecting the whole directory since it may contain branding
         # configuration files or third party plugins configuration files
@@ -56,10 +54,7 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
         ])
         # Add older ovirt-hosted-engine-ha log files only if requested
         if self.get_option('all_logs'):
-            self.add_copy_spec(
-                self.HA_LOG_GLOB,
-                sizelimit=self.limit,
-            )
+            self.add_copy_spec(self.HA_LOG_GLOB)
 
         # Add run-time status
         self.add_cmd_output([

--- a/sos/plugins/ovirt_imageio.py
+++ b/sos/plugins/ovirt_imageio.py
@@ -27,7 +27,6 @@ class OvirtImageIO(Plugin, RedHatPlugin):
     profiles = ('virt',)
 
     def setup(self):
-        self.limit = self.get_option('log_size')
         all_logs = self.get_option('all_logs')
 
         # Add configuration files
@@ -44,7 +43,7 @@ class OvirtImageIO(Plugin, RedHatPlugin):
                     '/var/log/ovirt-imageio-daemon/daemon.log']
 
         # Add log files
-        self.add_copy_spec(logs, sizelimit=self.limit)
+        self.add_copy_spec(logs)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/sos/plugins/ovirt_provider_ovn.py
+++ b/sos/plugins/ovirt_provider_ovn.py
@@ -28,7 +28,7 @@ class OvirtProviderOvn(Plugin, RedHatPlugin):
         spec = '/var/log/ovirt-provider-ovn.log'
         if self.get_option('all_logs'):
             spec += '*'
-        self.add_copy_spec(spec, sizelimit=self.get_option('log_size'))
+        self.add_copy_spec(spec)
 
     def postproc(self):
         self.do_file_sub(self.provider_conf,

--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -52,7 +52,7 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec([
             "/var/log/rabbitmq/*",
             "/var/log/containers/rabbitmq/*"
-        ], sizelimit=self.get_option('log_size'))
+        ])
 
     def postproc(self):
         self.do_file_sub("/etc/rabbitmq/rabbitmq.conf",

--- a/sos/plugins/rear.py
+++ b/sos/plugins/rear.py
@@ -20,20 +20,16 @@ class Rear(Plugin, RedHatPlugin):
     packages = ('rear',)
 
     def setup(self):
-        limit = self.get_option('log_size')
-
         # don't collect recovery ISOs or tar archives
         self.add_forbidden_path([
             '/var/log/rear/*.iso',
             '/var/log/rear/*.tar.gz'
         ])
 
-        rdirs = [
+        self.add_copy_spec([
             '/etc/rear/*conf',
             '/var/log/rear/*log*'
-        ]
-
-        self.add_copy_spec(rdirs, sizelimit=limit)
+        ])
 
         self.add_cmd_output([
             'rear -V',

--- a/sos/plugins/redis.py
+++ b/sos/plugins/redis.py
@@ -34,18 +34,18 @@ class Redis(Plugin, RedHatPlugin):
             self.var_puppet_gen + "/etc/redis/",
             self.var_puppet_gen + "/etc/security/limits.d/"
         ])
-        self.limit = self.get_option("log_size")
+
         self.add_cmd_output("redis-cli info")
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/redis/redis.log*",
                 "/var/log/containers/redis/redis.log*"
-            ], sizelimit=self.limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/redis/redis.log",
                 "/var/log/containers/redis/redis.log"
-            ], sizelimit=self.limit)
+            ])
 
     def postproc(self):
         self.do_file_sub(

--- a/sos/plugins/salt.py
+++ b/sos/plugins/salt.py
@@ -20,12 +20,11 @@ class Salt(Plugin, RedHatPlugin, DebianPlugin):
 
     def setup(self):
         all_logs = self.get_option("all_logs")
-        limit = self.get_option("log_size")
 
         if not all_logs:
-            self.add_copy_spec("/var/log/salt/minion", sizelimit=limit)
+            self.add_copy_spec("/var/log/salt/minion")
         else:
-            self.add_copy_spec("/var/log/salt", sizelimit=limit)
+            self.add_copy_spec("/var/log/salt")
 
         self.add_copy_spec("/etc/salt")
         self.add_forbidden_path("/etc/salt/pki/*/*.pem")

--- a/sos/plugins/saltmaster.py
+++ b/sos/plugins/saltmaster.py
@@ -19,12 +19,7 @@ class SaltMaster(Plugin, RedHatPlugin, DebianPlugin):
     packages = ('salt-master',)
 
     def setup(self):
-        if not self.get_option("all_logs"):
-            limit = self.get_option("log_size")
-        else:
-            limit = 0
-
-        self.add_copy_spec("/var/log/salt/master", sizelimit=limit)
+        self.add_copy_spec("/var/log/salt/master")
         self.add_cmd_output("salt-key --list all")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/samba.py
+++ b/sos/plugins/samba.py
@@ -17,24 +17,21 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     profiles = ('services',)
 
     def setup(self):
-        self.limit = self.get_option("log_size")
 
         self.add_copy_spec([
             "/etc/samba/smb.conf",
             "/etc/samba/lmhosts",
         ])
 
-        self.add_copy_spec("/var/log/samba/log.smbd", sizelimit=self.limit)
-        self.add_copy_spec("/var/log/samba/log.nmbd", sizelimit=self.limit)
-        self.add_copy_spec("/var/log/samba/log.winbindd", sizelimit=self.limit)
-        self.add_copy_spec("/var/log/samba/log.winbindd-idmap",
-                           sizelimit=self.limit)
-        self.add_copy_spec("/var/log/samba/log.winbindd-dc-connect",
-                           sizelimit=self.limit)
-        self.add_copy_spec("/var/log/samba/log.wb-*", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/samba/log.smbd")
+        self.add_copy_spec("/var/log/samba/log.nmbd")
+        self.add_copy_spec("/var/log/samba/log.winbindd")
+        self.add_copy_spec("/var/log/samba/log.winbindd-idmap")
+        self.add_copy_spec("/var/log/samba/log.winbindd-dc-connect")
+        self.add_copy_spec("/var/log/samba/log.wb-*")
 
         if self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/samba/", sizelimit=self.limit)
+            self.add_copy_spec("/var/log/samba/")
 
         self.add_cmd_output([
             "wbinfo --domain='.' -g",

--- a/sos/plugins/skydive.py
+++ b/sos/plugins/skydive.py
@@ -32,9 +32,8 @@ class Skydive(Plugin, RedHatPlugin):
     ]
 
     def setup(self):
-        self.limit = self.get_option("log_size")
         self.add_copy_spec("/etc/skydive/skydive.yml")
-        self.add_copy_spec("/var/log/skydive.log", sizelimit=self.limit)
+        self.add_copy_spec("/var/log/skydive.log")
 
         username = (self.get_option("username") or
                     os.getenv("SKYDIVE_USERNAME", "") or

--- a/sos/plugins/squid.py
+++ b/sos/plugins/squid.py
@@ -23,12 +23,11 @@ class RedHatSquid(Squid, RedHatPlugin):
     packages = ('squid',)
 
     def setup(self):
-        log_size = self.get_option('log_size')
         log_path = "/var/log/squid/"
         self.add_copy_spec("/etc/squid/squid.conf")
-        self.add_copy_spec(log_path + "access.log", sizelimit=log_size)
-        self.add_copy_spec(log_path + "cache.log", sizelimit=log_size)
-        self.add_copy_spec(log_path + "squid.out", sizelimit=log_size)
+        self.add_copy_spec(log_path + "access.log")
+        self.add_copy_spec(log_path + "cache.log")
+        self.add_copy_spec(log_path + "squid.out")
 
 
 class DebianSquid(Squid, DebianPlugin, UbuntuPlugin):
@@ -38,11 +37,9 @@ class DebianSquid(Squid, DebianPlugin, UbuntuPlugin):
     packages = ('squid3',)
 
     def setup(self):
-        self.add_copy_spec("/etc/squid3/squid.conf",
-                           sizelimit=self.get_option('log_size'))
-        self.add_copy_spec("/var/log/squid3/*",
-                           sizelimit=self.get_option('log_size'))
-        self.add_copy_spec(['/etc/squid-deb-proxy'])
-        self.add_copy_spec("/var/log/squid-deb-proxy/*",
-                           sizelimit=self.get_option('log_size'))
+        self.add_copy_spec("/etc/squid3/squid.conf")
+        self.add_copy_spec("/var/log/squid3/*")
+        self.add_copy_spec('/etc/squid-deb-proxy')
+        self.add_copy_spec("/var/log/squid-deb-proxy/*")
+
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/storageconsole.py
+++ b/sos/plugins/storageconsole.py
@@ -20,7 +20,6 @@ class StorageConsole(Plugin, RedHatPlugin, DebianPlugin):
 
     def setup(self):
         all_logs = self.get_option("all_logs")
-        limit = self.get_option("log_size")
 
         if not all_logs:
             self.add_copy_spec([
@@ -29,7 +28,7 @@ class StorageConsole(Plugin, RedHatPlugin, DebianPlugin):
                 "/var/log/carbon/console.log",
                 "/var/log/graphite-web/info.log",
                 "/var/log/graphite-web/exception.log",
-            ], sizelimit=limit)
+            ])
         else:
             self.add_copy_spec([
                 "/var/log/skyring/",

--- a/sos/plugins/tomcat.py
+++ b/sos/plugins/tomcat.py
@@ -27,17 +27,15 @@ class Tomcat(Plugin, RedHatPlugin):
             "/etc/tomcat8"
         ])
 
-        limit = self.get_option("log_size")
-
         if not self.get_option("all_logs"):
             log_glob = "/var/log/tomcat*/catalina.out"
-            self.add_copy_spec(log_glob, sizelimit=limit)
+            self.add_copy_spec(log_glob)
 
             # get today's date in iso format so that days/months below 10
             # prepend 0
             today = datetime.date(datetime.now()).isoformat()
             log_glob = "/var/log/tomcat*/catalina.%s.log" % today
-            self.add_copy_spec(log_glob, sizelimit=limit)
+            self.add_copy_spec(log_glob)
         else:
             self.add_copy_spec("/var/log/tomcat*/*")
 

--- a/sos/plugins/upstart.py
+++ b/sos/plugins/upstart.py
@@ -38,8 +38,7 @@ class Upstart(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec('/var/log/upstart/upstart.state')
 
         # Log files
-        self.add_copy_spec('/var/log/upstart/*',
-                           sizelimit=self.get_option('log_size'))
+        self.add_copy_spec('/var/log/upstart/*')
         # Session Jobs (running Upstart as a Session Init)
         self.add_copy_spec('/usr/share/upstart/')
 

--- a/sos/plugins/watchdog.py
+++ b/sos/plugins/watchdog.py
@@ -89,6 +89,6 @@ class Watchdog(Plugin, RedHatPlugin):
             log_files = (glob(os.path.join(log_dir, '*.stdout')) +
                          glob(os.path.join(log_dir, '*.stderr')))
 
-        self.add_copy_spec(log_files, sizelimit=self.get_option('log_size'))
+        self.add_copy_spec(log_files)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Since setting sizelimit to be equal to the log_size option unless
explicitly set otherwise, there is no longer a need for plugins to do
something like:

	self.limit = self.get_option('log_size')
	self.add_copy_spec('/foo/bar', sizelimit=self.limit)

As such, update plugins that were just using the log_size setting to no
longer set this sizelimit value unnecessarily.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
