### PR TITLE
[plugins] Add environment variable collection to multiple plugins

### DIFF
--- a/sos/plugins/crio.py
+++ b/sos/plugins/crio.py
@@ -37,6 +37,13 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
             "/etc/sysconfig/crio-*"
         ])
 
+        self.add_env_var([
+            'HTTP_PROXY',
+            'HTTPS_PROXY',
+            'NO_PROXY',
+            'ALL_PROXY'
+        ])
+
         subcmds = [
             'info',
             'images',

--- a/sos/plugins/dbus.py
+++ b/sos/plugins/dbus.py
@@ -27,4 +27,6 @@ class Dbus(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "busctl status"
         ])
 
+        self.add_env_var('DBUS_SESSION_BUS_ADDRESS')
+
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -33,6 +33,15 @@ class Docker(Plugin):
             "/var/lib/docker/repositories-*"
         ])
 
+        self.add_env_var([
+            'HTTP_PROXY',
+            'HTTPS_PROXY',
+            'NO_PROXY',
+            'ALL_PROXY',
+            'DOCKER_BUILD_PROXY',
+            'DOCKER_RUN_PROXY'
+        ])
+
         self.add_journal(units="docker")
         self.add_cmd_output("ls -alhR /etc/docker")
 

--- a/sos/plugins/host.py
+++ b/sos/plugins/host.py
@@ -33,3 +33,9 @@ class Host(Plugin, RedHatPlugin, DebianPlugin):
             '/etc/sos.conf',
             '/etc/hostid',
         ])
+
+        self.add_env_var([
+            'REMOTEHOST',
+            'TERM',
+            'COLORTERM'
+        ])

--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -49,6 +49,13 @@ class kubernetes(Plugin, RedHatPlugin):
         self.add_copy_spec("/etc/kubernetes")
         self.add_copy_spec("/var/run/flannel")
 
+        self.add_env_var([
+            'KUBECONFIG',
+            'KUBERNETES_HTTP_PROXY',
+            'KUBERNETES_HTTPS_PROXY',
+            'KUBERNETES_NO_PROXY'
+        ])
+
         svcs = [
             'kubelet',
             'kube-apiserver',

--- a/sos/plugins/libraries.py
+++ b/sos/plugins/libraries.py
@@ -25,6 +25,12 @@ class Libraries(Plugin, RedHatPlugin, UbuntuPlugin):
         if self.get_option("ldconfigv"):
             self.add_cmd_output("ldconfig -v -N -X")
 
+        self.add_env_var([
+            'PATH',
+            'LD_LIBRARY_PATH',
+            'LD_PRELOAD'
+        ])
+
         ldconfig_file = self.get_cmd_output_now("ldconfig -p -N -X")
 
         if not ldconfig_file:

--- a/sos/plugins/podman.py
+++ b/sos/plugins/podman.py
@@ -36,6 +36,13 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
             "/etc/containers/policy.json",
         ])
 
+        self.add_env_var([
+            'HTTP_PROXY',
+            'HTTPS_PROXY',
+            'NO_PROXY',
+            'ALL_PROXY'
+        ])
+
         subcmds = [
             'info',
             'images',

--- a/sos/plugins/qt.py
+++ b/sos/plugins/qt.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2019 Red Hat, Inc. Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class Qt(Plugin, RedHatPlugin):
+    '''QT widget toolkit'''
+
+    plugin_name = 'qt'
+    packages = ('qt', )
+
+    def setup(self):
+        self.add_env_var([
+            'QT_IM_MODULE',
+            'QTDIR',
+            'QTLIB',
+            'QT_PLUGIN_PATH',
+            'IMSETTINGS_MODULE'
+        ])
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/x11.py
+++ b/sos/plugins/x11.py
@@ -36,4 +36,19 @@ class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "xrandr --verbose"
         ])
 
+        self.add_env_var([
+            'DISPLAY',
+            'DESKTOP_SESSION',
+            'XDG_SESSION_TYPE',
+            'XDG_SESSION_DESKTOP',
+            'XMODIFIERS',
+            'XDG_CURRENT_DESKTOP',
+            'XDG_SEAT',
+            'XDG_RUNTIME_DIR',
+            'XAUTHORITY',
+            'XDG_SESSION_PATH',
+            'XDG_SEAT_PATH',
+            'XDG_SESSION_ID'
+        ])
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patchset adds environment variable collection to numerous plugins including the container plugins, host, x11, dbus, and a new `qt` plugin.

The environment variables collected were highlighted by the RH support teams and verified that they do not usually contain sensitive information, except in the case of user misconfiguration or best practice violation.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
