### PR TITLE
[pacemaker] Collect stonith and quorum status

### DIFF
--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -80,6 +80,11 @@ class Pacemaker(Plugin):
             "/var/log/cluster/bundles/*/",
         ])
 
+        self.add_cmd_output([
+            "pcs stonith sbd status",
+            "pcs quorum status"
+        ])
+
         self.setup_crm_mon()
 
         # crm_report needs to be given a --from "YYYY-MM-DD HH:MM:SS" start


### PR DESCRIPTION
Adds collection of stonith and quorum states within the cluster to the
pacemaker plugin. If either of these are not used in a given cluster,
these commands simply report that the resource is not in use so this is
safe to run on all clusters.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
