### PR TITLE
[apache] Collect config summary via apachectl -S

### DIFF
--- a/sos/plugins/apache.py
+++ b/sos/plugins/apache.py
@@ -23,7 +23,10 @@ class Apache(Plugin):
 
     def setup(self):
         # collect list of installed modules
-        self.add_cmd_output(["apachectl -M"])
+        self.add_cmd_output([
+            "apachectl -M",
+            "apachectl -S"
+        ])
 
 
 class RedHatApache(Apache, RedHatPlugin):


### PR DESCRIPTION
Adds collection of apachectl -S for quick config summary data

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
