### PR TITLE
[juju] Add support for Juju 2.x / refactoring work

### DIFF
--- a/sos/plugins/juju.py
+++ b/sos/plugins/juju.py
@@ -29,9 +29,8 @@ class Juju(Plugin, UbuntuPlugin):
     def collect_app_config(self, username, modelname, statusfilespath):
         statusinfo = {}
         try:
-            fp = open(statusfilespath, "r")
-            statusinfo = json_loads(fp.read())
-            fp.close()
+            with open(statusfilespath, 'r') as fd:
+                statusinfo = json_loads(fd.read())
         except Exception:
             return
         if "applications" in statusinfo:
@@ -48,9 +47,8 @@ class Juju(Plugin, UbuntuPlugin):
     def collect_model_output(self, username, modelsfilepath):
         modelsinfo = {}
         try:
-            fp = open(modelsfilepath, "r")
-            modelsinfo = json_loads(fp.read())
-            fp.close()
+            with open(modelsfilepath, 'r') as fd:
+                modelsinfo = json_loads(fd.read())
         except Exception:
             return
         if "models" in modelsinfo:


### PR DESCRIPTION
Adding support for Juju 2.x. This plugin needed some cleanup.
There are 3 use cases for the juju plugin: the juju client,
a juju deployed machine, and a juju controller.
We have broken the plugin into 3 parts to reflect this.

The juju plugin is now specifically for the juju client use case.
Juju is typically installed as a snap or a package, therefore, we added
/snap/bin to the path for Debian to handle this until a better method
for handling snaps is figured out.

Juju is configured as a user to communicate with the controller it is
therefore necessary to run the juju commands with sudo for them to
execute properly.

This plugin now collects as much information about the juju environment
as possible by using the juju command, this information includes the
configured clouds, models, spaces, model configs, status of each model
and configuration of each app in each model.

Closes #1653

Co-authored-by: David Negreira <david.negreira@canonical.com>
Co-authored-by: Nick Niehoff <nick.niehoff@canonical.com>
Signed-off-by: David Negreira <david.negreira@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
