### PR TITLE
[redhat] Fix RHELPolicy.dist_version()

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -2,7 +2,7 @@
 
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
-Version: 3.5
+Version: 3.6
 Release: 1%{?dist}
 Group: Applications/System
 Source0: http://people.redhat.com/breeves/sos/releases/sos-%{version}.tar.gz

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -65,11 +65,11 @@ class RedHatPolicy(LinuxPolicy):
 
         self.valid_subclasses = [RedHatPlugin]
 
-        pkgs = self.package_manager.all_pkgs()
+        self.pkgs = self.package_manager.all_pkgs()
         files = self.package_manager.all_files()
 
         # If rpm query failed, exit
-        if not pkgs:
+        if not self.pkgs:
             print("Could not obtain installed package list", file=sys.stderr)
             sys.exit(1)
 
@@ -79,7 +79,7 @@ class RedHatPolicy(LinuxPolicy):
                   manager", file=sys.stderr)
             sys.exit(1)
 
-        self.usrmove = self.check_usrmove(pkgs)
+        self.usrmove = self.check_usrmove(self.pkgs)
 
         if self.usrmove:
             self.PATH = "/usr/sbin:/usr/bin:/root/bin"
@@ -282,9 +282,8 @@ No changes will be made to system configuration.
 
     def dist_version(self):
         try:
-            pkg = self.pkg_by_name("redhat-release") or \
-                self.all_pkgs_by_name_regex("redhat-release-.*")[-1]
-            pkgname = pkg["version"]
+            rr = self.package_manager.all_pkgs_by_name_regex("redhat-release*")
+            pkgname = self.pkgs[rr[0]]["version"]
             if pkgname[0] == "4":
                 return 4
             elif pkgname[0] in ["5Server", "5Client"]:


### PR DESCRIPTION
The RHELPolicy dist_version() was always returning False due to an
invalid call to all_pkgs_by_name_regex(). Correct this call and use the
discovered redhat-release package to determine version.

Resolves: #216 

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
