### PR TITLE
[filesys] Use the correct interface when calling dumpe2fs

### DIFF
--- a/sos/plugins/filesys.py
+++ b/sos/plugins/filesys.py
@@ -48,7 +48,7 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin):
         if self.get_option('dumpe2fs'):
             dumpe2fs_opts = ''
         mounts = '/proc/mounts'
-        ext_fs_regex = r"^(/dev/.+).+ext[234]\s+"
+        ext_fs_regex = r"^(/dev/\S+).+ext[234]\s+"
         for dev in self.do_regex_find_all(ext_fs_regex, mounts):
                 self.add_cmd_output("dumpe2fs %s %s" % (dumpe2fs_opts, dev))
 


### PR DESCRIPTION
dumpe2fs takes one parameter indicating the device to be dumped.

Resolves: #1452

Signed-off-by: Xuewei Zhang <xueweiz@google.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
