### PR TITLE
[origin] Collect deploymentconfigs from additional namespaces

### DIFF
--- a/sos/plugins/origin.py
+++ b/sos/plugins/origin.py
@@ -44,6 +44,8 @@ class OpenShiftOrigin(Plugin):
          'fast', True),
         ("diag-prevent", "set --prevent-modification on 'oc adm diagnostics'",
          'fast', False),
+        ("all-namespaces", "collect dc output for all namespaces", "fast",
+         False)
     ]
 
     master_base_dir = "/etc/origin/master"
@@ -138,12 +140,28 @@ class OpenShiftOrigin(Plugin):
             jcmds = [
                 "hostsubnet",
                 "clusternetwork",
-                "netnamespaces",
-                "dc -n default"
+                "netnamespaces"
             ]
 
             self.add_cmd_output([
                 '%s get -o json %s' % (oc_cmd_admin, jcmd) for jcmd in jcmds
+            ])
+
+            if self.get_option('all-namespaces'):
+                ocn = self.get_command_output('%s get namespaces'
+                                              % oc_cmd_admin)
+                nmsps = [
+                    n.split()[0] for n in ocn['output'].splitlines()[1:] if n
+                ]
+            else:
+                nmsps = [
+                    'default',
+                    'openshift-web-console',
+                    'openshift-ansible-service-broker'
+                ]
+
+            self.add_cmd_output([
+                '%s get -o json dc -n %s' % (oc_cmd_admin, n) for n in nmsps
             ])
 
             if self.get_option('diag'):


### PR DESCRIPTION
The origin plugin will now collect deploymentconfig output from more
than just the 'default' namespace. Now it will collect from 'default',
'openshift-web-console', and 'openshift-ansible-broker' by default and a
new 'all-namespaces' option has been added to allow deploymentconfig
collection from all existing namespaces.

Resolves: #1410

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
