### PR TITLE
[powerpc] Add support to collect DLPAR and LPM related logs

### DIFF
--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -55,11 +55,15 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             ])
 
         if ispSeries:
+            cmd_output_path = self.get_cmd_output_path(name="ctsnap",
+                                                       make=True)
             self.add_copy_spec([
                 "/proc/ppc64/lparcfg",
                 "/proc/ppc64/eeh",
                 "/proc/ppc64/systemcfg",
-                "/var/log/platform"
+                "/var/log/platform",
+                "/var/log/drmgr",
+                "/var/log/drmgr.0"
             ])
             self.add_cmd_output([
                 "servicelog --dump",
@@ -68,7 +72,8 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                 "usysident",
                 "serv_config -l",
                 "bootlist -m both -r",
-                "lparstat -i"
+                "lparstat -i",
+                "ctsnap -xrunrpttr -d %s" % (cmd_output_path)
             ])
 
         if isPowerNV:


### PR DESCRIPTION
This patch updates powerpc plugin to collect
Dynamic Resource Manager (drmgr) log files
i.e. /var/log/drmgr and /var/log/drmgr.0.
In addition, it also adds ctsanp command to collect the information
about the Reliable Scalable Cluster Technology (RSCT) components.

Signed-off-by: Sourabh Jain <sourabhjain@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
