### PR TITLE
[origin] make origin.diag-prevent on by default

### DIFF
--- a/sos/plugins/origin.py
+++ b/sos/plugins/origin.py
@@ -43,7 +43,7 @@ class OpenShiftOrigin(Plugin):
         ("diag", "run 'oc adm diagnostics' to collect its output",
          'fast', True),
         ("diag-prevent", "set --prevent-modification on 'oc adm diagnostics'",
-         'fast', False),
+         'fast', True),
         ("all-namespaces", "collect dc output for all namespaces", "fast",
          False)
     ]


### PR DESCRIPTION
[origin] make origin.diag-prevent on by default
    
Making origin.diag-prevent option "on" by default,
so that sosreport does not create/modify/delete
projects by default in an OpenShift cluster.

Signed-off-by: Pablo Alonso Rodriguez <palonsor@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
