### PR TITLE
[autofs]: obfuscate password in autofs maps.

### DIFF
--- a/sos/plugins/autofs.py
+++ b/sos/plugins/autofs.py
@@ -48,6 +48,13 @@ class Autofs(Plugin):
         if self.checkdebug():
             self.add_copy_spec(self.getdaemondebug())
 
+    def postproc(self):
+        self.do_path_regex_sub(
+            "/etc/auto*",
+            r"(password=)[^,\s]*",
+            r"\1********"
+        )
+
 
 class RedHatAutofs(Autofs, RedHatPlugin):
 


### PR DESCRIPTION
This patch adds password scrubbing for autofs maps.

Before patch:
/etc/auto.test:test -fstype=cifs,username=test,password=passwd,test-opt /mnt

After patch:
/etc/auto.test:test -fstype=cifs,username=test,password=******,test-opt /mnt

Signed-off-by: Rohan Sable <rohanjsable@yahoo.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
