### PR TITLE
[man] remove obolete references to XML reports

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -39,8 +39,8 @@ to assist with technical fault-finding and debugging.
 .LP
 Sos is modular in design and is able to collect data from a wide
 range of subsystems and packages that may be installed. An
-XML or HTML report summarizing the collected information is
-optionally generated and stored within the archive.
+HTML report summarizing the collected information is optionally
+generated and stored within the archive.
 .SH OPTIONS
 .TP
 .B \-l, \--list-plugins
@@ -75,7 +75,7 @@ additional debugging messages.
 Only log fatal errors to stderr.
 .TP
 .B \--no-report
-Disable HTML/XML report writing.
+Disable HTML report writing.
 .TP
 .B \--config-file CONFIG
 Specify alternate configuration file.


### PR DESCRIPTION
As XML reports were removed from sos, manpages should not refer to
them further.

Resolves: #1669

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
