### PR TITLE
[pmem] Adds a new 'pmem' (Persistent Memory) plugin

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -241,6 +241,8 @@ class FileCacheArchive(Archive):
                 else:
                     self.log_debug("Making directory %s" % abs_path)
                     os.mkdir(abs_path, mode)
+                    dest = src_path
+
         return dest
 
     def _check_path(self, src, path_type, dest=None, force=False):
@@ -282,17 +284,13 @@ class FileCacheArchive(Archive):
         if not dest_dir:
             return dest
 
-        # Preserve destination basename for rewritten dest_dir
-        dest_name = os.path.split(src)[1]
-
         # Check containing directory presence and path type
         if os.path.exists(dest_dir) and not os.path.isdir(dest_dir):
             raise ValueError("path '%s' exists and is not a directory" %
                              dest_dir)
         elif not os.path.exists(dest_dir):
             src_dir = src if path_type == P_DIR else os.path.split(src)[0]
-            src_dir = self._make_leading_paths(src_dir)
-            dest = self.dest_path(os.path.join(src_dir, dest_name))
+            self._make_leading_paths(src_dir)
 
         def is_special(mode):
             return any([

--- a/sos/plugins/pmem.py
+++ b/sos/plugins/pmem.py
@@ -52,7 +52,6 @@ class Pmem(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
         ''' Use the Intel ipmctl(1) to collect data from
         Intel(R) Optane(TM) DC Persistent Memory Modules.
-        ixpdimm-cli is now deprecated and removed from this module.
         '''
         self.add_cmd_output([
             "ipmctl version",

--- a/sos/plugins/pmem.py
+++ b/sos/plugins/pmem.py
@@ -1,0 +1,79 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+
+
+class Pmem(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+    '''Persistent Memory Device Plugin
+
+    This plugin collects data from Persistent Memory Modules,
+    commonly referred to as NVDIMM's or Storage Class Memory (SCM).
+    '''
+
+    plugin_name = 'pmem'
+    profiles = ('storage', 'hardware', 'memory')
+    # Utilities can be installed by package or self compiled
+    packages = ('ndctl', 'ipmctl')
+    commands = ('ndctl', 'ipmctl')
+
+    def setup(self):
+        # Copy the contents of the /etc/ndctl directory and ipmctl.conf file
+        self.add_copy_spec([
+            "/etc/ndctl",
+            "/etc/ipmctl.conf"
+        ])
+
+        ''' Use the ndctl-list(1) command to collect:
+        -i      Include idle (not enabled) devices in the listing
+        -vvv    Increase verbosity of the output
+        -B      Include bus info in the listing
+        -D      Include dimm info in the listing
+        -F      Include dimm firmware info in the listing
+        -H      Include dimm health info in the listing
+        -M      Include media errors (badblocks) in the listing
+        -N      Include namespace info in the listing
+        -R      Include region info in the listing
+        -X      Include device-dax info in the listing
+
+        Output is JSON formatted
+        '''
+        self.add_cmd_output([
+            "ndctl --version",
+            "ndctl list -vvv",
+            "ndctl list -iBDFHMNRX",
+            "ndctl read-labels -j all"
+        ])
+
+        ''' Use the Intel ipmctl(1) to collect data from
+        Intel(R) Optane(TM) DC Persistent Memory Modules.
+        ixpdimm-cli is now deprecated and removed from this module.
+        '''
+        self.add_cmd_output([
+            "ipmctl version",
+            "ipmctl show -cap",
+            "ipmctl show -dimm",
+            "ipmctl show -a -dimm",
+            "ipmctl show -dimm -pcd",
+            "ipmctl show -dimm -performance",
+            "ipmctl show -error Thermal -dimm",
+            "ipmctl show -error Media -dimm",
+            "ipmctl show -event",
+            "ipmctl show -firmware",
+            "ipmctl show -memoryresources",
+            "ipmctl show -preferences",
+            "ipmctl show -region",
+            "ipmctl show -sensor",
+            "ipmctl show -socket",
+            "ipmctl show -system",
+            "ipmctl show -system -capabilities",
+            "ipmctl show -system -host",
+            "ipmctl show -topology"
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a new 'pmem' (Persistent Memory) plugin to collect data
using ndctl, ixpdimm-cli, and ipmctl.

Signed-off-by: sscargal <steve.scargall@intel.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
