### PR TITLE
[Predicate] Override __bool__ to allow py3 evaluation

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -203,6 +203,11 @@ class SoSPredicate(object):
         return ((self._eval_kmods() and self._eval_services() and
                  self._eval_packages()) and not self.dry_run)
 
+    def __bool__(self):
+        # Py3 evaluation ends in a __bool__() call where py2 ends in a call
+        # to __nonzero__(). Wrap the latter here, to support both versions
+        return self.__nonzero__()
+
     def __init__(self, owner, dry_run=False, kmods=[], services=[],
                  packages=[], required={}):
         """Initialise a new SoSPredicate object.


### PR DESCRIPTION
The check in `Plugin.test_predicate()` relies on a 'is not None' test,
which on py2 invokes a call to `SoSPredicate.__nonzero__()` which in
turns runs our evaluation of the predicate. On py3 however, this test is
an explicit check to see if the object is `NoneType`. As such,
`__nonzero__()` never runs and the predicate defaults to always
evaluating ad `True`. This effectively removed any gating for command
execution on py3.

By overriding `SoSPredicate.__bool__()` to wrap `__nonzero__()` we can
ensure that predicate evaluation is performed properly on both py2 and
py3 runtimes.

Closes: #1839
Resolves: #1840

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
