### PR TITLE
[nfs-ganesha] Update nfs-ganesha service log locations

### DIFF
--- a/sos/plugins/nfsganesha.py
+++ b/sos/plugins/nfsganesha.py
@@ -21,8 +21,7 @@ class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/ganesha",
             "/etc/sysconfig/ganesha",
             "/var/run/sysconfig/ganesha",
-            "/var/log/ganesha.log",
-            "/var/log/ganesha-gfapi.log"
+            "/var/log/ganesha/*.log"
         ])
 
         self.add_cmd_output([


### PR DESCRIPTION
nfs-ganesha service logs are now located at "/var/log/ganesha/"
directory by default. Updating the same in sos plugin.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
