### PR TITLE
[openstack_instack] Collect /home/stack/.tripleo/history

### DIFF
--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -23,7 +23,8 @@ CONTAINERIZED_DEPLOY = [
         '/var/log/heat-launcher/',
         '/home/stack/install-undercloud.log',
         '/home/stack/undercloud-install-*.tar.bzip2',
-        '/var/lib/mistral/config-download-latest/ansible.log'
+        '/var/lib/mistral/config-download-latest/ansible.log',
+        '/home/stack/.tripleo/history',
 ]
 
 
@@ -127,6 +128,9 @@ class OpenStackInstack(Plugin):
         json_regexp = r'((?m)"(%s)": )(".*?")' % "|".join(protected_json_keys)
         self.do_file_sub("/home/stack/instackenv.json", json_regexp,
                          r"\1*********")
+        self.do_file_sub('/home/stack/.tripleo/history',
+                         r'(password=)\w+',
+                         r'\1*********')
 
 
 class RedHatRDOManager(OpenStackInstack, RedHatPlugin):


### PR DESCRIPTION
The 'history' file includes one line for every cmdline
invocation of TripleO. The file includes useful information
to troubleshoot TripleO based OpenStack deployments, as it
includes timestamps for operations, so the troubleshooter
will now be able to know when the last operation happened.

Signed-off-by: Assaf Muller <amuller@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
