### PR TITLE
[sosreport] Allow user-controllable plugin timeouts

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -13,6 +13,7 @@ sosreport \- Collect and package diagnostic and support data
           [--batch] [--build] [--debug]\fR
           [--label label] [--case-id id] [--ticket-number nr]
           [--threads threads]
+          [--plugin-timeout TIMEOUT]\fR
           [-s|--sysroot SYSROOT]\fR
           [-c|--chroot {auto|always|never}\fR
           [--tmp-dir directory]\fR
@@ -162,6 +163,18 @@ alphanumeric characters.
 .TP
 .B \--threads THREADS
 Specify the number of threads sosreport will use for concurrency. Defaults to 4.
+.TP
+.B \--plugin-timeout TIMEOUT
+Specify a timeout in seconds to allow each plugin to run for. A value of 0
+means no timeout will be set.
+
+Note that this options sets the timeout for all plugins. If you want to set
+a timeout for a specific plugin, use the 'timeout' plugin option available to
+all plugins - e.g. '-k logs.timeout=600'.
+
+The plugin-specific timeout option will override this option. For example, using
+\'--plugin-timeout=60 -k logs.timeout=600\' will set a timeout of 600 seconds for
+the logs plugin and 60 seconds for all other enabled plugins.
 .TP
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -47,8 +47,8 @@ _arg_names = [
     'chroot', 'compression_type', 'config_file', 'desc', 'debug', 'del_preset',
     'enableplugins', 'encrypt_key', 'encrypt_pass', 'experimental', 'label',
     'list_plugins', 'list_presets', 'list_profiles', 'log_size', 'noplugins',
-    'noreport', 'note', 'onlyplugins', 'plugopts', 'preset', 'profiles',
-    'quiet', 'sysroot', 'threads', 'tmp_dir', 'verbosity', 'verify'
+    'noreport', 'note', 'onlyplugins', 'plugin_timeout', 'plugopts', 'preset',
+    'profiles', 'quiet', 'sysroot', 'threads', 'tmp_dir', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -96,6 +96,7 @@ class SoSOptions(object):
     noreport = False
     note = ""
     onlyplugins = []
+    plugin_timeout = None
     plugopts = []
     preset = ""
     profiles = []


### PR DESCRIPTION
Allows users to specify a timeout for each plugin using the '-k
plugin.timeout=value' syntax by adding the 'timeout' option to every
plugin.

Additionally, adds the --plugin-timeout option to set a timeout for
_all_ plugins. If --plugin-timeout and a specific -k timeout option is
provided, the -k timeout option will be applied for those specific
plugins, with --plugin-timeout being applied to all others.

In either case, specifying a timeout of 0 seconds results in no timeout
being applied. In the event that an invalid timeout is set, the timeout
will be set to the default value for the plugin.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
