### PR TITLE
[unpackaged] compare realpaths of files

### DIFF
--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -45,9 +45,10 @@ class Unpackaged(Plugin, RedHatPlugin):
                             path = os.path.abspath(os.readlink(path))
                     except Exception:
                         continue
-                    file_list.append(path)
+                    file_list.append(os.path.realpath(path))
                 for name in dirs:
-                    file_list.append(os.path.join(root, name))
+                    file_list.append(os.path.realpath(
+                                     os.path.join(root, name)))
 
             return file_list
 
@@ -63,7 +64,8 @@ class Unpackaged(Plugin, RedHatPlugin):
             return expanded
 
         all_fsystem = []
-        all_frpm = set(self.policy.mangle_package_path(
+        all_frpm = set(os.path.realpath(x)
+                       for x in self.policy.mangle_package_path(
                        self.policy.package_manager.files))
 
         for d in get_env_path_list():


### PR DESCRIPTION
To compare files in $PATH with files installed from a package, we must
expand all symlinks to their realpaths. Otherwise we get false positives
like /bin/systemctl (as /bin -> /usr/bin).

Resolves: #1437

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
