### PR TITLE
[Plugin] Add iterator for block devices, update relevant plugins, and remove add_udev_info 

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1593,25 +1593,6 @@ class Plugin(object):
         self._add_cmd_output(cmd=journal_cmd, timeout=timeout,
                              sizelimit=log_size, pred=pred)
 
-    def add_udev_info(self, device, attrs=False):
-        """Collect udevadm info output for a given device
-
-        :param device: A string or list of strings of device names or sysfs
-                       paths. E.G. either '/sys/class/scsi_host/host0' or
-                       '/dev/sda' is valid.
-        :param attrs: If True, run udevadm with the --attribute-walk option.
-        """
-        udev_cmd = 'udevadm info'
-        if attrs:
-            udev_cmd += ' -a'
-
-        if isinstance(device, six.string_types):
-            device = [device]
-
-        for dev in device:
-            self._log_debug("collecting udev info for: %s" % dev)
-            self._add_cmd_output(cmd='%s %s' % (udev_cmd, dev))
-
     def _expand_copy_spec(self, copyspec):
         return glob.glob(copyspec)
 

--- a/sos/plugins/fibrechannel.py
+++ b/sos/plugins/fibrechannel.py
@@ -10,9 +10,6 @@
 
 from sos.plugins import Plugin, RedHatPlugin
 
-from os import listdir
-from os.path import isdir, join
-
 
 class Fibrechannel(Plugin, RedHatPlugin):
     """Collects information on fibrechannel devices, if present"""
@@ -22,16 +19,6 @@ class Fibrechannel(Plugin, RedHatPlugin):
     files = ('/sys/class/fc_host')
 
     def setup(self):
-
-        dirs = [
-            '/sys/class/fc_host/',
-            '/sys/class/fc_remote_ports/',
-            '/sys/class/fc_transport/',
-            '/sys/class/fc_vports/'
-        ]
-
-        devs = [join(d, dev) for d in dirs if isdir(d) for dev in listdir(d)]
-        if devs:
-            self.add_udev_info(devs, attrs=True)
+        self.add_blockdev_cmd("udevadm info -a %(dev)s", devices='fibre')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/scsi.py
+++ b/sos/plugins/scsi.py
@@ -32,6 +32,7 @@ class Scsi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         self.add_cmd_output("sg_map -x")
 
         scsi_hosts = glob("/sys/class/scsi_host/*")
-        self.add_udev_info(scsi_hosts, attrs=True)
+        self.add_blockdev_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,
+                              prepend_path='/sys/class/scsi_host')
 
 # vim: set et ts=4 sw=4 :

--- a/tests/option_tests.py
+++ b/tests/option_tests.py
@@ -24,7 +24,8 @@ class GlobalOptionTest(unittest.TestCase):
         self.commons = {
             'sysroot': '/',
             'policy': LinuxPolicy(init=InitSystem()),
-            'cmdlineopts': MockOptions()
+            'cmdlineopts': MockOptions(),
+            'devices': {}
         }
         self.plugin = Plugin(self.commons)
         self.plugin.opt_names = ['baz', 'empty', 'test_option']

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -161,49 +161,50 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'policy': LinuxPolicy(init=InitSystem()),
             'sysroot': self.sysroot,
-            'cmdlineopts': MockOptions()
+            'cmdlineopts': MockOptions(),
+            'devices': {}
         })
         self.mp.archive = MockArchive()
 
     def test_plugin_default_name(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.name(), "mockplugin")
 
     def test_plugin_set_name(self):
         p = NamedMockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                             'cmdlineopts': MockOptions()})
+                             'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.name(), "testing")
 
     def test_plugin_no_descrip(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_description(), "<no description available>")
 
     def test_plugin_no_descrip(self):
         p = NamedMockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                             'cmdlineopts': MockOptions()})
