### PR TITLE
[instack] getting a copy of tripleo-config

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -22,7 +22,8 @@ NON_CONTAINERIZED_DEPLOY = [
 CONTAINERIZED_DEPLOY = [
         '/var/log/heat-launcher/',
         '/home/stack/install-undercloud.log',
-        '/home/stack/undercloud-install-*.tar.bzip2'
+        '/home/stack/undercloud-install-*.tar.bzip2',
+        '/var/lib/tripleo-config/'
 ]
 
 

--- a/sos/plugins/vdsm.py
+++ b/sos/plugins/vdsm.py
@@ -65,6 +65,7 @@ class Vdsm(Plugin, RedHatPlugin):
         self.add_forbidden_path('/etc/pki/libvirt/private/*')
 
         self.add_cmd_output('service vdsmd status')
+        self.add_cmd_output('service supervdsmd status')
 
         self.add_copy_spec([
             '/tmp/vds_installer*',


### PR DESCRIPTION
When troubleshooting containerized OOO Deployments,
it can help a lot to have the tripleo-config files
on the overcloud nodes.

Signed-off-by: David Vallee Delisle <dvd@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
