### PR TITLE
[sosreport] Allow users to set timeout for plugins

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -13,6 +13,7 @@ sosreport \- Collect and package diagnostic and support data
           [--batch] [--build] [--debug]\fR
           [--label label] [--case-id id] [--ticket-number nr]
           [--threads threads]
+          [--timeout timeout]\fR
           [-s|--sysroot SYSROOT]\fR
           [-c|--chroot {auto|always|never}\fR
           [--tmp-dir directory]\fR
@@ -162,6 +163,12 @@ alphanumeric characters.
 .TP
 .B \--threads THREADS
 Specify the number of threads sosreport will use for concurrency. Defaults to 4.
+.TP
+.B \--timeout TIMEOUT
+Specify the amount of time in seconds after starting a plugin to wait until a
+timeout is hit. Note that this value is applied to ALL plugins being run.
+
+A value of 0 (zero) means no timeout will be applied.
 .TP
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -48,7 +48,7 @@ _arg_names = [
     'enableplugins', 'encrypt_key', 'encrypt_pass', 'experimental', 'label',
     'list_plugins', 'list_presets', 'list_profiles', 'log_size', 'noplugins',
     'noreport', 'note', 'onlyplugins', 'plugopts', 'preset', 'profiles',
-    'quiet', 'sysroot', 'threads', 'tmp_dir', 'verbosity', 'verify'
+    'quiet', 'sysroot', 'threads', 'timeout', 'tmp_dir', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -102,6 +102,7 @@ class SoSOptions(object):
     quiet = False
     sysroot = None
     threads = 4
+    timeout = None
     tmp_dir = ""
     verbosity = 0
     verify = False


### PR DESCRIPTION
Previously, plugin timeouts were only able to be set in the plugin
itself, and could not be controlled by users. Now, a new timeout option
has been added to allow this. If a user specifies a timeout, then that
timeout applies to all plugins being run. Setting a timeout value of 0
(zero) means that no timeout will be applied.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
