### PR TITLE
[sosreport] Use 'append' mode in _log_plugin_exception()

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -85,7 +85,7 @@ class Archive(object):
     def add_file(self, src, dest=None):
         raise NotImplementedError
 
-    def add_string(self, content, dest):
+    def add_string(self, content, dest, mode='w'):
         raise NotImplementedError
 
     def add_binary(self, content, dest):
@@ -366,7 +366,7 @@ class FileCacheArchive(Archive):
             self.log_debug("added %s to FileCacheArchive '%s'" %
                            (file_name, self._archive_root))
 
-    def add_string(self, content, dest):
+    def add_string(self, content, dest, mode='w'):
         with self._path_lock:
             src = dest
 
@@ -376,7 +376,7 @@ class FileCacheArchive(Archive):
             # on file content.
             dest = self._check_path(dest, P_FILE, force=True)
 
-            f = codecs.open(dest, 'w', encoding='utf-8')
+            f = codecs.open(dest, mode, encoding='utf-8')
             if isinstance(content, bytes):
                 content = content.decode('utf8', 'ignore')
             f.write(content)

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -975,7 +975,7 @@ class SoSReport(object):
         logpath = os.path.join(self.logdir, plugin_err_log)
         self.soslog.error('%s "%s.%s()"' % (msg, plugin, method))
         self.soslog.error('writing traceback to %s' % logpath)
-        self.archive.add_string("%s\n" % trace, logpath)
+        self.archive.add_string("%s\n" % trace, logpath, mode='a')
 
     def prework(self):
         self.policy.pre_work()


### PR DESCRIPTION
[archive]

Add mode (e.g. to allow append) support to add_string() function.

[sosreport]

Use 'append' mode in _log_plugin_exception() so previous
tracebacks are not overwritten when more of them occur
in one module.

Signed-off-by: Filip Krska <fkrska@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
