### PR TITLE
[ipvs] do not execute ipvsadm if ip_vs is not loaded.

### DIFF
--- a/sos/plugins/ipvs.py
+++ b/sos/plugins/ipvs.py
@@ -21,14 +21,15 @@ class Ipvs(Plugin, RedHatPlugin, DebianPlugin):
     packages = ('ipvsadm',)
 
     def setup(self):
-        self.add_cmd_output([
-            "ipvsadm -Ln",
-            "ipvsadm -Ln --connection",
-            "ipvsadm -Ln --persistent-conn",
-            "ipvsadm -Ln --rate",
-            "ipvsadm -Ln --stats",
-            "ipvsadm -Ln --thresholds",
-            "ipvsadm -Ln --timeout"
-        ])
+        if self.check_ext_prog("grep -q ip_vs /proc/modules"):
+            self.add_cmd_output([
+                "ipvsadm -Ln",
+                "ipvsadm -Ln --connection",
+                "ipvsadm -Ln --persistent-conn",
+                "ipvsadm -Ln --rate",
+                "ipvsadm -Ln --stats",
+                "ipvsadm -Ln --thresholds",
+                "ipvsadm -Ln --timeout"
+            ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Signed-off-by: MIZUTA Takeshi <mizuta.takeshi@jp.fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

ipvsadm is executed by ipvs plugins.
ip_vs module is loaded automatically due to the execution of ipvsadm.
If ip_vs module is not loaded, sosreport should not execute ipvsadm.
This is the same idea as executing iptables.