### PR TITLE
[docker] Don't run docker commands when the service is not running

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -33,6 +33,14 @@ class Docker(Plugin):
             "/var/lib/docker/repositories-*"
         ])
 
+        self.add_journal(units="docker")
+        self.add_cmd_output("ls -alhR /etc/docker")
+
+        if not self.service_is_running('docker'):
+            # if docker is not running none of the below commands will provide
+            # any useful output
+            return
+
         subcmds = [
             'events --since 24h --until 1s',
             'info',
@@ -52,9 +60,6 @@ class Docker(Plugin):
         # separately grab ps -s as this can take a *very* long time
         if self.get_option('size'):
             self.add_cmd_output('docker ps -as')
-
-        self.add_journal(units="docker")
-        self.add_cmd_output("ls -alhR /etc/docker")
 
         nets = self.get_command_output('docker network ls')
 


### PR DESCRIPTION
Prevents the docker plugin from running docker commands when the service
is not running. This will prevent us from collecting the same 'docker is
not running' error message over and over again from the docker commands
that would otherwise get run.

Note this depends on #1567 

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
