### PR TITLE
[sosreport] Clear nested threadpool threads on timeout

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1096,7 +1096,7 @@ class SoSReport(object):
             except TimeoutError:
                 self.ui_log.error("\n Plugin %s timed out\n" % plugin[1])
                 self.running_plugs.remove(plugin[1])
-                pool.shutdown(wait=False)
+                pool._threads.clear()
 
     def collect_plugin(self, plugin):
         try:


### PR DESCRIPTION
We nest ThreadPoolExecutors to run plugins to enable whole-plugin
timeouts, with the timeout being handled by the nested threadpool.
However, calling shutdown() on the nested thread is incorrect in the
event of a plugin timeout, as it only cancels pending jobs, not
currently running jobs that the timed-out plugin is.

Instead, call _threads.clear() to forcibly cancel the running job, thus
allowing the thread to return to the higher level threadpool and allow
other plugins to run via that thread.

This still allows data captured up to the point of the timeout to be
written to the sosreport.

Resolves: #1446

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
