### PR TITLE
[networking] Extend ethtool command set

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -212,7 +212,13 @@ class Networking(Plugin):
                     "ethtool -T "+eth,
                     "ethtool -a "+eth,
                     "ethtool -c "+eth,
-                    "ethtool -g "+eth
+                    "ethtool -g "+eth,
+                    "ethtool -e "+eth,
+                    "ethtool -P "+eth,
+                    "ethtool -l "+eth,
+                    "ethtool --phy-statistics "+eth,
+                    "ethtool --show-priv-flags "+eth,
+                    "ethtool --show-eee "+eth
                 ])
 
         # brctl command will load bridge and related kernel modules


### PR DESCRIPTION
Update the list of ethtool commands to include:

ethtool -e (EEPROM dump)
ethtool -P (permanent MAC address)
ethtool -l (channel/queue settings)
ethtool --phy-statistics
ethtool --show-priv-flags
ethtool --show-eee

All of the above are helpful in understanding the state of modern NICs.
And -P is nice to have as otherwise there is no reliable way to see the
permanent MAC of team ports.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
