### PR TITLE
[juju] Support for Juju version 2

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -337,6 +337,7 @@ class Plugin(object):
         if not hasattr(pathexp, "match"):
             pathexp = re.compile(pathexp)
         match = pathexp.match
+        self.log_error("Nick " + self.copied_files)
         file_list = [f for f in self.copied_files if match(f['srcpath'])]
         for file in file_list:
             self.do_file_sub(file['srcpath'], regexp, subst)

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -337,7 +337,6 @@ class Plugin(object):
         if not hasattr(pathexp, "match"):
             pathexp = re.compile(pathexp)
         match = pathexp.match
-        self.log_error("Nick " + self.copied_files)
         file_list = [f for f in self.copied_files if match(f['srcpath'])]
         for file in file_list:
             self.do_file_sub(file['srcpath'], regexp, subst)

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -40,11 +40,11 @@ class Juju(Plugin, UbuntuPlugin):
             for appname, appinfo in statusinfo["applications"].items():
                 # Get the application config for every application in every
                 # model
-                cmd = "sudo -i -u {} juju config --format yaml -m {} {}".format(
-                    username, modelname, appname
+                self.add_cmd_output(
+                    "sudo -i -u {} juju config --format yaml -m {} {}".format(
+                        username, modelname, appname
+                    )
                 )
-                self.add_cmd_output(cmd)
-                self.juju_config_cmds.append(cmd)
 
     # Get some information pertaining to each model
     def collect_model_output(self, username, modelsfilepath):
@@ -103,16 +103,12 @@ class Juju(Plugin, UbuntuPlugin):
         for cmd in juju_cmds:
             # The file names can be long and confusing from the juju commands,
             # clean them up and give them an approriate extension if possible
-            sudocmd = "sudo -i -u {} {}".format(username, cmd)
-            self.add_cmd_output(sudocmd)
-            self.juju_controller_cmds.append(sudocmd)
+            self.add_cmd_output("sudo -i -u {} {}".format(username, cmd))
 
     def setup(self):
         # Make sure it looks like juju is configured before continuing
         username = self.get_option("juju-user")
         homedir = os.path.expanduser("~" + username)
-        self.juju_config_cmds = []
-        self.juju_controller_cmds = []
 
         if os.path.exists(homedir + "/.local/share/juju"):
             self.collect_juju_output(username)

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -146,10 +146,10 @@ class Juju(Plugin, UbuntuPlugin):
         certs_sub_regex = r"\1*********"
 
         self.do_cmd_output_sub(
-            r".*juju_config.*yaml.*", juju_config_regex, juju_config_sub_regex
+            "*juju_config*yaml*", juju_config_regex, juju_config_sub_regex
         )
         self.do_cmd_output_sub(
-            r".*juju.*controller.*yaml.*", certs_regex, certs_sub_regex
+            "*juju*controller*yaml", certs_regex, certs_sub_regex
         )
 
     # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -149,12 +149,12 @@ class Juju(Plugin, UbuntuPlugin):
         output_dir = self.get_cmd_output_path(make=False)
 
         self.do_path_regex_sub(
-            output_dir + "/*juju_config*yaml*",
+            output_dir + "/.*juju_config.*yaml.*",
             juju_config_regex,
             juju_config_sub_regex,
         )
         self.do_path_regex_sub(
-            output_dir + "/*juju*controller*yaml*", certs_regex, certs_sub_regex
+            output_dir + "/.*juju.*controller.*yaml.*", certs_regex, certs_sub_regex
         )
         # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")
         # juju_cert_files = glob.glob(output_dir + "/juju*controller*.yaml")

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -149,12 +149,12 @@ class Juju(Plugin, UbuntuPlugin):
         output_dir = self.get_cmd_output_path(make=False)
 
         self.do_path_regex_sub(
-            output_dir + "/juju_config*.yaml",
+            output_dir + "/*juju_config*yaml*",
             juju_config_regex,
             juju_config_sub_regex,
         )
         self.do_path_regex_sub(
-            output_dir + "/juju*controller*.yaml", certs_regex, certs_sub_regex
+            output_dir + "/*juju*controller*yaml*", certs_regex, certs_sub_regex
         )
         # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")
         # juju_cert_files = glob.glob(output_dir + "/juju*controller*.yaml")

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -146,10 +146,10 @@ class Juju(Plugin, UbuntuPlugin):
         certs_sub_regex = r"\1*********"
 
         self.do_cmd_output_sub(
-            self.juju_config_cmds, juju_config_regex, juju_config_sub_regex
+            r".*juju_config.*yaml.*", juju_config_regex, juju_config_sub_regex
         )
         self.do_cmd_output_sub(
-            self.juju_controller_cmds, certs_regex, certs_sub_regex
+            r".*juju.*controller.*yaml.*", certs_regex, certs_sub_regex
         )
 
     # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -105,7 +105,7 @@ class Juju(Plugin, UbuntuPlugin):
             # clean them up and give them an approriate extension if possible
             sudocmd = "sudo -i -u {} {}".format(username, cmd)
             self.add_cmd_output(sudocmd)
-            self.juju_controller_cmds.app(sudocmd)
+            self.juju_controller_cmds.append(sudocmd)
 
     def setup(self):
         # Make sure it looks like juju is configured before continuing

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -30,26 +30,6 @@ class Juju(Plugin, UbuntuPlugin):
     # Get the configuration of each application deployed in a model
     def collect_app_config(self, username, modelname, statusfilespath):
         statusinfo = {}
-        # Juju config parameter values to sanitize in the output yaml
-        juju_config_keys = [
-            "password",
-            "credentials",
-            "client_password",
-            "endpoint-tls-ca",
-            "docker-logins",
-            "license-key",
-            "registry-credentials",
-        ]
-
-        # Handle the case where the key and value are on seperate lines
-        # in a juju config yaml file
-        juju_config_regex = (
-            r"(?m)^(\s*)(((%s):((\n\1\s+.*)|\n)+)\1\s+value:\s*).*"
-            % "|".join(juju_config_keys)
-        )
-
-        juju_config_subst = r"\1\2*********"
-
         try:
             fp = open(statusfilespath, "r")
             statusinfo = json_loads(fp.read())
@@ -64,9 +44,7 @@ class Juju(Plugin, UbuntuPlugin):
                     username, modelname, appname
                 )
                 self.add_cmd_output(cmd)
