### PR TITLE
[ovirt] Don't collect engine heap dump

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -57,7 +57,9 @@ class Ovirt(Plugin, RedHatPlugin):
         ('jbosstrace', 'Enable oVirt Engine JBoss stack trace collection',
          '', True),
         ('sensitive_keys', 'Sensitive keys to be masked',
-         '', DEFAULT_SENSITIVE_KEYS)
+         '', DEFAULT_SENSITIVE_KEYS),
+        ('heapdump', 'Collect heap dumps from /var/log/ovirt-engine/dump/',
+         '', False)
     ]
 
     def setup(self):
@@ -80,6 +82,10 @@ class Ovirt(Plugin, RedHatPlugin):
             '/etc/ovirt-engine/.pgpass',
             '/etc/rhevm/.pgpass'
         ])
+
+        if not self.get_option('heapdump'):
+            self.add_forbidden_path('/var/log/ovirt-engine/dump')
+            self.add_cmd_output('ls -l /var/log/ovirt-engine/dump/')
 
         # Copy all engine tunables and domain information
         self.add_cmd_output("engine-config --all")


### PR DESCRIPTION
Currently the java heap dump of engine process is collected from
"/var/log/ovirt-engine/dump". The size of these dumps are very
large which will increase the size of collected sosreport
significantly. The dumps are not required for most of the cases
and hence ignore this directory and collect the 'ls' output of
the dump directory so that the support can collect it separately
if required.

Signed-off-by: Nijin Ashok <nashok@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
