### PR TITLE
[archive] fix typo from 322f4a5

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -428,7 +428,7 @@ class FileCacheArchive(Archive):
                 source = os.path.relpath(source)
                 self.log_debug("Adding link %s -> %s for link follow up" %
                                (link_name, source))
-                self.add_link(source, link_path)
+                self.add_link(source, link_name)
             elif os.path.isdir(host_source):
                 self.log_debug("Adding dir %s for link follow up" % source)
                 self.add_dir(host_source)


### PR DESCRIPTION
s/link_name/link_path

Resolves: #1425

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
