### PR TITLE
[libvirt] Collect rotated qemu logs and remove size limits

### DIFF
--- a/sos/plugins/libvirt.py
+++ b/sos/plugins/libvirt.py
@@ -46,10 +46,12 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         ])
 
         if not self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/libvirt/libvirtd.log", sizelimit=5)
-            self.add_copy_spec("/var/log/libvirt/qemu/*.log", sizelimit=5)
-            self.add_copy_spec("/var/log/libvirt/lxc/*.log", sizelimit=5)
-            self.add_copy_spec("/var/log/libvirt/uml/*.log", sizelimit=5)
+            self.add_copy_spec([
+                "/var/log/libvirt/libvirtd.log",
+                "/var/log/libvirt/qemu/*.log*",
+                "/var/log/libvirt/lxc/*.log",
+                "/var/log/libvirt/uml/*.log"
+            ])
         else:
             self.add_copy_spec("/var/log/libvirt")
 


### PR DESCRIPTION
Expands qemu log collection to included rotated logs.

Additionally, removes the 5MB limit for each path collection as sos now
has implicit size limiting in place, and 5MB would be too small of a
limit for systems running a large number of VMs (such as OSP or oVirt
nodes).

Related: RHBZ#1743329

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
