### PR TITLE
[lgtm] Fix several alerts highlighted by LGTM analysis

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -19,9 +19,6 @@ import errno
 import stat
 from threading import Lock
 
-# required for compression callout (FIXME: move to policy?)
-from subprocess import Popen
-
 from sos.utilities import sos_get_command_output, is_executable
 
 try:

--- a/sos/plugins/kimchi.py
+++ b/sos/plugins/kimchi.py
@@ -19,7 +19,6 @@ class Kimchi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     packages = ('kimchi',)
 
     def setup(self):
-        log_limit = self.get_option('log_size')
         self.add_copy_spec('/etc/kimchi/')
         if not self.get_option('all_logs'):
             self.add_copy_spec('/var/log/kimchi/*.log')

--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -9,7 +9,6 @@
 from sos.plugins import (Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin,
                          SoSPredicate)
 from os import listdir
-import re
 
 
 class Networking(Plugin):

--- a/sos/plugins/scsi.py
+++ b/sos/plugins/scsi.py
@@ -6,7 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 from glob import glob
 from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -65,8 +65,6 @@ class InitSystem(object):
         self.list_cmd = "%s %s" % (self.init_cmd, list_cmd) or None
         self.query_cmd = "%s %s" % (self.init_cmd, query_cmd) or None
 
-        self.load_all_services()
-
     def is_enabled(self, name):
         """Check if given service name is enabled """
         if self.services and name in self.services:
@@ -150,6 +148,7 @@ class SystemdInit(InitSystem):
             list_cmd='list-unit-files --type=service',
             query_cmd='status'
         )
+        self.load_all_services()
 
     def parse_query(self, output):
         for line in output.splitlines():

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -561,7 +561,7 @@ class SoSReport(object):
 
     def load_plugins(self):
 
-        import sos.plugins
+        import sos.plugins  # lgtm [py/import-and-import-from]
         helper = ImporterHelper(sos.plugins)
         plugins = helper.get_modules()
         self.plugin_names = []


### PR DESCRIPTION
This patchset fixes several LGTM.com alerts for unsued imports, unused variables, and overridden methods.

Removes the `log_size` variable from the `kimchi` plugin as that should have been removed in a previous sweep when we made `log_size` implicit.

Specifically disables one alert within `load_plugins()` as a false positive.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
