### PR TITLE
[pacemaker] Collect full status output

### DIFF
--- a/sos/plugins/pacemaker.py
+++ b/sos/plugins/pacemaker.py
@@ -44,7 +44,7 @@ class Pacemaker(Plugin):
         self.add_copy_spec("/var/log/pcsd/pcsd.log")
         self.add_cmd_output([
             "pcs config",
-            "pcs status",
+            "pcs status --full",
             "pcs property list --all"
         ])
 


### PR DESCRIPTION
Changes the 'pcs status' collection to display full status results.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
