### PR TITLE
[dbus] Collect busctl output

### DIFF
--- a/sos/plugins/dbus.py
+++ b/sos/plugins/dbus.py
@@ -22,5 +22,9 @@ class Dbus(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/var/lib/dbus/machine-id"
         ])
 
+        self.add_cmd_output([
+            "busctl list --no-pager",
+            "busctl status"
+        ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of busctl list and status.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
