### PR TITLE
[podman|docker] Add postprocessing for container inspect output

### DIFF
--- a/sos/plugins/podman.py
+++ b/sos/plugins/podman.py
@@ -75,5 +75,21 @@ class Podman(Plugin):
                 if self.get_option('logs'):
                     self.add_cmd_output("podman logs -t %s" % container)
 
+    def postproc(self):
+        # Attempts to match key=value pairs inside container inspect output
+        # for potentially sensitive items like env vars that contain passwords.
+        # Typically, these will be seen in env elements or similar, and look
+        # like this:
+        #             "Env": [
+        #                "mypassword=supersecret",
+        #                "container=oci"
+        #             ],
+        # This will mask values when the variable name looks like it may be
+        # something worth obfuscating.
+
+        env_regexp = r'(?P<var>(pass|key|secret|PASS|KEY|SECRET).*?)=' \
+                      '(?P<value>.*?)"'
+        self.do_cmd_output_sub('*inspect*', env_regexp,
+                               r'\g<var>=********"')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a postproc for the podman and docker plugins to attempt to
obfuscate sensitive keys in 'inspect' output for those runtimes.
Previously, these keys were being captured in plaintext which could lead
to passwords or similar being leaked when sysadmins configure containers
with environment variables (or similar) that contain this data.

Specifically, we match against 'key=value' pairs as that is how the
container runtimes accept and print these pairs, like so:

            "Env": [
                "mypassword=supersecret",
                "container=oci"
            ],

By comparison, the inspect outputs now read like the following when a
potentially sensitive key is found:

            "Env": [
                "mypassword=********",
                "container=oci"
            ],

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
