### PR TITLE
[postgresql] Use postgres 10 scl if installed

### DIFF
--- a/sos/plugins/postgresql.py
+++ b/sos/plugins/postgresql.py
@@ -80,13 +80,24 @@ class PostgreSQL(Plugin):
 
 class RedHatPostgreSQL(PostgreSQL, SCLPlugin):
 
-    packages = ('postgresql', 'rh-postgresql95-postgresql-server', )
+    packages = (
+        'postgresql',
+        'rh-postgresql95-postgresql-server',
+        'rh-postgresql10-postgresql-server'
+    )
 
     def setup(self):
         super(RedHatPostgreSQL, self).setup()
 
-        scl = "rh-postgresql95"
         pghome = self.get_option("pghome")
+
+        scl = None
+        for pkg in self.packages[1:]:
+            # The scl name, package name, and service name all differ slightly
+            # but is at least consistent in doing so across versions, so we
+            # need to do some mangling here
+            if self.service_is_running(pkg.replace('-server', '')):
+                scl = pkg.split('-postgresql-')[0]
 
         # Copy PostgreSQL log files.
         for filename in find("*.log", pghome):
@@ -111,7 +122,7 @@ class RedHatPostgreSQL(PostgreSQL, SCLPlugin):
             )
         )
 
-        if scl in self.scls_matched:
+        if scl and scl in self.scls_matched:
             self.do_pg_dump(scl=scl, filename="pgdump-scl-%s.tar" % scl)
 
 


### PR DESCRIPTION
Updates the plugin to check for the presence of the PostgreSQL10 scl
package and if present, use that instead of the 9.5 scl.

This is primarily aimed at RHV environments as 4.3 and later use version
10.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
