### PR TITLE
[nvme] collect config file everytime

### DIFF
--- a/sos/plugins/nvme.py
+++ b/sos/plugins/nvme.py
@@ -21,6 +21,7 @@ class Nvme(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         return [dev for dev in sys_block if dev.startswith('nvme')]
 
     def setup(self):
+        self.add_copy_spec("/etc/nvme/discovery.conf")
         self.add_cmd_output([
             "nvme list",
             "nvme list-subsys",
@@ -39,6 +40,5 @@ class Nvme(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                 "nvme show-regs /dev/%s" % dev,
                 "nvme get-ns-id /dev/%s" % dev
             ])
-            self.add_copy_spec("/etc/nvme/discovery.conf")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Collect /etc/nvme/discovery.conf every time, outside any for-loop block.

Resolves: #1740

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
