### PR TITLE
[foreman] decrease default task export to 1 month

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -22,7 +22,7 @@ class Foreman(Plugin):
     profiles = ('sysmgmt',)
     packages = ('foreman', 'foreman-proxy')
     option_list = [
-        ('months', 'number of months for dynflow output', 'fast', 6)
+        ('months', 'number of months for dynflow output', 'fast', 1)
     ]
 
     def setup(self):
@@ -154,11 +154,11 @@ class Foreman(Plugin):
 
         for table in foremandb:
             _cmd = self.build_query_cmd(foremandb[table])
-            self.add_cmd_output(_cmd, suggest_filename=table)
+            self.add_cmd_output(_cmd, suggest_filename=table, timeout=600)
 
         for dyn in foremancsv:
             _cmd = self.build_query_cmd(foremancsv[dyn], csv=True)
-            self.add_cmd_output(_cmd, suggest_filename=dyn)
+            self.add_cmd_output(_cmd, suggest_filename=dyn, timeout=600)
 
     def build_query_cmd(self, query, csv=False):
         """


### PR DESCRIPTION
For bigger foreman deployments, csv postgres queries timeout while
users are not much concerned about old tasks.

Let decrease default time span to 1 month and increase timeout for
collecting those commands.

Resolves: #1623

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
