### PR TITLE
[grub2] Enable plugin by grub2-common package also

### DIFF
--- a/sos/plugins/grub2.py
+++ b/sos/plugins/grub2.py
@@ -15,7 +15,7 @@ class Grub2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     plugin_name = 'grub2'
     profiles = ('boot',)
-    packages = ('grub2', 'grub2-efi')
+    packages = ('grub2', 'grub2-efi', 'grub2-common')
 
     def setup(self):
         self.add_copy_spec([
@@ -23,6 +23,7 @@ class Grub2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/boot/grub2/grub.cfg",
             "/boot/grub2/grubenv",
             "/boot/grub/grub.cfg",
+            "/boot/loader/entries",
             "/etc/default/grub",
             "/etc/grub2.cfg",
             "/etc/grub.d"


### PR DESCRIPTION
Newer Fedora systems, grub2 package is replaced by grub2-common
that needs to enable grub2 plugin by default as well.

Additionally, collect /boot/loader/entries with boot list entries.

Resolves: #1543

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