-                self.do_cmd_output_sub(
-                    cmd, juju_config_regex, juju_config_subst
-                )
+                self.juju_config_cmds.append(cmd)
 
     # Get some information pertaining to each model
     def collect_model_output(self, username, modelsfilepath):
@@ -114,17 +92,6 @@ class Juju(Plugin, UbuntuPlugin):
             "juju show-controller --format yaml",
         ]
 
-        # Certificates to sanitize in command output
-        juju_config_certs = ["ca-cert"]
-
-        # Will match and replace a certificat in a yaml file
-        certs_regex = (
-            r"((?m)^\s*(%s)\s*:\s*)(\|\s*\n\s+-+BEGIN (.*)"
-            r"-+\s(\s+\S+\n)+\s+-+END )\4(-+)" % "|".join(juju_config_certs)
-        )
-
-        certs_sub_regex = r"\1*********"
-
         # Get the model information as json so we can dig deeper
         models = self.get_cmd_output_now(
             "sudo -i -u {} juju models --format json".format(username)
@@ -138,85 +105,83 @@ class Juju(Plugin, UbuntuPlugin):
             # clean them up and give them an approriate extension if possible
             sudocmd = "sudo -i -u {} {}".format(username, cmd)
             self.add_cmd_output(sudocmd)
-            self.do_cmd_output_sub(sudocmd, certs_regex, certs_sub_regex)
+            self.juju_controller_cmds.app(sudocmd)
 
     def setup(self):
         # Make sure it looks like juju is configured before continuing
         username = self.get_option("juju-user")
         homedir = os.path.expanduser("~" + username)
+        self.juju_config_cmds = []
+        self.juju_controller_cmds = []
+
         if os.path.exists(homedir + "/.local/share/juju"):
             self.collect_juju_output(username)
 
-    # def postproc(self):
-    #     juju_config_keys = [
-    #         "password",
-    #         "credentials",
-    #         "client_password",
-    #         "endpoint-tls-ca",
-    #         "docker-logins",
-    #         "license-key",
-    #         "registry-credentials",
-    #     ]
+    def postproc(self):
+        juju_config_keys = [
+            "password",
+            "credentials",
+            "client_password",
+            "endpoint-tls-ca",
+            "docker-logins",
+            "license-key",
+            "registry-credentials",
+        ]
 
-    #     juju_config_certs = ["ca-cert"]
+        juju_config_certs = ["ca-cert"]
 
-    #     # Handle the case where the key and value are on seperate lines
-    #     # in a juju config yaml file
-    #     juju_config_regex = (
-    #         r"(?m)^(\s*)(((%s):((\n\1\s+.*)|\n)+)\1\s+value:\s*).*"
-    #         % "|".join(juju_config_keys)
-    #     )
-    #     juju_config_sub_regex = r"\1\2*********"
+        # Handle the case where the key and value are on seperate lines
+        # in a juju config yaml file
+        juju_config_regex = (
+            r"(?m)^(\s*)(((%s):((\n\1\s+.*)|\n)+)\1\s+value:\s*).*"
+            % "|".join(juju_config_keys)
+        )
+        juju_config_sub_regex = r"\1\2*********"
 
-    #     # Will match and replace a certificat in a yaml file
-    #     certs_regex = (
-    #         r"((?m)^\s*(%s)\s*:\s*)(\|\s*\n\s+-+BEGIN (.*)"
-    #         r"-+\s(\s+\S+\n)+\s+-+END )\4(-+)" % "|".join(juju_config_certs)
-    #     )
-    #     certs_sub_regex = r"\1*********"
+        # Will match and replace a certificat in a yaml file
+        certs_regex = (
+            r"((?m)^\s*(%s)\s*:\s*)(\|\s*\n\s+-+BEGIN (.*)"
+            r"-+\s(\s+\S+\n)+\s+-+END )\4(-+)" % "|".join(juju_config_certs)
+        )
+        certs_sub_regex = r"\1*********"
 
-    #     juju_username = self.get_option("juju-user")
+        self.do_cmd_output_sub(
+            self.juju_config_cmds, juju_config_regex, juju_config_sub_regex
+        )
+        self.do_cmd_output_sub(
+            self.juju_controller_cmds, certs_regex, certs_sub_regex
+        )
 
-    #     self.do_cmd_output_sub(
-    #         output_dir + "/.*juju_config.*yaml.*",
-    #         juju_config_regex,
-    #         juju_config_sub_regex,
-    #     )
-    #     self.do_cmd_output_sub(
-    #         output_dir + "/.*juju.*controller.*yaml.*",
-    #         certs_regex,
-    #         certs_sub_regex,
-    #     )
-        # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")
-        # juju_cert_files = glob.glob(output_dir + "/juju*controller*.yaml")
+    # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")
+    # juju_cert_files = glob.glob(output_dir + "/juju*controller*.yaml")
 
-        # for file in juju_config_files:
-        #     try:
-        #         fp = open(file, "r")
-        #         result, replacements = re.subn(
-        #             juju_config_regex, juju_config_sub_regex, fp.read()
-        #         )
-        #         fp.close()
-        #         fp = open(file, "w")
-        #         fp.write(result)
-        #         fp.close()
-        #     except Exception as e:
-        #         msg = "regex substitution failed for '%s' with: '%s'"
-        #         self.log_error(msg % (file, e))
+    # for file in juju_config_files:
+    #     try:
+    #         fp = open(file, "r")
+    #         result, replacements = re.subn(
+    #             juju_config_regex, juju_config_sub_regex, fp.read()
+    #         )
+    #         fp.close()
+    #         fp = open(file, "w")
+    #         fp.write(result)
+    #         fp.close()
+    #     except Exception as e:
+    #         msg = "regex substitution failed for '%s' with: '%s'"
+    #         self.log_error(msg % (file, e))
 
-        # for file in juju_cert_files:
-        #     try:
-        #         fp = open(file, "r")
-        #         result, replacements = re.subn(
-        #             certs_regex, certs_sub_regex, fp.read()
-        #         )
-        #         fp.close()
-        #         fp = open(file, "w")
-        #         fp.write(result)
-        #         fp.close()
-        #     except Exception as e:
-        #         msg = "regex substitution failed for '%s' with: '%s'"
-        #         self.log_error(msg % (file, e))
+    # for file in juju_cert_files:
+    #     try:
+    #         fp = open(file, "r")
+    #         result, replacements = re.subn(
+    #             certs_regex, certs_sub_regex, fp.read()
+    #         )
+    #         fp.close()
+    #         fp = open(file, "w")
+    #         fp.write(result)
+    #         fp.close()
+    #     except Exception as e:
+    #         msg = "regex substitution failed for '%s' with: '%s'"
+    #         self.log_error(msg % (file, e))
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -136,20 +136,20 @@ class Juju(Plugin, UbuntuPlugin):
             r"(?m)^(\s*)(((%s):((\n\1\s+.*)|\n)+)\1\s+value:\s*).*"
             % "|".join(juju_config_keys)
         )
