### PR TITLE
[krb5] Add more files to krb5 plugin

### DIFF
--- a/sos/plugins/krb5.py
+++ b/sos/plugins/krb5.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+# Copyright (C) 2013,2018 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
 
 # This file is part of the sos project: https://github.com/sosreport/sos
 #
@@ -8,19 +8,37 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.plugins import Plugin, RedHatPlugin
 
 
-class Krb5(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Krb5(Plugin):
     """Kerberos authentication
     """
     plugin_name = 'krb5'
     profiles = ('identity', 'system')
     packages = ('krb5-libs', 'krb5-user')
 
+    # This is Debian's default, which is closest to upstream's
+    kdcdir = "/var/lib/krb5kdc"
+
     def setup(self):
-        self.add_copy_spec("/etc/krb5.conf")
+        self.add_copy_spec([
+            "/etc/krb5.conf",
+            "/etc/krb5.conf.d/*",
+            "%s/kadm5.acl" % self.kdcdir,
+            "%s/kdc.conf" % self.kdcdir,
+            "/var/log/krb5kdc.log",
+            "/var/log/kadmind.log"
+        ])
+        self.add_cmd_output("klist -ekt %s/.k5*" % self.kdcdir)
         self.add_cmd_output("klist -ket /etc/krb5.keytab")
+
+
+class RedHatKrb5(Krb5, RedHatPlugin):
+
+    def setup(self):
+        self.kdcdir = "/var/kerberos/krb5kdc"
+        super(RedHatKrb5, self).setup()
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add files for KDC configuration and logging, including kadmin files
and a klist of the K/M stash.

Gather any additional configuration snippet files in
/etc/krb5.conf.d (which is configured by default on Fedora- and
RHEL-like systems, and hopefully on Debian systems in the future).
The sssd plugin already takes care of
/var/lib/sss/pubconf/krb5.include.d/, so don't include that.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
