### PR TITLE
[InitSystem] Cache service status information

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -124,17 +124,22 @@ class InitSystem(object):
         """Returns the status for the given service name along with the output
         of the query command
         """
+        _default = {
+            'name': name,
+            'status': 'missing',
+            'output': ''
+        }
+        if name not in self.services:
+            return _default
+        if 'status' in self.services[name]:
+            # service status has been queried before, return existing info
+            return self.services[name]
         svc = self._query_service(name)
         if svc is not None:
-            return {'name': name,
-                    'status': self.parse_query(svc['output']),
-                    'output': svc['output']
-                    }
-        else:
-            return {'name': name,
-                    'status': 'missing',
-                    'output': ''
-                    }
+            self.services[name]['status'] = self.parse_query(svc['output'])
+            self.services[name]['output'] = svc['output']
+            return self.services[name]
+        return _default
 
 
 class SystemdInit(InitSystem):


### PR DESCRIPTION
With the addition of predicates, there is the very real possibility that
plugins can end up gating multiple add_cmd_output() or similar calls
around the same predicate, such as service enablement.

Previously, this meant every single check of the predicate resulted in a
new InitSystem._query_service() call was made. Now, we only call
_query_service() once and save the results, since status is unlikely to
change during the course of plugin execution.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
