### PR TITLE
[nvme] Adjust per-device command collection

### DIFF
--- a/sos/plugins/nvme.py
+++ b/sos/plugins/nvme.py
@@ -21,17 +21,23 @@ class Nvme(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         return [dev for dev in sys_block if dev.startswith('nvme')]
 
     def setup(self):
+        self.add_cmd_output([
+            "nvme list",
+            "nvme list-subsys",
+        ])
         for dev in self.get_nvme_devices():
             # runs nvme-cli commands
             self.add_cmd_output([
-                                "nvme list",
-                                "nvme list-ns /dev/%s" % dev,
-                                "nvme fw-log /dev/%s" % dev,
-                                "nvme list-ctrl /dev/%s" % dev,
-                                "nvme id-ctrl -H /dev/%s" % dev,
-                                "nvme id-ns -H /dev/%s" % dev,
-                                "nvme smart-log /dev/%s" % dev,
-                                "nvme error-log /dev/%s" % dev,
-                                "nvme show-regs /dev/%s" % dev])
+                "smartctl --all /dev/%s" % dev,
+                "nvme list-ns /dev/%s" % dev,
+                "nvme fw-log /dev/%s" % dev,
+                "nvme list-ctrl /dev/%s" % dev,
+                "nvme id-ctrl -H /dev/%s" % dev,
+                "nvme id-ns -H /dev/%s" % dev,
+                "nvme smart-log /dev/%s" % dev,
+                "nvme error-log /dev/%s" % dev,
+                "nvme show-regs /dev/%s" % dev,
+                "nvme get-ns-id /dev/%s" % dev
+            ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Removes 'nvme list' from repeated collection, instead only capturing it
once and further collection 'nvme list-subsys'.

Additionally adds per-device collection of smartctl output for further
SMART information than what is provided by smart-log, and get-ns-id.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
