### PR TITLE
[Plugin|plugins] Consolidate command collection API methods

### DIFF
--- a/sos/plugins/abrt.py
+++ b/sos/plugins/abrt.py
@@ -24,16 +24,15 @@ class Abrt(Plugin, RedHatPlugin):
         ("detailed", 'collect detailed info for every report', 'slow', False)
     ]
 
-    def info_detailed(self, list_file):
-        for line in open(list_file).read().splitlines():
-            if line.startswith("Directory:"):
-                self.add_cmd_output("abrt-cli info -d '%s'" % line.split()[1])
-
     def setup(self):
         self.add_cmd_output("abrt-cli status")
-        list_file = self.get_cmd_output_now("abrt-cli list")
-        if self.get_option('detailed') and list_file:
-            self.info_detailed(list_file)
+        abrt_list = self.collect_cmd_output("abrt-cli list")
+        if self.get_option("detailed") and abrt_list['status'] == 0:
+            for line in abrt_list["output"].splitlines():
+                if line.startswith("Directory"):
+                    self.add_cmd_output(
+                        "abrt-cli info -d '%s'" % line.split()[1]
+                    )
 
         self.add_copy_spec([
             "/etc/abrt/abrt.conf",

--- a/sos/plugins/alternatives.py
+++ b/sos/plugins/alternatives.py
@@ -19,10 +19,7 @@ class Alternatives(Plugin, RedHatPlugin):
     commands = ('alternatives',)
 
     def setup(self):
-        self.add_cmd_output([
-            'alternatives --list',
-            'alternatives --version'
-        ])
+        self.add_cmd_output('alternatives --version')
 
         alts = []
         ignore = [
@@ -33,7 +30,7 @@ class Alternatives(Plugin, RedHatPlugin):
             'xinputrc'
         ]
 
-        res = self.get_command_output('alternatives --list')
+        res = self.collect_cmd_output('alternatives --list')
         if res['status'] == 0:
             for line in res['output'].splitlines():
                 alt = line.split()[0]

--- a/sos/plugins/apt.py
+++ b/sos/plugins/apt.py
@@ -31,8 +31,9 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
             "apt-cache stats",
             "apt-cache policy"
         ])
-        dpkg_result = self.call_ext_prog(
-            "dpkg-query -W -f='${binary:Package}\t${status}\n'")
+        dpkg_result = self.exec_cmd(
+            "dpkg-query -W -f='${binary:Package}\t${status}\n'"
+        )
         dpkg_output = dpkg_result['output'].splitlines()
         pkg_list = ' '.join(
             [v.split('\t')[0] for v in dpkg_output if 'ok installed' in v])

--- a/sos/plugins/atomichost.py
+++ b/sos/plugins/atomichost.py
@@ -31,8 +31,8 @@ class AtomicHost(Plugin, RedHatPlugin):
             # output (repeated "IMAGE ID" values). Use a set to filter
             # these out and only obtain 'docker info' data once per image
             # identifier.
-            images = self.get_command_output("docker images -q")['output']
-            for image in set(images.splitlines()):
+            images = self.exec_cmd("docker images -q")
+            for image in set(images['output'].splitlines()):
                 self.add_cmd_output("atomic info {0}".format(image))
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/buildah.py
+++ b/sos/plugins/buildah.py
@@ -38,7 +38,7 @@ class Buildah(Plugin, RedHatPlugin):
         self.add_cmd_output(["buildah %s" % sub for sub in subcmds])
 
         def make_chowdah(aurdah):
-            chowdah = self.get_command_output(aurdah)
+            chowdah = self.exec_cmd(aurdah)
             chowdah['auutput'] = chowdah.pop('output')
             chowdah['is_wicked_pissah'] = chowdah.pop('status') == 0
             return chowdah

--- a/sos/plugins/clear_containers.py
+++ b/sos/plugins/clear_containers.py
@@ -33,7 +33,7 @@ class ClearContainers(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin,
 
         # obtain a list of config files by asking the runtime
         cmd = '{} --cc-show-default-config-paths'.format(self.runtime)
-        configs = self.get_command_output(cmd)['output']
+        configs = self.exec_cmd(cmd)['output']
 
         for config in configs.splitlines():
             if config != "":
@@ -52,7 +52,7 @@ class ClearContainers(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin,
 
         # query the runtime to find the configured global log file
         cmd = '{} cc-env'.format(self.runtime)
-        output = self.get_command_output(cmd)['output']
+        output = self.exec_cmd(cmd)['output']
         for line in output.splitlines():
             result = re.search(r'\bGlobalLogPath\b\s+=\s+"(.+)"', line)
             if result:

--- a/sos/plugins/composer.py
+++ b/sos/plugins/composer.py
@@ -12,11 +12,10 @@ class Composer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     def _get_entries(self, cmd):
         entries = []
-        ent_file = self.get_cmd_output_now(cmd)
-        if ent_file:
-            with open(ent_file, "r") as ents:
-                for line in ents.read().splitlines():
-                    entries.append(line)
+        ent_file = self.collect_cmd_output(cmd)
+        if ent_file['status'] == 0:
+            for line in ent_file['output'].splitlines():
+                entries.append(line)
         return entries
 
     def setup(self):

--- a/sos/plugins/corosync.py
+++ b/sos/plugins/corosync.py
@@ -34,7 +34,7 @@ class Corosync(Plugin):
             "corosync-objctl -a",
             "corosync-cmapctl"
         ])
-        self.call_ext_prog("killall -USR2 corosync")
+        self.exec_cmd("killall -USR2 corosync")
 
         corosync_conf = "/etc/corosync/corosync.conf"
         if not os.path.exists(corosync_conf):

--- a/sos/plugins/crio.py
+++ b/sos/plugins/crio.py
@@ -84,7 +84,7 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
 
     def _get_crio_list(self, cmd):
         ret = []
