### PR TITLE
[policies] Default to sha256 over md5

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -9,6 +9,7 @@ import fnmatch
 import tempfile
 import random
 import string
+import sys
 from os import environ
 
 from sos.utilities import (ImporterHelper,
@@ -611,7 +612,7 @@ No changes will be made to system configuration.
     def get_preferred_hash_name(self):
         """Returns the string name of the hashlib-supported checksum algorithm
         to use"""
-        return "md5"
+        return "sha256"
 
     def display_results(self, archive, directory, checksum):
         # Display results is called from the tail of SoSReport.final_work()
@@ -800,17 +801,11 @@ class LinuxPolicy(Policy):
         if self._preferred_hash_name:
             return self._preferred_hash_name
 
-        checksum = "md5"
-        try:
-            fp = open("/proc/sys/crypto/fips_enabled", "r")
-        except IOError:
-            self._preferred_hash_name = checksum
-            return checksum
-
-        fips_enabled = fp.read()
-        if fips_enabled.find("1") >= 0:
+        if sys.version_info[0] <= 2:
+            checksum = "md5"
+        else:
             checksum = "sha256"
-        fp.close()
+
         self._preferred_hash_name = checksum
         return checksum
 


### PR DESCRIPTION
Previously sha256 only used if in a FIPS environment we now
default to it over md5.

From looking at dates and availability I believe python3 installations
should all have sha256 so used that as a cutoff point.  If you are
running sosreport with python2 you will stay on md5.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
