### PR TITLE
[juju] Add detection when juju is installed as a snap.

### DIFF
--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -37,7 +37,7 @@ class Juju(Plugin, UbuntuPlugin):
 
     plugin_name = 'juju'
     profiles = ('virt', 'sysmgmt')
-    files = ('/usr/bin/juju', '/usr/bin/juju-run')
+    files = ('/usr/bin/juju', '/usr/bin/juju-run', '/snap/bin/juju')
 
     option_list = [
         ('export-mongodb',


### PR DESCRIPTION
Fixes Issue #1475

Conventional DEB package extract juju binary in /usr/bin/juju,
but SNAP extract juju binary in /snap/bin/juju.

Signed-off-by: Eric Desrochers eric.desrochers@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
