### PR TITLE
[Plugin] Add SoSPredicate and predicates infrastructure

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -12,9 +12,9 @@ sosreport \- Collect and package diagnostic and support data
           [--no-report] [--config-file conf]\fR
           [--preset preset] [--add-preset add_preset]\fR
           [--del-preset del_preset] [--desc description]\fR
-          [--batch] [--build] [--debug]\fR
-          [--label label] [--case-id id] [--ticket-number nr]
-          [--threads threads]
+          [--batch] [--build] [--debug] [--dry-run]\fR
+          [--label label] [--case-id id] [--ticket-number nr]\fR
+          [--threads threads]\fR
           [--plugin-timeout TIMEOUT]\fR
           [-s|--sysroot SYSROOT]\fR
           [-c|--chroot {auto|always|never}\fR
@@ -226,6 +226,12 @@ archive as a temporary file or directory tree.
 .B \--debug
 Enable interactive debugging using the python debugger. Exceptions in
 sos or plug-in code will cause a trap to the pdb shell.
+.TP
+.B \--dry-run
+Execute plugins as normal, but do not collect any file content, command
+output, or string data from the system. The resulting logs may be used
+to understand the actions that sos would have taken without the dry run
+option.
 .TP
 .B \--experimental
 Enable plugins marked as experimental. Experimental plugins may not have

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -52,10 +52,11 @@ _sos = _default
 _arg_names = [
     'add_preset', 'alloptions', 'all_logs', 'batch', 'build', 'case_id',
     'chroot', 'compression_type', 'config_file', 'desc', 'debug', 'del_preset',
-    'enableplugins', 'encrypt_key', 'encrypt_pass', 'experimental', 'label',
-    'list_plugins', 'list_presets', 'list_profiles', 'log_size', 'noplugins',
-    'noreport', 'note', 'onlyplugins', 'plugin_timeout', 'plugopts', 'preset',
-    'profiles', 'quiet', 'sysroot', 'threads', 'tmp_dir', 'verbosity', 'verify'
+    'dry_run', 'enableplugins', 'encrypt_key', 'encrypt_pass', 'experimental',
+    'label', 'list_plugins', 'list_presets', 'list_profiles', 'log_size',
+    'noplugins', 'noreport', 'note', 'onlyplugins', 'plugin_timeout',
+    'plugopts', 'preset', 'profiles', 'quiet', 'sysroot', 'threads', 'tmp_dir',
+    'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -166,6 +167,7 @@ class SoSOptions(object):
         self.debug = False
         self.del_preset = ""
         self.desc = ""
+        self.dry_run = False
         self.enableplugins = []
         self.encrypt_key = None
         self.encrypt_pass = None

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -154,7 +154,7 @@ class SoSPredicate(object):
             pvalue |= self._owner.is_module_loaded(k)
 
         for s in self._services:
-            pvalue |= self._owner.is_service(s) and self._owner.is_enabled(s)
+            pvalue |= self._owner.service_is_running(s)
 
         return pvalue and not self._dry_run
 

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -749,7 +749,7 @@ class Plugin(object):
         """
         if not self.test_predicate(pred=pred):
             self._log_info("skipped copy spec '%s' due to predicate (%s)" %
-                           (copyspecs, pred))
+                           (copyspecs, self.get_predicate(pred=pred)))
             return
 
         if sizelimit is None:
@@ -884,7 +884,7 @@ class Plugin(object):
             self._log_info("added cmd output '%s'" % cmd)
         else:
             self._log_info("skipped cmd output '%s' due to predicate (%s)" %
-                           (cmd, pred))
+                           (cmd, self.get_predicate(cmd=True, pred=pred)))
 
     def add_cmd_output(self, cmds, suggest_filename=None,
                        root_symlink=None, timeout=300, stderr=True,
@@ -956,7 +956,7 @@ class Plugin(object):
 
         if not self.test_predicate(cmd=False, pred=pred):
             self._log_info("skipped string ...'%s' due to predicate (%s)" %
-                           (summary, pred))
+                           (summary, self.get_predicate(pred=pred)))
             return
 
         self.copy_strings.append((content, filename))
@@ -973,7 +973,7 @@ class Plugin(object):
 
         if not self.test_predicate(cmd=True, pred=pred):
             self._log_info("skipped cmd output '%s' due to predicate (%s)" %
-                           (exe, pred))
+                           (exe, self.get_predicate(cmd=True, pred=pred)))
             return None
 
         result = self.get_command_output(exe, timeout=timeout, stderr=stderr,

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -164,6 +164,7 @@ class SoSPredicate(object):
         self._owner = owner
         self._kmods = list(kmods)
         self._services = list(services)
+        self._dry_run = dry_run | self._owner.commons['cmdlineopts'].dry_run
 
 
 class Plugin(object):
@@ -239,6 +240,9 @@ class Plugin(object):
             self.opt_names.append(opt[0])
             self.opt_parms.append({'desc': opt[1], 'speed': opt[2],
                                    'enabled': opt[3]})
+
+        # Initialise the default --dry-run predicate
+        self.set_predicate(SoSPredicate(self))
 
     @property
     def timeout(self):
@@ -373,7 +377,7 @@ class Plugin(object):
         """
         if cmd and self.cmd_predicate:
             return self.cmd_predicate
-        return self.predicate or pred
+        return pred or self.predicate
 
     def do_cmd_private_sub(self, cmd):
         '''Remove certificate and key output archived by sosreport. cmd

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -906,11 +906,17 @@ class Plugin(object):
     def get_cmd_output_now(self, exe, suggest_filename=None,
                            root_symlink=False, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None,
-                           binary=False, sizelimit=None):
+                           binary=False, sizelimit=None, pred=None):
         """Execute a command and save the output to a file for inclusion in the
         report.
         """
         start = time()
+
+        if pred is not None and not pred:
+            self._log_info("skipped cmd output '%s' due to predicate (%s)" %
+                           (exe, pred))
+            return None
+
         result = self.get_command_output(exe, timeout=timeout, stderr=stderr,
                                          chroot=chroot, runat=runat,
                                          env=env, binary=binary,

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -379,6 +379,19 @@ class Plugin(object):
             return self.cmd_predicate
         return pred or self.predicate
 
+    def test_predicate(self, cmd=False, pred=None):
+        """Test the current predicate and return its value.
+
+            :param cmd: ``True`` if the predicate is gating a command or
+                        ``False`` otherwise.
+            :param pred: An optional predicate to override the current
+                         ``Plugin`` or command predicate.
+        """
+        pred = self.get_predicate(cmd=cmd, pred=pred)
+        if pred is not None:
+            return bool(pred)
+        return False
+
     def do_cmd_private_sub(self, cmd):
         '''Remove certificate and key output archived by sosreport. cmd
         is the command name from which output is collected (i.e. exlcuding
@@ -734,8 +747,7 @@ class Plugin(object):
         a single file the file will be tailed to meet sizelimit. If the first
         file in a glob is too large it will be tailed to meet the sizelimit.
         """
-        pred = self.get_predicate(pred=pred)
-        if pred is not None and not pred:
+        if not self.test_predicate(pred=pred):
             self._log_info("skipped copy spec '%s' due to predicate (%s)" %
                            (copyspecs, pred))
             return
@@ -867,8 +879,7 @@ class Plugin(object):
                      "'%s')")
         _logstr = "packed command tuple: " + _tuplefmt
         self._log_debug(_logstr % cmdt)
-        pred = self.get_predicate(pred=pred, cmd=True)
-        if pred is None or pred:
+        if self.test_predicate(cmd=True, pred=pred):
             self.collect_cmds.append(cmdt)
             self._log_info("added cmd output '%s'" % cmd)
         else:
@@ -943,8 +954,7 @@ class Plugin(object):
         if not isinstance(summary, six.string_types):
             summary = content.decode('utf8', 'ignore')
 
-        pred = self.get_predicate(pred=pred)
-        if pred is not None and not pred:
+        if not self.test_predicate(cmd=False, pred=pred):
             self._log_info("skipped string ...'%s' due to predicate (%s)" %
                            (summary, pred))
             return
@@ -961,8 +971,7 @@ class Plugin(object):
         """
         start = time()
 
-        pred = self.get_predicate(pred=pred, cmd=True)
-        if pred is not None and not pred:
+        if not self.test_predicate(cmd=True, pred=pred):
             self._log_info("skipped cmd output '%s' due to predicate (%s)" %
                            (exe, pred))
             return None

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -970,7 +970,7 @@ class Plugin(object):
 
     def add_journal(self, units=None, boot=None, since=None, until=None,
                     lines=None, allfields=False, output=None, timeout=None,
-                    identifier=None, catalog=None, sizelimit=None):
+                    identifier=None, catalog=None, sizelimit=None, pred=None):
         """Collect journald logs from one of more units.
 
         :param units: A string, or list of strings specifying the
@@ -1055,7 +1055,7 @@ class Plugin(object):
 
         self._log_debug("collecting journal: %s" % journal_cmd)
         self._add_cmd_output(journal_cmd, timeout=timeout,
-                             sizelimit=log_size)
+                             sizelimit=log_size, pred=pred)
 
     def add_udev_info(self, device, attrs=False):
         """Collect udevadm info output for a given device

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -935,14 +935,22 @@ class Plugin(object):
 
         return outfn
 
-    def add_string_as_file(self, content, filename):
+    def add_string_as_file(self, content, filename, pred=None):
         """Add a string to the archive as a file named `filename`"""
+
+        # Generate summary string for logging
+        summary = content.splitlines()[0]
+        if not isinstance(summary, six.string_types):
+            summary = content.decode('utf8', 'ignore')
+
+        pred = self.get_predicate(pred=pred)
+        if pred is not None and not pred:
+            self._log_info("skipped string ...'%s' due to predicate (%s)" %
+                           (summary, pred))
+            return
+
         self.copy_strings.append((content, filename))
-        if content:
-            content = content.splitlines()[0]
-            if not isinstance(content, six.string_types):
-                content = content.decode('utf8', 'ignore')
-        self._log_debug("added string ...'%s' as '%s'" % (content, filename))
+        self._log_debug("added string ...'%s' as '%s'" % (summary, filename))
 
     def get_cmd_output_now(self, exe, suggest_filename=None,
                            root_symlink=False, timeout=300, stderr=True,

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -695,11 +695,16 @@ class Plugin(object):
     def _add_copy_paths(self, copy_paths):
         self.copy_paths.update(copy_paths)
 
-    def add_copy_spec(self, copyspecs, sizelimit=None, tailit=True):
+    def add_copy_spec(self, copyspecs, sizelimit=None, tailit=True, pred=None):
         """Add a file or glob but limit it to sizelimit megabytes. If fname is
         a single file the file will be tailed to meet sizelimit. If the first
         file in a glob is too large it will be tailed to meet the sizelimit.
         """
+        if pred is not None and not pred:
+            self._log_info("skipped copy spec '%s' due to predicate (%s)" %
+                           (copyspecs, pred))
+            return
+
         if sizelimit is None:
             sizelimit = self.get_option("log_size")
 

--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, SoSPredicate
 
 
 class Docker(Plugin):
@@ -28,6 +28,8 @@ class Docker(Plugin):
     ]
 
     def setup(self):
+        self.set_cmd_predicate(SoSPredicate(services=["docker"]))
+
         self.add_copy_spec([
             "/etc/docker/daemon.json",
             "/var/lib/docker/repositories-*"

--- a/sos/plugins/npm.py
+++ b/sos/plugins/npm.py
@@ -76,7 +76,7 @@ class Npm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
         self._log_debug("modules in cache: %s" % output)
 
         outfn = self._make_command_filename("npm_cache_modules")
-        self.archive.add_string(json.dumps(output), outfn)
+        self.add_string_as_file(json.dumps(output), outfn)
 
     def setup(self):
         if self.get_option("project_path") != 0:

--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -63,6 +63,10 @@ class Unpackaged(Plugin, RedHatPlugin):
                     expanded.append(f)
             return expanded
 
+        # Check command predicate to avoid costly processing
+        if not self.test_predicate(cmd=True):
+            return
+
         all_fsystem = []
         all_frpm = set(os.path.realpath(x)
                        for x in self.policy.mangle_package_path(

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -148,6 +148,8 @@ def _get_parser():
                              "python debugger")
     parser.add_argument("--desc", "--description", type=str, action="store",
                         help="Description for a new preset", default="")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Run plugins but do not collect data")
     parser.add_argument("--experimental", action="store_true",
                         dest="experimental", default=False,
                         help="enable experimental plugins")

--- a/tests/option_tests.py
+++ b/tests/option_tests.py
@@ -6,12 +6,19 @@ from sos.plugins import Plugin
 from sos.policies import LinuxPolicy
 
 
+class MockOptions(object):
+    all_logs = False
+    dry_run = False
+    log_size = 25
+
+
 class GlobalOptionTest(unittest.TestCase):
 
     def setUp(self):
         self.commons = {
             'sysroot': '/',
             'policy': LinuxPolicy(),
+            'cmdlineopts': MockOptions()
         }
         self.plugin = Plugin(self.commons)
         self.plugin.opt_names = ['baz', 'empty', 'test_option']

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -92,6 +92,7 @@ class EnablerPlugin(Plugin):
 
 class MockOptions(object):
     all_logs = False
+    dry_run = False
     log_size = 25
 
 
@@ -136,54 +137,58 @@ class PluginTests(unittest.TestCase):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
             'policy': LinuxPolicy(),
-            'sysroot': self.sysroot
+            'sysroot': self.sysroot,
+            'cmdlineopts': MockOptions()
         })
         self.mp.archive = MockArchive()
 
     def test_plugin_default_name(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.name(), "mockplugin")
 
     def test_plugin_set_name(self):
-        p = NamedMockPlugin({
-            'sysroot': self.sysroot,
-            'policy': LinuxPolicy()
-        })
+        p = NamedMockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                             'cmdlineopts': MockOptions()})
         self.assertEquals(p.name(), "testing")
 
     def test_plugin_no_descrip(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_description(), "<no description available>")
 
     def test_plugin_no_descrip(self):
-        p = NamedMockPlugin({
-            'sysroot': self.sysroot,
-            'policy': LinuxPolicy()
-        })
+        p = NamedMockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                             'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_description(), "This plugin has a description.")
 
     def test_set_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option("opt"), "testing")
 
     def test_set_nonexistant_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertFalse(p.set_option("badopt", "testing"))
 
     def test_get_nonexistant_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_option("badopt"), 0)
 
     def test_get_unset_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_option("opt"), 0)
 
     def test_get_unset_plugin_option_with_default(self):
         # this shows that even when we pass in a default to get,
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_option("opt", True), True)
 
     def test_get_unset_plugin_option_with_default_not_none(self):
