### PR TITLE
[services] Don't collect chkconfig on RHEL 7 or newer

### DIFF
--- a/sos/plugins/services.py
+++ b/sos/plugins/services.py
@@ -36,7 +36,9 @@ class RedHatServices(Services, RedHatPlugin):
 
     def setup(self):
         super(RedHatServices, self).setup()
-        self.add_cmd_output("/sbin/chkconfig --list", root_symlink="chkconfig")
+        if self.policy.dist_version() <= 6:
+            self.add_cmd_output("/sbin/chkconfig --list",
+                                root_symlink="chkconfig")
 
 
 class DebianServices(Services, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
RHEL 7 and newer do not use chkconfig any more, so we should not pollute
the archive root with a chkconfig call on those systems.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
