### PR TITLE
[plugins] Preserve data type of a plugin option to the default one

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -509,9 +509,14 @@ class Plugin(object):
         return (self.opt_names, self.opt_parms)
 
     def set_option(self, optionname, value):
-        '''set the named option to value.'''
+        """Set the named option to value. Ensure the original type
+           of the option value is preserved.
+        """
         for name, parms in zip(self.opt_names, self.opt_parms):
             if name == optionname:
+                defaulttype = type(parms['enabled'])
+                if defaulttype != type(value) and defaulttype != type(None):
+                    value = (defaulttype)(value)
                 parms['enabled'] = value
                 return True
         else:


### PR DESCRIPTION
Some plugin options rely on the default data type that can be
automatically overwritten by Python (e.g. from str to int).

The commit preserves the original data type to ensure implicit data
type specified in option definition is always used.

Resolves: #1526

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
