### PR TITLE
[services/upstart] Cleanup and move commands to right plugin

### DIFF
--- a/sos/plugins/services.py
+++ b/sos/plugins/services.py
@@ -25,7 +25,7 @@ class Services(Plugin):
             "/etc/rc.d"
         ])
         if self.get_option('servicestatus'):
-            self.add_cmd_output("/sbin/service --status-all")
+            self.add_cmd_output("service --status-all")
         self.add_cmd_output([
             "/sbin/runlevel",
             "ls /var/lock/subsys"
@@ -44,10 +44,5 @@ class DebianServices(Services, DebianPlugin, UbuntuPlugin):
     def setup(self):
         super(DebianServices, self).setup()
         self.add_copy_spec("/etc/rc*.d")
-
-        self.add_cmd_output("/sbin/initctl show-config",
-                            root_symlink="initctl")
-        if self.get_option('servicestatus'):
-            self.add_cmd_output("/sbin/initctl list")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/upstart.py
+++ b/sos/plugins/upstart.py
@@ -24,7 +24,8 @@ class Upstart(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             'initctl --system list',
             'initctl --system version',
             'init --version',
-            "ls -l /etc/init/"
+            "ls -l /etc/init/",
+            'initctl show-config'
         ])
 
         # Job Configuration Files


### PR DESCRIPTION
Remove /sbin/ for service command so it runs on ubuntu.
Move initctl command to upstart plugin

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
