### PR TITLE
[gluster] collect statedumps from /run directly

### DIFF
--- a/sos/plugins/gluster.py
+++ b/sos/plugins/gluster.py
@@ -20,7 +20,7 @@ class Gluster(Plugin, RedHatPlugin):
     plugin_name = 'gluster'
     profiles = ('storage', 'virt')
 
-    statedump_dir = '/var/run/gluster'
+    statedump_dir = '/run/gluster'
     packages = ["glusterfs", "glusterfs-core"]
     files = ["/etc/glusterd", "/var/lib/glusterd"]
 


### PR DESCRIPTION
As /run being the default runtime directory for units, we should
methodically generate statedumps to /run instead of /var/run.

Resolves: #1773

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
