### PR TITLE
[pep8] Fix E501 line too long

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -923,8 +923,11 @@ class Plugin(object):
                         file_name = _file
                         if file_name[0] == os.sep:
                             file_name = file_name.lstrip(os.sep)
-                        strfile = file_name.replace(os.path.sep, ".") + ".tailed"
-                        self.add_string_as_file(tail(_file, sizelimit), strfile)
+                        strfile = (
+                            file_name.replace(os.path.sep, ".") + ".tailed"
+                        )
+                        self.add_string_as_file(tail(_file, sizelimit),
+                                                strfile)
                         rel_path = os.path.relpath('/', os.path.dirname(_file))
                         link_path = os.path.join(rel_path, 'sos_strings',
                                                  self.name(), strfile)


### PR DESCRIPTION
Fix pep8 issues from increasing indentation.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
