### PR TITLE
[openstack_nova] apply sizelimit to each logfile separately

### DIFF
--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -94,12 +94,24 @@ class OpenStackNova(Plugin):
                 "/var/log/containers/httpd/nova-placement/"
             ])
         else:
-            self.add_copy_spec([
-                "/var/log/nova/*.log",
-                "/var/log/containers/nova/*.log",
-                "/var/log/containers/httpd/nova-api/*log",
-                "/var/log/containers/httpd/nova-placement/*log"
-            ])
+            # apply sizelimit to individual logs separately
+            novadirs = [
+                "/var/log/nova/",
+                "/var/log/containers/nova/",
+                "/var/log/containers/httpd/nova-api/",
+                "/var/log/containers/httpd/nova-placement/"
+            ]
+            novalogs = [
+                "nova-api.log*",
+                "nova-compute.log*",
+                "nova-conductor.log*",
+                "nova-manage.log*",
+                "nova-placement-api.log*",
+                "nova-scheduler.log*"
+            ]
+            for novadir in novadirs:
+                for novalog in novalogs:
+                    self.add_copy_spec(os.path.join(novadir, novalog))
 
         self.add_copy_spec([
             "/etc/nova/",


### PR DESCRIPTION
Apply sizelimit separately to individual logfile types to esnure
newest logfile of each type is always collected.

Further, collect also logrotated version fo those files
(up to sizelimit).

Resolves: #1747

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
