### PR TITLE
[boot] add information about secure boot state (uefi)

### DIFF
--- a/sos/plugins/boot.py
+++ b/sos/plugins/boot.py
@@ -37,6 +37,7 @@ class Boot(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
 
         self.add_cmd_output("efibootmgr -v")
+        self.add_cmd_output("mokutil --sb-state")
 
         if self.get_option("all-images"):
             for image in glob('/boot/initr*.img'):


### PR DESCRIPTION
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