-        juju_config_sub_regex = r"\1\2*********"
+        juju_config_subst = r"\1\2*********"
 
         # Will match and replace a certificat in a yaml file
         certs_regex = (
             r"((?m)^\s*(%s)\s*:\s*)(\|\s*\n\s+-+BEGIN (.*)"
             r"-+\s(\s+\S+\n)+\s+-+END )\4(-+)" % "|".join(juju_config_certs)
         )
-        certs_sub_regex = r"\1*********"
+        certs_subst = r"\1*********"
 
         self.do_cmd_output_sub(
-            "*juju_config*yaml*", juju_config_regex, juju_config_sub_regex
+            "*juju*config*yaml*", juju_config_regex, juju_config_subst
         )
         self.do_cmd_output_sub(
-            "*juju*controller*yaml", certs_regex, certs_sub_regex
+            "*juju*controller*yaml", certs_regex, certs_subst
         )
 
     # juju_config_files = glob.glob(output_dir + "/juju_config*.yaml")

--- a/sos/plugins/juju_controller.py
+++ b/sos/plugins/juju_controller.py
@@ -1,0 +1,193 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+# Copyright (C) 2019 Nick Niehoff <nick.niehoff@canonical.com>
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import re
+import os
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+# A Juju Controller is a juju machine so this plugin assumes the juju_machine
+# plugin will be executed to collect that information
+class JujuController(Plugin, UbuntuPlugin):
+    """ Juju orchestration tool - Controller
+    """
+
+    plugin_name = "juju_controller"
+    profiles = ("virt", "sysmgmt")
+
+    # Use files instead of packages here because there is no package installed
+    #  on a juju controller that uniquely identifies it:
+    files = "/var/lib/juju/db"
+
+    option_list = [
+        (
+            "export-mongodb",
+            "Export mongodb collections as json files",
+            "",
+            False,
+        )
+    ]
+
+    def export_mongodb(self, machineid, dbpass):
+        collections = [
+            "actionnotifications",
+            "actions",
+            "annotations",
+            "applicationOfferConnections",
+            "applicationOffers",
+            "applications",
+            "bakeryStorageItems",
+            "blockdevices",
+            "charms",
+            "cleanups",
+            "cloudCredentials",
+            "cloudimagemetadata",
+            "clouds",
+            "constraints",
+            "containerRefs",
+            "controllers",
+            "controllerusers",
+            "deviceConstraints",
+            "endpointbindings",
+            "filesystems",
+            "generations",
+            "globalRefcounts",
+            "globalSettings",
+            "instanceData",
+            "ip.addresses",
+            "leaseholders",
+            "leases",
+            "linklayerdevices",
+            "linklayerdevicesrefs",
+            "machineUpgradeSeriesLocks",
+            "machineremovals",
+            "machines",
+            "managedStoredResources",
+            "meterStatus",
+            "metricsmanager",
+            "migrations",
+            "modelEntityRefs",
+            "modelUserLastConnection",
+            "models",
+            "modelusers",
+            "openedPorts",
+            "payloads",
+            "permissions",
+            "providerIDs",
+            "refcounts",
+            "relationNetworks",
+            "relations",
+            "relationscopes",
+            "remoteEntities",
+            "resources",
+            "sequence",
+            "settings",
+            "sshhostkeys",
+            "statuses",
+            "storageattachments",
+            "storageconstraints",
+            "storageinstances",
+            "storedResources",
+            "subnets",
+            "toolsmetadata",
+            "txns.prune",
+            "txns.stash",
+            "units",
+            "userLastLogin",
+            "usermodelname",
+            "users",
+            "volumes",
+        ]
+        # We don't collect txns.log, statuseshistory, metrics, txns due to size
+
+        for collection in collections:
+            filename = "mongoexport_collection_{}.json".format(collection)
+            # This will execute a mongoexport command, note it will add the
+            # password to the sos log
+            mongocmd = (
+                "mongoexport --host 127.0.0.1 --port 37017 --db juju "
+                + "--authenticationDatabase admin --ssl "
+                + "--sslAllowInvalidCertificates --username '{}' --password "
+                + "'{}' --collection {} --jsonArray"
+            )
+            self.add_cmd_output(
+                mongocmd.format(machineid, dbpass, collection),
+                suggest_filename=filename,
+            )
+
+    def get_machine_id(self):
+        # get the juju machine name machine-X
+        for dirpath, dirnames, filenames in os.walk("/var/lib/juju/agents"):
+            for dirname in dirnames:
+                match = re.match(r"(machine-\d+)", dirname)
+                if match:
+                    return match.group(1)
+        return None
+
+    def get_jujudb_pass(self, machineid):
+        # Get agent config and figure out password
+        try:
+            fp = open("/var/lib/juju/agents/" + machineid + "/agent.conf", "r")
+            filecontents = fp.read()
+            fp.close()
+        except Exception:
+            return None
+        for line in iter(filecontents.splitlines()):
+            match = re.match(r"^statepassword: (\S+)", line)
+            if match:
+                return match.group(1)
+        return None
+
+    def add_query(self, machineid, dbpass, queryname, query):
+        # Run a command for a single query
+        filename = "mongo_{}.json".format(queryname)
+        # This will execute a mongo command, note it will add the password to
+        # the sos log
+        mongocmd = (
+            "mongo 127.0.0.1:37017/juju --authenticationDatabase admin"
+            + " --ssl --sslAllowInvalidCertificates --quiet --username '{}' "
+            + "--password '{}' --eval '{}'"
+        )
+        self.add_cmd_output(
+            mongocmd.format(machineid, dbpass, query),
+            suggest_filename=filename,
+        )
+
+    def setup(self):
+        self.add_copy_spec("/etc/default/mongodb")
+        self.add_copy_spec("/var/lib/juju/bootstrap-params")
+        self.add_copy_spec("/lib/systemd/system/juju-db/juju-db.service")
+
+        # The key is the queryname to be used as the file name instead of the
+        # entire query
+        mongo_db_queries = {
+            "rs.status": "JSON.stringify(rs.status());",
+            "db.serverStatus": "JSON.stringify(db.serverStatus());",
+            "db.stats": "JSON.stringify(db.stats());",
+            "getCollectionInfos": "JSON.stringify(db.getCollectionInfos());",
+            "collections.stats": "stats = new Array(); "
+            + "db.getCollectionNames().forEach(function(coll) { "
+            + "var c = db.getCollection(coll); "
+            + "stats.push(JSON.stringify(c.stats())); "
+            + "}); "
+            + 'print("["); print(stats.join(",")); print("]")',
+        }
+
+        machineid = self.get_machine_id()
+        dbpass = self.get_jujudb_pass(machineid)
+
+        # If we got the password we can run some queries and export if needed
+        if dbpass:
+            for queryname, query in mongo_db_queries.items():
+                self.add_query(machineid, dbpass, queryname, query)
+            if self.get_option("export-mongodb"):
+                self.export_mongodb(machineid, dbpass)
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/juju_machine.py
+++ b/sos/plugins/juju_machine.py
@@ -1,0 +1,91 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+# Copyright (C) 2019 Nick Niehoff <nick.niehoff@canonical.com>
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+import re
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+class JujuMachine(Plugin, UbuntuPlugin):
+    """ Juju orchestration tool - Machine
+    """
+
+    plugin_name = "juju_machine"
+    profiles = ("virt", "sysmgmt")
+
+    # Using files instead of packages here because there is no identifying
+    # package on a juju machine
+    files = ("/var/log/juju", "/usr/bin/juju-run")
+
+    def setup(self):
+        # Get juju services, they are uniquely named based on the deployment
+        # so we need to parse what their names are:
+        cmd = "systemctl --no-pager --all --no-legend list-units juju\\*"
+        juju_systemctl_output = self.call_ext_prog(cmd)["output"]
+        for line in iter(juju_systemctl_output.splitlines()):
+            match = re.match(r"^(juju\S+)\s.*", line)
+            if match:
+                self.add_journal(units=str(match.group(1)))
+
+        # Get agent configs for each agent
+        for dirpath, dirnames, filenames in os.walk("/var/lib/juju/agents"):
+            for dirname in dirnames:
+                self.add_copy_spec(
+                    "/var/lib/juju/agents/" + dirname + "/agent.conf"
+                )
+
+        self.add_cmd_output("ls -alRh /var/log/juju*")
+        self.add_cmd_output("ls -alRh /var/lib/juju*")
+        if self.get_option("all_logs"):
+            # /var/lib/juju used to be in the default capture moving here
+            # because it usually was way to big.  However, in most cases you
+            # want all logs you want this too.
+            self.add_copy_spec(["/var/log/juju", "/var/lib/juju"])
+        else:
+            # We need this because we want to collect to the limit of all
+            # *.logs in the directory.
+            if os.path.isdir("/var/log/juju/"):
+                for filename in os.listdir("/var/log/juju/"):
+                    if filename.endswith(".log"):
+                        fullname = os.path.join("/var/log/juju/" + filename)
+                        self.add_copy_spec(fullname)
+
+    def apply_regex_sub(self, regexp, subst):
+        self.do_path_regex_sub("/var/lib/juju/agents/*", regexp, subst)
+
+    def postproc(self):
+        protect_keys = [
+            "sharedsecret",
+            "apipassword",
+            "oldpassword",
+            "statepassword",
+        ]
+
+        protect_certs = [
+            "systemidentity",
+            "caprivatekey",
+            "controllerkey",
+            "controllercert",
+            "cacert",
+        ]
+
+        # Replace simple yamle sytle "key: value"
+        keys_regex = r"((?m)^\s*(%s)\s*:\s*)(.*)" % "|".join(protect_keys)
+        # Will match and replace a yaml multiline string that is a certificate
+        certs_regex = (
+            r"((?m)^\s*(%s)\s*:\s*)(\|\s*\n\s+-+BEGIN (.*)"
+            r"-+\s(\s+\S+\n)+\s+-+END )\4(-+)" % "|".join(protect_certs)
+        )
+        sub_regex = r"\1*********"
+
+        self.apply_regex_sub(keys_regex, sub_regex)
+        self.apply_regex_sub(certs_regex, sub_regex)
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/juju_machine.py
+++ b/sos/plugins/juju_machine.py
@@ -40,8 +40,11 @@ class JujuMachine(Plugin, UbuntuPlugin):
                     "/var/lib/juju/agents/" + dirname + "/agent.conf"
                 )
 
