### PR TITLE
[debian/lxd] Add /snap/bin and have lxd detection use it

### DIFF
--- a/sos/plugins/lxd.py
+++ b/sos/plugins/lxd.py
@@ -17,6 +17,7 @@ class LXD(Plugin, UbuntuPlugin):
     plugin_name = 'lxd'
     profiles = ('container',)
     packages = ('lxd',)
+    commands = ('lxc', 'lxd')
 
     def setup(self):
         self.add_copy_spec([

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -14,7 +14,7 @@ class DebianPolicy(LinuxPolicy):
     _debv_filter = ""
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
-           + ":/usr/local/sbin:/usr/local/bin"
+           + ":/usr/local/sbin:/usr/local/bin:/snap/bin"
 
     def __init__(self, sysroot=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot)


### PR DESCRIPTION
Adds /snap/bin to Debian policy path
Have lxd plugin use it for detecting when it should run

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
