### PR TITLE
[lustre] Collect ring buffer dumps on all_logs

### DIFF
--- a/sos/plugins/lustre.py
+++ b/sos/plugins/lustre.py
@@ -51,4 +51,8 @@ class Lustre(Plugin, RedHatPlugin):
         self.get_params("quota", ["osd-*.*.quota_slave." +
                                   "{info,limit_*,acct_*}"])
 
+        # Grab emergency ring buffer dumps
+        if self.get_option("all_logs"):
+            self.add_copy_spec("/tmp/lustre-log.*")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Collect emergancy dumps of the lustre ring buffer if all_logs is set.

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
