### PR TITLE
[openvswitch] Add FDB bridge statistics

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -106,7 +106,8 @@ class OpenVSwitch(Plugin):
                     "ovs-ofctl dump-ports %s" % br,
                     "ovs-ofctl queue-get-config %s" % br,
                     "ovs-ofctl queue-stats %s" % br,
-                    "ovs-ofctl show %s" % br
+                    "ovs-ofctl show %s" % br,
+                    "ovs-appctl fdb/stats-show %s" % br
                 ])
 
                 # Flow protocols currently supported


### PR DESCRIPTION
Add the ovs-appctl fdb/stats command for each bridge, and do two
iterations. This so the output can be used to get an idea how fast
the counters increment.

Signed-off-by: Eelco Chaudron <echaudron@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
