### PR TITLE
(WIP) [services] Make it work in debian and condense differences

### DIFF
--- a/sos/plugins/services.py
+++ b/sos/plugins/services.py
@@ -9,26 +9,23 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Services(Plugin):
+class Services(Plugin, DebianPlugin, UbuntuPlugin):
     """System services
     """
 
     plugin_name = "services"
     profiles = ('system', 'boot')
 
-    option_list = [("servicestatus", "get a status of all running services",
-                    "slow", False)]
-
     def setup(self):
         self.add_copy_spec([
             "/etc/inittab",
-            "/etc/rc.d"
+            "/etc/rc.d",
+            "/etc/rc*.d"
         ])
-        if self.get_option('servicestatus'):
-            self.add_cmd_output("/sbin/service --status-all")
         self.add_cmd_output([
             "/sbin/runlevel",
-            "ls /var/lock/subsys"
+            "ls /var/lock/subsys",
+            "service --status-all"
         ])
 
 
@@ -38,16 +35,5 @@ class RedHatServices(Services, RedHatPlugin):
         super(RedHatServices, self).setup()
         self.add_cmd_output("/sbin/chkconfig --list", root_symlink="chkconfig")
 
-
-class DebianServices(Services, DebianPlugin, UbuntuPlugin):
-
-    def setup(self):
-        super(DebianServices, self).setup()
-        self.add_copy_spec("/etc/rc*.d")
-
-        self.add_cmd_output("/sbin/initctl show-config",
-                            root_symlink="initctl")
-        if self.get_option('servicestatus'):
-            self.add_cmd_output("/sbin/initctl list")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
WIP because I'm unsure which is the correct way to write a plugin that only needs changes for one distro.

Adds other distros to initial class
azure.py, cgroups.py

Creates "empty" classes:
corosync.py

In my testing, doing it the initial class way ends up creating a chkconfig file (so I guess the RH plugin runs?)

[services] Make it work in debian and condense differences
The debian/ubuntu plugin's commands startin with /sbin/ have not been
run in any supported releases (and they have not been missed).

Systemd systems capture an equivalent of "service --status-all"
(although this will double it up) I don't believe it needs to be
begind a flag

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
