### PR TITLE
[ovn_central] dont add db outputs when no table is found in schema

### DIFF
--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -56,6 +56,8 @@ class OVNCentral(Plugin):
             self._log_error("DB schema %s has no 'tables' key" % filename)
 
     def add_database_output(self, tables, cmds, ovn_cmd):
+        if not tables:
+            return
         for table in tables:
             cmds.append('%s list %s' % (ovn_cmd, table))
 


### PR DESCRIPTION
When get_tables_from_schema method returns None (i.e. due to a
parsing error or missing config file), add_database_output tries
to iterate over None object, what raises an exception.

Resolves: #1808

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
