### PR TITLE
[python] Update plugin to run properly on RHEL 8

### DIFF
--- a/sos/plugins/python.py
+++ b/sos/plugins/python.py
@@ -11,7 +11,7 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Python(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Python(Plugin, DebianPlugin, UbuntuPlugin):
     """Python runtime
     """
 
@@ -22,5 +22,20 @@ class Python(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         self.add_cmd_output("python -V", suggest_filename="python-version")
+
+
+class RedHatPython(Python, RedHatPlugin):
+
+    packages = ('python', 'python36', 'python2', 'platform-python')
+
+    def setup(self):
+        self.add_cmd_output(['python2 -V', 'python3 -V'])
+        if self.policy.dist_version() > 7:
+            self.add_cmd_output(
+                '/usr/libexec/platform-python -V',
+                suggest_filename='python-version'
+            )
+        else:
+            self.add_cmd_output('python -V', suggest_filename='python-version')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
RHEL 8 replaces the standard 'python' binary with platform-python,
following PEP394. RHEL 8 sysadmins can however install python2 and/or
python3 alongside this system installation of python and optionally also
set 'python' to point to either of these installations.

This updates the python plugin to enable on the presence of any of these
packages and also get version information for any version of python
installed, including the platform-python installation.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
