### PR TITLE
[gluster] process files only from a statedump dir

### DIFF
--- a/sos/plugins/gluster.py
+++ b/sos/plugins/gluster.py
@@ -42,7 +42,9 @@ class Gluster(Plugin, RedHatPlugin):
 
     def wait_for_statedump(self, name_dir):
         statedumps_present = 0
-        statedump_entries = os.listdir(name_dir)
+        statedump_entries = [
+                f for f in os.listdir(name_dir) if os.path.isfile(f)
+        ]
         for statedump_file in statedump_entries:
             statedumps_present = statedumps_present+1
             ret = -1


### PR DESCRIPTION
Traversing statedump dir for statedump files must skip
subdirectories (where the dump files won't appear).

Resolves: #1812

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