-        result = self.get_command_output(cmd)
+        result = self.exec_cmd(cmd)
         if result['status'] == 0:
             for ent in result['output'].splitlines():
                 ret.append(ent)

--- a/sos/plugins/dlm.py
+++ b/sos/plugins/dlm.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-import os.path
 import re
 
 
@@ -20,9 +19,6 @@ class Dlm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     option_list = [
         ("lockdump", "capture lock dumps for DLM", "slow", False),
     ]
-
-    debugfs_path = "/sys/kernel/debug"
-    _debugfs_cleanup = False
 
     def setup(self):
         self.add_copy_spec([
@@ -37,36 +33,17 @@ class Dlm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             self.do_lockdump()
 
     def do_lockdump(self):
-        if self._mount_debug():
-            dlm_tool = "dlm_tool ls"
-            result = self.call_ext_prog(dlm_tool)
-            if result["status"] != 0:
-                return
+        dlm_tool = "dlm_tool ls"
+        result = self.collect_cmd_output(dlm_tool)
+        if result["status"] != 0:
+            return
 
-            lock_exp = r'^name\s+([^\s]+)$'
-            lock_re = re.compile(lock_exp, re.MULTILINE)
-            for lockspace in lock_re.findall(result["output"]):
-                self.add_cmd_output(
-                    "dlm_tool lockdebug -svw '%s'" % lockspace,
-                    suggest_filename="dlm_locks_%s" % lockspace
-                )
-
-    def _mount_debug(self):
-        if not os.path.ismount(self.debugfs_path):
-            self._debugfs_cleanup = True
-            r = self.call_ext_prog("mount -t debugfs debugfs %s"
-                                   % self.debugfs_path)
-            if r["status"] != 0:
-                self._log_error("debugfs not mounted and mount attempt failed")
-                self._debugfs_cleanup = False
-        return os.path.ismount(self.debugfs_path)
-
-    def postproc(self):
-        if self._debugfs_cleanup and os.path.ismount(self.debugfs_path):
-            r = self.call_ext_prog("umount %s" % self.debugfs_path)
-            if r["status"] != 0:
-                self._log_error("could not unmount %s" % self.debugfs_path)
-
-        return
+        lock_exp = r'^name\s+([^\s]+)$'
+        lock_re = re.compile(lock_exp, re.MULTILINE)
+        for lockspace in lock_re.findall(result["output"]):
+            self.add_cmd_output(
+                "dlm_tool lockdebug -svw '%s'" % lockspace,
+                suggest_filename="dlm_locks_%s" % lockspace
+            )
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -57,11 +57,11 @@ class DNFPlugin(Plugin, RedHatPlugin):
             "package-cleanup --problems"
         ])
 
-        if self.get_option("history"):
+        if self.get_option("history") and not self.get_option("history-info"):
             self.add_cmd_output("dnf history")
 
         if self.get_option("history-info"):
-            history = self.call_ext_prog("dnf history")
+            history = self.collect_cmd_output("dnf history")
             transactions = -1
             if history['output']:
                 for line in history['output'].splitlines():
@@ -74,7 +74,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
                 self.add_cmd_output("dnf history info %d" % tr_id)
 
         # Get list of dnf installed modules and their details.
-        module_file = self.get_cmd_output_now("dnf module list --installed")
-        self.get_modules_info(module_file)
+        module_file = self.collect_cmd_output("dnf module list --installed")
+        self.get_modules_info(module_file['filename'])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -51,7 +51,6 @@ class Docker(Plugin):
             'events --since 24h --until 1s',
             'info',
             'images',
-            'network ls',
             'ps',
             'ps -a',
             'stats --no-stream',
@@ -67,7 +66,7 @@ class Docker(Plugin):
             self.add_cmd_output('docker ps -as')
             self.add_cmd_output('docker system df')
 
-        nets = self.get_command_output('docker network ls')
+        nets = self.collect_cmd_output('docker network ls')
 
         if nets['status'] == 0:
             n = [n.split()[1] for n in nets['output'].splitlines()[1:]]
@@ -104,7 +103,7 @@ class Docker(Plugin):
 
     def _get_docker_list(self, cmd):
         ret = []
-        result = self.get_command_output(cmd)
+        result = self.exec_cmd(cmd)
         if result['status'] == 0:
             for ent in result['output'].splitlines():
                 ret.append(ent)

--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -67,8 +67,10 @@ class Foreman(Plugin):
             "/etc/foreman*/encryption_key.rb"
         ])
 
-        _hostname = self.get_command_output('hostname')['output'].strip()
-        _host_f = self.get_command_output('hostname -f')['output'].strip()
+        _hostname = self.exec_cmd('hostname')['output']
+        _hostname = _hostname.strip()
+        _host_f = self.exec_cmd('hostname -f')['output']
+        _host_f = _host_f.strip()
 
         # Collect these completely everytime
         self.add_copy_spec([

--- a/sos/plugins/gfs2.py
+++ b/sos/plugins/gfs2.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-import os.path
 
 
 class Gfs2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
@@ -23,9 +22,6 @@ class Gfs2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
          "slow", False),
     ]
 