-        self.add_cmd_output("ls -alRh /var/log/juju*")
-        self.add_cmd_output("ls -alRh /var/lib/juju*")
+        # Get a directory listing of /var/log/juju and /var/lib/juju
+        self.add_cmd_output(
+            ["ls -alRh /var/log/juju*", "ls -alRh /var/lib/juju*"]
+        )
+
         if self.get_option("all_logs"):
             # /var/lib/juju used to be in the default capture moving here
             # because it usually was way to big.  However, in most cases you
@@ -50,16 +53,10 @@ class JujuMachine(Plugin, UbuntuPlugin):
         else:
             # We need this because we want to collect to the limit of all
             # *.logs in the directory.
-            if os.path.isdir("/var/log/juju/"):
-                for filename in os.listdir("/var/log/juju/"):
-                    if filename.endswith(".log"):
-                        fullname = os.path.join("/var/log/juju/" + filename)
-                        self.add_copy_spec(fullname)
-
-    def apply_regex_sub(self, regexp, subst):
-        self.do_path_regex_sub("/var/lib/juju/agents/*", regexp, subst)
+            self.add_copy_spec("/var/log/juju/*.log")
 
     def postproc(self):
+        agents_path = "/var/lib/juju/agents/*"
         protect_keys = [
             "sharedsecret",
             "apipassword",
@@ -84,8 +81,8 @@ class JujuMachine(Plugin, UbuntuPlugin):
         )
         sub_regex = r"\1*********"
 
