### PR TITLE
[archive] Handle checking container sysroot in _make_leading_paths

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -139,12 +139,13 @@ class FileCacheArchive(Archive):
     _archive_root = ""
     _archive_name = ""
 
-    def __init__(self, name, tmpdir, policy, threads, enc_opts):
+    def __init__(self, name, tmpdir, policy, threads, enc_opts, sysroot):
         self._name = name
         self._tmp_dir = tmpdir
         self._policy = policy
         self._threads = threads
         self.enc_opts = enc_opts
+        self.sysroot = sysroot
         self._archive_root = os.path.join(tmpdir, name)
         with self._path_lock:
             os.makedirs(self._archive_root, 0o700)
@@ -155,6 +156,13 @@ class FileCacheArchive(Archive):
         if os.path.isabs(name):
             name = name.lstrip(os.sep)
         return (os.path.join(self._archive_root, name))
+
+    def join_sysroot(self, path):
+        if path.startswith(self.sysroot):
+            return path
+        if path[0] == os.sep:
+            path = path[1:]
+        return os.path.join(self.sysroot, path)
 
     def _make_leading_paths(self, src, mode=0o700):
         """Create leading path components
@@ -191,7 +199,8 @@ class FileCacheArchive(Archive):
             src_dir = src
         else:
             # Host file path
-            src_dir = src if os.path.isdir(src) else os.path.split(src)[0]
+            src_dir = (src if os.path.isdir(self.join_sysroot(src))
+                       else os.path.split(src)[0])
 
         # Build a list of path components in root-to-leaf order.
         path = src_dir
@@ -670,9 +679,9 @@ class TarFileArchive(FileCacheArchive):
     method = None
     _with_selinux_context = False
 
-    def __init__(self, name, tmpdir, policy, threads, enc_opts):
+    def __init__(self, name, tmpdir, policy, threads, enc_opts, sysroot):
         super(TarFileArchive, self).__init__(name, tmpdir, policy, threads,
-                                             enc_opts)
+                                             enc_opts, sysroot)
         self._suffix = "tar"
         self._archive_name = os.path.join(tmpdir, self.name())
 

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -379,12 +379,12 @@ class SoSReport(object):
             auto_archive = self.policy.get_preferred_archive()
             self.archive = auto_archive(archive_name, self.tmpdir,
                                         self.policy, self.opts.threads,
-                                        enc_opts)
+                                        enc_opts, self.sysroot)
 
         else:
             self.archive = TarFileArchive(archive_name, self.tmpdir,
                                           self.policy, self.opts.threads,
-                                          enc_opts)
+                                          enc_opts, self.sysroot)
 
         self.archive.set_debug(True if self.opts.debug else False)
 

--- a/tests/archive_tests.py
+++ b/tests/archive_tests.py
@@ -20,7 +20,7 @@ class TarFileArchiveTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         enc = {'encrypt': False}
-        self.tf = TarFileArchive('test', self.tmpdir, Policy(), 1, enc)
+        self.tf = TarFileArchive('test', self.tmpdir, Policy(), 1, enc, '/')
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
Previously, in _make_leading_paths(), checking host file paths did not
account for non / sysroots, for situations where sos is run in a
container and the host's / is actually mounted under /host for example.
This would lead to copy errors when trying to copy symlinks.

This method now will use sysroot if one is set, thus avoiding copy
errors.

Credit to Pavel Moravec for identification of where this flaw was
originating, and the correction within _make_leading_paths().

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
