### PR TITLE
[docker] strip network ID properly from "docker network ls"

### DIFF
--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -61,7 +61,7 @@ class Docker(Plugin):
         nets = self.get_command_output('docker network ls')
 
         if nets['status'] == 0:
-            n = [n.split()[1] for n in nets['output'].splitlines()[1:]]
+            n = [n.split()[0] for n in nets['output'].splitlines()[1:]]
             for net in n:
                 self.add_cmd_output("docker network inspect %s" % net)
 


### PR DESCRIPTION
"docker network ls" prints network ID in the first column.

Resolves: #1718

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
