### PR TITLE
[policies] Fix default xz version

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -537,7 +537,7 @@ No changes will be made to system configuration.
                 xz_version = self.package_manager\
                                  .all_pkgs()[xz_package]["version"]
             except Exception as e:
-                xz_version = [0]  # deal like xz version is really old
+                xz_version = [u'0']  # deal like xz version is really old
             if xz_version >= [u'5', u'2']:
                 cmd = "%s -T%d" % (cmd, threads)
         return cmd


### PR DESCRIPTION
Hello! I've ran into an issue (described in the commit message below) and am proposing a patch for it. It's my first contribution to sosreport, so I hope I'm doing it right. Please let me know if anything needs to be amended or adjusted.

Thanks!

---
While running some tests using sosreport in a snap, I ran into the
following issue:

Creating compressed archive...

[archive:TarFileArchive] An error occurred compressing the archive:
unorderable types: int() >= str()

This is because the `xz_version` variable might be set to a list
containing one integer, but it was later compared to a list of strings,
raising an exception.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
