### PR TITLE
[ipvs] Only run ipvsadm commands if the ip_vs kernel module is loaded

### DIFF
--- a/sos/plugins/ipvs.py
+++ b/sos/plugins/ipvs.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin, RedHatPlugin, DebianPlugin
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, SoSPredicate
 
 
 class Ipvs(Plugin, RedHatPlugin, DebianPlugin):
@@ -29,6 +29,6 @@ class Ipvs(Plugin, RedHatPlugin, DebianPlugin):
             "ipvsadm -Ln --stats",
             "ipvsadm -Ln --thresholds",
             "ipvsadm -Ln --timeout"
-        ])
+        ], pred=SoSPredicate(self, kmods=['ip_vs']))
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Running any ipvsadm command can cause the kernel to autoload the
ip_vs module. So only run ipvsadm commands if the ip_vs kernel module
is found to already be loaded on the system.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
