### PR TITLE
[crio] Write outputs to subdir, fix possible exception in output parsing

### DIFF
--- a/sos/plugins/crio.py
+++ b/sos/plugins/crio.py
@@ -66,13 +66,14 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
         for container in containers:
             self.add_cmd_output("crictl inspect %s" % container)
             if self.get_option('logs'):
-                self.add_cmd_output("crictl logs -t %s" % container)
+                self.add_cmd_output("crictl logs -t %s" % container,
+                                    subdir="containers")
 
         for image in images:
-            self.add_cmd_output("crictl inspecti %s" % image)
+            self.add_cmd_output("crictl inspecti %s" % image, subdir="images")
 
         for pod in pods:
-            self.add_cmd_output("crictl inspectp %s" % pod)
+            self.add_cmd_output("crictl inspectp %s" % pod, subdir="pods")
 
     def _get_crio_list(self, cmd):
         ret = []
@@ -81,7 +82,7 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
             for ent in result['output'].splitlines():
                 ret.append(ent)
             # Prevent the socket deprecation warning from being iterated over
-            if 'deprecated' in ret[0]:
+            if ret and 'deprecated' in ret[0]:
                 ret.pop(0)
         return ret
 


### PR DESCRIPTION
Updates the plugin to write container/image/pod output from crictl to
subdirs.

Additionally, fixes an issue where an exception could be raised when a
crictl command has no output at all.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
