### PR TITLE
[openswan] Forbid collection of secrets and certdb

### DIFF
--- a/sos/plugins/openswan.py
+++ b/sos/plugins/openswan.py
@@ -42,6 +42,10 @@ class Openswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         if self.get_option("ipsec-barf"):
             self.add_cmd_output("ipsec barf")
 
-        self.add_forbidden_path("/etc/ipsec.d/key[3-4].db")
+        self.add_forbidden_path([
+            '/etc/ipsec.secrets',
+            '/etc/ipsec.secrets.d/*',
+            '/etc/ipsec.d/*.db',
+            '/etc/ipsec.d/*.secrets'])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
When collecting IPSec data, currently nothing prevents the collection of
keys or the cert.db files.  Ensure we don't collect this information as
it is private.

Thanks to Robert Bost (@bostrt) for discovering this and Matt Rogers
(@mrogers950) for double checking what we should ignore.

Signed-off-by: Robb Manes <rmanes@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
