### PR TITLE
[katello] support both locations of qpid SSL certs

### DIFF
--- a/sos/plugins/katello.py
+++ b/sos/plugins/katello.py
@@ -10,6 +10,7 @@
 
 from sos.plugins import Plugin, RedHatPlugin
 from pipes import quote
+import os.path
 
 
 class Katello(Plugin, RedHatPlugin):
@@ -24,7 +25,12 @@ class Katello(Plugin, RedHatPlugin):
             "/var/log/httpd/katello-reverse-proxy_error_ssl.log*"
         ])
 
-        cert = "/etc/pki/katello/qpid_client_striped.crt"
+        # certificate file location relies on katello version, it can be either
+        # /etc/pki/katello/qpid_client_striped.crt (for older versions) or
+        # /etc/pki/pulp/qpid/client.crt (for newer versions)
+        cert = "/etc/pki/pulp/qpid/client.crt"
+        if not os.path.isfile(cert):
+            cert = "/etc/pki/katello/qpid_client_striped.crt"
         self.add_cmd_output([
             "qpid-stat -%s --ssl-certificate=%s -b amqps://localhost:5671" %
             (opt, cert) for opt in "quc"


### PR DESCRIPTION
Newer katello versions deploy certs for qpid to
/etc/pki/pulp/qpid/client.crt certs instead of
/etc/pki/katello/qpid_client_striped.crt .

Sosreport should use either of the location that exists, to successfully
run few qpid-stat commands.

Resolves: #1680

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
