### PR TITLE
[Plugin] Add method to collect service status based on InitSystem

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1043,6 +1043,28 @@ class Plugin(object):
         """
         self.custom_text += text
 
+    def add_service_status(self, services, timeout=None, pred=None):
+        '''Collect service status information based on the InitSystem used.
+
+        :param services: A string, or list of strings, specifying the services
+                          to collect
+        :param timeout:  Option timeout in seconds
+        :param pred:     An optional predicate to gate collection
+        '''
+        if isinstance(services, six.string_types):
+            services = [services]
+
+        query = self.policy.init_system.query_cmd
+        if not query:
+            # No policy defined InitSystem, cannot use add_service_status
+            self._log_debug('Cannot add service output, policy does not define'
+                            ' an InitSystem to use')
+            return
+
+        for service in services:
+            self._add_cmd_output(cmd="%s %s" % (query, service), pred=pred,
+                                 timeout=timeout)
+
     def add_journal(self, units=None, boot=None, since=None, until=None,
                     lines=None, allfields=False, output=None, timeout=None,
                     identifier=None, catalog=None, sizelimit=None, pred=None):


### PR DESCRIPTION
Adds a method to Plugin() to allow plugins to capture service status
information based on a policy-defined InitSystem() to use. This will
allow plugins to not need to account for host installation when trying
to collect service information, such as from 'systemctl status'
commands.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
