### PR TITLE
[rhui] Fix detection of CDS for RHUI3

### DIFF
--- a/sos/plugins/rhui.py
+++ b/sos/plugins/rhui.py
@@ -22,7 +22,8 @@ class Rhui(Plugin, RedHatPlugin):
     files = [rhui_debug_path]
 
     def setup(self):
-        if self.is_installed("pulp-cds"):
+        if self.is_installed("pulp-cds") \
+                or self.is_installed("rhui-mirrorlist"):
             cds = "--cds"
         else:
             cds = ""


### PR DESCRIPTION
Detection of CDS node on RHUI 3 cant rely on deprecated pulp-cds package
but rather on rhui-mirrorlist one.

Resolves: #1375

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
