### PR TITLE
[mysql] Collect galera cluster node state

### DIFF
--- a/sos/plugins/mysql.py
+++ b/sos/plugins/mysql.py
@@ -36,6 +36,7 @@ class Mysql(Plugin):
             "/var/log/mysql/mysqld.log",
             "/var/log/containers/mysql/mysqld.log",
             "/var/log/mariadb/mariadb.log",
+            "/var/lib/mysql/grastate.dat"
         ])
 
         if self.get_option("all_logs"):


### PR DESCRIPTION
This patch collects the galera mysql node state
stored in the following file:

/var/lib/mysql/grastate.dat

It contains details of the galera node like version,
uuid, seqno, and current value in that node of
safe_to_bootstrap. The idea is that for a galera
mysql cluster, we'll get this status file from
each node in the sosreport, and we'll have a fuller
picture of the issue.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
