### PR TITLE
[sar] collect whole sar log dir

### DIFF
--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -22,24 +22,9 @@ class Sar(Plugin,):
     option_list = [("all_sar", "gather all system activity records",
                     "", False)]
 
-    # size-limit SAR data collected by default (MB)
-    sa_size = 20
-
     def setup(self):
-        if self.get_option("all_sar"):
-            self.sa_size = 0
-
-        # Copy all sa??, sar??, sa??.* and sar??.* files, which will net
-        # compressed and uncompressed versions, typically.
-        for suffix in ('', '.*'):
-            self.add_copy_spec(
-                os.path.join(self.sa_path, "sa[0-3][0-9]" + suffix),
-                sizelimit=self.sa_size, tailit=False
-            )
-            self.add_copy_spec(
-                os.path.join(self.sa_path, "sar[0-3][0-9]" + suffix),
-                sizelimit=self.sa_size, tailit=False
-            )
+        self.add_copy_spec(self.sa_path,
+                           sizelimit=0 if self.get_option("all_sar") else None)
 
         try:
             dir_list = os.listdir(self.sa_path)


### PR DESCRIPTION
Currently, sosreport does not collect files in saYYYYMMDD or
similar format. Assuming sar log dir contains only sar related data
it is safe to collect whole dir (up to size limit, from newest to
oldest files).

Resolves: #1700

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
