### PR TITLE
[sosreport,reporting] replace HTML reports by Report subclass

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1338,59 +1338,6 @@ class Plugin(object):
         """
         pass
 
-    def report(self):
-        """ Present all information that was gathered in an html file that
-        allows browsing the results.
-        """
-        # make this prettier
-        html = u'<hr/><a name="%s"></a>\n' % self.name()
-
-        # Intro
-        html = html + "<h2> Plugin <em>" + self.name() + "</em></h2>\n"
-
-        # Files
-        if len(self.copied_files):
-            html = html + "<p>Files copied:<br><ul>\n"
-            for afile in self.copied_files:
-                html = html + '<li><a href="%s">%s</a>' % \
-                    (u'..' + _to_u(afile['dstpath']), _to_u(afile['srcpath']))
-                if afile['symlink'] == "yes":
-                    html = html + " (symlink to %s)" % _to_u(afile['pointsto'])
-                html = html + '</li>\n'
-            html = html + "</ul></p>\n"
-
-        # Command Output
-        if len(self.executed_commands):
-            html = html + "<p>Commands Executed:<br><ul>\n"
-            # convert file name to relative path from our root
-            # don't use relpath - these are HTML paths not OS paths.
-            for cmd in self.executed_commands:
-                if cmd["file"] and len(cmd["file"]):
-                    cmd_rel_path = u"../" + _to_u(self.commons['cmddir']) \
-                        + "/" + _to_u(cmd['file'])
-                    html = html + '<li><a href="%s">%s</a></li>\n' % \
-                        (cmd_rel_path, _to_u(cmd['exe']))
-                else:
-                    html = html + '<li>%s</li>\n' % (_to_u(cmd['exe']))
-            html = html + "</ul></p>\n"
-
-        # Alerts
-        if len(self.alerts):
-            html = html + "<p>Alerts:<br><ul>\n"
-            for alert in self.alerts:
-                html = html + '<li>%s</li>\n' % _to_u(alert)
-            html = html + "</ul></p>\n"
-
-        # Custom Text
-        if self.custom_text != "":
-            html = html + "<p>Additional Information:<br>\n"
-            html = html + _to_u(self.custom_text) + "</p>\n"
-
-        if six.PY2:
-            return html.encode('utf8')
-        else:
-            return html
-
     def check_process_by_name(self, process):
         """Checks if a named process is found in /proc/[0-9]*/cmdline.
         Returns either True or False."""


### PR DESCRIPTION
Current HTML report generation is slow and its implementation is full
of scattered html code. We shall utilize Report class instead.

Additionally, add JSON report format for easy automated parsing.

Resolves: #1713

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
