### PR TITLE
[archive] dont update dest file to copy when creating directory struct

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -282,17 +282,13 @@ class FileCacheArchive(Archive):
         if not dest_dir:
             return dest
 
-        # Preserve destination basename for rewritten dest_dir
-        dest_name = os.path.split(src)[1]
-
         # Check containing directory presence and path type
         if os.path.exists(dest_dir) and not os.path.isdir(dest_dir):
             raise ValueError("path '%s' exists and is not a directory" %
                              dest_dir)
         elif not os.path.exists(dest_dir):
             src_dir = src if path_type == P_DIR else os.path.split(src)[0]
-            src_dir = self._make_leading_paths(src_dir)
-            dest = self.dest_path(os.path.join(src_dir, dest_name))
+            self._make_leading_paths(src_dir)
 
         def is_special(mode):
             return any([


### PR DESCRIPTION
Remove the ridiculous dest variable update and also code made dead or
unused due to the remove.

Resolves: #1432

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
