### PR TITLE
[buildah] parse container list properly even for scratch ones

### DIFF
--- a/sos/plugins/buildah.py
+++ b/sos/plugins/buildah.py
@@ -47,7 +47,7 @@ class Buildah(Plugin, RedHatPlugin):
         if containahs['is_wicked_pissah']:
             for containah in containahs['auutput'].splitlines():
                 # obligatory Tom Brady
-                goat = containah.split()[4]
+                goat = containah.split()[-1]
                 self.add_cmd_output('buildah inspect -t container %s' % goat)
 
         pitchez = make_chowdah('buildah images -n')


### PR DESCRIPTION
Scratch containers dont have id (empty 3rd column in container list), therefore we shall get container name as the latest string on each line instead of 5th.

Resolves: #1647

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
