### PR TITLE
[openstack_instack] add ansible.log

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -22,7 +22,8 @@ NON_CONTAINERIZED_DEPLOY = [
 CONTAINERIZED_DEPLOY = [
         '/var/log/heat-launcher/',
         '/home/stack/install-undercloud.log',
-        '/home/stack/undercloud-install-*.tar.bzip2'
+        '/home/stack/undercloud-install-*.tar.bzip2',
+        '/var/lib/mistral/config-download-latest/ansible.log'
 ]
 
 


### PR DESCRIPTION
Collect /var/lib/mistral/config-download-latest/ansible.log which is an
important log to be able to debug issues with Ansible playbooks.

/var/lib/mistral/config-download-latest is a directory that exists
anyway on the undercloud and is the place where the ansible logs is
stored.

Note: we don't want to collect the whole /var/lib/mistral because it
contains sensitive informations like username/passwords/endpoints.

rhbz#1702806
rhbz#1702802

Signed-off-by: Emilien Macchi <emilien@redhat.com>