### PR TITLE
[policies] Fix setting the custom name_pattern

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -495,6 +495,7 @@ No changes will be made to system configuration.
         name = self.get_local_name().split('.')[0]
         case = self.case_id
         label = self.commons['cmdlineopts'].label
+        date = ''
         rand = ''.join(random.choice(string.ascii_lowercase) for x in range(7))
 
         if self.name_pattern == 'legacy':


### PR DESCRIPTION
Added initialization of date variable, so that it's possible to set the
custom name_pattern.

Without the fix, if the name_pattern is set in the plugin to be something
else than 'legacy' or 'friendly', the report generation will fail to
error

UnboundLocalError: local variable 'date' referenced before assignment

Signed-off-by: Ville Heikkinen <ville.heikkinen@nokia.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
