### PR TITLE
[virtwho] collect /etc/virt-who.conf

### DIFF
--- a/sos/plugins/virtwho.py
+++ b/sos/plugins/virtwho.py
@@ -18,11 +18,12 @@ class VirtWho(Plugin, RedHatPlugin):
     packages = ('virt-who',)
 
     def setup(self):
-        self.add_copy_spec("/etc/virt-who.d/*")
+        self.add_copy_spec(["/etc/virt-who.d/*", "/etc/virt-who.conf"])
         self.add_cmd_output("virt-who -dop")
 
     def postproc(self):
-        self.do_path_regex_sub(r"\/etc\/virt-who\.d",
+        # the regexp path catches both /etc/virt-who.d/ and /etc/virt-who.conf
+        self.do_path_regex_sub(r"\/etc\/virt-who\.",
                                r"(.*password=)(\S*)",
                                r"\1********")
 


### PR DESCRIPTION
The most basic config file also matters :)

Resolves: #1778

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
