### PR TITLE
[networkmanager] collect custom scripts

### DIFF
--- a/sos/plugins/networkmanager.py
+++ b/sos/plugins/networkmanager.py
@@ -21,7 +21,8 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/NetworkManager/NetworkManager.conf",
-            "/etc/NetworkManager/system-connections"
+            "/etc/NetworkManager/system-connections",
+            "/etc/NetworkManager/dispatcher.d"
         ])
 
         # There are some incompatible changes in nmcli since


### PR DESCRIPTION
Collect custom scripts from /etc/NetworkManager/dispatcher.d directory

Resolves: #1701

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
