### PR TITLE
[logging] Always cleanup temp directory

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1497,5 +1497,6 @@ def main(args):
     """The main entry point"""
     sos = SoSReport(args)
     sos.execute()
+    sos._cleanup()
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
When running `sosreport -l`, or the more specific --list-* options, sos
still creates a temp directory and log files, however we were not
cleaning those up - so over time we could have a multitude of sos temp
directories littering the filesystem.

Now always cleanup the temp directory after execution, unless the
--build option is specified by the user.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
