### PR TITLE
[Policies|Plugins] Add services member

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -45,6 +45,7 @@ class RedHatPolicy(LinuxPolicy):
     _host_sysroot = '/'
     default_scl_prefix = '/opt/rh'
     name_pattern = 'friendly'
+    init = 'systemd'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)


### PR DESCRIPTION
Adds a services member to facilitate plugin enablement. This is tied to
a new InitSystem class that gets attached to policies. The InitSystem
class is used to determine services that are present on the system and
what those service statuses currently are (e.g. enabled/disable).

Plugins can now specify a set of services to enable the plugin on if
that service exists on the system, similar to the file, command, and
package checks.

Additionally, the Plugin class now has methods to check on service
states, and make decisions based off of. For example:

	def setup(self):
	    if self.is_service('foobar'):
	        self.add_cmd_output('barfoo')

Currently, only systemd has actual functionality for this. The base
InitSystem inherited by policies by default will always return False for
service checks, thus resulting in the same behavior as before this
change.

The Red Hat family of distributions has been set to systemd, as all
current versions of those distributions use systemd.

Resolves: #83

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