+                             'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_description(), "This plugin has a description.")
 
     def test_set_plugin_option(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option("opt"), "testing")
 
     def test_set_nonexistant_plugin_option(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertFalse(p.set_option("badopt", "testing"))
 
     def test_get_nonexistant_plugin_option(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_option("badopt"), 0)
 
     def test_get_unset_plugin_option(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_option("opt"), 0)
 
     def test_get_unset_plugin_option_with_default(self):
@@ -211,7 +212,7 @@ class PluginTests(unittest.TestCase):
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_option("opt", True), True)
 
     def test_get_unset_plugin_option_with_default_not_none(self):
@@ -220,23 +221,23 @@ class PluginTests(unittest.TestCase):
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_option("opt2", True), False)
 
     def test_get_option_as_list_plugin_option(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         p.set_option("opt", "one,two,three")
         self.assertEquals(p.get_option_as_list("opt"), ['one', 'two', 'three'])
 
     def test_get_option_as_list_plugin_option_default(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         self.assertEquals(p.get_option_as_list("opt", default=[]), [])
 
     def test_get_option_as_list_plugin_option_not_list(self):
         p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+                        'cmdlineopts': MockOptions(), 'devices': {}})
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option_as_list("opt"), ['testing'])
 
@@ -252,7 +253,8 @@ class PluginTests(unittest.TestCase):
         p = ForbiddenMockPlugin({
             'cmdlineopts': MockOptions(),
             'sysroot': self.sysroot,
-            'policy': LinuxPolicy(init=InitSystem())
+            'policy': LinuxPolicy(init=InitSystem()),
+            'devices': {}
         })
         p.archive = MockArchive()
         p.setup()
@@ -263,7 +265,8 @@ class PluginTests(unittest.TestCase):
         p = PostprocMockPlugin({
             'cmdlineopts': MockOptions(),
             'sysroot': self.sysroot,
-            'policy': LinuxPolicy(init=InitSystem())
+            'policy': LinuxPolicy(init=InitSystem()),
+            'devices': {}
         })
         p.postproc()
         self.assertTrue(p.did_postproc)
@@ -278,7 +281,8 @@ class AddCopySpecTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'policy': LinuxPolicy(init=InitSystem()),
             'sysroot': os.getcwd(),
-            'cmdlineopts': MockOptions()
+            'cmdlineopts': MockOptions(),
+            'devices': {}
         })
         self.mp.archive = MockArchive()
 
@@ -355,7 +359,8 @@ class CheckEnabledTests(unittest.TestCase):
         self.mp = EnablerPlugin({
             'policy': sos.policies.load(),
             'sysroot': os.getcwd(),
-            'cmdlineopts': MockOptions()
+            'cmdlineopts': MockOptions(),
+            'devices': {}
         })
 
     def test_checks_for_file(self):
@@ -383,7 +388,8 @@ class RegexSubTests(unittest.TestCase):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
             'policy': LinuxPolicy(init=InitSystem()),
-            'sysroot': os.getcwd()
+            'sysroot': os.getcwd(),
+            'devices': {}
         })
         self.mp.archive = MockArchive()
 


### PR DESCRIPTION
This series of commits adds a new `add_blockdev_cmd()` method to the Plugin class that allows for easy iteration of commands over block devices on a system running sosreport.

This removes the need for each plugin to independently enumerate block devices (and in turn standardizes the way we do that). The `add_blockdev_cmd()` method can take either a string or list of strings as commands, substituting the `%(dev)s` var for the block device. 

By default, this method will run against block devices (per `/sys/block/`) and prepend devices names with `/dev/`. This can be controlled by setting the `prepend_path` parameter, and the `devices` can be set to either `block` for block devices (default behavior) `fibre` for fibre devices, or handed a list of device names manually.

Additionally, a `whitelist` or `blacklist` can be applied to filter which devices are valid for commands to be run against. Both of that arguments can be either a regex string or a list of regex strings. 

Included in this are update to the `block`, `nvme`, and `fibrechannel` plugins to use this new method.

Finally, remove `add_udev_info()` as it's initial concept was easy device iteration, which this new method handles better and also provides for the previously mentioned device filters. 

I imagine this will eventually be expanded upon to include network devices, so the actual work of filtering and building the commands is handled by `_add_device_cmd()` and `add_blockdev_cmd()` simply handles setting the correct device list - much like I envision a potential `add_netdev_cmd()` will do.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
