### PR TITLE
[policies/amazon] Handle missing /etc/os-release properly

### DIFF
--- a/sos/policies/amazon.py
+++ b/sos/policies/amazon.py
@@ -12,6 +12,7 @@
 from __future__ import print_function
 
 from sos.policies.redhat import RedHatPolicy, OS_RELEASE
+import os
 
 
 class AmazonPolicy(RedHatPolicy):
@@ -25,6 +26,9 @@ class AmazonPolicy(RedHatPolicy):
 
     @classmethod
     def check(cls):
+        if not os.path.exists(OS_RELEASE):
+            return False
+
         with open(OS_RELEASE, 'r') as f:
             for line in f:
                 if line.startswith('NAME'):


### PR DESCRIPTION
Catch use cases when /etc/os-release is missing by returning
Amazon policy as disabled.

Resolves: #1763

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
