### PR TITLE
[Plugin] Apply cmd predicates to add_cmd_output

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -957,6 +957,8 @@ class Plugin(object):
             self._log_warn("ambiguous filename or symlink for command list")
         if sizelimit is None:
             sizelimit = self.get_option("log_size")
+        if pred is None:
+            pred = self.get_predicate(cmd=True)
         for cmd in cmds:
             self._add_cmd_output(cmd=cmd, suggest_filename=suggest_filename,
                                  root_symlink=root_symlink, timeout=timeout,


### PR DESCRIPTION
If no predicate was passed to add_cmd_output() calls, then a predicate
set by set_cmd_predicate() was not being applied to those calls, thus
leading to a 'None' predicate being evaluated and potentially causing an
exception in plugins such as docker where the bulk of command collection
is gated by the service running.

Now if no predicate is handed to add_cmd_output(), and a cmd_predicate
has been set, then the cmd_predicate is applied before being handed off
to the _add_cmd_output() helper.

Fixes: #1756

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
