### PR TITLE
[networking] call ethtool for proper vlan device names

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -43,18 +43,6 @@ class Networking(Plugin):
             out.append(br_name)
         return out
 
-    def get_eth_interfaces(self, ip_link_out):
-        """Return a dictionary for which keys are ethernet interface
-        names taken from the output of "ip -o link".
-        """
-        out = {}
-        for line in ip_link_out.splitlines():
-            match = re.match('.*link/ether', line)
-            if match:
-                iface = match.string.split(':')[1].lstrip()
-                out[iface] = True
-        return out
-
     def get_ip_netns(self, ip_netns_file):
         """Returns a list for which items are namespaces in the output of
         ip netns stored in the ip_netns_file.
@@ -72,19 +60,6 @@ class Networking(Plugin):
                 return out
             out.append(line.partition(' ')[0])
         return out
-
-    def get_netns_devs(self, namespace):
-        """Returns a list for which items are devices that exist within
-        the provided namespace.
-        """
-        ip_link_result = self.call_ext_prog("ip netns exec " + namespace +
-                                            " ip -o link")
-        dev_list = []
-        if ip_link_result['status'] == 0:
-            for eth in self.get_eth_interfaces(ip_link_result['output']):
-                dev = eth.replace('@NONE', '')
-                dev_list.append(dev)
-        return dev_list
 
     def collect_iptable(self, tablename):
         """ When running the iptables command, it unfortunately auto-loads
@@ -199,21 +174,22 @@ class Networking(Plugin):
 
         # Get ethtool output for every device that does not exist in a
         # namespace.
-        ip_link_result = self.call_ext_prog("ip -o link")
-        if ip_link_result['status'] == 0:
-            for dev in self.get_eth_interfaces(ip_link_result['output']):
-                eth = dev.replace('@NONE', '')
-                self.add_cmd_output([
-                    "ethtool "+eth,
-                    "ethtool -d "+eth,
-                    "ethtool -i "+eth,
-                    "ethtool -k "+eth,
-                    "ethtool -S "+eth,
-                    "ethtool -T "+eth,
-                    "ethtool -a "+eth,
-                    "ethtool -c "+eth,
-                    "ethtool -g "+eth
-                ])
+        for eth in os.listdir("/sys/class/net/"):
+            # skip 'bonding_masters' file created when loading the bonding
+            # module but the file does not correspond to a device
+            if eth == "bonding_masters":
+                continue
+            self.add_cmd_output([
+                "ethtool " + eth,
+                "ethtool -d " + eth,
+                "ethtool -i " + eth,
+                "ethtool -k " + eth,
+                "ethtool -S " + eth,
+                "ethtool -T " + eth,
+                "ethtool -a " + eth,
+                "ethtool -c " + eth,
+                "ethtool -g " + eth
+            ])
 
         # brctl command will load bridge and related kernel modules
         # if those modules are not loaded at the time of brctl command running
@@ -251,8 +227,15 @@ class Networking(Plugin):
             # Devices that exist in a namespace use less ethtool
             # parameters. Run this per namespace.
             for namespace in self.get_ip_netns(ip_netns_file):
-                for eth in self.get_netns_devs(namespace):
-                    ns_cmd_prefix = cmd_prefix + namespace + " "
+                ns_cmd_prefix = cmd_prefix + namespace + " "
+                netns_netdev_list = self.call_ext_prog(ns_cmd_prefix +
+                                                       "ls -1 /sys/class/net/")
+                for eth in netns_netdev_list['output'].splitlines():
+                    # skip 'bonding_masters' file created when loading the
+                    # bonding module but the file does not correspond to
+                    # a device
+                    if eth == "bonding_masters":
+                        continue
                     self.add_cmd_output([
                         ns_cmd_prefix + "ethtool " + eth,
                         ns_cmd_prefix + "ethtool -i " + eth,


### PR DESCRIPTION
Dont rely on device names from "ip -o link" output where the names
contain also physical device name. Rather get the list of device names
from listing /sys/class/net/ directory.

Resolves: #1458

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