-        self.apply_regex_sub(keys_regex, sub_regex)
-        self.apply_regex_sub(certs_regex, sub_regex)
+        self.do_path_regex_sub(agents_path, keys_regex, sub_regex)
+        self.do_path_regex_sub(agents_path, certs_regex, sub_regex)
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -14,7 +14,7 @@ class DebianPolicy(LinuxPolicy):
     _debv_filter = ""
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
-           + ":/usr/local/sbin:/usr/local/bin"
+        + ":/usr/local/sbin:/usr/local/bin:/snap/bin"
 
     def __init__(self, sysroot=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot)


### PR DESCRIPTION
Adding support for Juju 2.x.  This plugin needed some cleanup.  There are 3
use cases for the juju plugin: the juju client, a juju deployed machine, and
a juju controller.  I have broken the plugin into 3 parts to reflect this.

The juju plugin is now specifically for the juju client use case.  Juju is
typically installed as a snap or a package, therefore I added /snap/bin to the
path for Debian to handle this until a better method for handling snaps is
figured out.  Juju is configured as a user to communicate with the controller
it is therefore necessary to run the juju commands with sudo for them to
execute properly.  This plugin now collects as much information about the juju
environment as possible by using the juju command, this information includes
the configured clouds, models, spaces, model configs, status of each model,
and configuration of each app in each model.

The juju_machine plugin is for the machines deployed by juju use case.  This
plugin handles config, log and journal collection for a juju machine.  There
is no package installed to indicate it is a juju machine, so this plugin is
activated by the presence of /var/log/juju.

The juju_controller plugin is for the juju controller use case.  A juju
controller is a juju machine so the machine plugin should handle the
collection of logs from that aspect.  The only identifying piece of
information that this is a juju controller is the /var/lib/juju/db directory
and really juju is just a mongodb server.  This plugin instruments some mongo
queries to get the status of that database.

Signed-off-by: Nick Niehoff nick.niehoff@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
