### PR TITLE
[Plugin] Allow plugins to write output to subdirs, and update container plugins

### DIFF
--- a/sos/plugins/buildah.py
+++ b/sos/plugins/buildah.py
@@ -48,12 +48,14 @@ class Buildah(Plugin, RedHatPlugin):
             for containah in containahs['auutput'].splitlines():
                 # obligatory Tom Brady
                 goat = containah.split()[-1]
-                self.add_cmd_output('buildah inspect -t container %s' % goat)
+                self.add_cmd_output('buildah inspect -t container %s' % goat,
+                                    subdir='containers')
 
         pitchez = make_chowdah('buildah images -n')
         if pitchez['is_wicked_pissah']:
             for pitchah in pitchez['auutput'].splitlines():
                 brady = pitchah.split()[1]
-                self.add_cmd_output('buildah inspect -t image %s' % brady)
+                self.add_cmd_output('buildah inspect -t image %s' % brady,
+                                    subdir='images')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -78,17 +78,20 @@ class Docker(Plugin):
         volumes = self._get_docker_list(vol_cmd)
 
         for container in containers:
-            self.add_cmd_output("docker inspect %s" % container)
+            self.add_cmd_output("docker inspect %s" % container,
+                                subdir='containers')
             if self.get_option('logs'):
-                self.add_cmd_output("docker logs -t %s" % container)
+                self.add_cmd_output("docker logs -t %s" % container,
+                                    subdir='containers')
 
         for img in images:
             name, img_id = img.strip().split()
             insp = name if 'none' not in name else img_id
-            self.add_cmd_output("docker inspect %s" % insp)
+            self.add_cmd_output("docker inspect %s" % insp, subdir='images')
 
         for vol in volumes:
-            self.add_cmd_output("docker volume inspect %s" % vol)
+            self.add_cmd_output("docker volume inspect %s" % vol,
+                                subdir='volumes')
 
     def _get_docker_list(self, cmd):
         ret = []

--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -117,7 +117,7 @@ class kubernetes(Plugin, RedHatPlugin):
                 self.add_cmd_output('%s events' % k_cmd)
 
                 for res in resources:
-                    self.add_cmd_output('%s %s' % (k_cmd, res))
+                    self.add_cmd_output('%s %s' % (k_cmd, res), subdir=res)
 
             if self.get_option('describe'):
                 # need to drop json formatting for this
@@ -131,7 +131,9 @@ class kubernetes(Plugin, RedHatPlugin):
                         for k in k_list:
                             k_cmd = '%s %s' % (kube_cmd, knsp)
                             self.add_cmd_output(
-                                '%s describe %s %s' % (k_cmd, res, k))
+                                '%s describe %s %s' % (k_cmd, res, k),
+                                subdir=res
+                            )
 
             if self.get_option('podlogs'):
                 k_cmd = '%s %s' % (kube_cmd, knsp)
@@ -145,12 +147,13 @@ class kubernetes(Plugin, RedHatPlugin):
                     for pod in pods:
                         if reg and not re.match(reg, pod):
                             continue
-                        self.add_cmd_output('%s logs %s' % (k_cmd, pod))
+                        self.add_cmd_output('%s logs %s' % (k_cmd, pod),
+                                            subdir='pods')
 
         if not self.get_option('all'):
             k_cmd = '%s get --all-namespaces=true' % kube_cmd
             for res in resources:
-                self.add_cmd_output('%s %s' % (k_cmd, res))
+                self.add_cmd_output('%s %s' % (k_cmd, res), subdir=res)
 
     def postproc(self):
         # First, clear sensitive data from the json output collected.

--- a/sos/plugins/podman.py
+++ b/sos/plugins/podman.py
@@ -70,19 +70,22 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
         volumes = self._get_podman_list(vol_cmd)
 
         for container in containers:
-            self.add_cmd_output("podman inspect %s" % container)
+            self.add_cmd_output("podman inspect %s" % container,
+                                subdir='containers')
 
         for img in images:
             name, img_id = img.strip().split()
             insp = name if 'none' not in name else img_id
-            self.add_cmd_output("podman inspect %s" % insp)
+            self.add_cmd_output("podman inspect %s" % insp, subdir='images')
 
         for vol in volumes:
-            self.add_cmd_output("podman volume inspect %s" % vol)
+            self.add_cmd_output("podman volume inspect %s" % vol,
+                                subdir='volumes')
 
         if self.get_option('logs'):
             for con in containers:
-                self.add_cmd_output("podman logs -t %s" % con)
+                self.add_cmd_output("podman logs -t %s" % con,
+                                    subdir='containers')
 
     def _get_podman_list(self, cmd):
         ret = []


### PR DESCRIPTION
Updates `add_cmd_output()` and the associated methods to allow plugins to specify if command output should be saved in a subdir within the plugin directory.

Additionally, update the container plugins to make use of this as these plugins are notorious for generating hundreds of files under the plugin directory, and this organization will help support representatives parsing an sosreport.

Fixes: #1600

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
