### PR TITLE
[kdump] collect kdump initramfs content

### DIFF
--- a/sos/plugins/kdump.py
+++ b/sos/plugins/kdump.py
@@ -6,6 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
+import platform
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
@@ -28,11 +30,17 @@ class RedHatKDump(KDump, RedHatPlugin):
     packages = ('kexec-tools',)
 
     def setup(self):
+        initramfs_img = "/boot/initramfs-" + platform.release() \
+                        + "kdump.img"
+
         self.add_copy_spec([
             "/etc/kdump.conf",
             "/etc/udev/rules.d/*kexec.rules",
             "/var/crash/*/vmcore-dmesg.txt"
         ])
+
+        if os.path.exists(initramfs_img):
+            self.add_cmd_output("lsinitrd %s" % initramfs_img)
 
 
 class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
@@ -41,8 +49,13 @@ class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
     packages = ('kdump-tools',)
 
     def setup(self):
+        initramfs_img = "/var/lib/kdump/initrd.img-" + platform.release()
+
         self.add_copy_spec([
             "/etc/default/kdump-tools"
         ])
+
+        if os.path.exists(initramfs_img):
+            self.add_cmd_output("lsinitrd %s" % initramfs_img)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch adds a command (lsinitrd) to extract the content of
kdump initramfs.

Signed-off-by: Sourabh Jain <sourabhjain@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
