### PR TITLE
[postgresql] Use the custom dump format

### DIFF
--- a/sos/plugins/postgresql.py
+++ b/sos/plugins/postgresql.py
@@ -39,7 +39,7 @@ class PostgreSQL(Plugin):
         ('dbport', 'database server port number', '', '5432')
     ]
 
-    def do_pg_dump(self, scl=None, filename="pgdump.tar"):
+    def do_pg_dump(self, scl=None, filename="pgdump.dump"):
         if self.get_option("dbname"):
             if self.get_option("password") or "PGPASSWORD" in os.environ:
                 # We're only modifying this for ourself and our children so
@@ -49,14 +49,14 @@ class PostgreSQL(Plugin):
                     os.environ["PGPASSWORD"] = str(self.get_option("password"))
 
                 if self.get_option("dbhost"):
-                    cmd = "pg_dump -U %s -h %s -p %s -w -F t %s" % (
+                    cmd = "pg_dump -U %s -h %s -p %s -w -F c %s" % (
                         self.get_option("username"),
                         self.get_option("dbhost"),
                         self.get_option("dbport"),
                         self.get_option("dbname")
                     )
                 else:
-                    cmd = "pg_dump -C -U %s -w -F t %s " % (
+                    cmd = "pg_dump -C -U %s -w -F c %s " % (
                         self.get_option("username"),
                         self.get_option("dbname")
                     )
@@ -112,7 +112,7 @@ class RedHatPostgreSQL(PostgreSQL, SCLPlugin):
         )
 
         if scl in self.scls_matched:
-            self.do_pg_dump(scl=scl, filename="pgdump-scl-%s.tar" % scl)
+            self.do_pg_dump(scl=scl, filename="pgdump-scl-%s.dump" % scl)
 
 
 class DebianPostgreSQL(PostgreSQL, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Instead of tar.

'custom' should be smaller, faster, and allows more features - in
particlar, using the '-j' option to pg_restore (to run stuff in
parallel, so hopefully faster).

One drawback is that you can't use 'tar' and 'less' to open and
view it - you need pg_restore. But I think it's worth it.

Signed-off-by: Yedidyah Bar David <didi@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
