### PR TITLE
[lstopo] Fix to not depend on distutils

### DIFF
--- a/sos/plugins/lstopo.py
+++ b/sos/plugins/lstopo.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-from distutils.spawn import find_executable
+from sos.utilities import is_executable
 
 
 class Lstopo(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
@@ -16,13 +16,13 @@ class Lstopo(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     plugin_name = "lstopo"
     profiles = ("system", "hardware")
-    packages = ("hwloc-libs", )
+    packages = ("hwloc-libs", "libhwloc5")
 
     def setup(self):
         # binary depends on particular package, both require hwloc-libs one
         # hwloc-gui provides lstopo command
         # hwloc provides lstopo-no-graphics command
-        if find_executable("lstopo"):
+        if is_executable("lstopo"):
             cmd = "lstopo"
         else:
             cmd = "lstopo-no-graphics"


### PR DESCRIPTION
This adds support for Ubuntu and drops the depends
on distutils replacing with the sos utility.

I believe the functionality should be the same, and
appears to work on Ubuntu.

Closes: #1656

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
