### PR TITLE
[plugins] Replace /var/run paths by /run

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -55,7 +55,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "/etc/ceph/",
             "/etc/calamari/",
             "/var/lib/ceph/",
-            "/var/run/ceph/"
+            "/run/ceph/"
         ])
 
         self.add_cmd_output([

--- a/sos/plugins/docker.py
+++ b/sos/plugins/docker.py
@@ -150,7 +150,7 @@ class UbuntuDocker(Docker, UbuntuPlugin):
         super(UbuntuDocker, self).setup()
         self.add_copy_spec([
             "/etc/default/docker",
-            "/var/run/docker/libcontainerd/containerd/events.log"
+            "/run/docker/libcontainerd/containerd/events.log"
         ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/gluster.py
+++ b/sos/plugins/gluster.py
@@ -83,8 +83,8 @@ class Gluster(Plugin, RedHatPlugin):
             "/etc/glusterfs",
             "/var/lib/glusterd/",
             # collect nfs-ganesha related configuration
-            "/var/run/gluster/shared_storage/nfs-ganesha/"
-        ] + glob.glob('/var/run/gluster/*tier-dht/*'))
+            "/run/gluster/shared_storage/nfs-ganesha/"
+        ] + glob.glob('/run/gluster/*tier-dht/*'))
 
         if not self.get_option("all_logs"):
             self.add_copy_spec([

--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -38,7 +38,7 @@ class Kubernetes(Plugin):
 
     def setup(self):
         self.add_copy_spec("/etc/kubernetes")
-        self.add_copy_spec("/var/run/flannel")
+        self.add_copy_spec("/run/flannel")
 
         self.add_env_var([
             'KUBECONFIG',

--- a/sos/plugins/libvirt.py
+++ b/sos/plugins/libvirt.py
@@ -36,7 +36,7 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "/etc/libvirt/nwfilter/*.xml",
             "/etc/libvirt/qemu/*.xml",
             "/etc/libvirt/qemu.conf",
-            "/var/run/libvirt/",
+            "/run/libvirt/",
             "/etc/libvirt/qemu/networks/*.xml",
             "/etc/libvirt/qemu/networks/autostart/*.xml",
             "/etc/libvirt/storage/*.xml",
@@ -61,7 +61,7 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         self.add_cmd_output("ls -lR /var/lib/libvirt/qemu")
 
         # get details of processes of KVM hosts
-        for pidfile in glob.glob("/var/run/libvirt/*/*.pid"):
+        for pidfile in glob.glob("/run/libvirt/*/*.pid"):
             pid = open(pidfile).read().splitlines()[0]
             for pf in ["environ", "cgroup", "maps", "numa_maps", "limits"]:
                 self.add_copy_spec("/proc/%s/%s" % (pid, pf))
@@ -70,7 +70,7 @@ class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
         match_exp = r"(\s*passwd=\s*')([^']*)('.*)"
         libvirt_path_exps = [
             r"/etc/libvirt/qemu/.*\.xml",
-            r"/var/run/libvirt/qemu/.*\.xml",
+            r"/run/libvirt/qemu/.*\.xml",
             r"/etc/libvirt/.*\.conf"
         ]
         for path_exp in libvirt_path_exps:

--- a/sos/plugins/nfsganesha.py
+++ b/sos/plugins/nfsganesha.py
@@ -20,7 +20,7 @@ class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_copy_spec([
             "/etc/ganesha",
             "/etc/sysconfig/ganesha",
-            "/var/run/sysconfig/ganesha",
+            "/run/sysconfig/ganesha",
             "/var/log/ganesha/*.log"
         ])
 

--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -38,8 +38,8 @@ class OpenVSwitch(Plugin):
             self.add_copy_spec(log_dirs)
 
         self.add_copy_spec([
-            "/var/run/openvswitch/ovsdb-server.pid",
-            "/var/run/openvswitch/ovs-vswitchd.pid"
+            "/run/openvswitch/ovsdb-server.pid",
+            "/run/openvswitch/ovs-vswitchd.pid"
         ])
 
         self.add_cmd_output([
@@ -56,7 +56,7 @@ class OpenVSwitch(Plugin):
             # Gather the database.
             "ovsdb-client -f list dump",
             # List the contents of runtime directory
-            "ls -laZ /var/run/openvswitch",
+            "ls -laZ /run/openvswitch",
             # List devices and their drivers
             "dpdk_nic_bind --status",
             "dpdk_devbind.py --status",

--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -39,7 +39,7 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
             '/etc/ovirt-hosted-engine-ha/broker.conf',
             '/etc/ovirt-hosted-engine-ha/broker-log.conf',
             '/etc/ovirt-hosted-engine-ha/notifications/state_transition.txt',
-            '/var/run/ovirt-hosted-engine-ha/vm.conf',
+            '/run/ovirt-hosted-engine-ha/vm.conf',
             '/var/lib/ovirt-hosted-engine-ha/broker.conf',
         ])
 

--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -84,7 +84,6 @@ class OVNCentral(Plugin):
             self.add_copy_spec([
                 os.path.join('/var/lib/openvswitch/ovn', pidfile),
                 os.path.join('/usr/local/var/run/openvswitch', pidfile),
-                os.path.join('/var/run/openvswitch/', pidfile),
                 os.path.join('/run/openvswitch/', pidfile),
             ])
 

--- a/sos/plugins/ovn_host.py
+++ b/sos/plugins/ovn_host.py
@@ -16,7 +16,6 @@ pidfile = 'ovn-controller.pid'
 pid_paths = [
         '/var/lib/openvswitch/ovn',
         '/usr/local/var/run/openvswitch',
-        '/var/run/openvswitch',
         '/run/openvswitch'
 ]
 

--- a/sos/plugins/vdsm.py
+++ b/sos/plugins/vdsm.py
@@ -77,7 +77,7 @@ class Vdsm(Plugin, RedHatPlugin):
 
         self._add_vdsm_forbidden_paths()
         self.add_copy_spec([
-            '/var/run/vdsm/*',
+            '/run/vdsm/*',
             '/usr/libexec/vdsm/hooks',
             '/var/lib/vdsm',
         ])
@@ -142,9 +142,9 @@ class Vdsm(Plugin, RedHatPlugin):
             )
 
     def _add_vdsm_forbidden_paths(self):
-        """Add confidential sysprep vfds under /var/run/vdsm to
+        """Add confidential sysprep vfds under /run/vdsm to
          forbidden paths """
 
-        for file_path in glob.glob("/var/run/vdsm/*"):
+        for file_path in glob.glob("/run/vdsm/*"):
             if file_path.endswith(('.vfd', '/isoUploader', '/storage')):
                 self.add_forbidden_path(file_path)


### PR DESCRIPTION
Since FHS 3.0, the system information data since boot are located in
/run. Sosreport shall collect the data directly, without the need to
follow symlink from /var/run to /run that exists just for the sake
of legacy reasons.

Resolves: #1824

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
