### PR TITLE
[systemd] Add 'systemctl list-jobs' to systemd plugin

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -29,6 +29,7 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "systemctl status --all",
             "systemctl show --all",
             "systemctl show *service --all",
+            "systemctl list-jobs",
             # It is possible to do systemctl show with target, slice,
             # device, socket, scope, and mount too but service and
             # status --all mostly seems to cover the others.


### PR DESCRIPTION
This patch adds the output of 'systemctl list-jobs', providing a list
of jobs that are in progress.  This is sometimes useful when we try to
analyze troubles such as some units are unexpectedly not
started/stopped.

For example, consider there is the inquiry from some customer that
multi-user.target on our system is configured as default.target but is
still inactive after system boot, why?

    # LANG=C systemctl get-default
    multi-user.target
    # LANG=C systemctl status multi-user.target
    * multi-user.target - Multi-User System
       Loaded: loaded (/usr/lib/systemd/system/multi-user.target; \
    enabled; vendor preset: disabled)
       Active: inactive (dead)
         Docs: man:systemd.special(7)

In such case, systemctl list-jobs gives us the clear suggestion that
there is a still running start job for foobar.service and
multi-user.target and the other units are waiting for it to finish.

    # LANG=C systemctl --no-pager list-jobs
    JOB UNIT                                 TYPE  STATE
    112 multi-user.target                    start waiting
    226 systemd-update-utmp-runlevel.service start waiting
    258 foobar.service                       start running
    236 systemd-readahead-done.timer         start waiting

    4 jobs listed.

Signed-off-by: HATAYAMA Daisuke <d.hatayama@jp.fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
