### PR TITLE
[networking] Collect NUMA Node of each NIC

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -129,6 +129,7 @@ class Networking(Plugin):
             "/etc/sysconfig/nftables.conf",
             "/etc/nftables.conf",
             "/etc/dnsmasq*",
+            "/sys/class/net/*/device/numa_node",
             "/sys/class/net/*/flags",
             "/sys/class/net/*/statistics/",
             "/etc/iproute2"


### PR DESCRIPTION
It is often useful to know the NUMA locality of each network device.
Collect /sys/class/net/*/device/numa_node to add this information.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
