### PR TITLE
[openvswitch] catch all openvswitch2.* packages

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -158,7 +158,7 @@ class OpenVSwitch(Plugin):
 
 class RedHatOpenVSwitch(OpenVSwitch, RedHatPlugin):
 
-    packages = ('openvswitch', 'openvswitch-dpdk')
+    packages = ('openvswitch', 'openvswitch2.*', 'openvswitch-dpdk')
 
 
 class DebianOpenVSwitch(OpenVSwitch, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Since the release of openvswitch 2.10, the Red Hat Fast Datapath channel
maintains multiple versions of openvswitch.
Update the list of packages using a wildcard to catch all openvswitch2.*
packages.

Signed-off-by: David Marchand <david.marchand@redhat.com>