### PR TITLE
[firewalld] Fetch "direct" rule details as well as overall state and …

### DIFF
--- a/sos/plugins/firewalld.py
+++ b/sos/plugins/firewalld.py
@@ -36,7 +36,15 @@ class FirewallD(Plugin, RedHatPlugin):
         # docker containers.
         self.add_cmd_output([
             "firewall-cmd --list-all-zones",
-            "firewall-cmd --permanent --list-all-zones"
+            "firewall-cmd --direct --get-all-chains",
+            "firewall-cmd --direct --get-all-rules",
+            "firewall-cmd --direct --get-all-passthroughs",
+            "firewall-cmd --permanent --list-all-zones",
+            "firewall-cmd --permanent --direct --get-all-chains",
+            "firewall-cmd --permanent --direct --get-all-rules",
+            "firewall-cmd --permanent --direct --get-all-passthroughs",
+            "firewall-cmd --state",
+            "firewall-cmd --get-log-denied"
         ], timeout=10)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
…logging setting

Direct Rules are an increasingly common way to control the firewall, but
current sos plugin output does not get these.

Update the plugin to grab firewall-cmd output about Direct Rules, and
also pick up the 'state' output and newer logging settings.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
