### PR TITLE
[corosync] Fix logging syntax

### DIFF
--- a/sos/plugins/corosync.py
+++ b/sos/plugins/corosync.py
@@ -52,7 +52,7 @@ class Corosync(Plugin):
                     if re.match(pattern, line):
                         self.add_copy_spec(re.search(pattern, line).group(2))
         except IOError as e:
-            self._log_warn("could not read from %s: %s", corosync_conf, e)
+            self._log_warn("could not read from %s: %s" % (corosync_conf, e))
 
     def postproc(self):
         self.do_cmd_output_sub(


### PR DESCRIPTION
Fixes an error in a _log_warn() call that was not properly constructing
the logged string.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
