### PR TITLE
[xfs] call xfs_admin on device name

### DIFF
--- a/sos/plugins/xfs.py
+++ b/sos/plugins/xfs.py
@@ -24,7 +24,7 @@ class Xfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             for e in dev:
                 parts = e.split(' ')
                 self.add_cmd_output("xfs_info %s" % (parts[1]))
-                self.add_cmd_output("xfs_admin -l -u %s" % (parts[1]))
+                self.add_cmd_output("xfs_admin -l -u %s" % (parts[0]))
 
         self.add_copy_spec([
             '/proc/fs/xfs',


### PR DESCRIPTION
xfs_admin is called with argument of mounting point while it accepts
device name.

Resolves: #1610

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
