### PR TITLE
[redhat] Automatically enable cantboot preset in emergency/rescue mode

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -300,6 +300,10 @@ support representative.
         return False
 
     def probe_preset(self):
+        # Emergency or rescue mode?
+        for target in ["rescue", "emergency"]:
+            if self.init_system.is_running("%s.target" % target):
+                return self.find_preset(CB)
         # Package based checks
         if self.pkg_by_name("satellite-common") is not None:
             return self.find_preset(RH_SATELLITE)


### PR DESCRIPTION
If sos is being run in emergency or rescue mode on a RH family system,
then automatically load the cantboot preset by default, instead of other
package-based presets.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
