### PR TITLE
[ceph] Add quorum_status and mon_status

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -56,6 +56,8 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph osd stat",
             "ceph osd dump",
             "ceph mon stat",
+            "ceph mon_status",
+            "ceph quorum_status",
             "ceph mon dump",
             "ceph df",
             "ceph report",


### PR DESCRIPTION
This change adds the quorum_status and mon_status output 
to the ceph plugin.

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
