### PR TITLE
[subscription_manager] Add syspurpose collection

### DIFF
--- a/sos/plugins/subscription_manager.py
+++ b/sos/plugins/subscription_manager.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin
+import glob
 
 
 class SubscriptionManager(Plugin, RedHatPlugin):
@@ -29,10 +30,14 @@ class SubscriptionManager(Plugin, RedHatPlugin):
         self.add_cmd_output([
             "subscription-manager list --installed",
             "subscription-manager list --consumed",
-            "subscription-manager identity"
+            "subscription-manager identity",
+            "syspurpose show"
         ])
         self.add_cmd_output("rhsm-debug system --sos --no-archive "
                             "--no-subscriptions --destination %s"
                             % self.get_cmd_output_path())
+
+        certs = glob.glob('/etc/pki/product-default/*.pem')
+        self.add_cmd_output(["rct cat-cert %s" % cert for cert in certs])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Adds syspurpose output collection which is a new tool to assist with
subscription manager on RHEL systems.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
