### PR TITLE
[kernel] Add timeout when collecting trace file

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -26,6 +26,8 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ("with-timer", "gather /proc/timer* statistics", "slow", False)
     ]
 
+    trace_timeout = 60
+
     def get_bpftool_prog_ids(self, prog_file):
         out = []
         try:
@@ -86,6 +88,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         # FIXME: provide a a long-term solution for #1299
         self.add_forbidden_path([
+            '/sys/kernel/debug/tracing/trace',
             '/sys/kernel/debug/tracing/trace_pipe',
             '/sys/kernel/debug/tracing/README',
             '/sys/kernel/debug/tracing/trace_stat/*',
@@ -132,6 +135,12 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             clocksource_path + "available_clocksource",
             clocksource_path + "current_clocksource"
         ])
+
+        if self.get_option('all_logs'):
+            self.trace_timeout=0
+
+        self.add_cmd_output("cat /sys/kernel/debug/tracing/trace",
+                            timeout=self.trace_timeout)
 
         if self.get_option("with-timer"):
             # This can be very slow, depending on the number of timers,


### PR DESCRIPTION
Updates the plugin to add timeout when collecting trace file.
Collecting a whole trace file may take a lot of time.

Resolves: #1688

Signed-off-by: MIZUTA Takeshi <mizuta.takeshi@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
