### PR TITLE
[redhat] Add a 'cantboot' preset

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -195,6 +195,9 @@ _opts_all_logs = SoSOptions(all_logs=True)
 _opts_all_logs_verify = SoSOptions(all_logs=True, verify=True)
 _opts_all_logs_no_lsof = SoSOptions(all_logs=True,
                                     plugopts=['process.lsof=off'])
+_cb_plugs = ['abrt', 'block', 'boot', 'dnf', 'dracut', 'filesys', 'grub2',
+             'hardware', 'host', 'kernel', 'logs', 'lvm2', 'memory', 'rpm',
+             'process', 'systemd', 'yum', 'xfs']
 
 RHEL_RELEASE_STR = "Red Hat Enterprise Linux"
 
@@ -213,6 +216,11 @@ RHOCP_DESC = "OpenShift Container Platform by Red Hat"
 RH_SATELLITE = "satellite"
 RH_SATELLITE_DESC = "Red Hat Satellite"
 
+CB = "cantboot"
+CB_DESC = "For use when normal system startup fails"
+CB_OPTS = SoSOptions(verify=True, all_logs=True, onlyplugins=_cb_plugs)
+CB_NOTE = ("Data collection will be limited to a boot-affecting scope")
+
 NOTE_SIZE = "This preset may increase report size"
 NOTE_TIME = "This preset may increase report run time"
 NOTE_SIZE_TIME = "This preset may increase report size and run time"
@@ -227,6 +235,7 @@ rhel_presets = {
                           opts=_opts_all_logs_verify),
     RH_SATELLITE: PresetDefaults(name=RH_SATELLITE, desc=RH_SATELLITE_DESC,
                                  note=NOTE_TIME, opts=_opts_verify),
+    CB: PresetDefaults(name=CB, desc=CB_DESC, note=CB_NOTE, opts=CB_OPTS)
 }
 
 


### PR DESCRIPTION
Adds a 'cantboot' preset to enable a small number of plugins that may be
useful when troubleshooting a situation in which normal system startup
is failing.

Longer term, it would be beneficial if this preset could be
automatically loaded if sos detects that it is running in a system that
has been booted to rescue/emergency mode.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
