### PR TITLE
[utilities] Fix high CPU usage and slow command collection

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -18,6 +18,7 @@ import errno
 import shlex
 import glob
 import threading
+import time
 
 from contextlib import closing
 from collections import deque
@@ -158,6 +159,7 @@ def sos_get_command_output(command, timeout=300, stderr=False,
                 if poller():
                     p.terminate()
                     raise SoSTimeoutError
+                time.sleep(0.01)
         stdout = reader.get_contents()
         while p.poll() is None:
             pass
@@ -248,7 +250,7 @@ class AsyncReader(threading.Thread):
         # block until command completes or timesout (separate from the plugin
         # hitting a timeout)
         while self.running:
-            pass
+            time.sleep(0.01)
         if not self.binary:
             return ''.join(ln.decode('utf-8', 'ignore') for ln in self.deque)
         else:


### PR DESCRIPTION
[utilities] Fix high CPU usage and slow command collection
    
commit fc6721ac83c2 ("[Plugin] Terminate running commands when a plugin
exceeds timeout") introduced a polling method to sos_get_command_output()
but it is busy wait, and seems to increase the CPU usage and slow down
AsyncReader significantly.
    
As a result, a command that outputs much data like journalctl takes
longer time, and the plugin times out.

Inserting a sleep is a possible fix for this.

Signed-off-by: Kazuhito Hagio &lt;k-hagio@ab.jp.nec.com&gt;

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
