### PR TITLE
[kubernetes] Fix 'describe' option enablement and function

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -98,19 +98,19 @@ class kubernetes(Plugin, RedHatPlugin):
                 for res in resources:
                     self.add_cmd_output('%s %s' % (k_cmd, res))
 
-                if self.get_option('describe'):
-                    # need to drop json formatting for this
-                    k_cmd = '%s get %s' % (kube_cmd, knsp)
-                    for res in resources:
-                        r = self.get_command_output(
-                            '%s %s' % (k_cmd, res))
-                        if r['status'] == 0:
-                            k_list = [k.split()[0] for k in
-                                      r['output'].splitlines()[1:]]
-                            for k in k_list:
-                                k_cmd = '%s %s' % (kube_cmd, knsp)
-                                self.add_cmd_output(
-                                    '%s describe %s %s' % (k_cmd, res, k))
+            if self.get_option('describe'):
+                # need to drop json formatting for this
+                k_cmd = '%s %s' % (kube_cmd, knsp)
+                for res in resources:
+                    r = self.get_command_output(
+                        '%s get %s' % (k_cmd, res))
+                    if r['status'] == 0:
+                        k_list = [k.split()[0] for k in
+                                  r['output'].splitlines()[1:]]
+                        for k in k_list:
+                            k_cmd = '%s %s' % (kube_cmd, knsp)
+                            self.add_cmd_output(
+                                '%s describe %s %s' % (k_cmd, res, k))
 
             if self.get_option('podlogs'):
                 k_cmd = '%s %s' % (kube_cmd, knsp)


### PR DESCRIPTION
The 'describe' option logic was incorrectly nested behind the 'all'
option logic - so users couldn't successfully use the 'describe' option
unless they also specified 'all'.

Fixes the alignment so that 'describe' can be used properly and
separately.

Additionally fixes an issue where the syntax for getting resources for a
specified namespace only worked for pods, and otherwise generated an
error.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
