### PR TITLE
[plugins] add_string_as_file to deal with empty content properly

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -959,7 +959,7 @@ class Plugin(object):
         """Add a string to the archive as a file named `filename`"""
 
         # Generate summary string for logging
-        summary = content.splitlines()[0]
+        summary = content.splitlines()[0] if content else ''
         if not isinstance(summary, six.string_types):
             summary = content.decode('utf8', 'ignore')
 


### PR DESCRIPTION
If add_string_as_file is called with emtpy content, dont attempt to
parse it but set summary to '' directly.

Resolves: #1620

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
