### PR TITLE
[kernel] handle case when bpftool installed but not implemented

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -2,7 +2,7 @@
 
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
-Version: 3.5
+Version: 3.6
 Release: 1%{?dist}
 Group: Applications/System
 Source0: http://people.redhat.com/breeves/sos/releases/sos-%{version}.tar.gz

--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -34,7 +34,8 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             self._log_info("Could not parse bpftool prog list as JSON: %s" % e)
             return out
         for item in range(len(prog_data)):
-            out.append(prog_data[item]["id"])
+            if "id" in prog_data[item]:
+                out.append(prog_data[item]["id"])
         return out
 
     def get_bpftool_map_ids(self, map_file):
@@ -45,7 +46,8 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             self._log_info("Could not parse bpftool map list as JSON: %s" % e)
             return out
         for item in range(len(map_data)):
-            out.append(map_data[item]["id"])
+            if "id" in map_data[item]:
+                out.append(map_data[item]["id"])
         return out
 
     def setup(self):


### PR DESCRIPTION
on older kernels, bpftool can return error

"can't get next program: Function not implemented"

that lacks "id" we search for in the dict.

Resolves: #1363

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
