### PR TITLE
[travis] robustness, actually fail on errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
   - "nosetests -v --with-cover --cover-package=sos --cover-html"
   - "sudo ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python ./sosreport --help"
   - "sudo ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python ./sosreport -l --config-file=sos.conf"
-  - "sudo ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python ./sosreport -n kernel --batch --config-file=sos.conf | tee batch_output"
+  - "sudo ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python ./sosreport --batch --config-file=sos.conf 2> errors | tee batch_output"
+  - "[[ ! -s errors ]]"
+  - "cat errors"
+  - "sudo ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python ./sosreport --batch --build --config-file=sos.conf"
 git:
   depth: 5

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -971,7 +971,7 @@ class SoSReport(object):
             self.plugpool = ThreadPoolExecutor(self.opts.threads)
             # Pass the plugpool its own private copy of self.pluglist
             results = self.plugpool.map(self._collect_plugin,
-                                        list(self.pluglist), chunksize=1)
+                                        list(self.pluglist))
             self.plugpool.shutdown(wait=True)
             for res in results:
                 if not res:


### PR DESCRIPTION
This makes sure if we get errors (anything to stderr) in the build
it gets flagged.  Today, it can be easily silently ignored.

Current build is broken by recent lgtm pull.

3.4 python also appears to be broken by something else.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
