### PR TITLE
[openstack_octavia] fix debian/ubuntu package name

### DIFF
--- a/sos/plugins/openstack_octavia.py
+++ b/sos/plugins/openstack_octavia.py
@@ -103,7 +103,7 @@ class OpenStackOctavia(Plugin):
 
 class DebianOctavia(OpenStackOctavia, DebianPlugin, UbuntuPlugin):
 
-    packages = ('openstack-octavia-common',)
+    packages = ('octavia-common',)
 
 
 class RedHatOctavia(OpenStackOctavia, RedHatPlugin):


### PR DESCRIPTION
The correct package name for Debian/Ubuntu is 'octavia-common' rather
than 'openstack-octavia-common' (which was from RedHat)

Signed-off-by: Trent Lloyd <trent@lloyd.id.au>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
