### PR TITLE
[rpmostree] Add new plugin

### DIFF
--- a/sos/plugins/atomichost.py
+++ b/sos/plugins/atomichost.py
@@ -25,7 +25,6 @@ class AtomicHost(Plugin, RedHatPlugin):
         return self.policy.in_container()
 
     def setup(self):
-        self.add_copy_spec("/etc/ostree/remotes.d")
         self.add_cmd_output("atomic host status")
 
         if self.get_option('info'):

--- a/sos/plugins/rpmostree.py
+++ b/sos/plugins/rpmostree.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2019 Red Hat, Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class Rpmostree(Plugin, RedHatPlugin):
+    """rpm-ostree image/package system"""
+
+    plugin_name = 'rpmostree'
+    packages = ('rpm-ostree',)
+
+    def setup(self):
+        self.add_copy_spec('/etc/ostree/remotes.d/')
+
+        subcmds = [
+            'status',
+            'db list',
+            'db diff',
+            '--version'
+        ]
+
+        self.add_cmd_output(["rpm-ostree %s" % subcmd for subcmd in subcmds])
+
+        units = [
+            'rpm-ostreed',
+            'rpm-ostreed-automatic',
+            'rpm-ostree-bootstatus'
+        ]
+        for unit in units:
+            self.add_journal(unit)
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a new plugin for rpm-ostree, which is no longer limited to use in
Atomic Host.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
