### PR TITLE
[process] dump all processes cpu affinity

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -50,4 +50,19 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "%s %s" % (ps_axo, ps_sched_opts)
         ])
 
+        self.add_cmd_output("""sh -c '
+for pgm in /proc/*/comm; do
+    [ "$pgm" != "/proc/self/comm" ] || continue;
+    pid=${pgm##/proc/};
+    pid=${pid%%/comm};
+    for thread in ${pgm%%/comm}/task/*/comm; do
+        tid=${thread##${pgm%%/comm}/task/};
+        tid=${tid%%/comm};
+        affinity=$(taskset -p $tid 2>/dev/null);
+        printf "%s,%s,%s,%s,%s\n" "$pid" "$(cat $pgm 2>/dev/null)" \
+            "$tid" "$(cat $thread 2>/dev/null)" "${affinity##*: }";
+    done;
+done'
+""")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Capture all processes (and their threads) cpu affinity.

On systems where process location (wrt cpu) is important, it greatly
helps to get a picture of the cpu affinities at the time the sos report
has been taken.

Example on a 28 cores system with qemu and ovs (in dpdk mode):
1,systemd,1,systemd,4001
10,lru-add-drain,10,lru-add-drain,fffffff
100,ksoftirqd/16,100,ksoftirqd/16,10000
101,kworker/16:0,101,kworker/16:0,10000
102,kworker/16:0H,102,kworker/16:0H,10000
103,rcuob/16,103,rcuob/16,4001
104,rcuos/16,104,rcuos/16,4001
105,migration/17,105,migration/17,20000
106,ksoftirqd/17,106,ksoftirqd/17,20000
106147,qemu-kvm,106147,qemu-kvm,8
106147,qemu-kvm,106199,qemu-kvm,8
106147,qemu-kvm,106222,IO mon_iothread,8
106147,qemu-kvm,106223,CPU 0/KVM,8
106147,qemu-kvm,106224,CPU 1/KVM,20000
106147,qemu-kvm,106225,CPU 2/KVM,10
106147,qemu-kvm,106226,CPU 3/KVM,40000
106147,qemu-kvm,106227,CPU 4/KVM,20
106147,qemu-kvm,106228,CPU 5/KVM,80000
106147,qemu-kvm,106229,CPU 6/KVM,40
106147,qemu-kvm,106230,CPU 7/KVM,100000
106147,qemu-kvm,106231,CPU 8/KVM,80
106147,qemu-kvm,106232,CPU 9/KVM,200000
106147,qemu-kvm,106233,CPU 10/KVM,100
106147,qemu-kvm,106234,CPU 11/KVM,400000
106147,qemu-kvm,106235,CPU 12/KVM,200
106147,qemu-kvm,106236,CPU 13/KVM,800000
106147,qemu-kvm,106237,CPU 14/KVM,400
106147,qemu-kvm,106238,CPU 15/KVM,1000000
106147,qemu-kvm,106239,SPICE Worker,8
106147,qemu-kvm,106240,vnc_worker,8
106147,qemu-kvm,139788,worker,8
...
51179,ovsdb-server,51179,ovsdb-server,4001
51242,ovs-vswitchd,51242,ovs-vswitchd,4001
51242,ovs-vswitchd,51243,ovs-vswitchd,4000
51242,ovs-vswitchd,51244,ovs-vswitchd,4000
51242,ovs-vswitchd,51250,dpdk_watchdog1,4001
51242,ovs-vswitchd,51253,urcu2,4001
51242,ovs-vswitchd,51258,ct_clean4,4001
51242,ovs-vswitchd,51259,ipf_clean3,4001
51242,ovs-vswitchd,51288,pmd33,2
51242,ovs-vswitchd,51289,pmd34,8000
51242,ovs-vswitchd,51290,ovs-vswitchd,4000
51242,ovs-vswitchd,51291,ovs-vswitchd,4000
51242,ovs-vswitchd,51292,handler46,4001
51242,ovs-vswitchd,51293,handler41,4001
51242,ovs-vswitchd,51294,handler35,4001
51242,ovs-vswitchd,51295,handler36,4001
51242,ovs-vswitchd,51296,handler37,4001
51242,ovs-vswitchd,51297,handler38,4001
51242,ovs-vswitchd,51298,handler39,4001
51242,ovs-vswitchd,51299,handler40,4001
51242,ovs-vswitchd,51300,handler47,4001
51242,ovs-vswitchd,51301,handler44,4001
51242,ovs-vswitchd,51302,handler42,4001
51242,ovs-vswitchd,51303,handler43,4001
51242,ovs-vswitchd,51304,handler45,4001
51242,ovs-vswitchd,51305,handler49,4001
51242,ovs-vswitchd,51306,handler48,4001
51242,ovs-vswitchd,51307,handler50,4001
51242,ovs-vswitchd,51308,handler58,4001
51242,ovs-vswitchd,51309,handler57,4001
51242,ovs-vswitchd,51310,handler51,4001
51242,ovs-vswitchd,51311,handler52,4001
51242,ovs-vswitchd,51312,revalidator53,4001
51242,ovs-vswitchd,51313,revalidator54,4001
51242,ovs-vswitchd,51314,revalidator55,4001
51242,ovs-vswitchd,51315,revalidator56,4001
51242,ovs-vswitchd,51316,revalidator61,4001
51242,ovs-vswitchd,51317,revalidator59,4001
51242,ovs-vswitchd,51318,revalidator60,4001
51242,ovs-vswitchd,51319,revalidator62,4001
...

Signed-off-by: David Marchand <david.marchand@redhat.com>

---
I did not find a way to do this in python and still get the output in a single file, so I went with calling some shellscript from the process plugin.
Is there a better way to achieve this?