### PR TITLE
[plugins] Decrease log verbosity when do_file_sub failed on missing file

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -322,8 +322,14 @@ class Plugin(object):
             else:
                 replacements = 0
         except Exception as e:
-            msg = "regex substitution failed for '%s' with: '%s'"
-            self._log_error(msg % (path, e))
+            # if trying to regexp a nonexisting file, dont log it as an
+            # error to stdout
+            if e.errno == errno.ENOENT:
+                msg = "file '%s' not collected, substitution skipped"
+                self._log_debug(msg % path)
+            else:
+                msg = "regex substitution failed for '%s' with: '%s'"
+                self._log_error(msg % (path, e))
             replacements = 0
         return replacements
 


### PR DESCRIPTION
In case do_file_sub fails to apply a substitution on a non-existing file,
don't log it as an error log to stdout.

Resolves: #1471

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
