### PR TITLE
[rasdaemon] Add new plugin

### DIFF
--- a/sos/plugins/rasdaemon.py
+++ b/sos/plugins/rasdaemon.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2019 Red Hat, Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class Rasdaemon(Plugin, RedHatPlugin):
+    '''rasdaemon kernel trace event monitor
+    '''
+
+    plugin_name = 'rasdaemon'
+    packages = ('rasdaemon', )
+    services = ('rasdaemon', )
+
+    def setup(self):
+        subcmds = [
+            '--errors',
+            '--guess-labels',
+            '--layout',
+            '--mainboard',
+            '--print-labels',
+            '--status',
+            '--summary'
+        ]
+        self.add_cmd_output(["ras-mc-ctl %s" % sub for sub in subcmds])
+        self.add_journal('rasdaemon')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a new plugin for rasdaemon - a monitor for platform Reliability,
Availability, and Serviceability (RAS) reports.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
