### PR TITLE
[composer] Collect sources info for all sources

### DIFF
--- a/sos/plugins/composer.py
+++ b/sos/plugins/composer.py
@@ -10,14 +10,14 @@ class Composer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     packages = ('composer-cli',)
 
-    def _get_blueprints(self):
-        blueprints = []
-        bp_file = self.get_cmd_output_now("composer-cli blueprints list")
-        if bp_file:
-            with open(bp_file, "r") as bps:
-                for line in bps.read().splitlines():
-                    blueprints.append(line)
-        return blueprints
+    def _get_entries(self, cmd):
+        entries = []
+        ent_file = self.get_cmd_output_now(cmd)
+        if ent_file:
+            with open(ent_file, "r") as ents:
+                for line in ents.read().splitlines():
+                    entries.append(line)
+        return entries
 
     def setup(self):
         self.add_copy_spec([
@@ -27,10 +27,12 @@ class Composer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/var/log/lorax-composer/program.log",
             "/var/log/lorax-composer/server.log",
         ])
-        blueprints = self._get_blueprints()
+        blueprints = self._get_entries("composer-cli blueprints list")
         for blueprint in blueprints:
             self.add_cmd_output("composer-cli blueprints show %s" % blueprint)
 
-        self.add_cmd_output("composer-cli sources list")
+        sources = self._get_entries("composer-cli sources list")
+        for src in sources:
+            self.add_cmd_output("composer-cli sources info %s" % src)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of info on each source found by composer-cli. The
_get_blueprints() method has been made more generic to accommodate both
blueprints and sources.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
