### PR TITLE
[ipa] copy httpd cert from new location

### DIFF
--- a/sos/plugins/ipa.py
+++ b/sos/plugins/ipa.py
@@ -115,6 +115,7 @@ class Ipa(Plugin, RedHatPlugin):
             "/var/lib/certmonger/requests/[0-9]*",
             "/var/lib/certmonger/cas/[0-9]*",
             "/var/lib/ipa/ra-agent.pem",
+            "/var/lib/ipa/certs/httpd.crt",
             "/var/kerberos/krb5kdc/kdc.crt",
             "/var/lib/ipa/sysrestore/sysrestore.state"
         ])


### PR DESCRIPTION
With the FreeIPA 4.7.0 release, httpd moved from mod_nss to mod_ssl. As                                                                                                                                             
a result the httpd X.509 certificate is now no longer stored in NSS DB                                                                                                                                              
but as plain PEM text file: /var/lib/ipa/certs/httpd.crt. The plugin                                                                                                                                                
needs to copy this file into the sos archive.

https://github.com/sosreport/sos/issues/1715

Signed-off-by: Thorsten Scherf <tscherf@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
