### PR TITLE
[kubernetes] Only use kubeconfig file if file is present

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -177,7 +177,9 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
         '/etc/origin/node/pods/master-config.yaml',
     )
 
-    kube_cmd = "kubectl --kubeconfig=/etc/origin/master/admin.kubeconfig"
+    kube_cmd = "kubectl"
+    if path.exists('/etc/origin/master/admin.kubeconfig'):
+        kube_cmd += ' --kubeconfig=/etc/origin/master/admin.kubeconfig'
 
 
 class UbuntuKubernetes(Kubernetes, UbuntuPlugin):


### PR DESCRIPTION
Updates the plugin for Red Hat systems to only use the OCP kubeconfig
file, /etc/origin/master/admin.kubeconfig, if it is actually present.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
