### PR TITLE
[subscription_manager] obfuscate proxy password in rhsm.conf

### DIFF
--- a/sos/plugins/subscription_manager.py
+++ b/sos/plugins/subscription_manager.py
@@ -42,4 +42,9 @@ class SubscriptionManager(Plugin, RedHatPlugin):
         certs = glob.glob('/etc/pki/product-default/*.pem')
         self.add_cmd_output(["rct cat-cert %s" % cert for cert in certs])
 
+    def postproc(self):
+        passwdreg = r"(proxy_password(\s)*=(\s)*)(.*)"
+        repl = r"\1 ********"
+        self.do_path_regex_sub("/etc/rhsm/rhsm.conf", passwdreg, repl)
+
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Obfuscate proxy password in /etc/rhsm/rhsm.conf on line:

proxy_password = someSecret

Resolves: #1837

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
