### PR TITLE
[redhat] Enable RHV preset on managers and hypervisors

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -300,6 +300,9 @@ support representative.
             return self.find_preset(RH_SATELLITE)
         if self.pkg_by_name("rhosp-release") is not None:
             return self.find_preset(RHOSP)
+        if self.pkg_by_name("ovirt-engine") is not None or \
+                self.pkg_by_name("vdsm") is not None:
+            return self.find_preset(RHV)
 
         # Vanilla RHEL is default
         return self.find_preset(RHEL)


### PR DESCRIPTION
The RHV preset was previously not being automatically enabled on manager
or hypervisor systems.

This adds a check for the appropriate packages and enables the preset if
either are present.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
