### PR TITLE
[kubernetes] Collect vm/vmi information if CNV is in use

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -97,6 +97,11 @@ class kubernetes(Plugin, RedHatPlugin):
             "{} get --raw /metrics".format(kube_cmd)
         ])
 
+        # CNV is not part of the base installation, but can be added
+        if self.is_installed('kubevirt-virtctl'):
+            resources.extend(['vms', 'vmis'])
+            self.add_cmd_output('virtctl version')
+
         for n in knsps:
             knsp = '--namespace=%s' % n
             if self.get_option('all'):


### PR DESCRIPTION
If CNV is installed ontop of the base kubernetes installation, collect
output for the 'vms' and 'vmis' resources as well as virtctl.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
