### PR TITLE
[sosreport] initialize disabled plugins properly when parsing sos.conf

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -250,8 +250,8 @@ class SoSOptions(object):
                 optlist.extend(SoSOptions._opt_to_args(opt, val))
             opts._merge_opts(argparser.parse_args(optlist), is_default)
 
+        opts.noplugins = []
         if config.has_option("plugins", "disable"):
-            opts.noplugins = []
             opts.noplugins.extend([plugin.strip() for plugin in
                                   config.get("plugins", "disable").split(',')])
 


### PR DESCRIPTION
opts.noplugins is referred when parsing "tunables" section, so
the variable must be set to empty list every time.

Resolves: #1651

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
