### PR TITLE
[kernel] Add the output of 'dmesg -H'

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -78,6 +78,7 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         self.add_cmd_output([
             "dmesg",
+            "dmesg -H",
             "sysctl -a",
             "dkms status"
         ])


### PR DESCRIPTION
At the moment we have the output of 'dmesg' only in the sosreport, plus
the file /var/log/dmesg. But the output of 'dmesg' doesn't contain
timestamps in a human readable format. While the timestamps could be
inaccurate in some circumstances (see the man page of dmesg), it
can be still very helpful.

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
