### PR TITLE
[archive] fix stat typo

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -203,10 +203,10 @@ class FileCacheArchive(Archive):
 
         def is_special(mode):
             return any([
-                stat.ISBLK(mode),
-                stat.ISCHR(mode),
-                stat.ISFIFO(mode),
-                stat.ISSOCK(mode)
+                stat.S_ISBLK(mode),
+                stat.S_ISCHR(mode),
+                stat.S_ISFIFO(mode),
+                stat.S_ISSOCK(mode)
             ])
 
         if force:


### PR DESCRIPTION
They're just missing the S_ in front of them so if that code gets
reached it fails.

Resolves: #1373

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
