### PR TITLE
[megacli] Correct MegaCli commands and enablement

### DIFF
--- a/sos/plugins/megacli.py
+++ b/sos/plugins/megacli.py
@@ -9,8 +9,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
-import os.path
 from sos.plugins import Plugin, RedHatPlugin
 
 
@@ -20,21 +18,19 @@ class MegaCLI(Plugin, RedHatPlugin):
 
     plugin_name = 'megacli'
     profiles = ('system', 'storage', 'hardware')
+    files = ('/opt/MegaRAID/MegaCli/MegaCli64',)
 
     def setup(self):
-        if os.path.isfile("/opt/MegaRAID/MegaCli/MegaCli64"):
-            self.add_custom_text("LSI MegaCLI is installed.<br>")
-            self.get_megacli_files()
-
-    def get_megacli_files(self):
-        """ MegaCLI specific output
-        """
+        cmd = '/opt/MegaRAID/MegaCli/MegaCli64'
+        subcmds = [
+            'LDPDInfo',
+            '-AdpAllInfo',
+            '-AdpBbuCmd -GetBbuStatus',
+            '-ShowSummary'
+        ]
 
         self.add_cmd_output([
-            "MegaCli64 LDPDInfo -aALL",
-            "MegaCli64 -AdpAllInfo -aALL",
-            "MegaCli64 -AdpBbuCmd -GetBbuStatus -aALL",
-            "MegaCli64 -ShowSummary -a0"
+            "%s %s -aALL" % (cmd, subcmd) for subcmd in subcmds
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The MegaCli64 command needs to be called using the full path to the
binary. Also, correct the -ShowSummary adapter argument.

Additionally, use the builtin 'files' check to enable the plugin only if
the binary exists.

Resolves: #403

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
