### PR TITLE
Handle OVN new package naming

### DIFF
--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -139,7 +139,7 @@ class OVNCentral(Plugin):
 
 class RedHatOVNCentral(OVNCentral, RedHatPlugin):
 
-    packages = ('openvswitch-ovn-central', )
+    packages = ('openvswitch-ovn-central', 'ovn2.*-central', )
 
 
 class DebianOVNCentral(OVNCentral, DebianPlugin, UbuntuPlugin):

--- a/sos/plugins/ovn_host.py
+++ b/sos/plugins/ovn_host.py
@@ -50,7 +50,7 @@ class OVNHost(Plugin):
 
 class RedHatOVNHost(OVNHost, RedHatPlugin):
 
-    packages = ('openvswitch-ovn-host', )
+    packages = ('openvswitch-ovn-host', 'ovn2.*-host', )
 
 
 class DebianOVNHost(OVNHost, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Complementing this commit [0], this PR aims to capture the ovn2.* packages after the split of OVN from OVS. Since version 2.10, the new package names for both openvswitch and ovn are openvswitch2.x and ovn2.x in Red Hat Fast Datapath.

[0] https://github.com/sosreport/sos/commit/255c0b08321e9d81f69798d3df16c7548bd3c0db