### PR TITLE
[last] run lastlog to limit listing user to the UID_MIN-UID_MAX range.

### DIFF
--- a/sos/plugins/last.py
+++ b/sos/plugins/last.py
@@ -21,7 +21,11 @@ class Last(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output([
             "last reboot",
             "last shutdown",
-            "lastlog"
+            "lastlog",
+            "lastlog -u 0-999",
+            "lastlog -u 1000-60000",
+            "lastlog -u 60001-65536",
+            "lastlog -u 65537-4294967295"
         ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Currently SOSCleaner relies on lastlog output.
This would be useful for SOSCleaner to sanitize users created
by users by making sure they are in the UID_MIN-UID_MAX range as per /etc/login.defs.

This will highly help avoiding false positive user obfuscation in SOSCleaner.

Fix: #1743

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
