### PR TITLE
[openstack_nova] Remove redundant Docker call

### DIFF
--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -33,7 +33,6 @@ class OpenStackNova(Plugin):
             "systemctl status openstack-nova-api.service"
         )
 
-        container_status = self.get_command_output("docker ps")
         in_container = self.running_in_container()
 
         if (service_status['status'] == 0) or in_container:


### PR DESCRIPTION
This call is no longer used and was missed during the clean up in
2b29530eb50ab1016937f5c28adaf4e2288e46be.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