-    debugfs_path = "/sys/kernel/debug"
-    _debugfs_cleanup = False
-
     def setup(self):
         self.add_copy_spec([
             "/sys/fs/gfs2/*/withdraw"
@@ -36,24 +32,6 @@ class Gfs2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
 
         if self.get_option("gfs2lockdump"):
-            if self._mount_debug():
-                self.add_copy_spec(["/sys/kernel/debug/gfs2/*"])
-
-    def _mount_debug(self):
-        if not os.path.ismount(self.debugfs_path):
-            self._debugfs_cleanup = True
-            r = self.call_ext_prog("mount -t debugfs debugfs %s"
-                                   % self.debugfs_path)
-            if r["status"] != 0:
-                self._log_error("debugfs not mounted and mount attempt failed")
-                self._debugfs_cleanup = False
-        return os.path.ismount(self.debugfs_path)
-
-    def postproc(self):
-        if self._debugfs_cleanup and os.path.ismount(self.debugfs_path):
-            r = self.call_ext_prog("umount %s" % self.debugfs_path)
-            if r["status"] != 0:
-                self._log_error("could not unmount %s" % self.debugfs_path)
-        return
+            self.add_copy_spec(["/sys/kernel/debug/gfs2/*"])
 
 # vim: et ts=4 sw=4

--- a/sos/plugins/ipmitool.py
+++ b/sos/plugins/ipmitool.py
@@ -21,7 +21,7 @@ class IpmiTool(Plugin, RedHatPlugin, DebianPlugin):
     packages = ('ipmitool',)
 
     def setup(self):
-        result = self.get_command_output("ipmitool -I usb mc info")
+        result = self.collect_cmd_output("ipmitool -I usb mc info")
         have_usbintf = result['status']
 
         if not have_usbintf:

--- a/sos/plugins/iprconfig.py
+++ b/sos/plugins/iprconfig.py
@@ -36,7 +36,7 @@ class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "iprconfig -c show-slots",
         ])
 
-        show_ioas = self.call_ext_prog("iprconfig -c show-ioas")
+        show_ioas = self.collect_cmd_output("iprconfig -c show-ioas")
         if not show_ioas['status'] == 0:
             return
 
@@ -55,7 +55,7 @@ class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             self.add_cmd_output("iprconfig -c show-perf %s" % device)
 
         # Look for IBM Power RAID enclosures (iprconfig lists them)
-        show_config = self.call_ext_prog("iprconfig -c show-config")
+        show_config = self.collect_cmd_output("iprconfig -c show-config")
         if not show_config['status'] == 0:
             return
 
@@ -76,7 +76,7 @@ class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 #        0005:60:00.0/0:8:1:0       Enclosure                 Active
 
         show_alt_config = "iprconfig -c show-alt-config"
-        altconfig = self.call_ext_prog(show_alt_config)
+        altconfig = self.collect_cmd_output(show_alt_config)
         if not (altconfig['status'] == 0):
             return
 

--- a/sos/plugins/kata_containers.py
+++ b/sos/plugins/kata_containers.py
@@ -37,7 +37,7 @@ class KataContainers(Plugin, RedHatPlugin, DebianPlugin,
 
         # obtain a list of config files by asking the runtime
         cmd = 'kata-runtime --kata-show-default-config-paths'
-        configs = self.get_command_output(cmd)
+        configs = self.collect_cmd_output(cmd)
         if configs and configs['status']:
             for config in configs['output'].splitlines():
                 if config != "":

--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -148,12 +148,12 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output("bpftool net list")
 
         # collect list of eBPF programs and maps and their dumps
-        prog_file = self.get_cmd_output_now("bpftool -j prog list")
+        prog_file = self.exec_cmd("bpftool -j prog list")
         for prog_id in self.get_bpftool_prog_ids(prog_file):
             for dumpcmd in ["xlated", "jited"]:
                 self.add_cmd_output("bpftool prog dump %s id %s" %
                                     (dumpcmd, prog_id))
-        map_file = self.get_cmd_output_now("bpftool -j map list")
+        map_file = self.exec_cmd("bpftool -j map list")
         for map_id in self.get_bpftool_map_ids(map_file):
             self.add_cmd_output("bpftool map dump id %s" % map_id)
 

--- a/sos/plugins/kpatch.py
+++ b/sos/plugins/kpatch.py
@@ -21,10 +21,10 @@ class Kpatch(Plugin, RedHatPlugin):
     packages = ('kpatch',)
 
     def setup(self):
-        kpatch_list = self.get_cmd_output_now("kpatch list")
-        if not kpatch_list:
+        kpatch_list = self.collect_cmd_output("kpatch list")
+        if not kpatch_list['stauts'] == 0:
             return
-        kpatches = open(kpatch_list, "r").read().splitlines()
+        kpatches = kpatch_list['output'].splitlines()
         for patch in kpatches:
             if not re.match(r"^kpatch-.*\(.*\)", patch):
                 continue

--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -67,7 +67,7 @@ class Kubernetes(Plugin):
             self.add_cmd_output('%s %s' % (self.kube_cmd, subcmd))
 
         # get all namespaces in use
-        kn = self.get_command_output('%s get namespaces' % self.kube_cmd)
+        kn = self.collect_cmd_output('%s get namespaces' % self.kube_cmd)
         # namespace is the 1st word on line, until the line has spaces only
         kn_output = kn['output'].splitlines()[1:]
         knsps = [n.split()[0] for n in kn_output if n and len(n.split())]
@@ -117,8 +117,7 @@ class Kubernetes(Plugin):
                 # need to drop json formatting for this
                 k_cmd = '%s %s' % (self.kube_cmd, knsp)
                 for res in resources:
-                    r = self.get_command_output(
-                        '%s get %s' % (k_cmd, res))
+                    r = self.exec_cmd('%s get %s' % (k_cmd, res))
                     if r['status'] == 0:
                         k_list = [k.split()[0] for k in
                                   r['output'].splitlines()[1:]]
@@ -131,7 +130,7 @@ class Kubernetes(Plugin):
 
             if self.get_option('podlogs'):
                 k_cmd = '%s %s' % (self.kube_cmd, knsp)
-                r = self.get_command_output('%s get pods' % k_cmd)
+                r = self.exec_cmd('%s get pods' % k_cmd)
                 if r['status'] == 0:
                     pods = [p.split()[0] for p in
                             r['output'].splitlines()[1:]]

--- a/sos/plugins/kvm.py
+++ b/sos/plugins/kvm.py
@@ -19,9 +19,6 @@ class Kvm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     plugin_name = 'kvm'
     profiles = ('system', 'virt')
-    debugfs_path = "/sys/kernel/debug"
-
-    _debugfs_cleanup = False
 
     def check_enabled(self):
         return os.access("/sys/module/kvm", os.R_OK)
@@ -33,19 +30,7 @@ class Kvm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/sys/module/kvm_amd/srcversion",
             "/sys/module/ksm/srcversion"
         ])
