### PR TITLE
[policy|plugin] Add 'is_running' check for services

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -215,9 +215,13 @@ class Plugin(object):
         '''Is the service $name disabled?'''
         return self.policy.init_system.is_disabled(name)
 
+    def service_is_running(self, name):
+        '''Is the service $name currently running?'''
+        return self.policy.init_system.is_running(name)
+
     def get_service_status(self, name):
         '''Return the reported status for service $name'''
-        return self.policy.init_system.get_service_status(name)
+        return self.policy.init_system.get_service_status(name)['status']
 
     def do_cmd_private_sub(self, cmd):
         '''Remove certificate and key output archived by sosreport. cmd


### PR DESCRIPTION
Adds a method to the InitSystem class used by policies and plugins to
check if a given service name is running. Plugins can make use of this
through the new self.service_is_running() method.

For policies that use the base InitSystem class, this method will always
return True as the service_is_running() method is likely to be used when
determining if we should run commands or not, and we do not want to
incorrectly stop running those commands where they would collect
meaningful output today.

The SystemD init system for policies properly checks to see if the given
service is active or not when reporting is the service is running.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
