### PR TITLE
[Plugin] Allow plugins to capture environment variables

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -54,9 +54,9 @@ _arg_names = [
     'chroot', 'compression_type', 'config_file', 'desc', 'debug', 'del_preset',
     'dry_run', 'enableplugins', 'encrypt_key', 'encrypt_pass', 'experimental',
     'label', 'list_plugins', 'list_presets', 'list_profiles', 'log_size',
-    'noplugins', 'noreport', 'note', 'onlyplugins', 'plugin_timeout',
-    'plugopts', 'preset', 'profiles', 'quiet', 'sysroot', 'threads', 'tmp_dir',
-    'verbosity', 'verify'
+    'noplugins', 'noreport', 'no_env_vars', 'note', 'onlyplugins',
+    'plugin_timeout', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
+    'threads', 'tmp_dir', 'verbosity', 'verify'
 ]
 
 #: Arguments with non-zero default values
@@ -179,6 +179,7 @@ class SoSOptions(object):
         self.log_size = _arg_defaults["log_size"]
         self.noplugins = []
         self.noreport = False
+        self.no_env_vars = False
         self.note = ""
         self.onlyplugins = []
         self.plugin_timeout = None
@@ -220,7 +221,7 @@ class SoSOptions(object):
         no_value = (
             "alloptions", "all-logs", "batch", "build", "debug",
             "experimental", "list-plugins", "list-presets", "list-profiles",
-            "noreport", "quiet", "verify"
+            "noreport", "no-env-vars", "quiet", "verify"
         )
         count = ("verbose",)
         if opt in no_value:

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -220,6 +220,7 @@ class Plugin(object):
 
         self.copied_files = []
         self.executed_commands = []
+        self._env_vars = set()
         self.alerts = []
         self.custom_text = ""
         self.opt_names = []
@@ -954,6 +955,21 @@ class Plugin(object):
                 inc += 1
 
         return outfn
+
+    def add_env_var(self, name):
+        """Add an environment variable to the list of to-be-collected env vars.
+
+        Accepts either a single variable name or a list of names. Any value
+        given will be added as provided to the method, as well as an upper-
+        and lower- cased version.
+        """
+        if not isinstance(name, list):
+            name = [name]
+        for env in name:
+            # get both upper and lower cased vars since a common support issue
+            # is setting the env vars to the wrong case, and if the plugin
+            # adds a mixed case variable name, still get that as well
+            self._env_vars.update([env, env.upper(), env.lower()])
 
     def add_string_as_file(self, content, filename, pred=None):
         """Add a string to the archive as a file named `filename`"""


### PR DESCRIPTION
Adds a new 'add_env_var()' method to the Plugin class, which allows
plugins to specify which environment variables should be recorded in the
sos archive. This functions as a whitelist, as only environment
variables requested by plugins will be captured. The new method accepts
either a single string, or a list of strings.

Collection of environment variables is done _after_ we have run
collect() for each plugin, and will be written to the 'environment' file
in the archive root. Only environment variables that exist will be
written, so if a plugin requests an environment variable be captured and
it does not appear in the file the chances are good that the variable is
not set on the system.

Each environment variable will only be captured once - so multiple
plugins may specify the same environment variable without an issue.

Additionally, when a plugin uses add_env_var(), the value passed as well
as an upper- and lower- cased variant of the value will be added to the
list of variables to be collected as well. This is because it is a
frequent support issue where end users set an incorrectly-cased
variable, and support representatives will want to know when this is the
case.

Because this functionality works off of a whitelist, environment
variable values are not sanitized. Note also that due to the variable
name casing functionality mentioned above, this means there is a small
chance where sensitive data stored in differently-cased variables of the
same name as common variables could be unintentionally captured.

Use the --no-env-vars option to prevent capturing any environment
variables wholesale.

Fixes: #1396

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
