### PR TITLE
[unpackaged|RedHat] Don't exit on failed file list query

### DIFF
--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -70,7 +70,7 @@ class Unpackaged(Plugin, RedHatPlugin):
         all_fsystem = []
         all_frpm = set(os.path.realpath(x)
                        for x in self.policy.mangle_package_path(
-                       self.policy.package_manager.files))
+                       self.policy.package_manager.all_files()))
 
         for d in get_env_path_list():
             all_fsystem += all_files_system(d)

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -66,17 +66,10 @@ class RedHatPolicy(LinuxPolicy):
         self.valid_subclasses = [RedHatPlugin]
 
         self.pkgs = self.package_manager.all_pkgs()
-        files = self.package_manager.all_files()
 
         # If rpm query failed, exit
         if not self.pkgs:
             print("Could not obtain installed package list", file=sys.stderr)
-            sys.exit(1)
-
-        # If the files rpm query failed, exit
-        if not files:
-            print("Could not obtain the files list known to the package \
-                  manager", file=sys.stderr)
             sys.exit(1)
 
         self.usrmove = self.check_usrmove(self.pkgs)


### PR DESCRIPTION
The unpackaged plugin is the only one currently using a policy's file
list as determined by PackageManager.all_files(). As such, we should not
fail an entire sosreport run when the package file list query fails.

Accordingly, the call to all_files() to populate and store the file list
is now moved directly into the unpackaged plugin, rather than at policy
initialization.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
