### PR TITLE
[apt] add /etc/apt/auth.conf to forbidden path

### DIFF
--- a/sos/plugins/apt.py
+++ b/sos/plugins/apt.py
@@ -23,6 +23,8 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
             "/etc/apt", "/var/log/apt"
         ])
 
+        self.add_forbidden_path("/etc/apt/auth.conf")
+
         self.add_cmd_output([
             "apt-get check",
             "apt-config dump",


### PR DESCRIPTION
Add /etc/apt/auth.conf to forbidden path for apt plugin.

Signed-off-by: Yuan-Chen Cheng <yc.cheng@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
