### PR TITLE
[openstack_instack] Add container-image-prepare log

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -23,7 +23,8 @@ CONTAINERIZED_DEPLOY = [
         '/var/log/heat-launcher/',
         '/home/stack/install-undercloud.log',
         '/home/stack/undercloud-install-*.tar.bzip2',
-        '/var/lib/mistral/config-download-latest/ansible.log'
+        '/var/lib/mistral/config-download-latest/ansible.log',
+        '/var/log/tripleo-container-image-prepare.log'
 ]
 
 


### PR DESCRIPTION
During undercloud and overcloud deploy preparation steps, a task is
fetching container images and pushing them to a local registry
(usually on the undercloud directly).

Since this task might fail at some point, we need this log in order to
properly debug the issue and provide better support.

The task itself doesn't produce any other output than this log, and only
exists on the undercloud.

Signed-off-by: Cédric Jeanneret <cjeanner@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
