### PR TITLE
[lvm2] Use metadata_read_only=1 for lvm commands

### DIFF
--- a/sos/plugins/lvm2.py
+++ b/sos/plugins/lvm2.py
@@ -37,14 +37,18 @@ class Lvm2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output(cmd, chroot=self.tmp_in_sysroot())
 
     def setup(self):
-        # use locking_type 0 (no locks) when running LVM2 commands,
-        # from lvm.conf:
-        # Turn locking off by setting to 0 (dangerous: risks metadata
-        # corruption if LVM2 commands get run concurrently).
-        # None of the commands issued by sos ever modify metadata and this
-        # avoids the possibility of hanging lvm commands when another process
-        # or node holds a conflicting lock.
-        lvm_opts = '--config="global{locking_type=0}"'
+        # When running LVM2 comamnds:
+        # - use locking_type 0 (no locks) from lvm.conf: Turn locking
+        #   off by setting to 0 (dangerous: risks metadata corruption if
+        #   LVM2 commands get run concurrently).  This avoids the
+        #   possibility of hanging lvm commands when another process or
+        #   node holds a conflicting lock.
+        # - use metadata_read_only 1 (forbidd on-disk changes). Although
+        #   all LVM2 commands we use should be read-only, any LVM2
+        #   command may attempt to recover on-disk data in some cases.
+        #   This option prevents such changes, allowing safe use of
+        #   locking_type=0.
+        lvm_opts = '--config="global{locking_type=0 metadata_read_only=1}"'
 
         self.add_cmd_output(
             "vgdisplay -vv %s" % lvm_opts,


### PR DESCRIPTION
We use locking_type=0 to ensure that we can collect data even if another
process holds a conflicting lock. This introduce a small risk since even
the read-only commands we use may attempt to recover on-disk data in
some cases. The risk is bigger when running lvm2 plugin in oVirt system,
when LVM is used on shared storage, accessible from many hosts.

Add metadata_read_only=1 to ensure that no command can attempt to do
unwanted on-disk changes.

Resolves: #1533

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
