### PR TITLE
Gather additional OVS commands output for Datapaths

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -95,7 +95,13 @@ class OpenVSwitch(Plugin):
             # Capture DPDK pmd stats
             "ovs-appctl dpif-netdev/pmd-stats-show",
             # Capture DPDK pmd performance counters
-            "ovs-appctl dpif-netdev/pmd-perf-show"
+            "ovs-appctl dpif-netdev/pmd-perf-show",
+            # Capture OVS offload enabled flows
+            "ovs-dpctl dump-flows --name -m type=offloaded",
+            # Capture OVS slowdatapth flows
+            "ovs-dpctl dump-flows --name -m type=ovs",
+            # Capture Userspace Datapath flows
+            "ovs-appctl dpctl/dump-flows -m netdev@ovs-netdev"
         ])
 
         # Gather systemd services logs


### PR DESCRIPTION
This patch add support to collect following additional information of
OVS offload,DPDK,OVS datapath details.

- ovs-dpctl dump-flows --name -m type=offloaded
- ovs-dpctl dump-flows --name -m type=ovs
- ovs-appctl dpctl/dump-flows -m netdev@ovs-netdev

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
