### PR TITLE
[openswan,libreswan] Don't run openswan use new plugin for "libreswan"

### DIFF
--- a/sos/plugins/libreswan.py
+++ b/sos/plugins/libreswan.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007 Sadique Puthen <sputhenp@redhat.com>
+# Copyright (C) 2019 Red Hat Inc., Stepan Broz <sbroz@redhat.com>
 
 # This file is part of the sos project: https://github.com/sosreport/sos
 #
@@ -11,29 +12,38 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Openswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Openswan IPsec
+class Libreswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """Libreswan IPsec
     """
 
-    plugin_name = 'openswan'
-    profiles = ('network', 'security')
+    plugin_name = 'libreswan'
+    profiles = ('network', 'security', 'openshift')
     option_list = [
         ("ipsec-barf", "collect the output of the ipsec barf command",
          "slow", False)
     ]
 
     files = ('/etc/ipsec.conf',)
-    packages = ('openswan', 'libreswan')
+    packages = ('libreswan', 'openswan')
 
     def setup(self):
         self.add_copy_spec([
             "/etc/ipsec.conf",
-            "/etc/ipsec.d"
+            "/etc/ipsec.d",
+            "/proc/net/xfrm_stat"
         ])
 
         # although this is 'verification' it's normally a very quick
         # operation so is not conditional on --verify
-        self.add_cmd_output("ipsec verify")
+        self.add_cmd_output([
+            'ipsec verify',
+            'ipsec whack --status',
+            'ipsec whack --listall',
+            'certutil -L -d sql:/etc/ipsec.d',
+            'ip xfrm policy',
+            'ip xfrm state'
+        ])
+
         if self.get_option("ipsec-barf"):
             self.add_cmd_output("ipsec barf")
 
@@ -43,5 +53,18 @@ class Openswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             '/etc/ipsec.d/*.db',
             '/etc/ipsec.d/*.secrets'
         ])
+
+    def postproc(self):
+        # Remove any sensitive data.
+        # "ip xfrm state" output contains encryption or authentication private
+        # keys:
+        xfrm_state_regexp = r'(aead|auth|auth-trunc|enc)' \
+                            r'(\s.*\s)(0x[0-9a-f]+)'
+        self.do_cmd_output_sub("state", xfrm_state_regexp,
+                               r"\1\2********")
+
+        if self.get_option("ipsec-barf"):
+            self.do_cmd_output_sub("barf", xfrm_state_regexp,
+                                   r"\1\2********")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Changes openswan plugin to run for "openswan" package only.

Adds a new plugin that collects IPsec information for "libreswan" package that replaced "openswan". Removes old "openswan" plugin.

Data collected now include configuration, current status, XFRM policy and state, XFRM statistics, basic information about certificates and NSS database.

No private data (keys, certificates, secrets) are collected, authentication and encryption keys are removed from the output of "ip xfrm state".

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
