### PR TITLE
[plugin_hardware] Add persistent memory information

### DIFF
--- a/sos/plugins/hardware.py
+++ b/sos/plugins/hardware.py
@@ -28,6 +28,7 @@ class Hardware(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
 
         self.add_cmd_output("dmidecode", root_symlink="dmidecode")
+        self.add_cmd_output("ndctl list -NXRBDHMFi")
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add the result of ndctl command to get persistent memory information.

Signed-off-by: Masayoshi Mizuma msys.mizuma@gmail.com
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
