### PR TITLE
[filesys] fix postprocessing for /etc/fstab passwords.

### DIFF
--- a/sos/plugins/filesys.py
+++ b/sos/plugins/filesys.py
@@ -58,7 +58,7 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin):
     def postproc(self):
         self.do_file_sub(
             "/etc/fstab",
-            r"(password=)[^\s]*",
+            r"(password=)[^,\s]*",
             r"\1********"
         )
 


### PR DESCRIPTION
The current regex will replace the entire string after password=
with * including the mount options.
This patch fixes this issue by stopping the replacement when ","
(mount option separator)is detected.

Before patch:
//cifs-server/share /mnt cifs username=user1,password=********

After patch:
//cifs-sever/share /mnt cifs username=user1,password=********,nounix,vers=1.0 0 0

Signed-off-by: Kenneth D'souza <kennethdsouza94@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
