### PR TITLE
Fix buildah plugin to capture the buildah version

### DIFF
--- a/sos/plugins/buildah.py
+++ b/sos/plugins/buildah.py
@@ -30,7 +30,7 @@ class Buildah(Plugin, RedHatPlugin):
         self.add_cmd_output([
             'buildah containers',
             'buildah images',
-            'buildah version'
+            'buildah --version'
         ])
 
         def make_chowdah(aurdah):


### PR DESCRIPTION
After capturing the sosreport with the buildah plugin enabled captures the `buildah version` with the below command:

$ buildah version

However, the correct invocation should be:

$ buildah --version


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
