### PR TITLE
[manageiq] import os.environ variable properly

### DIFF
--- a/sos/plugins/manageiq.py
+++ b/sos/plugins/manageiq.py
@@ -12,9 +12,8 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin
-
+from os import environ
 import os.path
-import os.environ
 
 
 class ManageIQ(Plugin, RedHatPlugin):
@@ -74,8 +73,8 @@ class ManageIQ(Plugin, RedHatPlugin):
         ])
         self.add_copy_spec("/var/log/tower.log")
 
-        if "APPLIANCE_PG_DATA" in os.environ:
-            pg_dir = os.environ["APPLIANCE_PG_DATA"]
+        if environ.get("APPLIANCE_PG_DATA"):
+            pg_dir = environ.get("APPLIANCE_PG_DATA")
             self.add_copy_spec([
                     os.path.join(pg_dir, 'pg_log'),
                     os.path.join(pg_dir, 'postgresql.conf')


### PR DESCRIPTION
os.environ is a variable not a module, so "import os.environ" doesnt
work, causing plugin isnt loaded.

Resolves: #1607

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
