### PR TITLE
[kubernetes] separate Red Hat and Ubuntu Kubernetes plugins

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -188,11 +188,6 @@ class UbuntuKubernetes(Kubernetes, UbuntuPlugin):
 
     files = ('/root/cdk/kubeproxyconfig',)
 
-    def setup(self):
-        if path.exists('/root/cdk/kubeproxyconfig'):
-            kube_cmd = "/snap/bin/kubectl"
-            kube_cmd += " --kubeconfig=/root/cdk/kubeproxyconfig"
-
-        return super(UbuntuKubernetes, self).setup()
+    kube_cmd = "/snap/bin/kubectl --kubeconfig=/root/cdk/kubeproxyconfig"
 
 # vim: et ts=5 sw=4


### PR DESCRIPTION
Separate the Red Hat and Ubuntu versions of the kubernetes plugin to account for differences in packaging and configuration paths.

This preserves the logic for setting `kube_cmd` from #1654 - i.e. the default is `kubectl`, which is overridden in the Red Hat plugin to add admin.kubeconfig for `--kubeconfig`, and in the Ubuntu Plugin to add`/root/cdk/kubeproxyconfig` if that path exists.

If Kubernetes is only distributed as a snap on Ubuntu and will always use this path then we can simplify the `UbuntuPlugin` and get rid of the `setup()` method - it wasn't clear from the original change to the single Kubernetes class whether this was the case or not.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
