### PR TITLE
[nvme] Capture /etc/nvme/discovery.conf

### DIFF
--- a/sos/plugins/nvme.py
+++ b/sos/plugins/nvme.py
@@ -33,5 +33,6 @@ class Nvme(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                                 "nvme smart-log /dev/%s" % dev,
                                 "nvme error-log /dev/%s" % dev,
                                 "nvme show-regs /dev/%s" % dev])
+            self.add_copy_spec(["/etc/nvme/discovery.conf"])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The file /etc/nvme/discovery.conf is used by the command
'nvme discover' to send Get Log Page requests to a
NVMe-over-Fabrics Discovery Controller. This plugin
ensures that the sosreport captures the configuration, if it
exists.

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
