### PR TITLE
[Plugin] Add method to scrub certs/keys from collected files

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -502,6 +502,35 @@ class Plugin(object):
             replacements = None
         return replacements
 
+    def do_file_private_sub(self, pathregex):
+        '''Scrub certificate/key/etc information from files collected by sos.
+
+        Files matching the provided pathregex are searched for content that
+        resembles certificate, ssh keys, or similar information. Any matches
+        are replaced with "-----SCRUBBED $thing" where $thing is the specific
+        type of content being replaced, e.g. "-----SCRUBBED RSA PRIVATE KEY" so
+        that support representatives can at least be informed of what type of
+        content it was originally.
+
+        Positional arguments:
+            :param pathregex: A string or regex of a filename to match against
+        '''
+        certmatch = re.compile("-*BEGIN.*?-*END", re.DOTALL)
+        match = re.compile(pathregex).match
+        file_list = [f for f in self.copied_files if match(f['srcpath'])]
+        for i in file_list:
+            path = i['dstpath']
+            if not path:
+                continue
+            self._log_debug("Scrubbing %s for certificate content" % path)
+            readable = self.archive.open_file(path)
+            content = readable.read()
+            if not isinstance(content, six.string_types):
+                content = content.decode('utf-8', 'ignore')
+            result, replacements = certmatch.subn('-----SCRUBBED', content)
+            if replacements:
+                self.archive.add_string(result, path)
+
     def do_file_sub(self, srcpath, regexp, subst):
         '''Apply a regexp substitution to a file archived by sosreport.
         srcpath is the path in the archive where the file can be found.  regexp


### PR DESCRIPTION
This adds a new do_file_private_sub() method to the Plugin class to
allow for easy, and standardized scrubbing of private data such as
certificates or key pairs from files collected by sos, in much the same
way that do_cmd_private_sub() provides that functionality for command
output.

This method only takes a path or path regex representing the
filename/pattern to match against. Matches are replaced with
"-----SCRUBBED $thing" where $thing is the specific type of content
being replaced as provided in the collected file content. For example, a
private key would be replaced with "-----SCRUBBED RSA PRIVATE KEY-----".

This is done so that support representatives can still know the type of
information that was collected, without knowing the actual sensitive
content.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
