### PR TITLE
[extras] A new plugin to collect user defined commands outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ install:
 	mkdir -p $(DESTDIR)/usr/share/$(NAME)/extras
 	@gzip -c man/en/sosreport.1 > sosreport.1.gz
 	@gzip -c man/en/sos.conf.5 > sos.conf.5.gz
-	mkdir -p $(DESTDIR)/etc
+	mkdir -p $(DESTDIR)/etc/sos.extras.d
 	install -m755 sosreport $(DESTDIR)/usr/sbin/sosreport
 	install -m644 sosreport.1.gz $(DESTDIR)/usr/share/man/man1/.
 	install -m644 sos.conf.5.gz $(DESTDIR)/usr/share/man/man5/.

--- a/sos/plugins/extras.py
+++ b/sos/plugins/extras.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2019 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+import os
+
+
+class Extras(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+    """Extras plugin to collect user declared commands outputs
+       The plugin traverses /etc/sos.extras.d directory and for each
+       file there, it executes each line as a bash command.
+    """
+
+    plugin_name = 'extras'
+
+    def setup(self):
+        _dir = '/etc/sos.extras.d'
+
+        if os.path.isdir(_dir):
+            try:
+                for _file in os.listdir(_dir):
+                    # ignore hidden files
+                    if _file.startswith("."):
+                        continue
+                    p = os.path.join(_dir, _file)
+                    for line in open(p).read().splitlines():
+                        self.add_cmd_output(line, subdir=_file)
+            except IOError as e:
+                # fallback when the cfg file is not accessible
+                self._log_warn("Unable to exec extras due to %s" % e)
+
+
+# vim: et ts=4 sw=4

--- a/sos/plugins/sosreport.py
+++ b/sos/plugins/sosreport.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2019 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+
+
+class Sosreport(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+    """Sos plugin collects information about SoS report itself
+    """
+
+    plugin_name = 'sos'
+
+    def setup(self):
+        self.add_copy_spec([
+            '/etc/sos.conf',
+            '/etc/sos.extras.d'
+        ])
+
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
The plugin traverses /etc/sos.extras.d directory and for each file F there,
it collects outputs of commands on all its lines and stores them in
sos_commands/<F>/<command> sosreport directory tree.

Additionally, a tiny sosreport/sos plugin collecting /etc/sos.conf and
/etc/sos.extras.d is added.

Resolves: #1663

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
