### PR TITLE
[amazon] Add Amazon Linux policy

### DIFF
--- a/sos/plugins/amazon.py
+++ b/sos/plugins/amazon.py
@@ -1,0 +1,35 @@
+# Copyright (C) Steve Conklin <sconklin@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+# This enables the use of with syntax in python 2.5 (e.g. jython)
+from __future__ import print_function
+
+from sos.policies.redhat import RedHatPolicy, OS_RELEASE
+
+
+class AmazonPolicy(RedHatPolicy):
+
+    distro = "Amazon Linux"
+    vendor = "Amazon"
+    vendor_url = "https://aws.amazon.com"
+
+    def __init__(self, sysroot=None):
+        super(AmazonPolicy, self).__init__(sysroot=sysroot)
+
+    @classmethod
+    def check(cls):
+        with open(OS_RELEASE, 'r') as f:
+            for line in f:
+                if line.startswith('NAME'):
+                    if 'Amazon Linux' in line:
+                        return True
+        return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/policies/amazon.py
+++ b/sos/policies/amazon.py
@@ -1,0 +1,35 @@
+# Copyright (C) Steve Conklin <sconklin@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+# This enables the use of with syntax in python 2.5 (e.g. jython)
+from __future__ import print_function
+
+from sos.policies.redhat import RedHatPolicy, OS_RELEASE
+
+
+class AmazonPolicy(RedHatPolicy):
+
+    distro = "Amazon Linux"
+    vendor = "Amazon"
+    vendor_url = "https://aws.amazon.com"
+
+    def __init__(self, sysroot=None):
+        super(AmazonPolicy, self).__init__(sysroot=sysroot)
+
+    @classmethod
+    def check(cls):
+        with open(OS_RELEASE, 'r') as f:
+            for line in f:
+                if line.startswith('NAME'):
+                    if 'Amazon Linux' in line:
+                        return True
+        return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -447,5 +447,4 @@ class FedoraPolicy(RedHatPolicy):
             self.all_pkgs_by_name_regex("fedora-release-.*")[-1]
         return int(pkg["version"])
 
-
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a policy for Amazon Linux. As Amazon Linux is a RHEL clone, it
inherits from the base RedHatPolicy and uses the RedHatPlugin tagging
class.

Fixes: #1563

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
