### PR TITLE
[leapp] Add Plugin From Downstream

### DIFF
--- a/sos/plugins/leapp.py
+++ b/sos/plugins/leapp.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2019 Red Hat, Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class Leapp(Plugin, RedHatPlugin):
+    """
+    Leapp upgrade handling tool
+    """
+
+    plugin_name = 'leapp'
+    packages = ('leapp', 'leapp-repository')
+
+    def setup(self):
+        self.add_copy_spec([
+            '/var/log/leapp/dnf-debugdata/',
+            '/var/log/leapp/leapp-upgrade.log',
+            '/var/log/leapp/leapp-report.txt',
+            '/var/log/leapp/dnf-plugin-data.txt'
+        ])
+
+        # capture DB without sizelimit
+        self.add_copy_spec('/var/lib/leapp/leapp.db', sizelimit=0)
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds the downstream leapp plugin directly into sos. Additionally fixing
an issue where the leapp database may be truncated, rendering the
collected database file unusable.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
