### PR TITLE
[process] collect /proc/[0-9]*/smaps via plug.option

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -19,7 +19,8 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     option_list = [
         ("lsof", "gathers information on all open files", "slow", True),
         ("lsof-threads", "gathers threads' open file info if supported",
-         "slow", False)
+         "slow", False),
+        ("smaps", "gathers all /proc/*/smaps files", "", False)
     ]
 
     def setup(self):
@@ -33,6 +34,9 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/proc/sched_debug",
             "/proc/stat"
         ])
+
+        if self.get_option("smaps"):
+            self.add_copy_spec("/proc/[0-9]*/smaps")
 
         self.add_cmd_output("ps auxwww", root_symlink="ps")
         self.add_cmd_output("pstree", root_symlink="pstree")


### PR DESCRIPTION
Usefull to identify e.g. swapiness of individual processes.

Must be enabled via -k process.smaps.

Resolves: #1725

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
