### PR TITLE
[sosreport] [rfe] grab logs since date

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -24,6 +24,7 @@ sosreport \- Collect and package diagnostic and support data
           [--verify]\fR
           [--log-size]\fR
           [--all-logs]\fR
+          [--since YYYYMMDD[HHMMSS]]\fR
           [-z|--compression-type method]\fR
           [--encrypt-key KEY]\fR
           [--encrypt-pass PASS]\fR
@@ -152,6 +153,10 @@ plugin.
 Tell plugins to collect all possible log data ignoring any size limits
 and including logs in non-default locations. This option may significantly
 increase the size of reports.
+.TP
+.B \--since YYYYMMDD[HHMMSS]
+Limits the collection to logs newer than this date.
+This also affects \--all-logs. Will pad with 0s if HHMMSS isn't specified.
 .TP
 .B \-z, \--compression-type METHOD
 Override the default compression type specified by the active policy.

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -56,7 +56,7 @@ _arg_names = [
     'label', 'list_plugins', 'list_presets', 'list_profiles', 'log_size',
     'noplugins', 'noreport', 'no_env_vars', 'note', 'onlyplugins',
     'plugin_timeout', 'plugopts', 'preset', 'profiles', 'quiet', 'sysroot',
-    'threads', 'tmp_dir', 'verbosity', 'verify'
+    'threads', 'tmp_dir', 'verbosity', 'verify', 'since'
 ]
 
 #: Arguments with non-zero default values
@@ -158,6 +158,7 @@ class SoSOptions(object):
         self.add_preset = ""
         self.alloptions = False
         self.all_logs = False
+        self.since = None
         self.batch = False
         self.build = False
         self.case_id = ""

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -52,7 +52,8 @@ class Logs(Plugin):
                 self.add_copy_spec(i)
 
         if self.get_option('all_logs'):
-            self.add_journal(boot="this", allfields=True, output="verbose")
+            self.add_journal(boot="this", since=self.get_option("since"),
+                             allfields=True, output="verbose")
             self.add_journal(boot="last", allfields=True, output="verbose")
 
     def postproc(self):
@@ -95,8 +96,8 @@ class RedHatLogs(Logs, RedHatPlugin):
                 days = int(self.get_option("log_days"))
             except ValueError:
                 days = 3
-            if self.get_option("all_logs"):
-                since = ""
+            if self.get_option("all_logs") and self.get_options("since"):
+                since = self.get_options("since")
             else:
                 since = "-%ddays" % days
             self.add_journal(since=since)
@@ -122,7 +123,7 @@ class DebianLogs(Logs, DebianPlugin, UbuntuPlugin):
 
         if journal and self.is_installed("systemd"):
             if self.get_option("all_logs"):
-                since = ""
+                since = self.get_options("since")
             else:
                 since = "-%ddays" % days
             self.add_journal(since=since)

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -93,6 +93,7 @@ class EnablerPlugin(Plugin):
 class MockOptions(object):
     all_logs = False
     dry_run = False
+    since = None
     log_size = 25
 
 


### PR DESCRIPTION
Adds a --since switch that takes a date as argument.  This switch
will skip the archive files with a mtime older than the date.

Also, --since affects journalctl execution for --all.

Signed-off-by: David Vallee Delisle <dvd@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
