### PR TITLE
[peripety] collect proper config file

### DIFF
--- a/sos/plugins/peripety.py
+++ b/sos/plugins/peripety.py
@@ -20,7 +20,7 @@ class Peripety(Plugin, RedHatPlugin):
     services = ('peripetyd',)
 
     def setup(self):
-        self.add_copy_spec('/etc/peripety.conf')
+        self.add_copy_spec('/etc/peripetyd.conf')
 
         forbid_reg = [
             'vd.*',


### PR DESCRIPTION
The config file is /etc/peripetyd.conf .

Resolves: #1737

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
