### PR TITLE
[crio] import all plugins referred by CRIO class

### DIFF
--- a/sos/plugins/crio.py
+++ b/sos/plugins/crio.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):


### PR DESCRIPTION
Resolves: #1606

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
