### PR TITLE
[redhat] Update policy to identify RHEL 8

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -295,6 +295,8 @@ No changes will be made to system configuration.
                 return 6
             elif pkgname[0] == "7":
                 return 7
+            elif pkgname[0] == "8":
+                return 8
         except Exception:
             pass
         return False


### PR DESCRIPTION
Now that RHEL 8 Beta is out, update the redhat policy dist_version to be
able to properly set the version.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
