### PR TITLE
[utilities] Remove the __path__ attribute comparison with empty string

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -285,7 +285,7 @@ class ImporterHelper(object):
         package. """
         plugins = []
         for path in self.package.__path__:
-            if os.path.isdir(path) or path == '':
+            if os.path.isdir(path):
                 plugins.extend(self._find_plugins_in_dir(path))
 
         return plugins


### PR DESCRIPTION
This patch removes an unnecessary comparison on package's __path__
attribute with an empty string in get_modules method.

When we pass an empty path to _find_plugins_from_list function it
returns None. The NoneType is not an iterable entity, so this
will leads to runtime error when we extend the plugins list with
None value.

Signed-off-by: Sourabh Jain <sourabhjain@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
