### PR TITLE
[process] Specify 20 for wchan length

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -27,7 +27,7 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         # process group and thread options
         ps_group_opts = "pid,ppid,user,group,lwp,nlwp,start_time,comm,cgroup"
         ps_sched_opts = "flags,state,uid,pid,ppid,pgid,sid,cls,pri,addr,sz,"
-        ps_sched_opts += "wchan,lstart,tty,time,cmd"
+        ps_sched_opts += "wchan:20,lstart,tty,time,cmd"
 
         self.add_copy_spec([
             "/proc/sched_debug",


### PR DESCRIPTION
wchan column is now truncated because there are many columns.
It is impossible to distinguish the symbol name if there are many
similar symbol names. Therefore, specify wchan size.

In this commit, we choose 20 for the wchan size but there could be
better value. Let's change this if it turns out that in the future.

Example: here is an output of ps command when plymouthd process
got hanged:

    F  UID    PID PPID PRI  NI    VSZ   RSS WCHAN  STAT TTY      TIME COMMAND
    5    0    159    1  20   0  44644  1696 n_tty_ S    ?        0:04 /bin/plymouthd --attach-to-session

The prefix n_tty_ is used in tty device driver of linux kernel
as follows:

    struct tty_ldisc_ops tty_ldisc_N_TTY = {
	    .magic           = TTY_LDISC_MAGIC,
	    .name            = "n_tty",
	    .open            = n_tty_open,
	    .close           = n_tty_close,
	    .flush_buffer    = n_tty_flush_buffer,
	    .chars_in_buffer = n_tty_chars_in_buffer,
	    .read            = n_tty_read,
	    .write           = n_tty_write,
	    .ioctl           = n_tty_ioctl,
	    .set_termios     = n_tty_set_termios,
	    .poll            = n_tty_poll,
	    .receive_buf     = n_tty_receive_buf,
	    .write_wakeup    = n_tty_write_wakeup,
	    .fasync          = n_tty_fasync,
    };

As you can see, it is impossible to find the symbol name of the
kernel function where plymouthd process slept from n_tty_.

Signed-off-by: Tomofumi Yoshida <yoshida.tomo@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
