### PR TITLE
[plugins] do_file_sub to catch nonexisting file

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -503,7 +503,7 @@ class Plugin(object):
                 self.archive.add_string(result, srcpath)
             else:
                 replacements = 0
-        except OSError as e:
+        except (OSError, IOError) as e:
             # if trying to regexp a nonexisting file, dont log it as an
             # error to stdout
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
If trying to do_file_sub on not-captured file, IOError is raised that
we have to catch like OSError.

Resolves: #1621

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
