### PR TITLE
[openstack_container_image_prepare] New plugin

### DIFF
--- a/sos/plugins/openstack_container_image_prepare.py
+++ b/sos/plugins/openstack_container_image_prepare.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2019 Cédric Jeanneret <cjeanner@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class OpenStackContainerImagePrepare(Plugin, RedHatPlugin,
+                                     DebianPlugin, UbuntuPlugin):
+    """OpenStack container-image-prepare sos plugin."""
+
+    plugin_name = "openstack_container_image_prepare"
+    profiles = ('openstack',)
+    files = ('/var/log/tripleo-container-image-prepare.log',)
+
+    def setup(self):
+        """Gathering the contents of the report."""
+        self.add_copy_spec([
+            '/var/log/tripleo-container-image-prepare.log'
+        ])


### PR DESCRIPTION
The OpenStack installer (tripleo) creates a dedicated log at an early
step, when it fetches the container images for the deploy. Until now,
this log is absent from SOSReport, making debugging this specific step
impossible, since the output isn't in any other log.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
