### PR TITLE
[pcp] collect pmlogger without a sizelimit

### DIFF
--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -130,7 +130,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
             pmlogger_ls = self.get_cmd_output_now("ls -t1 %s" % path)
             if pmlogger_ls:
                 for line in open(pmlogger_ls).read().splitlines():
-                    self.add_copy_spec(line, sizelimit=None)
+                    self.add_copy_spec(line, sizelimit=0)
                     files_collected = files_collected + 1
                     if self.countlimit and files_collected == self.countlimit:
                         break


### PR DESCRIPTION
sizelimit=None defaults to --log-size, use sizelimit=0 instead

Resolves: #1632

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
