### PR TITLE
[opendaylight] Update directory for openDaylight logs

### DIFF
--- a/sos/plugins/opendaylight.py
+++ b/sos/plugins/opendaylight.py
@@ -27,14 +27,27 @@ class OpenDaylight(Plugin, RedHatPlugin):
         ])
 
         if self.get_option("all_logs"):
+
+            # /var/log/containers/opendaylight/ path is specific to ODL
+            # Oxygen-SR3 and earlier versions, and may be removed in a future
+            # update.
+
             self.add_copy_spec([
                 "/opt/opendaylight/data/log/",
                 "/var/log/containers/opendaylight/",
+                "/var/log/containers/opendaylight/karaf/logs/",
             ])
+
         else:
+
+            # /var/log/containers/opendaylight/ path is specific to ODL
+            # Oxygen-SR3 and earlier versions, and may be removed in a future
+            # update.
+
             self.add_copy_spec([
                 "/opt/opendaylight/data/log/*.log*",
                 "/var/log/containers/opendaylight/*.log*",
+                "/var/log/containers/opendaylight/karaf/logs/*.log*",
             ])
 
         self.add_cmd_output("docker logs opendaylight_api")


### PR DESCRIPTION
OpenDaylight karaf logs are now located in:
/var/log/containers/opendaylight/karaf/logs, so
update the plugin to get the karaf.log files
from new location.

Resolves: #1793566
Depends-on: https://review.openstack.org/#/c/603907/
Signed-off-by: Victor Pickard <vpickard@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
