### PR TITLE
[python] check dist_version only on RHELPolicy only

### DIFF
--- a/sos/plugins/python.py
+++ b/sos/plugins/python.py
@@ -9,6 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import sos.policies
 
 
 class Python(Plugin, DebianPlugin, UbuntuPlugin):
@@ -30,7 +31,8 @@ class RedHatPython(Python, RedHatPlugin):
 
     def setup(self):
         self.add_cmd_output(['python2 -V', 'python3 -V'])
-        if self.policy.dist_version() > 7:
+        if isinstance(self.policy, sos.policies.redhat.RHELPolicy) and \
+                self.policy.dist_version() > 7:
             self.add_cmd_output(
                 '/usr/libexec/platform-python -V',
                 suggest_filename='python-version'


### PR DESCRIPTION
Call /usr/libexec/platform-python only on RHEL (of version bigger
than 7).

Resolves: #1605

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
