### PR TITLE
[policy] Add a 'none' preset to Policy to override automatic presets

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -378,6 +378,16 @@ class PresetDefaults(object):
         os.unlink(os.path.join(presets_path, self.name))
 
 
+NO_PRESET = 'none'
+NO_PRESET_DESC = 'Do not load a preset'
+NO_PRESET_NOTE = 'Use to disable automatically loaded presets'
+
+GENERIC_PRESETS = {
+    NO_PRESET: PresetDefaults(name=NO_PRESET, desc=NO_PRESET_DESC,
+                              note=NO_PRESET_NOTE, opts=SoSOptions())
+    }
+
+
 class Policy(object):
 
     msg = _("""\
@@ -421,6 +431,7 @@ No changes will be made to system configuration.
         self._valid_subclasses = []
         self.set_exec_path()
         self._host_sysroot = sysroot
+        self.register_presets(GENERIC_PRESETS)
 
     def get_valid_subclasses(self):
         return [IndependentPlugin] + self._valid_subclasses
@@ -702,7 +713,7 @@ No changes will be made to system configuration.
 
             :returns: a ``PresetDefaults`` object.
         """
-        return self.presets[""]
+        return self.presets[NO_PRESET]
 
     def load_presets(self, presets_path=None):
         """Load presets from disk.


### PR DESCRIPTION
Adds a 'none' preset to the base Policy class that can be used to
override any distro-specific presets that may be otherwise automatically
loaded when a bare 'sosreport' is run due to the presence of certian
packages. In other words, using '--preset=none' will cause sosreport to
run identically to how sosreport ran before presets were introduced.

Additionally this 'none' preset is now the default preset returned by
the Policy class if probe_preset() is not overridden by individual
policies.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
