### PR TITLE
[block] proper parsing of luks partition on self device

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -27,11 +27,11 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             return out
         for line in lsblk_out.splitlines():
             # find in output lines like
-            # |-sda2    crypto_LUKS    <uuid>
-            # and separate device name - it will be 1st string on the line
-            # after first '-'
+            # sda2      crypto_LUKS    <uuid>
+            # loop0     crypto_LUKS    <uuid>
+            # and separate device name - it will be the 1st string on the line
             if 'crypto_LUKS' in line:
-                dev = line.split()[0].split('-', 1)[1]
+                dev = line.split()[0]
                 out.append(dev)
         return out
 
@@ -67,7 +67,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                     "fdisk -l %s" % disk_path
                 ])
 
-        lsblk_file = self.get_cmd_output_now("lsblk -f -a")
+        lsblk_file = self.get_cmd_output_now("lsblk -f -a -l")
         # for LUKS devices, collect cryptsetup luksDump
         if lsblk_file:
             for dev in self.get_luks_devices(lsblk_file):


### PR DESCRIPTION
If LUKS partition is located on the device itself, lsblk output
does not contain '|-' before the device name - so we must parse the
device name more carefuly.

Resolves: #1449

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
