### PR TITLE
[mysql] Enable mysql for OSP container env

### DIFF
--- a/sos/plugins/mysql.py
+++ b/sos/plugins/mysql.py
@@ -82,7 +82,8 @@ class RedHatMysql(Mysql, RedHatPlugin):
         'mysql-server',
         'mysql',
         'mariadb-server',
-        'mariadb'
+        'mariadb',
+        'openstack-selinux'
     )
 
     def setup(self):


### PR DESCRIPTION
In containerized OSP env we now do not have no mysql packages installed
outside the containers. Therefore the mysql plugin does not auto run.
This adds the openstack-selinux package to the RH package list of the
mysql plugin like on the OSP plugins.

Signed-off-by: Martin Schuppert <mschuppert@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
