### PR TITLE
[instack] getting a copy of tripleo-config

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -23,6 +23,7 @@ CONTAINERIZED_DEPLOY = [
         '/var/log/heat-launcher/',
         '/home/stack/install-undercloud.log',
         '/home/stack/undercloud-install-*.tar.bzip2',
+        '/var/lib/tripleo-config/',
         '/var/lib/mistral/config-download-latest/ansible.log'
 ]
 


### PR DESCRIPTION
When troubleshooting containerized OOO Deployments,
it can help a lot to have the tripleo-config files
on the overcloud nodes.

Supersedes #1650

Signed-off-by: David Vallee Delisle dvd@redhat.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
