### PR TITLE
[manageiq] modify plugin to account for regularly large files

### DIFF
--- a/sos/plugins/manageiq.py
+++ b/sos/plugins/manageiq.py
@@ -57,10 +57,20 @@ class ManageIQ(Plugin, RedHatPlugin):
 
     # Log files to collect from miq_dir/log/
     miq_log_dir = os.path.join(miq_dir, "log")
+
+    miq_main_log_files = [
+        'ansible_tower.log',
+        'top_output.log',
+        'evm.log',
+        'production.log',
+        'automation.log',
+    ]
+
     miq_log_files = [
         '*.log',
         'apache/*.log',
         '*.txt',
+        '*.yml',
     ]
 
     def setup(self):
@@ -73,6 +83,10 @@ class ManageIQ(Plugin, RedHatPlugin):
         self.add_copy_spec([
             os.path.join(self.miq_conf_dir, x) for x in self.miq_conf_files
         ])
+
+        self.add_copy_spec([
+            os.path.join(self.miq_log_dir, x) for x in self.miq_main_log_files
+        ], sizelimit=0)
 
         self.add_copy_spec([
             os.path.join(self.miq_log_dir, x) for x in self.miq_log_files


### PR DESCRIPTION
The following 5 files are usually over the default 25mb limit:
    ansible_tower.log
    automation.log
    evm.log
    production.log
    top_output.log

Those 5 files interfere with the *.log glob to behave as users
expect.  These 5 files were broken out to miq_main_log_files.

Signed-off by: David Luong <dluong@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
