### PR TITLE
[login] new plugin based in last

### DIFF
--- a/sos/plugins/login.py
+++ b/sos/plugins/login.py
@@ -9,12 +9,12 @@
 from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Last(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Login(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     """login information
     """
 
-    plugin_name = 'last'
-    profiles = ('system',)
+    plugin_name = 'login'
+    profiles = ('system', 'identity')
 
     def setup(self):
         self.add_cmd_output("last", root_symlink="last")
@@ -26,6 +26,11 @@ class Last(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "lastlog -u 1000-60000",
             "lastlog -u 60001-65536",
             "lastlog -u 65537-4294967295"
+        ])
+
+        self.add_copy_spec([
+            "/etc/login.defs",
+            "/etc/default/useradd",
         ])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
login.defs is required by some security compliance checks and could
be useful to collect it. Added to system plugin, as seems the most
neutral plugin to collect it.

Closes #1808

Signed-off-by: Mikel Olasagasti Uranga <mikel@olasagasti.info>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
