### PR TITLE
[networking] Replace "brctl: by "bridge" commands

### DIFF
--- a/sos/plugins/xen.py
+++ b/sos/plugins/xen.py
@@ -78,7 +78,7 @@ class Xen(Plugin, RedHatPlugin):
                 "xm info",
                 "xm list",
                 "xm list --long",
-                "brctl show"
+                "bridge link show"
             ])
             self.dom_collect_proc()
             if self.is_running_xenstored():


### PR DESCRIPTION
As bridge-utils containing brctl command are being deprecated,
sosreport should call bridge command instead.

Although the mapping of the commands is not 1:1, the data collected
(together with few "ip .." commands) will remain the same.

Resolves: #1472

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
