### PR TITLE
[buildah] Collect --all separately for containers and images

### DIFF
--- a/sos/plugins/buildah.py
+++ b/sos/plugins/buildah.py
@@ -27,11 +27,15 @@ class Buildah(Plugin, RedHatPlugin):
             "/etc/containers/policy.json",
         ])
 
-        self.add_cmd_output([
-            'buildah containers',
-            'buildah images',
-            'buildah version'
-        ])
+        subcmds = [
+            'containers',
+            'containers --all',
+            'images',
+            'images --all',
+            'version'
+        ]
+
+        self.add_cmd_output(["buildah %s" % sub for sub in subcmds])
 
         def make_chowdah(aurdah):
             chowdah = self.get_command_output(aurdah)
@@ -43,8 +47,8 @@ class Buildah(Plugin, RedHatPlugin):
         if containahs['is_wicked_pissah']:
             for containah in containahs['auutput'].splitlines():
                 # obligatory Tom Brady
-                brady = containah.split()[4]
-                self.add_cmd_output('buildah inspect -t container %s' % brady)
+                goat = containah.split()[4]
+                self.add_cmd_output('buildah inspect -t container %s' % goat)
 
         pitchez = make_chowdah('buildah images -n')
         if pitchez['is_wicked_pissah']:


### PR DESCRIPTION
Adds a separate collections of --all for both the containers and images
lists.

Also, small fix to rename a variable to avoid using the same variable
name twice.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
