### PR TITLE
[pcp] Collect summary data for the current day

### DIFF
--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -136,6 +136,16 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
 
         # Need to get the current status of the PCP infrastructure
         self.add_cmd_output("pcp")
-
+        # Collect a summary for the current day
+        res = self.get_command_output('pcp')
+        if res['status'] == 0:
+            for line in res['output'].splitlines():
+                if line.startswith(' pmlogger:'):
+                    arc = line.split()[-1]
+                    self.add_cmd_output(
+                        "pmstat -S 00:00 -T 23:59 -t 5m -x -a %s" % arc,
+                        root_symlink="pmstat"
+                    )
+                    break
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of a pmstat summary output using 5 minute intervals for
the current day, and makes a root symlink to it in the archive.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
