### PR TITLE
[systemd] avoid collecting /dev/null

### DIFF
--- a/sos/plugins/systemd.py
+++ b/sos/plugins/systemd.py
@@ -71,5 +71,6 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/etc/modules-load.d/*.conf",
             "/etc/yum/protected.d/systemd.conf"
         ])
+        self.add_forbidden_path('/dev/null')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Avoid "collecting" /dev/null as part of the systemd plugin.

In my testing that was the only plugin that brought it in.

Creating these character devices makes it harder to manage
(delete) extracted sosreports without more permissions.

This supersedes #1469 which removed the ability to "collect"
char devices.  As we only have one example today, let's just
exclude that.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
