### PR TITLE
[plugins] Add plugin for gssproxy

### DIFF
--- a/sos/plugins/gssproxy.py
+++ b/sos/plugins/gssproxy.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2018 Red Hat, Inc., Robbie Harwood <rharwood@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin
+
+
+class GSSProxy(Plugin):
+    """GSSAPI Proxy
+    """
+
+    plugin_name = "gssproxy"
+    profiles = ('services', 'security', 'identity')
+    packages = ('gssproxy',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/gssproxy/*.conf",
+            "/etc/gss/mech.d/*"
+        ])


### PR DESCRIPTION
gssproxy stores its configuration in /etc/gssproxy.  Also capture the
mech configuration so that we can tell if gssproxy is enabled and any
other GSS mechs in use.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
