### PR TITLE
[kubernetes] Enable Ubuntu kubectl cmd from any k8s nodes

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -9,11 +9,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin, RedHatPlugin
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 from os import path
 
 
-class kubernetes(Plugin, RedHatPlugin):
+class kubernetes(Plugin, RedHatPlugin, UbuntuPlugin):
 
     """Kubernetes plugin
     """
@@ -26,7 +26,8 @@ class kubernetes(Plugin, RedHatPlugin):
     files = (
         "/var/run/kubernetes/apiserver.key",
         "/etc/origin/master/",
-        "/etc/origin/node/pods/master-config.yaml"
+        "/etc/origin/node/pods/master-config.yaml",
+        "/root/cdk/kubeproxyconfig"
     )
 
     option_list = [
@@ -59,9 +60,15 @@ class kubernetes(Plugin, RedHatPlugin):
         if not self.check_is_master():
             return
 
+        # Red Hat
         kube_cmd = "kubectl "
         if path.exists('/etc/origin/master/admin.kubeconfig'):
             kube_cmd += "--kubeconfig=/etc/origin/master/admin.kubeconfig"
+
+        # Ubuntu Charmed Distribution of Kubernetes
+        if path.exists('/root/cdk/kubeproxyconfig'):
+            kube_cmd = "/snap/bin/kubectl "
+            kube_cmd += "--kubeconfig=/root/cdk/kubeproxyconfig"
 
         kube_get_cmd = "get -o json "
         for subcmd in ['version', 'config view']:


### PR DESCRIPTION
    [kubernetes] Enable Ubuntu kubectl cmd from any k8s nodes
    
    Enable Ubuntu kubectl command, delivered as a SNAP,
    on any k8s nodes using CDK installation.
    
    CDK stands for Charmed Distribution of Kubernetes.
    
    Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
