### PR TITLE
[kernel] Stop collecting char devices, instead move common to plugin

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -68,11 +68,10 @@ def _path_in_path_list(path, path_list):
 
 def _node_type(st):
     """ return a string indicating the type of special node represented by
-    the stat buffer st (block, character, fifo, socket).
+    the stat buffer st (block, fifo, socket).
     """
     _types = [
         (stat.S_ISBLK, "block device"),
-        (stat.S_ISCHR, "character device"),
         (stat.S_ISFIFO, "named pipe"),
         (stat.S_ISSOCK, "socket")
     ]
@@ -503,7 +502,12 @@ class Plugin(object):
                 self._copy_dir(srcpath)
                 return
 
-        # handle special nodes (block, char, fifo, socket)
+        if stat.S_ISCHR(st.st_mode):
+            self._log_debug("not creating char device:'%s'"
+                            % (dest))
+            return
+
+        # handle special nodes (block, fifo, socket)
         if not (stat.S_ISREG(st.st_mode) or stat.S_ISDIR(st.st_mode)):
             ntype = _node_type(st)
             self._log_debug("creating %s node at archive:'%s'"

--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -79,7 +79,8 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "dmesg",
             "sysctl -a",
-            "dkms status"
+            "dkms status",
+            "file /dev/null /dev/zero /dev/urandom /dev/random"
         ])
 
         clocksource_path = "/sys/devices/system/clocksource/clocksource0/"


### PR DESCRIPTION
Instead of creating char devices which is usually just
/dev/null symlinked from systemd- we can just check that a
couple key ones exist.

Creating these character devices makes it harder to manage
(delete) extracted sosreports without more permissions.

I can't envision the exact attack/problem but I think it's better
practice if sosreport doesn't create these special devices on
collecting systems.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
