### PR TITLE
Remind to put 'Closes' for PR's

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,4 @@ Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor G
 - [] Is the subject and message clear and concise?
 - [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
 - [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
+- [ ] If this commit closes an existing issue, is the line `Closes #ISSUENUMBER` included in an independent line?


### PR DESCRIPTION
Signed-off-by: Pablo Iranzo Gómez <Pablo.Iranzo@gmail.com>

Closes #1792 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
