### PR TITLE
[smartcard] collect info about smart card readers via opensc

### DIFF
--- a/sos/plugins/smartcard.py
+++ b/sos/plugins/smartcard.py
@@ -19,16 +19,23 @@ class Smartcard(Plugin, RedHatPlugin):
     profiles = ('security', 'identity', 'hardware')
 
     files = ('/etc/pam_pkcs11/pam_pkcs11.conf',)
-    packages = ('pam_pkcs11',)
+    packages = ('pam_pkcs11', 'pcsc-tools', 'opensc')
 
     def setup(self):
         self.add_copy_spec([
             "/etc/reader.conf",
             "/etc/reader.conf.d/",
-            "/etc/pam_pkcs11/"])
+            "/etc/pam_pkcs11/",
+            "/etc/opensc-*.conf"
+        ])
         self.add_cmd_output([
             "pklogin_finder debug",
-            "ls -nl /usr/lib*/pam_pkcs11/"
+            "ls -nl /usr/lib*/pam_pkcs11/",
+            "pcsc_scan",
+            "pkcs11-tool --show-info",
+            "pkcs11-tool --list-mechanisms",
+            "pkcs11-tool --list-slots",
+            "pkcs11-tool --list-objects"
         ])
         self.add_forbidden_path("/etc/pam_pkcs11/nssdb/key[3-4].db")
 


### PR DESCRIPTION
Inspect smart card reader information using opensc command
pkcs11-tool and collect its configuration.

Resolves: #1478

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
