### PR TITLE
[Plugin] Fix get_predicate evaluation and remove duplicate gating

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -379,7 +379,7 @@ class Plugin(object):
             If no default predicate is set and a `pred` value is passed
             it will be returned.
         """
-        if cmd and self.cmd_predicate:
+        if cmd and self.cmd_predicate is not None:
             return self.cmd_predicate
         return pred or self.predicate
 
@@ -977,11 +977,6 @@ class Plugin(object):
         report.
         """
         start = time()
-
-        if not self.test_predicate(cmd=True, pred=pred):
-            self._log_info("skipped cmd output '%s' due to predicate (%s)" %
-                           (exe, self.get_predicate(cmd=True, pred=pred)))
-            return None
 
         result = self.get_command_output(exe, timeout=timeout, stderr=stderr,
                                          chroot=chroot, runat=runat,


### PR DESCRIPTION
If a predicate evaluates False, we still need to return it in
get_predicate(), so update the check on if cmd_predicate is set
accordingly.

Predicate gating was done in both _add_cmd_output() and
get_cmd_output_now(), which meant that while _add_cmd_output() would
properly block commands from being added to the collection list if the
predicate evaluated False, get_cmd_output_now() would also block
_any_ commands from being collected that were added via an
add_cmd_output() call before the cmd_predicate was set.

This removes the predicate check from get_cmd_output_now() so we can
still collect command output that was added before a cmd_predicate was
set, e.g. journal units still get collected even if the service for that
unit is not running which would normally block commands from being
collected.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
