### PR TITLE
[plugins] fix mangled command filenames collisions

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -959,20 +959,27 @@ class Plugin(object):
         if subdir:
             # only allow a single level of subdir to be created
             plugin_dir += "/%s" % subdir.split('/')[0]
-        outfn = os.path.join(self.commons['cmddir'], plugin_dir,
-                             self._mangle_command(exe))
+        outdir = os.path.join(self.commons['cmddir'], plugin_dir)
+        outfn = self._mangle_command(exe)
 
         # check for collisions
-        if os.path.exists(outfn):
-            inc = 2
+        if os.path.exists(os.path.join(self.archive.get_tmp_dir(),
+                                       outdir, outfn)):
+            inc = 1
+            name_max = self.archive.name_max()
             while True:
-                newfn = "%s_%d" % (outfn, inc)
-                if not os.path.exists(newfn):
+                suffix = ".%d" % inc
+                newfn = outfn
+                if name_max < len(newfn)+len(suffix):
+                    newfn = newfn[:(name_max-len(newfn)-len(suffix))]
+                newfn = newfn + suffix
+                if not os.path.exists(os.path.join(self.archive.get_tmp_dir(),
+                                                   outdir, newfn)):
                     outfn = newfn
                     break
                 inc += 1
 
-        return outfn
+        return os.path.join(outdir, outfn)
 
     def add_env_var(self, name):
         """Add an environment variable to the list of to-be-collected env vars.


### PR DESCRIPTION
- Command filenames collisions must be tested tested against absolute path, not
  relative. Otherwise false positive results about no collisions are returned.
    
- Filenames must have shorter lenghts in case collision happens. Since that appends
  "_2" to the name that still must constitute a filename of supported length.
    
Resolves: #1684

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
