### PR TITLE
[foreman,satellite] increase plugin default timeouts

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -19,6 +19,7 @@ class Foreman(Plugin):
     """
 
     plugin_name = 'foreman'
+    plugin_timeout = 1800
     profiles = ('sysmgmt',)
     packages = ('foreman', 'foreman-proxy')
     option_list = [

--- a/sos/plugins/satellite.py
+++ b/sos/plugins/satellite.py
@@ -14,6 +14,7 @@ class Satellite(Plugin, RedHatPlugin):
     """
 
     plugin_name = 'satellite'
+    plugin_timeout = 1200
     profiles = ('sysmgmt',)
     verify_packages = ('spacewalk.*',)
     satellite = False


### PR DESCRIPTION
Those two plugins call commands with bigger timeouts than the default
plugin timeout is. That can unexpectedly kill the plugin execution when
the commands execution took longer than the plugin timeout (but within
cmd timeout).

Resolves: #1642

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
