### PR TITLE
[grub2] call grub2-config with --no-grubenv-update when appropriate

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -208,7 +208,7 @@ class SoSPredicate(object):
         '''Does 'cmd' output contain string 'output'?'''
         if 'cmd' not in cmd_output or 'output' not in cmd_output:
             return False
-        result = self._owner.get_command_output(cmd_output['cmd'])
+        result = sos_get_command_output(cmd_output['cmd'])
         if result['status'] != 0:
             return False
         for line in result['output'].splitlines():


### PR DESCRIPTION
On some newer grub2 versions, grub2-config removes extra args in
$kernel_opts until --no-grubenv-update option is used.

Test if the option is present in grub2-config --help and if so, use it.

Resolves: #1682

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
