### PR TITLE
[openstack_cinder] Blacklist /etc/cinder/volumes

### DIFF
--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -24,6 +24,7 @@ class OpenStackCinder(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated/cinder"
 
     def setup(self):
+        self.add_forbidden_path('/etc/cinder/volumes')
         cinder_config = ""
         cinder_config_opt = "--config-dir %s/etc/cinder/"
 


### PR DESCRIPTION
Adds a blacklist to prevent sos from trying to copy volumes when those
volumes are configured to be saved under /etc/cinder/volumes.

Fixes: #1056
Resolves: #1827

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
