### PR TITLE
[etcd] Don't collect private keys

### DIFF
--- a/sos/plugins/etcd.py
+++ b/sos/plugins/etcd.py
@@ -30,7 +30,10 @@ class etcd(Plugin, RedHatPlugin):
 
         etcd_url = self.get_etcd_url()
 
-        self.add_forbidden_path('/etc/etcd/ca')
+        self.add_forbidden_path([
+            '/etc/etcd/ca',
+            '/etc/etcd/*.key'
+        ])
         self.add_copy_spec('/etc/etcd')
 
         subcmds = [


### PR DESCRIPTION
Prevent the etcd plugin from capturing private keys.

Resolves: #1403

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