-        if not os.path.ismount(self.debugfs_path):
-            self._debugfs_cleanup = True
-            r = self.call_ext_prog("mount -t debugfs debugfs %s"
-                                   % self.debugfs_path)
-            if r['status'] != 0:
-                self._log_error("debugfs not mounted and mount attempt failed")
-                self._debugfs_cleanup = False
-                return
-        self.add_cmd_output("kvm_stat --once")
 
-    def postproc(self):
-        if self._debugfs_cleanup and os.path.ismount(self.debugfs_path):
-            self.call_ext_prog("umount %s" % self.debugfs_path)
-            self._log_error("could not unmount %s" % self.debugfs_path)
+        self.add_cmd_output("kvm_stat --once")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/libraries.py
+++ b/sos/plugins/libraries.py
@@ -31,22 +31,19 @@ class Libraries(Plugin, RedHatPlugin, UbuntuPlugin):
             'LD_PRELOAD'
         ])
 
-        ldconfig_file = self.get_cmd_output_now("ldconfig -p -N -X")
+        ldconfig = self.collect_cmd_output("ldconfig -p -N -X")
 
-        if not ldconfig_file:
-            return
-
-        # Collect library directories from ldconfig's cache
-        dirs = set()
-        with open(ldconfig_file) as f:
-            for l in f.read().splitlines():
+        if ldconfig['status'] == 0:
+            # Collect library directories from ldconfig's cache
+            dirs = set()
+            for l in ldconfig['output'].splitlines():
                 s = l.split(" => ", 2)
                 if len(s) != 2:
                     continue
                 dirs.add(s[1].rsplit('/', 1)[0])
 
-        if dirs:
-            self.add_cmd_output("ls -lanH %s" % " ".join(dirs),
-                                suggest_filename="ld_so_cache")
+            if dirs:
+                self.add_cmd_output("ls -lanH %s" % " ".join(dirs),
+                                    suggest_filename="ld_so_cache")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/maas.py
+++ b/sos/plugins/maas.py
@@ -32,10 +32,13 @@ class Maas(Plugin, UbuntuPlugin):
             and self.get_option("profile-name")
 
     def _remote_api_login(self):
-        ret = self.call_ext_prog("maas login %s %s %s" % (
-            self.get_option("profile-name"),
-            self.get_option("url"),
-            self.get_option("credentials")))
+        ret = self.exec_cmd(
+            "maas login %s %s %s" % (
+                self.get_option("profile-name"),
+                self.get_option("url"),
+                self.get_option("credentials")
+            )
+        )
 
         return ret['status'] == 0
 

--- a/sos/plugins/navicli.py
+++ b/sos/plugins/navicli.py
@@ -68,7 +68,7 @@ class Navicli(Plugin, RedHatPlugin):
                 ans = input("CLARiiON SP IP Address or [Enter] to exit: ")
             except Exception:
                 return
-            if self.check_ext_prog("navicli -h %s getsptime" % (ans,)):
+            if self.exec_cmd("navicli -h %s getsptime" % (ans,))['status']:
                 CLARiiON_IP_address_list.append(ans)
             else:
                 if ans != "":

--- a/sos/plugins/networkmanager.py
+++ b/sos/plugins/networkmanager.py
@@ -42,7 +42,7 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
                 "nm",        # <  0.9.9
                 "general"    # >= 0.9.9
             ]
-            status = self.call_ext_prog(status_template % obj_table[version])
+            status = self.exec_cmd(status_template % obj_table[version])
             return status['output'].lower().startswith("running")
 
         # NetworkManager >= 0.9.9 (Use short name of objects for nmcli)
@@ -71,8 +71,9 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
             nmcli_dev_details_cmd = ""
 
         if len(nmcli_con_details_cmd) > 0:
-            nmcli_con_show_result = self.call_ext_prog(
-                "nmcli --terse --fields NAME con")
+            nmcli_con_show_result = self.exec_cmd(
+                "nmcli --terse --fields NAME con"
+            )
             if nmcli_con_show_result['status'] == 0:
                 for con in nmcli_con_show_result['output'].splitlines():
                     if con[0:7] == 'Warning':
@@ -90,8 +91,9 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
                     self.add_cmd_output('%s "%s"' %
                                         (nmcli_con_details_cmd, con))
 
-            nmcli_dev_status_result = self.call_ext_prog(
-                "nmcli --terse --fields DEVICE dev")
+            nmcli_dev_status_result = self.exec_cmd(
+                "nmcli --terse --fields DEVICE dev"
+            )
             if nmcli_dev_status_result['status'] == 0:
                 for dev in nmcli_dev_status_result['output'].splitlines():
                     if dev[0:7] == 'Warning':

