### PR TITLE
[plugins] Change forbidden_path from partial-match to exact-match

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -63,7 +63,7 @@ def _mangle_command(command, name_max):
 
 
 def _path_in_path_list(path, path_list):
-    return any(p in path for p in path_list)
+    return any(p == path for p in path_list)
 
 
 def _node_type(st):


### PR DESCRIPTION
forbidden_path is evaluated on partial-match.
However, it will be correct to evaluate on exact-match.

Resolves: #1692

Signed-off-by: MIZUTA Takeshi <mizuta.takeshi@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
