### PR TITLE
[hardware] collect Extended Display Identification Data

### DIFF
--- a/sos/plugins/hardware.py
+++ b/sos/plugins/hardware.py
@@ -24,7 +24,8 @@ class Hardware(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/devices",
             "/proc/rtc",
             "/var/log/mcelog",
-            "/sys/class/dmi/id/*"
+            "/sys/class/dmi/id/*",
+            "/sys/class/drm/*/edid"
         ])
 
         self.add_cmd_output("dmidecode", root_symlink="dmidecode")


### PR DESCRIPTION
Collect /sys/class/drm/*/edid .

Resolves: #1507

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
