### PR TITLE
[sosreport] Print header before policy initialization

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -259,6 +259,8 @@ class SoSReport(object):
         except Exception:
             pass  # not available in java, but we don't care
 
+        self.print_header()
+
         # load default options and store them in self.opts
         parser = _get_parser()
         self.opts = SoSOptions().from_args(parser.parse_args([]))
@@ -341,8 +343,7 @@ class SoSReport(object):
             self._exit(1)
 
     def print_header(self):
-        self.ui_log.info("\n%s\n" % _("sosreport (version %s)" %
-                                      (__version__,)))
+        print("\n%s\n" % _("sosreport (version %s)" % (__version__,)))
 
     def get_commons(self):
         return {
@@ -1328,7 +1329,6 @@ class SoSReport(object):
     def execute(self):
         try:
             self.policy.set_commons(self.get_commons())
-            self.print_header()
             self.load_plugins()
             self._set_all_options()
             self._set_tunables()


### PR DESCRIPTION
The version header is now printed before policy initialization as part
of the SoSReport() constructor instead of in the execute() message.

Fixes: #762

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
