### PR TITLE
[archive] opening a file should ignore UTF errors

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -518,7 +518,7 @@ class FileCacheArchive(Archive):
 
     def open_file(self, path):
         path = self.dest_path(path)
-        return codecs.open(path, "r", encoding='utf-8')
+        return codecs.open(path, "r", encoding='utf-8', errors='ignore')
 
     def cleanup(self):
         if os.path.isdir(self._archive_root):


### PR DESCRIPTION
When opening a file in archive e.g. for do_file_sub, we should ignore
UTF encoding errors to prevent UnicodeDecodeError.

Resolves: #1622

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
