### PR TITLE
[policies] RHOSP preset without --all-logs

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -174,8 +174,7 @@ ENV_HOST_SYSROOT = 'HOST'
 _opts_verify = SoSOptions(verify=True)
 _opts_all_logs = SoSOptions(all_logs=True)
 _opts_all_logs_verify = SoSOptions(all_logs=True, verify=True)
-_opts_all_logs_no_lsof = SoSOptions(all_logs=True,
-                                    plugopts=['process.lsof=off'])
+_opts_no_lsof = SoSOptions(plugopts=['process.lsof=off'])
 _cb_plugs = ['abrt', 'block', 'boot', 'dnf', 'dracut', 'filesys', 'grub2',
              'hardware', 'host', 'kernel', 'logs', 'lvm2', 'memory', 'rpm',
              'process', 'systemd', 'yum', 'xfs']
@@ -214,8 +213,7 @@ rhel_presets = {
     RHV: PresetDefaults(name=RHV, desc=RHV_DESC, note=NOTE_TIME,
                         opts=_opts_verify),
     RHEL: PresetDefaults(name=RHEL, desc=RHEL_DESC),
-    RHOSP: PresetDefaults(name=RHOSP, desc=RHOSP_DESC, note=NOTE_SIZE,
-                          opts=_opts_all_logs_no_lsof),
+    RHOSP: PresetDefaults(name=RHOSP, desc=RHOSP_DESC, opts=_opts_no_lsof),
     RHOCP: PresetDefaults(name=RHOCP, desc=RHOCP_DESC, note=NOTE_SIZE_TIME,
                           opts=_opts_all_logs_verify),
     RH_CFME: PresetDefaults(name=RH_CFME, desc=RH_CFME_DESC, note=NOTE_TIME,


### PR DESCRIPTION
OpenStack deployments do not need to collect all logs by default.

Resolves: #1841

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
