### PR TITLE
[memory] Add lsmem collection

### DIFF
--- a/sos/plugins/memory.py
+++ b/sos/plugins/memory.py
@@ -32,7 +32,8 @@ class Memory(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "free -m",
             "swapon --bytes --show",
-            "swapon --summary --verbose"
+            "swapon --summary --verbose",
+            "lsmem -a -o RANGE,SIZE,STATE,REMOVABLE,ZONES,NODE,BLOCK"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of lsmem output for all memory blocks to the memory
plugin.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
