### PR TITLE
[kernel] Don't collect trace file by default

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -23,7 +23,8 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     sys_module = '/sys/module'
 
     option_list = [
-        ("with-timer", "gather /proc/timer* statistics", "slow", False)
+        ("with-timer", "gather /proc/timer* statistics", "slow", False),
+        ("trace", "gather /sys/kernel/debug/tracing/trace file", "slow", False)
     ]
 
     def get_bpftool_prog_ids(self, prog_file):
@@ -137,6 +138,9 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             # This can be very slow, depending on the number of timers,
             # and may also cause softlockups
             self.add_copy_spec("/proc/timer*")
+
+        if not self.get_option("trace"):
+            self.add_forbidden_path("/sys/kernel/debug/tracing/trace")
 
         # collect list of bpf program attachments in the kernel
         # networking subsystem


### PR DESCRIPTION
Updates the plugin to don't collect trace file by default. Collecting
trace file may take a lot of time, so trace file is not collected
by default, and use the new plug-in option when collecting.

Original author: MIZUTA Takeshi <mizuta.takeshi@fujitsu.com>

Resolves: #1688

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
