### PR TITLE
[podman] allow the plugin for RedHatPlugin and UbuntuPlugin

### DIFF
--- a/sos/plugins/podman.py
+++ b/sos/plugins/podman.py
@@ -11,7 +11,7 @@
 from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
-class Podman(Plugin):
+class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
     """Podman containers
     """
@@ -69,11 +69,10 @@ class Podman(Plugin):
                 for con in result['output'].splitlines():
                     insp.add(con)
 
-        if insp:
-            for container in insp:
-                self.add_cmd_output("podman inspect %s" % container)
-                if self.get_option('logs'):
-                    self.add_cmd_output("podman logs -t %s" % container)
+        for container in insp:
+            self.add_cmd_output("podman inspect %s" % container)
+            if self.get_option('logs'):
+                self.add_cmd_output("podman logs -t %s" % container)
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Until Podman inherits RedHatPlugin and/or UbuntuPlugin, the plugin
can not be executed on underlying distros.

Further, remove one redundant test as "for container in insp" will
work properly also for empty "insp".

Resolves: #1473

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
