### PR TITLE
[plugins] Stop plugin execution after timeout hit

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -652,6 +652,9 @@ class Plugin(object):
         everything below it is recursively copied. A list of copied files are
         saved for use later in preparing a report.
         '''
+        if self._timeout_hit:
+            return
+
         if self._is_forbidden_path(srcpath):
             self._log_debug("skipping forbidden path '%s'" % srcpath)
             return ''
@@ -852,6 +855,9 @@ class Plugin(object):
     def get_command_output(self, prog, timeout=300, stderr=True,
                            chroot=True, runat=None, env=None,
                            binary=False, sizelimit=None):
+        if self._timeout_hit:
+            return
+
         if chroot or self.commons['cmdlineopts'].chroot == 'always':
             root = self.sysroot
         else:
@@ -1012,6 +1018,9 @@ class Plugin(object):
         """Execute a command and save the output to a file for inclusion in the
         report.
         """
+        if self._timeout_hit:
+            return
+
         start = time()
 
         result = self.get_command_output(cmd, timeout=timeout, stderr=stderr,
@@ -1201,6 +1210,8 @@ class Plugin(object):
 
     def _collect_strings(self):
         for string, file_name in self.copy_strings:
+            if self._timeout_hit:
+                return
             content = ''
             if string:
                 content = string.splitlines()[0]


### PR DESCRIPTION
When a plugin timeouts, it must stop collecting further data. Otherwise
a race issues with archive.finalize() can happen.

So any data collection must be skipped if _timeout_hit is True.

Resolves: #1736

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
