### PR TITLE
[Plugin] Avoid potential duplicate sysroot join

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -758,7 +758,7 @@ class Plugin(object):
         return None
 
     def _is_forbidden_path(self, path):
-        if self.use_sysroot():
+        if self.use_sysroot() and not path.startswith(self.sysroot):
             path = self.join_sysroot(path)
         return _path_in_path_list(path, self.forbidden_paths)
 


### PR DESCRIPTION
An issue was discovered when sos was run in a container where the
sysroot when set to something other than '/' (e.g. '/host' in the Red
Hat support-tools container) was getting duplicated in checks against
defined forbidden paths.

This was because self.join_sysroot() is called in multiple spots during
file collection phases (both in `setup()` and `collect()`) before it is
additionally called in the internal `_is_forbidden_path()`. Since the
test for if `join_sysroot()` should be called will always return True in
a containerized environment (because the sysroot is not '/'), this would
cause the container's sysroot (e.g. '/host') to be appended again,
creating for example '/host/host/foo.txt'. Since this duplicated sysroot
append would cause forbidden path comparisons to fail, sos would not
only collect blacklisted sensitive files but would also hang in the
`kernel` plugin due to the fact it was now trying to collect trace_pipe
and other such files that it should otherwise skip.

This commit adds a conditional to `_is_forbidden_path()` to not call
`join_sysroot()` if the path in question already starts with the
sysroot.

Resolves: #1842

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
