### PR TITLE
[policies/debian] Make sosreport archive names friendly

### DIFF
--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -12,6 +12,7 @@ class DebianPolicy(LinuxPolicy):
     _debq_cmd = "dpkg-query -W -f='${Package}|${Version}\\n'"
     _debv_cmd = "dpkg --verify"
     _debv_filter = ""
+    name_pattern = 'friendly'
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin"


### PR DESCRIPTION
From the source, currently it's on legacy
legacy - 'sosreport-tux.123456-20171224185433'
friendly - 'sosreport-tux-mylabel-123456-2017-12-24-ezcfcop.tar.xz'

This also makes adding a label actually do something.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
