### PR TITLE
[kubernetes] Split out non-namespaced resources

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -77,11 +77,8 @@ class kubernetes(Plugin, RedHatPlugin):
             'deployments',
             'ingresses',
             'limitranges',
-            'namespaces',
             'pods',
             'policies',
-            'projects',
-            'pv',
             'pvc',
             'rc',
             'resourcequotas',
@@ -89,13 +86,18 @@ class kubernetes(Plugin, RedHatPlugin):
             'services'
         ]
 
-        # nodes and pvs are not namespaced, must pull separately.
-        # Also collect master metrics
+        # these are not namespaced, must pull separately.
+        global_resources = [
+            'namespaces',
+            'nodes',
+            'projects',
+            'pvs'
+        ]
         self.add_cmd_output([
-            "{} get -o json nodes".format(kube_cmd),
-            "{} get -o json pv".format(kube_cmd),
-            "{} get --raw /metrics".format(kube_cmd)
+            "%s get %s" % (kube_cmd, res) for res in global_resources
         ])
+        # Also collect master metrics
+        self.add_cmd_output("%s get --raw /metrics" % kube_cmd)
 
         # CNV is not part of the base installation, but can be added
         if self.is_installed('kubevirt-virtctl'):


### PR DESCRIPTION
Removes non-namespaced resources from being iterated over by the
namespace-sensitive loops such as describe.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
