### PR TITLE
[plugins] Fix ignored parameters in get_cmd_output_now()

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1061,7 +1061,9 @@ class Plugin(object):
                            (exe, self.get_predicate(cmd=True, pred=pred)))
             return None
 
-        return self._get_cmd_output_now(exe, timeout=timeout, stderr=stderr,
+        return self._get_cmd_output_now(exe, suggest_filename=suggest_filename,
+                                        root_symlink=root_symlink,
+                                        timeout=timeout, stderr=stderr,
                                         chroot=chroot, runat=runat,
                                         env=env, binary=binary,
                                         sizelimit=sizelimit)


### PR DESCRIPTION
Currently the `get_cmd_output_now()` function does not pass
`suggest_filename` and `root_symlink` parameters to
`_get_cmd_output_now()` function, so the parameters passed
from plugins are ignored.  Let's fix this.

Signed-off-by: Kazuhito Hagio &lt;k-hagio@ab.jp.nec.com&gt;

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?