### PR TITLE
Collect additional sysfs attribute data from block/<dev>/queue, scsi_host, and fc_vports

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -51,8 +51,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/blkid.tab",
             "/run/blkid/blkid.tab",
             "/proc/partitions",
-            "/proc/diskstats",
-            "/sys/block/*/queue/scheduler"
+            "/proc/diskstats"
         ])
 
         if os.path.isdir("/sys/block"):
@@ -60,8 +59,10 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                 if disk.startswith("ram"):
                     continue
                 disk_path = os.path.join('/dev/', disk)
+                queue_path = os.path.join('/sys/block/', disk, 'queue')
                 self.add_udev_info(disk_path)
                 self.add_udev_info(disk_path, attrs=True)
+                self.add_udev_info(queue_path, attrs=True)
                 self.add_cmd_output([
                     "parted -s %s unit s print" % (disk_path),
                     "fdisk -l %s" % disk_path

--- a/sos/plugins/fibrechannel.py
+++ b/sos/plugins/fibrechannel.py
@@ -26,7 +26,8 @@ class Fibrechannel(Plugin, RedHatPlugin):
         dirs = [
             '/sys/class/fc_host/',
             '/sys/class/fc_remote_ports/',
-            '/sys/class/fc_transport/'
+            '/sys/class/fc_transport/',
+            '/sys/class/fc_vports/'
         ]
 
         devs = [join(d, dev) for d in dirs if isdir(d) for dev in listdir(d)]

--- a/sos/plugins/scsi.py
+++ b/sos/plugins/scsi.py
@@ -6,6 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
 from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
@@ -31,5 +32,10 @@ class Scsi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "lsscsi",
             "sg_map -x"
         ])
+
+        if os.path.isdir("/sys/class/scsi_host"):
+            for host in os.listdir("/sys/class/scsi_host"):
+                host_path = os.path.join('/sys/class/scsi_host/', host)
+                self.add_udev_info(host_path, attrs=True)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

In order to aide in efficient troubleshooting, gather a bit more data from sysfs in relation to block devices queue directory, the scsi_host subsystem, and the fc_vports directory.  All data is gathered through the add_udev_info method.  These changes are an attempt at resolution for Red Hat bz1090485.