### PR TITLE
[vdo] Get status output individually, and collect stats output

### DIFF
--- a/sos/plugins/vdo.py
+++ b/sos/plugins/vdo.py
@@ -25,6 +25,12 @@ class Vdo(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec(self.files)
-        self.add_cmd_output("vdo status")
+        vdos = self.get_command_output('vdo list --all')
+        for vdo in vdos['output'].splitlines():
+            self.add_cmd_output("vdo status -n %s" % vdo)
+        self.add_cmd_output([
+            'vdostats --human-readable',
+            'vdo list --all'
+        ])
 
 # vim set et ts=4 sw=4 :


### PR DESCRIPTION
Updates the vdo plugin to grab status information for each individual
volume rather than dumping everything into a single output. Additionally
collect vdostats output.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
