### PR TITLE
[tuned] Collect verify output

### DIFF
--- a/sos/plugins/tuned.py
+++ b/sos/plugins/tuned.py
@@ -22,7 +22,8 @@ class Tuned(Plugin, RedHatPlugin):
         self.add_cmd_output([
             "tuned-adm list",
             "tuned-adm active",
-            "tuned-adm recommend"
+            "tuned-adm recommend",
+            "tuned-adm verify"
         ])
         self.add_copy_spec([
             "/etc/tuned.conf",


### PR DESCRIPTION
Adds collection of 'tuned-adm verify' to allow for quick and easy
reference as to if tunables have been changed on a system using tuned.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
