### PR TITLE
[ovirt] Collect host certs

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -132,6 +132,14 @@ class Ovirt(Plugin, RedHatPlugin):
             "/var/lib/ovirt-engine-reports/jboss_runtime/config"
         ])
 
+        # Copying host certs.
+        self.add_forbidden_path([
+            "/etc/pki/ovirt-engine/keys",
+            "/etc/pki/ovirt-engine/private",
+            "/etc/pki/ovirt-engine/.truststore"
+        ])
+        self.add_copy_spec("/etc/pki/ovirt-engine/")
+
     def postproc(self):
         """
         Obfuscate sensitive keys.


### PR DESCRIPTION
Collecting /etc/pki/ovirt-engine/ helps to identify expired host certs.

Resolves: #1704

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
