### PR TITLE
[Plugin] fix get_option() on Python3 runtimes

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -532,10 +532,10 @@ class Plugin(object):
             return getattr(self.commons['cmdlineopts'], optionname)
 
         def _check(key):
-            if hasattr(optionname, "__iter__"):
-                return key in optionname
-            else:
+            if hasattr(optionname, "encode"):
                 return key == optionname
+            else:
+                return key in optionname
 
         for name, parms in zip(self.opt_names, self.opt_parms):
             if _check(name):


### PR DESCRIPTION
Fix `get_option()` to properly distinguish string and iterable types on Python3 runtimes.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
