### PR TITLE
[openstack_neutron] skip collecting /var/lib/neutron/lock

### DIFF
--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -41,7 +41,12 @@ class OpenStackNeutron(Plugin):
             self.var_puppet_gen + "/etc/default/neutron-server",
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
         ])
+        # copy whole /var/lib/neutron except for potentially huge lock subdir;
+        # rather take a list of files in the dir only
         self.add_copy_spec("/var/lib/neutron/")
+        self.add_forbidden_path("/var/lib/neutron/lock")
+        self.add_cmd_option("ls -laZR /var/lib/neutron/lock")
+
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 


### PR DESCRIPTION
Since the directory can have huge number of less important files,
don't collect but just list them.

Resolves: #1598

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
