### PR TITLE
[vdsm]: Fix executing shell commands

### DIFF
--- a/sos/plugins/vdsm.py
+++ b/sos/plugins/vdsm.py
@@ -92,8 +92,8 @@ class Vdsm(Plugin, RedHatPlugin):
             ])
         self.add_cmd_output([
             "ls -ldZ /etc/vdsm",
-            "su vdsm -s sh -c 'tree -l /rhev/data-center'",
-            "su vdsm -s sh -c 'ls -lR /rhev/data-center'"
+            "su vdsm -s /bin/sh -c 'tree -l /rhev/data-center'",
+            "su vdsm -s /bin/sh -c 'ls -lR /rhev/data-center'"
         ])
         self.add_cmd_output([
             "lvm vgs -v -o +tags --config \'%s\'" % LVM_CONFIG,


### PR DESCRIPTION
During review process of [1] it was suggested to replace '/bin/sh' with
just 'sh', but unfortunately this change caused an error to not include
information about VDSM mount points as described in [2]. This fix
restores previous state and add full path to shell executions.

[1] https://github.com/sosreport/sos/pull/1205
[2] https://bugzilla.redhat.com/1743304

Closes: https://bugzilla.redhat.com/1743304
Signed-off-by: Martin Perina <mperina@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
