### PR TITLE
[presets] Create preset directory if it does not exist

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -371,6 +371,9 @@ class PresetDefaults(object):
         odict = self.opts.dict()
         pdict = {self.name: {DESC: self.desc, NOTE: self.note, OPTS: odict}}
 
+        if not os.path.exists(presets_path):
+            os.makedirs(presets_path)
+
         with open(os.path.join(presets_path, self.name), "w") as pfile:
             json.dump(pdict, pfile)
 


### PR DESCRIPTION
When attempting to add a preset when /var/lib/sos/presets does not
exist, the attempt will fail. Now, if the directory does not exist, sos
will attempt to create it.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
