### PR TITLE
Gather hashes for all py files

### DIFF
--- a/sos/plugins/python.py
+++ b/sos/plugins/python.py
@@ -10,6 +10,9 @@
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 import sos.policies
+import os
+import json
+import hashlib
 
 
 class Python(Plugin, DebianPlugin, UbuntuPlugin):
@@ -21,25 +24,69 @@ class Python(Plugin, DebianPlugin, UbuntuPlugin):
 
     packages = ('python',)
 
+    python_version = "python -V"
+
     def setup(self):
-        self.add_cmd_output("python -V", suggest_filename="python-version")
+        self.add_cmd_output(
+            self.python_version, suggest_filename="python-version"
+        )
         self.add_cmd_output("pip list")
 
 
 class RedHatPython(Python, RedHatPlugin):
 
     packages = ('python', 'python36', 'python2', 'platform-python')
+    option_list = [
+        ('hashes', "gather hashes for all python files", 'slow',
+         False)]
 
     def setup(self):
         self.add_cmd_output(['python2 -V', 'python3 -V'])
-        self.add_cmd_output("pip list")
         if isinstance(self.policy, sos.policies.redhat.RHELPolicy) and \
                 self.policy.dist_version() > 7:
-            self.add_cmd_output(
-                '/usr/libexec/platform-python -V',
-                suggest_filename='python-version'
-            )
-        else:
-            self.add_cmd_output('python -V', suggest_filename='python-version')
+            self.python_version = "/usr/libexec/platform-python -V"
+        super(RedHatPython, self).setup()
+
+        if self.get_option('hashes'):
+            digests = {
+                'digests': []
+            }
+
+            py_paths = [
+                '/usr/lib',
+                '/usr/lib64',
+                '/usr/local/lib',
+                '/usr/local/lib64'
+            ]
+
+            for py_path in py_paths:
+                for root, _, files in os.walk(py_path):
+                    for file_ in files:
+                        filepath = os.path.join(root, file_)
+                        if filepath.endswith('.py'):
+                            try:
+                                with open(filepath, 'rb') as f:
+                                    digest = hashlib.sha256()
+                                    chunk = 1024
+                                    while True:
+                                        data = f.read(chunk)
+                                        if data:
+                                            digest.update(data)
+                                        else:
+                                            break
+
+                                    digest = digest.hexdigest()
+
+                                    digests['digests'].append({
+                                        'filepath': filepath,
+                                        'sha256': digest
+                                    })
+                            except IOError:
+                                self._log_error(
+                                    "Unable to read python file at %s" %
+                                    filepath
+                                )
+
+            self.add_string_as_file(json.dumps(digests), 'digests.json')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
`python` plugin is being added a new option `hashes` which finds all python files and calculates `sha256` checksums. 
It generates a json file like this:
```json
{
   "digests": {
      "filepath": "/usr/lib/python2.7/site-packages/typing.py",
      "sha256": "ce88d334fe5370179b4395c89fcc08bf2c30bc4cd286ab765b3ea7a53e0a73c9"
   }
}
```
The result of this plugin would be used by project Thoth (https://thoth-station.ninja/) for provenance checking purposes.
As part of our project, we analyze most of the ML related packages on PyPI (https://pypi.org) and gather checksums of all files inside wheel files.
Looking at this checksums, we can ensure that a user is using right python packages and files from valid sources. 

Signed-off-by: Bissenbay Dauletbayev <bissenbay@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
