### PR TITLE
[atomic] Define valid preset for RHEL Atomic

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -325,6 +325,12 @@ No changes will be made to system configuration.
 
 ATOMIC = "atomic"
 ATOMIC_RELEASE_STR = "Atomic"
+ATOMIC_DESC = "Red Hat Enterprise Linux Atomic Host"
+
+atomic_presets = {
+    ATOMIC: PresetDefaults(name=ATOMIC, desc=ATOMIC_DESC, note=NOTE_TIME,
+                           opts=_opts_verify)
+}
 
 
 class RedHatAtomicPolicy(RHELPolicy):
@@ -347,6 +353,10 @@ organization before being passed to any third party.
 %(vendor_text)s
 """)
 
+    def __init__(self, sysroot=None):
+        super(RedHatAtomicPolicy, self).__init__(sysroot=sysroot)
+        self.register_presets(atomic_presets)
+
     @classmethod
     def check(cls):
         atomic = False
@@ -363,7 +373,10 @@ organization before being passed to any third party.
         return atomic
 
     def probe_preset(self):
-        return ATOMIC
+        if self.pkg_by_name('atomic-openshift'):
+            return self.find_preset(RHOCP)
+
+        return self.find_preset(ATOMIC)
 
 
 class FedoraPolicy(RedHatPolicy):


### PR DESCRIPTION
Defines an 'atomic' preset for use with the RedHatAtomic policy for RHEL
Atomic Host. Fixes sos being unable to run due to the preset probe
returning a string rather than a preset.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
