### PR TITLE
[npm] plugin to requires_root

### DIFF
--- a/sos/plugins/npm.py
+++ b/sos/plugins/npm.py
@@ -19,7 +19,6 @@ class Npm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
     Get info about available npm modules
     """
 
-    requires_root = False
     plugin_name = 'npm'
     profiles = ('system',)
     option_list = [("project_path",


### PR DESCRIPTION
Until our utils support commands execution for unpriviledged users,
we should disable requires_root = False.

Resolves: #1625

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
