### PR TITLE
[utilities|i18n] Correct locale output

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -2,7 +2,7 @@
 
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
-Version: 3.5
+Version: 3.6
 Release: 1%{?dist}
 Group: Applications/System
 Source0: http://people.redhat.com/breeves/sos/releases/sos-%{version}.tar.gz

--- a/sos/plugins/i18n.py
+++ b/sos/plugins/i18n.py
@@ -21,6 +21,6 @@ class I18n(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/X11/xinit/xinput.d/*",
             "/etc/locale.conf"
         ])
-        self.add_cmd_output("locale")
+        self.add_cmd_output("locale", env={'LC_ALL': None})
 
 # vim: set et ts=4 sw=4 :

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -121,13 +121,16 @@ def sos_get_command_output(command, timeout=300, stderr=False,
         if (chdir):
                 os.chdir(chdir)
 
-    cmd_env = os.environ
+    cmd_env = os.environ.copy()
     # ensure consistent locale for collected command output
     cmd_env['LC_ALL'] = 'C'
     # optionally add an environment change for the command
     if env:
         for key, value in env.items():
-            cmd_env[key] = value
+            if value:
+                cmd_env[key] = value
+            else:
+                cmd_env.pop(key, None)
     # use /usr/bin/timeout to implement a timeout
     if timeout and is_executable("timeout"):
         command = "timeout %ds %s" % (timeout, command)


### PR DESCRIPTION
First, allows any command to filter out unwanted environment variables from the environment used by `sos_get_command_output()`.

Using this, removes the `LC_ALL` environment variable from the capture of `locale` which was causing erroneous output due to that variable being set to get consistent locale output from all other commands captured by sos.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
