### PR TITLE
[archive] convert absolute symlink targets to relative

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -232,6 +232,11 @@ class FileCacheArchive(Archive):
                     dest = self._make_leading_paths(target_src, mode=mode)
                     dest = os.path.normpath(dest)
 
+                    # In case symlink target is an absolute path, make it
+                    # relative to the directory with symlink source
+                    if os.path.isabs(target):
+                        target = os.path.relpath(target, target_dir)
+
                     self.log_debug("Making symlink '%s' -> '%s'" %
                                    (abs_path, target))
                     os.symlink(target, abs_path)


### PR DESCRIPTION
Calling _make_leading_paths for a symlink with absolute symlink target
must create the symlink relative to the source. This will prevent
creating symlinks outside sosreport build dir.

Resolves: #1710

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
