### PR TITLE
[manpages] Fix path for docs in /usr/share/doc

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -192,7 +192,7 @@ Display usage message.
 Bryn M. Reeves <bmr@redhat.com>
 .fi
 .SH AUTHORS & CONTRIBUTORS
-See \fBAUTHORS\fR file in /usr/share/doc/sosreport.
+See \fBAUTHORS\fR file in the package documentation.
 .nf
 .SH TRANSLATIONS
 .nf


### PR DESCRIPTION
In the Makefile we have specified the path for sosreport docs as:

install -m644 AUTHORS README.md $(DESTDIR)/usr/share/$(NAME)/.

And NAME is 'sos'. But in the manpage we have the path as
/usr/share/doc/sosreport. This fix changes that to 'sos'.

Resolves: #1531
Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
