### PR TITLE
[plugin] add_copy_spec handle same file diff sizelimit

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -900,6 +900,9 @@ class Plugin(object):
             limit_reached = False
 
             for _file in files:
+                if _file in self.copy_paths:
+                    self._log_debug("skipping redundant file '%s'" % _file)
+                    continue
                 if self._is_forbidden_path(_file):
                     self._log_debug("skipping forbidden path '%s'" % _file)
                     continue


### PR DESCRIPTION
This change allows add_copy_spec to handle the same file with the
different size limits.

For example:

```
log = evm.log
all_logs = *.log
miq_log_dir = '/var/www/miq/vmdb/log/'

self.add_copy_spec([
    os.path.join(self.miq_log_dir, log)
], sizelimit=0)
self.add_copy_spec([
    os.path.join(self.miq_log_dir, x) for x in self.all_logs
])
```

Here, it would copy evm.log first with no sizelimit since
add_copy_spec was called on 'log' first.  It would then skip
the next time it tries to get added from the glob contained in
all_logs.

Addresses #1786

Signed-off by: David Luong <dluong@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
