### PR TITLE
[vdsm] Use add_service_status()

### DIFF
--- a/sos/plugins/vdsm.py
+++ b/sos/plugins/vdsm.py
@@ -64,8 +64,7 @@ class Vdsm(Plugin, RedHatPlugin):
         self.add_forbidden_path('/etc/pki/vdsm/libvirt-spice/*-key.*')
         self.add_forbidden_path('/etc/pki/libvirt/private/*')
 
-        self.add_cmd_output('service vdsmd status')
-        self.add_cmd_output('service supervdsmd status')
+        self.add_service_status(['vdsmd', 'supervdsmd'])
 
         self.add_copy_spec([
             '/tmp/vds_installer*',


### PR DESCRIPTION
Updates the vdsm plugin to use add_service_status() for vdsmd and
supervdsmd.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
