### PR TITLE
[policies] Detect CentOS distribution without D/S patches

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -279,7 +279,7 @@ No changes will be made to system configuration.
                 if line.startswith("NAME"):
                     (name, value) = line.split("=")
                     value = value.strip("\"'")
-                    if value.startswith(RHEL_RELEASE_STR):
+                    if value.startswith(cls.distro):
                         return True
         return False
 
@@ -321,6 +321,12 @@ No changes will be made to system configuration.
 
         # Vanilla RHEL is default
         return self.find_preset(RHEL)
+
+
+class CentOsPolicy(RHELPolicy):
+    distro = "CentOS"
+    vendor = "CentOS"
+    vendor_url = "http://www.centos.org/"
 
 
 ATOMIC = "atomic"
@@ -377,6 +383,12 @@ organization before being passed to any third party.
             return self.find_preset(RHOCP)
 
         return self.find_preset(ATOMIC)
+
+
+class CentOsAtomicPolicy(RedHatAtomicPolicy):
+    distro = "CentOS Atomic Host"
+    vendor = "CentOS"
+    vendor_url = "http://www.centos.org/"
 
 
 class FedoraPolicy(RedHatPolicy):


### PR DESCRIPTION
This partially fixes issue #1264 by handling the CentOS and
CentOS Atomic hosts, partially based on the CentOS packaging
patch [1]. Without this patch, if you try to develop sosreports
on a CentOS host, you will get an empty list of plugins.

[1] https://git.centos.org/blob/rpms!sos.git/c7/SOURCES!sos-3.4-centos-branding.patch

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
