### PR TITLE
[openstack_*] Remove duplicate rpm verify from OpenStack plugins

### DIFF
--- a/sos/plugins/openstack_ceilometer.py
+++ b/sos/plugins/openstack_ceilometer.py
@@ -39,8 +39,6 @@ class OpenStackCeilometer(Plugin):
             "/etc/ceilometer/*",
             self.var_puppet_gen + "/etc/ceilometer/*"
         ])
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/ceilometer/*", regexp, subst)

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -72,9 +72,6 @@ class OpenStackCinder(Plugin):
                 "/var/log/containers/httpd/cinder-api/*log"
             ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
             container_status = self.get_command_output(runtime + " ps")

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -44,9 +44,6 @@ class OpenStackGlance(Plugin):
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf"
         ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
         # collect commands output only if the openstack-glance-api service
         # is running
         service_status = self.get_command_output(

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -89,9 +89,6 @@ class OpenStackHeat(Plugin):
             self.var_puppet_gen + "_api_cfn/var/spool/cron/heat",
         ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
             container_status = self.get_command_output(runtime + " ps")

--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -47,9 +47,6 @@ class OpenStackHorizon(Plugin):
         ])
         self.add_forbidden_path("*.py[co]")
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def postproc(self):
         var_puppet_gen = self.var_puppet_gen + "/horizon"
         protect_keys = [

--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -35,8 +35,6 @@ class OpenStackInstack(Plugin):
 
     def setup(self):
         self.add_copy_spec(NON_CONTAINERIZED_DEPLOY + CONTAINERIZED_DEPLOY)
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
 
         if self.get_option("all_logs"):
             self.add_copy_spec([

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -60,9 +60,6 @@ class OpenStackIronic(Plugin):
             self.add_cmd_output('ls -laRt %s' % path)
             self.add_cmd_output('ls -laRt %s' % (self.var_puppet_gen + path))
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]
 

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -60,9 +60,6 @@ class OpenStackKeystone(Plugin):
             self.domain_config_dir = "/etc/keystone/domains"
         self.add_copy_spec(self.domain_config_dir)
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]
 

--- a/sos/plugins/openstack_neutron.py
+++ b/sos/plugins/openstack_neutron.py
@@ -47,9 +47,6 @@ class OpenStackNeutron(Plugin):
         self.add_forbidden_path("/var/lib/neutron/lock")
         self.add_cmd_output("ls -laZR /var/lib/neutron/lock")
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]
 

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -123,9 +123,6 @@ class OpenStackNova(Plugin):
             self.var_puppet_gen + "_libvirt/var/lib/nova/.ssh/config",
         ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
             container_status = self.get_command_output(runtime + " ps")

--- a/sos/plugins/openstack_octavia.py
+++ b/sos/plugins/openstack_octavia.py
@@ -84,9 +84,6 @@ class OpenStackOctavia(Plugin):
                 "openstack loadbalancer member list %s" % (pool)
             )
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def postproc(self):
         protect_keys = [
             "ca_private_key_passphrase", "heartbeat_key", "password",

--- a/sos/plugins/openstack_sahara.py
+++ b/sos/plugins/openstack_sahara.py
@@ -39,9 +39,6 @@ class OpenStackSahara(Plugin):
                 "/var/log/containers/sahara/*.log"
             ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/sahara/*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/plugins/openstack_swift.py
+++ b/sos/plugins/openstack_swift.py
@@ -45,9 +45,6 @@ class OpenStackSwift(Plugin):
             self.var_puppet_gen + "/memcached/etc/sysconfig/memcached"
         ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub(r"/etc/swift/.*\.conf.*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/plugins/openstack_trove.py
+++ b/sos/plugins/openstack_trove.py
@@ -39,9 +39,6 @@ class OpenStackTrove(Plugin):
             self.var_puppet_gen + '/etc/trove/'
         ])
 
-        if self.get_option("verify"):
-            self.add_cmd_output("rpm -V %s" % ' '.join(self.packages))
-
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/trove/*", regexp, subst)
         self.do_path_regex_sub(


### PR DESCRIPTION
A number of openstack plugins were calling 'rpm -V' against their own
package lists as part of their setup() method when the --verify option
is given to sos. This is already done in normal plugin execution, so
there is no need to duplicate the calls.

This change removes these calls from the openstack plugins.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
