### PR TITLE
[policies.ibmkvm] Fix unhandled return statements reported by LGTM

### DIFF
--- a/sos/policies/ibmkvm.py
+++ b/sos/policies/ibmkvm.py
@@ -38,9 +38,9 @@ class PowerKVMPolicy(RedHatPolicy):
             with open('/etc/ibm_powerkvm-release', 'r') as fp:
                 version_string = fp.read()
                 return version_string[2][0]
-            return False
         except IOError:
-            return False
+            pass
+        return False
 
 
 class ZKVMPolicy(RedHatPolicy):
@@ -63,9 +63,9 @@ class ZKVMPolicy(RedHatPolicy):
             with open('/etc/base-release', 'r') as fp:
                 version_string = fp.read()
                 return version_string.split(' ', 4)[3][0]
-            return False
         except IOError:
-            return False
+            pass
+        return False
 
 
 # vim: set ts=4 sw=4


### PR DESCRIPTION
Two of the return statements were not reachable and the exceptions were directly
handling `return`[1]

https://lgtm.com/projects/g/sosreport/sos/rev/8cded9af8d1d75f4896699f83ae3ce289337dd6b

Signed-off-by: Sachin Patil <psachin@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
