### PR TITLE
[nfsganesha] Collect rotated logs when using --all-logs

### DIFF
--- a/sos/plugins/nfsganesha.py
+++ b/sos/plugins/nfsganesha.py
@@ -24,6 +24,10 @@ class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/var/log/ganesha/*.log"
         ])
 
+        if self.get_option("all_logs"):
+            # Grab rotated logs as well
+            self.add_copy_spec("/var/log/ganesha/*.log*")
+
         self.add_cmd_output([
             "dbus-send --type=method_call --print-reply"
             " --system --dest=org.ganesha.nfsd "


### PR DESCRIPTION
If --all-logs is specified, the nfsganesha plugin will now gather the
rotated log files from /var/log/ganesha, not just the current log file.

Fixes: #1016

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