@@ -191,20 +196,24 @@ class PluginTests(unittest.TestCase):
         # if the plugin default is not None
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_option("opt2", True), False)
 
     def test_get_option_as_list_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         p.set_option("opt", "one,two,three")
         self.assertEquals(p.get_option_as_list("opt"), ['one', 'two', 'three'])
 
     def test_get_option_as_list_plugin_option_default(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         self.assertEquals(p.get_option_as_list("opt", default=[]), [])
 
     def test_get_option_as_list_plugin_option_not_list(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy()})
+        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(),
+                        'cmdlineopts': MockOptions()})
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option_as_list("opt"), ['testing'])
 
@@ -236,7 +245,8 @@ class AddCopySpecTests(unittest.TestCase):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
             'policy': LinuxPolicy(),
-            'sysroot': os.getcwd()
+            'sysroot': os.getcwd(),
+            'cmdlineopts': MockOptions()
         })
         self.mp.archive = MockArchive()
 
@@ -312,7 +322,8 @@ class CheckEnabledTests(unittest.TestCase):
     def setUp(self):
         self.mp = EnablerPlugin({
             'policy': sos.policies.load(),
-            'sysroot': os.getcwd()
+            'sysroot': os.getcwd(),
+            'cmdlineopts': MockOptions()
         })
 
     def test_checks_for_file(self):


### PR DESCRIPTION
Predicates add a new facility to the `Plugin` class that allow file, command, and string collection to be overridden (skipped) based on the predicate's value, without the need for conditional code in plugins themselves.

This is useful since it allows collection gating to be controlled from both within and outside the plugin; for example, implementing a global `--dry-run` mode (a long standing feature request previously needing a great deal of conditionals) becomes relatively trivial.

The current implementation allows collection to be gated based on the presence of kernel modules, running services, or the global `--dry-run` command line argument.

Plugins may define their own predicates, and pass them to methods as appropriate, or they may specify a default predicate (or a default command predicate) that will apply automatically to future operations.

When `--dry-run` is given all default plugin predicates are initialised to evaluate `False`.

Setting up and using a predicate is simple:

```python
    # Gating all collection by presence of a kernel module:
    self.set_predicate(SoSPredicate(self, kmods=["a_kernel_module"]))
```

```python
    # Gating all command collection by presence of a kernel module:
    self.set_cmd_predicate(SoSPredicate(self, kmods=["a_kernel_module"]))
```

```python
    # Gating a single command by presence of a service
    self.add_cmd_output("acmd", pred=SoSPredicate(self, services=["a_service"]))
```
```
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
