### PR TITLE
[openstack_neutron] fix add_cmd_output typo

### DIFF
--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -45,7 +45,7 @@ class OpenStackNeutron(Plugin):
         # rather take a list of files in the dir only
         self.add_copy_spec("/var/lib/neutron/")
         self.add_forbidden_path("/var/lib/neutron/lock")
-        self.add_cmd_option("ls -laZR /var/lib/neutron/lock")
+        self.add_cmd_output("ls -laZR /var/lib/neutron/lock")
 
         if self.get_option("verify"):
             self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))


### PR DESCRIPTION
Resolves: #1609

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
