### PR TITLE
[sosreport] Fix unhandled Out of Memory exception

### DIFF
--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1180,10 +1180,13 @@ class SoSReport(object):
         if not archive:
             return False
 
-        archive_fp = open(archive, 'rb')
-        digest = hashlib.new(hash_name)
-        digest.update(archive_fp.read())
-        archive_fp.close()
+        try:
+            archive_fp = open(archive, 'rb')
+            digest = hashlib.new(hash_name)
+            digest.update(archive_fp.read())
+            archive_fp.close()
+        except Exception:
+            self.handle_exception()
         return digest.hexdigest()
 
     def _write_checksum(self, archive, hash_name, checksum):


### PR DESCRIPTION
This patches attempts to address the Memory Error exception thrown
by sosreport when it attempts to compress the sosreport file.
An example of the backtrace thrown is the following:

Creating compressed archive...
[archive:TarFileArchive] An error occurred compressing the archive:  [Errno 12] Cannot allocate memory
Traceback (most recent call last):
  File "/usr/sbin/sosreport", line 25, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/sos/sosreport.py", line 1637, in main
    sos.execute()
  File "/usr/lib/python2.7/site-packages/sos/sosreport.py", line 1616, in execute
    return self.final_work()
  File "/usr/lib/python2.7/site-packages/sos/sosreport.py", line 1529, in final_work
    checksum = self._create_checksum(archive, hash_name)
  File "/usr/lib/python2.7/site-packages/sos/sosreport.py", line 1469, in _create_checksum
    digest.update(archive_fp.read())
MemoryError

Resolves: #1317

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
