### PR TITLE
[logrotate] fix path for logrotate.status in RHEL7/CentOS7

### DIFF
--- a/sos/plugins/logrotate.py
+++ b/sos/plugins/logrotate.py
@@ -24,6 +24,7 @@ class LogRotate(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec([
             "/etc/logrotate*",
             "/var/lib/logrotate.status",
+            "/var/lib/logrotate/logrotate.status",
             self.var_puppet_gen + "/etc/logrotate-crond.conf",
             self.var_puppet_gen + "/var/spool/cron/root"
         ])


### PR DESCRIPTION
In RHEL7/CentOS7 logrotate.status is placed in /var/lib/logrotate rather then is /var/lib

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
