### PR TITLE
[landscape] Add copy of Landscape OOPS files

### DIFF
--- a/sos/plugins/landscape.py
+++ b/sos/plugins/landscape.py
@@ -24,6 +24,7 @@ class Landscape(Plugin, UbuntuPlugin):
         self.add_copy_spec("/etc/landscape/service.conf")
         self.add_copy_spec("/etc/landscape/service.conf.old")
         self.add_copy_spec("/etc/default/landscape-server")
+        self.add_copy_spec("/var/lib/landscape/landscape-oops/*/OOPS-*")
         if not self.get_option("all_logs"):
             self.add_copy_spec("/var/log/landscape/*.log")
             self.add_copy_spec("/var/log/landscape-server/*.log")


### PR DESCRIPTION
 When a deviation from correct behaviour occurs Landscape may generate
 a very lightweight OOPS file useful for debugging as follow:

 Format:
 /var/lib/landscape/landscape-oops/<YYYY-MM-DD>/OOPS-<OOPS-ID>

 OOPS-ID represent the ID displayed in the Landscape WebUI
 when an oops occurs.

 Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
