### PR TITLE
[boot] Capture SecureBoot configuration state

### DIFF
--- a/sos/plugins/boot.py
+++ b/sos/plugins/boot.py
@@ -36,7 +36,10 @@ class Boot(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "lsinitrd"
         ])
 
-        self.add_cmd_output("efibootmgr -v")
+        self.add_cmd_output([
+            "efibootmgr -v",
+            "mokutil --sb-state"
+        ])
 
         if self.get_option("all-images"):
             for image in glob('/boot/initr*.img'):


### PR DESCRIPTION
Adds collection of mokutil to show is SecureBoot is enabled on the
system or not.

Fixes: #1574

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
