### PR TITLE
[kdump] collect kexec_crash_* on all distributions

### DIFF
--- a/sos/plugins/kdump.py
+++ b/sos/plugins/kdump.py
@@ -18,7 +18,9 @@ class KDump(Plugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/proc/cmdline"
+            "/proc/cmdline",
+            "/sys/kernel/kexec_crash_loaded",
+            "/sys/kernel/kexec_crash_size"
         ])
 
 
@@ -28,6 +30,7 @@ class RedHatKDump(KDump, RedHatPlugin):
     packages = ('kexec-tools',)
 
     def setup(self):
+        super(RedHatKDump, self).setup()
         self.add_copy_spec([
             "/etc/kdump.conf",
             "/etc/udev/rules.d/*kexec.rules",
@@ -41,6 +44,7 @@ class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
     packages = ('kdump-tools',)
 
     def setup(self):
+        super(DebianKDump, self).setup()
         self.add_copy_spec([
             "/etc/default/kdump-tools"
         ])


### PR DESCRIPTION
Collect /sys/kernel/kexec_crash_[size|loaded] on both RedHat
and Debian distributions.

Resolves: #1742

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
