### PR TITLE
[plugins] fix 6db459e for SCL services

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1018,16 +1018,18 @@ class Plugin(object):
                     files = [f % {"scl_name": scl} for f in self.files]
                     packages = [p % {"scl_name": scl} for p in self.packages]
                     commands = [c % {"scl_name": scl} for c in self.commands]
-                    if self._files_pkgs_or_cmds_present(files,
-                                                        packages,
-                                                        commands):
+                    services = [s % {"scl_name": scl} for s in self.services]
+                    if self._check_plugin_triggers(files,
+                                                   packages,
+                                                   commands,
+                                                   services):
                         type(self)._scls_matched.append(scl)
                 return len(type(self)._scls_matched) > 0
 
-            return self._files_pkgs_or_cmds_present(self.files,
-                                                    self.packages,
-                                                    self.commands,
-                                                    self.services)
+            return self._check_plugin_triggers(self.files,
+                                               self.packages,
+                                               self.commands,
+                                               self.services)
 
         if isinstance(self, SCLPlugin):
             # if files and packages weren't specified, we take all SCLs
@@ -1035,7 +1037,7 @@ class Plugin(object):
 
         return True
 
-    def _files_pkgs_or_cmds_present(self, files, packages, commands, services):
+    def _check_plugin_triggers(self, files, packages, commands, services):
             kernel_mods = self.policy.lsmod()
 
             def have_kmod(kmod):


### PR DESCRIPTION
Calling _files_pkgs_or_cmds_present for SCLs lacks "services"
argument that was added in 6db459e commit.

Resolves: #1416

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
