### PR TITLE
[foreman] collect http[|s]_proxy env.variables

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -216,6 +216,9 @@ class Foreman(Plugin):
             self.add_cmd_output(_cmd, suggest_filename=dyn, timeout=600,
                                 env=self.env)
 
+        # collect http[|s]_proxy env.variables
+        self.add_env_var(["http_proxy", "https_proxy"])
+
     def build_query_cmd(self, query, csv=False):
         """
         Builds the command needed to invoke the pgsql query as the postgres


### PR DESCRIPTION
Presence or values of the variables is crucial in some foreman-installer issues.

Resolves: #1804

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
