### PR TITLE
[kubernetes] improve parsing namespaces

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -69,7 +69,9 @@ class kubernetes(Plugin, RedHatPlugin):
 
         # get all namespaces in use
         kn = self.get_command_output('%s get namespaces' % kube_cmd)
-        knsps = [n.split()[0] for n in kn['output'].splitlines()[1:] if n]
+        # namespace is the 1st word on line, until the line has spaces only
+        kn_output = kn['output'].splitlines()[1:]
+        knsps = [n.split()[0] for n in kn_output if n and len(n.split())]
 
         resources = [
             'limitrange',


### PR DESCRIPTION
Handle (theoretical) cases when "kubectl get namespace" returns a line with
white characters only, and prevent IndexError to be raised.

Resolves: #1442

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
