### PR TITLE
[ovn] Minor enhancements to the OVN plugin

### DIFF
--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -57,6 +57,8 @@ class OVNCentral(Plugin):
 
         # Some user-friendly versions of DB output
         cmds = [
+            'ovn-nbctl show',
+            'ovn-sbctl show',
             'ovn-sbctl lflow-list',
             'ovn-nbctl get-ssl',
             'ovn-nbctl get-connection',

--- a/sos/plugins/ovn_host.py
+++ b/sos/plugins/ovn_host.py
@@ -35,7 +35,7 @@ class OVNHost(Plugin):
         self.add_cmd_output([
             'ovs-ofctl -O OpenFlow13 dump-flows br-int',
             'ovs-vsctl list-br',
-            'ovs-vsctl list OpenVswitch',
+            'ovs-vsctl list Open_vSwitch',
         ])
 
         self.add_journal(units="ovn-controller")

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -147,7 +147,7 @@ def sos_get_command_output(command, timeout=300, stderr=False,
         else:
             expanded_args.append(arg)
     try:
-        p = Popen(expanded_args, shell=False, stdout=PIPE,
+        p = Popen(expanded_args, stdin=PIPE, shell=False, stdout=PIPE,
                   stderr=STDOUT if stderr else PIPE,
                   bufsize=-1, env=cmd_env, close_fds=True,
                   preexec_fn=_child_prep_fn)


### PR DESCRIPTION
This patch is adding 'show' commands for both OVN
NorthBound and SouthBound databases.

It's also fixing a table name when listing the local
Open_vSwitch table.

Signed-off-by: Daniel Alvarez <dalvarez@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
