### PR TITLE
[apparmor,ceph] fix typo in add_forbidden_path

### DIFF
--- a/sos/plugins/apparmor.py
+++ b/sos/plugins/apparmor.py
@@ -26,7 +26,7 @@ class Apparmor(Plugin, UbuntuPlugin):
         self.add_forbidden_path([
             "/etc/apparmor.d/cache",
             "/etc/apparmor.d/libvirt/libvirt*",
-            "etc/apparmor.d/abstractions"
+            "/etc/apparmor.d/abstractions"
         ])
 
         self.add_cmd_output([

--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -77,7 +77,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "/var/lib/ceph/mon/*",
             # Excludes temporary ceph-osd mount location like
             # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
-            "var/lib/ceph/tmp/*mnt*",
+            "/var/lib/ceph/tmp/*mnt*",
             "/etc/ceph/*bindpass*"
         ])
 


### PR DESCRIPTION
commit 29a40b7 removed leading '/' from two forbidden paths

Resolves: #1388

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