--- a/sos/plugins/npm.py
+++ b/sos/plugins/npm.py
@@ -59,7 +59,7 @@ class Npm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
         """
         output = {}
         # with chroot=True (default) the command fails when run as non-root
-        user_cache = self.get_command_output("npm cache ls", chroot=False)
+        user_cache = self.collect_cmd_output("npm cache ls", chroot=False)
         if user_cache['status'] == 0:
             # filter out dirs with .cache.json ('registry.npmjs.org')
             for package in [l for l in user_cache['output'].splitlines()

--- a/sos/plugins/ntp.py
+++ b/sos/plugins/ntp.py
@@ -26,11 +26,10 @@ class Ntp(Plugin):
         ])
         self.add_cmd_output([
             "ntptime",
-            "ntpq -pn",
-            "ntpq -c as"
+            "ntpq -pn"
         ])
 
-        ids = self.get_command_output('ntpq -c as')
+        ids = self.exec_cmd('ntpq -c as')
         if ids['status'] == 0:
             for asid in [i.split()[1] for i in ids['output'].splitlines()[3:]]:
                 self.add_cmd_output("ntpq -c 'rv %s'" % asid)

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -70,7 +70,7 @@ class OpenStackCinder(Plugin):
 
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
-            container_status = self.get_command_output(runtime + " ps")
+            container_status = self.exec_cmd(runtime + " ps")
             if container_status['status'] == 0:
                 for line in container_status['output'].splitlines():
                     if line.endswith("cinder_api"):

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -42,13 +42,9 @@ class OpenStackGlance(Plugin):
 
         # collect commands output only if the openstack-glance-api service
         # is running
-        service_status = self.get_command_output(
-            "systemctl status openstack-glance-api.service"
-        )
-
         in_container = self.running_in_container()
 
-        if (service_status['status'] == 0) or in_container:
+        if self.service_is_running('openstack-glance-api') or in_container:
             glance_config = ""
             # if containerized we need to pass the config to the cont.
             if in_container:
@@ -76,7 +72,7 @@ class OpenStackGlance(Plugin):
 
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
-            container_status = self.get_command_output(runtime + " ps")
+            container_status = self.exec_cmd(runtime + " ps")
             if container_status['status'] == 0:
                 for line in container_status['output'].splitlines():
                     if line.endswith("glance_api"):

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -26,13 +26,9 @@ class OpenStackHeat(Plugin):
 
         # collect commands output only if the openstack-heat-api service
         # is running
-        service_status = self.get_command_output(
-            "systemctl status openstack-heat-api.service"
-        )
-
         in_container = self.running_in_container()
 
-        if (service_status['status'] == 0) or in_container:
+        if self.service_is_running('openstack-heat-api') or in_container:
             heat_config = ""
             # if containerized we need to pass the config to the cont.
             if in_container:
@@ -85,7 +81,7 @@ class OpenStackHeat(Plugin):
 
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
-            container_status = self.get_command_output(runtime + " ps")
+            container_status = self.exec_cmd(runtime + " ps")
             if container_status['status'] == 0:
                 for line in container_status['output'].splitlines():
                     if line.endswith("heat_api"):

--- a/sos/plugins/openstack_instack.py
+++ b/sos/plugins/openstack_instack.py
@@ -63,7 +63,7 @@ class OpenStackInstack(Plugin):
         else:
             # capture all the possible stack uuids
             get_stacks = "openstack stack list"
-            stacks = self.call_ext_prog(get_stacks)['output']
+            stacks = self.collect_cmd_output(get_stacks)['output']
             stack_ids = re.findall(r'(\s(\w+-\w+)+\s)', stacks)
             # get status of overcloud stack and resources
             for sid in stack_ids:
@@ -74,8 +74,8 @@ class OpenStackInstack(Plugin):
 
                 # get details on failed deployments
                 cmd = "openstack stack resource list -f value -n 5 %s" % sid[0]
-                deployments = self.call_ext_prog(cmd)['output']
-                for deployment in deployments.splitlines():
+                deployments = self.exec_cmd(cmd)
+                for deployment in deployments['output'].splitlines():
                     if 'FAILED' in deployment:
                         check = [
                             "OS::Heat::StructuredDeployment",

--- a/sos/plugins/openstack_ironic.py
+++ b/sos/plugins/openstack_ironic.py
@@ -119,8 +119,9 @@ class RedHatIronic(OpenStackIronic, RedHatPlugin):
     ]
 
     def collect_introspection_data(self):
-        uuids_result = self.call_ext_prog('openstack baremetal node list '
-                                          '-f value -c UUID')
+        uuids_result = self.collect_cmd_output(
+            'openstack baremetal node list -f value -c UUID'
+        )
         if uuids_result['status']:
             self.soslog.warning('Failed to fetch list of ironic node UUIDs, '
                                 'introspection data won\'t be collected')

--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -48,7 +48,7 @@ class OpenStackKeystone(Plugin):
 
         # collect domain config directory, if specified
         # if not, collect default /etc/keystone/domains
-        self.domain_config_dir = self.get_cmd_output_now(
+        self.domain_config_dir = self.exec_cmd(
                 "crudini --get /etc/keystone/keystone.conf "
                 "identity domain_config_dir")
         if self.domain_config_dir is None or \

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -48,7 +48,7 @@ class OpenStackManila(Plugin):
 
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
-            container_status = self.get_command_output(runtime + " ps")
+            container_status = self.exec_cmd(runtime + " ps")
             if container_status['status'] == 0:
                 for line in container_status['output'].splitlines():
                     if line.endswith("manila_api"):

--- a/sos/plugins/openstack_octavia.py
+++ b/sos/plugins/openstack_octavia.py
@@ -55,7 +55,7 @@ class OpenStackOctavia(Plugin):
 
         # get details from each loadbalancer
         cmd = "openstack loadbalancer list -f value -c id"
-        loadbalancers = self.call_ext_prog(cmd)['output']
+        loadbalancers = self.exec_cmd(cmd)['output']
         for loadbalancer in loadbalancers.splitlines():
             loadbalancer = loadbalancer.split()[0]
             self.add_cmd_output(
@@ -64,7 +64,7 @@ class OpenStackOctavia(Plugin):
 
         # get details from each l7policy
         cmd = "openstack loadbalancer l7policy list -f value -c id"
-        l7policies = self.call_ext_prog(cmd)['output']
+        l7policies = self.exec_cmd(cmd)['output']
         for l7policy in l7policies.splitlines():
             l7policy = l7policy.split()[0]
             self.add_cmd_output(
@@ -73,7 +73,7 @@ class OpenStackOctavia(Plugin):
 
         # get details from each pool
         cmd = "openstack loadbalancer pool list -f value -c id"
-        pools = self.call_ext_prog(cmd)['output']
+        pools = self.exec_cmd(cmd)['output']
         for pool in pools.splitlines():
             pool = pool.split()[0]
             self.add_cmd_output(

--- a/sos/plugins/openstack_placement.py
+++ b/sos/plugins/openstack_placement.py
@@ -61,7 +61,7 @@ class OpenStackPlacement(Plugin):
 
     def running_in_container(self):
         for runtime in ["docker", "podman"]:
-            container_status = self.get_command_output(runtime + " ps")
+            container_status = self.exec_cmd(runtime + " ps")
             if container_status['status'] == 0:
                 for line in container_status['output'].splitlines():
                     if line.endswith("placement_api"):

--- a/sos/plugins/origin.py
+++ b/sos/plugins/origin.py
@@ -148,8 +148,9 @@ class OpenShiftOrigin(Plugin):
             ])
 
             if self.get_option('all-namespaces'):
-                ocn = self.get_command_output('%s get namespaces'
-                                              % oc_cmd_admin)
+                ocn = self.exec_cmd(
+                    '%s get namespaces' % oc_cmd_admin
+                )
                 ns_output = ocn['output'].splitlines()[1:]
                 nmsps = [n.split()[0] for n in ns_output if n]
             else:
@@ -173,8 +174,9 @@ class OpenShiftOrigin(Plugin):
                                     "atomic-openshift-master-controllers"])
 
             # get logs from the infrastruture pods running in the default ns
-            pods = self.get_command_output("%s get pod -o name -n default"
-                                           % oc_cmd_admin)
+            pods = self.exec_cmd(
+                "%s get pod -o name -n default" % oc_cmd_admin
+            )
             for pod in pods['output'].splitlines():
                 self.add_cmd_output("%s logs -n default %s"
                                     % (oc_cmd_admin, pod))

--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -62,8 +62,8 @@ class Ovirt(Plugin, RedHatPlugin):
         if self.get_option('jbosstrace') and self.is_installed('ovirt-engine'):
             engine_pattern = r"^ovirt-engine\ -server.*jboss-modules.jar"
             pgrep = "pgrep -f '%s'" % engine_pattern
-            lines = self.call_ext_prog(pgrep)['output'].splitlines()
-            engine_pids = [int(x) for x in lines]
+            lines = self.exec_cmd(pgrep)
+            engine_pids = [int(x) for x in lines['output'].splitlines()]
             if not engine_pids:
                 self.soslog.error('Unable to get ovirt-engine pid')
                 self.add_alert('Unable to get ovirt-engine pid')

--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -26,7 +26,7 @@ class OVNCentral(Plugin):
         if self._container_name:
             cmd = "%s exec %s cat %s" % (
                 self._container_runtime, self._container_name, filename)
-            res = self.get_command_output(cmd)
+            res = self.exec_cmd(cmd)
             if res['status'] != 0:
                 self._log_error("Could not retrieve DB schema file from "
                                 "container %s" % self._container_name)
@@ -63,7 +63,7 @@ class OVNCentral(Plugin):
 
     def running_in_container(self):
         for runtime in ["podman", "docker"]:
-            container_status = self.get_command_output(runtime + " ps")
+            container_status = self.exec_cmd(runtime + " ps")
             if container_status['status'] == 0:
                 for line in container_status['output'].splitlines():
                     if "ovn-dbs-bundle" in line:

--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -127,7 +127,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
             files_collected = 0
             path = os.path.join(self.pcp_log_dir, 'pmlogger',
                                 self.pcp_hostname, '*')
-            pmlogger_ls = self.get_cmd_output_now("ls -t1 %s" % path)
+            pmlogger_ls = self.exec_cmd("ls -t1 %s" % path)
             if pmlogger_ls:
                 for line in open(pmlogger_ls).read().splitlines():
                     self.add_copy_spec(line, sizelimit=0)
@@ -148,10 +148,8 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
             os.path.join(self.pcp_log_dir, '*/*/config*')
         ])
 
-        # Need to get the current status of the PCP infrastructure
-        self.add_cmd_output("pcp")
         # Collect a summary for the current day
-        res = self.get_command_output('pcp')
+        res = self.collect_cmd_output('pcp')
         if res['status'] == 0:
             for line in res['output'].splitlines():
                 if line.startswith(' pmlogger:'):

--- a/sos/plugins/podman.py
+++ b/sos/plugins/podman.py
@@ -96,7 +96,7 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
     def _get_podman_list(self, cmd):
         ret = []
-        result = self.get_command_output(cmd)
+        result = self.exec_cmd(cmd)
         if result['status'] == 0:
             for ent in result['output'].splitlines():
                 ret.append(ent)

--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -22,8 +22,9 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     packages = ('rabbitmq-server',)
 
     def setup(self):
-        container_status = self.get_command_output(
-            "docker ps -a --format='{{ .Names }}'")
+        container_status = self.exec_cmd(
+            "docker ps -a --format='{{ .Names }}'"
+        )
 
         in_container = False
         container_names = []

--- a/sos/plugins/runc.py
+++ b/sos/plugins/runc.py
@@ -22,7 +22,7 @@ class Runc(Plugin):
 
         self.add_cmd_output('runc list')
 
-        cons = self.get_command_output('runc list -q')
+        cons = self.exec_cmd('runc list -q')
         conlist = [c for c in cons['output'].splitlines()]
         for con in conlist:
             self.add_cmd_output('runc ps %s' % con)

--- a/sos/plugins/s390.py
+++ b/sos/plugins/s390.py
@@ -59,7 +59,7 @@ class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "icainfo",
             "icastats"
         ])
-        r = self.call_ext_prog("ls /dev/dasd?")
+        r = self.exec_cmd("ls /dev/dasd?")
         dasd_dev = r['output']
         for x in dasd_dev.split('\n'):
             self.add_cmd_output([

--- a/sos/plugins/sapnw.py
+++ b/sos/plugins/sapnw.py
@@ -28,7 +28,7 @@ class sapnw(Plugin, RedHatPlugin):
 
     def collect_list_instances(self):
         # list installed instances
-        inst_out = self.get_cmd_output_now("/usr/sap/hostctrl/exe/saphostctrl \
+        inst_out = self.collect_cmd_output("/usr/sap/hostctrl/exe/saphostctrl \
                                            -function ListInstances",
                                            suggest_filename="SAPInstances")
         if not inst_out:
@@ -93,7 +93,7 @@ class sapnw(Plugin, RedHatPlugin):
 
     def collect_list_dbs(self):
         # list installed sap dbs
-        db_out = self.get_cmd_output_now("/usr/sap/hostctrl/exe/saphostctrl \
+        db_out = self.collect_cmd_output("/usr/sap/hostctrl/exe/saphostctrl \
                                          -function ListDatabases",
                                          suggest_filename="SAPDatabases")
         if not db_out:

--- a/sos/plugins/sas3ircu.py
+++ b/sos/plugins/sas3ircu.py
@@ -23,11 +23,9 @@ class SAS3ircu(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     def setup(self):
 
         # get list of adapters
-        result = self.call_ext_prog("sas3ircu list", timeout=5)
+        result = self.collect_cmd_output("sas3ircu list", timeout=5)
 
         if (result["status"] == 0):
-            self.add_cmd_output("sas3ircu list", timeout=5)
-
             # only want devices
             sas_lst = result["output"].splitlines()[10:-1]
 

--- a/sos/plugins/selinux.py
+++ b/sos/plugins/selinux.py
@@ -27,7 +27,7 @@ class SELinux(Plugin, RedHatPlugin):
         ])
         self.add_cmd_output('sestatus')
 
-        state = self.get_command_output('getenforce')['output']
+        state = self.exec_cmd('getenforce')['output']
         if state != 'Disabled':
             self.add_cmd_output([
                 'ps auxZww',

--- a/sos/plugins/sssd.py
+++ b/sos/plugins/sssd.py
@@ -30,10 +30,10 @@ class Sssd(Plugin):
 
         self.add_cmd_output("sssctl config-check")
 
-        domain_file = self.get_cmd_output_now("sssctl domain-list")
-        if domain_file:
-            for domain_name in open(domain_file).read().splitlines():
-                self.add_cmd_output("sssctl domain-status -o "+domain_name)
+        domain = self.collect_cmd_output("sssctl domain-list")
+        if domain['status'] == 0:
+            for domain_name in domain['output'].splitlines():
+                self.add_cmd_output("sssctl domain-status -o " + domain_name)
 
     def postproc(self):
         regexp = r"(\s*ldap_default_authtok\s*=\s*)\S+"

--- a/sos/plugins/teamd.py
+++ b/sos/plugins/teamd.py
@@ -21,7 +21,7 @@ class Teamd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     def _get_team_interfaces(self):
         teams = []
-        ip_result = self.get_command_output("ip -o link")
+        ip_result = self.exec_cmd("ip -o link")
         if ip_result['status'] != 0:
             return teams
         for line in ip_result['output'].splitlines():

--- a/sos/plugins/vdo.py
+++ b/sos/plugins/vdo.py
@@ -25,12 +25,9 @@ class Vdo(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec(self.files)
-        vdos = self.get_command_output('vdo list --all')
+        vdos = self.collect_cmd_output('vdo list --all')
         for vdo in vdos['output'].splitlines():
             self.add_cmd_output("vdo status -n %s" % vdo)
-        self.add_cmd_output([
-            'vdostats --human-readable',
-            'vdo list --all'
-        ])
+        self.add_cmd_output('vdostats --human-readable')
 
 # vim set et ts=4 sw=4 :

--- a/sos/plugins/vdsm.py
+++ b/sos/plugins/vdsm.py
@@ -113,7 +113,7 @@ class Vdsm(Plugin, RedHatPlugin):
         ])
 
         try:
-            res = self.call_ext_prog(
+            res = self.collect_cmd_output(
                 'vdsm-client Host getConnectedStoragePools'
             )
             if res['status'] == 0:
@@ -129,7 +129,7 @@ class Vdsm(Plugin, RedHatPlugin):
             )
 
         try:
-            res = self.call_ext_prog('vdsm-client Host getStorageDomains')
+            res = self.collect_cmd_output('vdsm-client Host getStorageDomains')
             if res['status'] == 0:
                 sd_uuids = json.loads(res['output'])
                 dump_volume_chains_cmd = 'vdsm-tool dump-volume-chains %s'

--- a/sos/plugins/veritas.py
+++ b/sos/plugins/veritas.py
@@ -27,7 +27,7 @@ class Veritas(Plugin, RedHatPlugin):
 
     def setup(self):
         """ interface with vrtsexplorer to capture veritas related data """
-        r = self.call_ext_prog(self.get_option("script"))
+        r = self.exec_cmd(self.get_option("script"))
         if r['status'] == 0:
             tarfile = ""
             for line in r['output']:

--- a/sos/plugins/vhostmd.py
+++ b/sos/plugins/vhostmd.py
@@ -20,7 +20,7 @@ class vhostmd(Plugin, RedHatPlugin):
     packages = ['virt-what']
 
     def setup(self):
-        vw = self.get_command_output("virt-what")['output'].splitlines()
+        vw = self.exec_cmd("virt-what")['output'].splitlines()
 
         if not vw:
             return
@@ -38,8 +38,9 @@ class vhostmd(Plugin, RedHatPlugin):
                 for disk in os.listdir(sysblock):
                     if "256K" in disk:
                         dev = disk.split()[0]
-                        check = self.get_command_output(
-                            "dd if=/dev/%s bs=25 count=1" % dev)
+                        check = self.exec_cmd(
+                            "dd if=/dev/%s bs=25 count=1" % dev
+                        )
                         if 'metric' in check['output']:
                             self.add_cmd_output("dd if=/dev/%s bs=256k count=1"
                                                 % dev,

--- a/sos/plugins/virsh.py
+++ b/sos/plugins/virsh.py
@@ -43,9 +43,8 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
         # get network, pool and nwfilter elements
         for k in ['net', 'nwfilter', 'pool']:
-            self.add_cmd_output('%s %s-list' % (cmd, k))
-            k_list = self.get_command_output('%s %s-list' % (cmd, k))
-            if k_list and k_list['status'] == 0:
+            k_list = self.exec_cmd('%s %s-list' % (cmd, k))
+            if k_list['status'] == 0:
                 k_lines = k_list['output'].splitlines()
                 # the 'Name' column position changes between virsh cmds
                 pos = k_lines[0].split().index('Name')
@@ -55,8 +54,8 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
         # cycle through the VMs/domains list, ignore 2 header lines and latest
         # empty line, and dumpxml domain name in 2nd column
-        domains_output = self.get_command_output('%s list --all' % cmd)
-        if domains_output and domains_output['status'] == 0:
+        domains_output = self.exec_cmd('%s list --all' % cmd)
+        if domains_output['status'] == 0:
             domains_lines = domains_output['output'].splitlines()[2:]
             for domain in filter(lambda x: x, domains_lines):
                 d = domain.split()[1]

--- a/sos/plugins/xen.py
+++ b/sos/plugins/xen.py
@@ -20,13 +20,16 @@ class Xen(Plugin, RedHatPlugin):
 
     def determine_xen_host(self):
         if os.access("/proc/acpi/dsdt", os.R_OK):
-            result = self.call_ext_prog("grep -qi xen /proc/acpi/dsdt")
+            result = self.exec_cmd(
+                "grep -qi xen /proc/acpi/dsdt"
+            )
             if result['status'] == 0:
                 return "hvm"
 
         if os.access("/proc/xen/capabilities", os.R_OK):
-            result = self.call_ext_prog(
-                "grep -q control_d /proc/xen/capabilities")
+            result = self.exec_cmd(
+                "grep -q control_d /proc/xen/capabilities"
+            )
             if result['status'] == 0:
                 return "dom0"
             else:
@@ -37,7 +40,7 @@ class Xen(Plugin, RedHatPlugin):
         return (self.determine_xen_host() == "baremetal")
 
     def is_running_xenstored(self):
-        xs_pid = self.call_ext_prog("pidof xenstored")['output']
+        xs_pid = self.exec_cmd("pidof xenstored")['output']
         xs_pidnum = re.split('\n$', xs_pid)[0]
         return xs_pidnum.isdigit()
 

--- a/sos/plugins/yum.py
+++ b/sos/plugins/yum.py
@@ -79,9 +79,9 @@ class Yum(Plugin, RedHatPlugin):
 
         # packages installed/erased/updated per transaction
         if self.get_option("yum-history-info"):
-            history = self.call_ext_prog("yum history")
+            history = self.exec_cmd("yum history")
             transactions = None
-            if history['output']:
+            if history['status'] == 0:
                 for line in history['output'].splitlines():
                     try:
                         transactions = int(line.split('|')[0].strip())
@@ -99,7 +99,7 @@ class Yum(Plugin, RedHatPlugin):
             # RHEL6+ alternative for this whole function:
             # self.add_cmd_output("yum-debug-dump '%s'"
             # % os.path.join(self.commons['dstroot'],"yum-debug-dump"))
-            r = self.call_ext_prog("yum-debug-dump")
+            r = self.exec_cmd("yum-debug-dump")
             try:
                 self.add_cmd_output("zcat %s" % (r['output'].split()[-1],))
             except IndexError:

--- a/sos/plugins/zfs.py
+++ b/sos/plugins/zfs.py
@@ -28,7 +28,7 @@ class Zfs(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "zpool status -vx"
         ])
 
-        zpools = self.call_ext_prog("zpool list -H -o name")
+        zpools = self.collect_cmd_output("zpool list -H -o name")
         if zpools['status'] == 0:
             zpools_list = zpools['output'].splitlines()
             for zpool in zpools_list:

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1122,7 +1122,7 @@ class SoSReport(object):
                                        href=".." + f['dstpath']))
 
             for cmd in plug.executed_commands:
-                section.add(Command(name=cmd['exe'], return_code=0,
+                section.add(Command(name=cmd['cmd'], return_code=0,
                                     href=os.path.join(
                                         "..",
                                         self.get_commons()['cmddir'],


### PR DESCRIPTION
Removed `call_ext_prog()`, `check_ext_prog()`, and
`get_command_output()` in favor of consolidating Plugin command
collection into two public methods: `add_cmd_output()` and
`get_cmd_output_now()`.

- `add_cmd_output()` remains unchanged and is the interface to use when
plugins should collect command output during their collect() phase.

- `get_cmd_output_now()` will now return the content of a command's
execution as well as the filename within the sos archive, instead of
just returning the filename. This should help streamline plugin code
that runs a command and then iterates over that output.

The `get_cmd_output_now()` has a `save` keyword arg (default True), that
if set to False will skip writing the command output to the archive.

Also updates the plugins to no longer use `get_command_output()`,
`call_ext_prog()`, or `check_ext_prog()` - instead only using
`get_cmd_output_now()`.

For the vast majority of plugins, these calls were able to be changed
in-place with little to no further alteration of plugin code outside of
no longer making indenpendent open() calls to files created, as the
content of those files is now directly available. Exceptions are noted
below.

For the dlm, gfs2, and kvm plugins the only use of get_command_output()
was to mount /sys/kernel/debugfs which in modern distributions is no
longer needed, so those plugins have had that functionality entirely
removed instead of being ported to the new `get_cmd_output_now()`.

For the networking plugin, many of the checks are handled by
SoSPredicates, and so those command collections now use Predicates
rather than being gated by individual `get_cmd_output_now()` calls.


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
