### PR TITLE
[peripety] Add new plugin

### DIFF
--- a/sos/plugins/peripety.py
+++ b/sos/plugins/peripety.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2018 Red Hat, Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin
+from re import match
+import glob
+
+
+class Peripety(Plugin, RedHatPlugin):
+    '''Peripety Storage Event Monitor'''
+
+    packages = ('peripety',)
+    services = ('peripetyd',)
+
+    def setup(self):
+        self.add_copy_spec('/etc/peripety.conf')
+
+        forbid_reg = [
+            'vd.*',
+            'sr.*',
+            'loop.*',
+            'ram.*'
+        ]
+
+        disks = filter(lambda x: not any(match(reg, x) for reg in forbid_reg),
+                       [d.split('/')[-1] for d in glob.glob('/sys/block/*')])
+        for disk in disks:
+            self.add_cmd_output([
+                "prpt info %s" % disk,
+                "prpt query --blk %s" % disk
+            ])
+        self.add_journal('peripetyd')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a new plugin for the storage event monitoring daemon peripety.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
