### PR TITLE
[Plugin, kernel] interim sysroot fixes

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -738,10 +738,11 @@ class Plugin(object):
 
     def _copy_dir(self, srcpath):
         try:
-            for afile in os.listdir(srcpath):
+            for name in os.listdir(srcpath):
                 self._log_debug("recursively adding '%s' from '%s'"
-                                % (afile, srcpath))
-                self._do_copy_path(os.path.join(srcpath, afile), dest=None)
+                                % (name, srcpath))
+                path = os.path.join(srcpath, name)
+                self._do_copy_path(path)
         except OSError as e:
             if e.errno == errno.ELOOP:
                 msg = "Too many levels of symbolic links copying"

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -800,7 +800,7 @@ class Plugin(object):
                 if not os.listdir(srcpath):
                     self.archive.add_dir(dest)
                     return
-                self._copy_dir(dest)
+                self._copy_dir(srcpath)
                 return
 
         # handle special nodes (block, char, fifo, socket)

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -798,9 +798,9 @@ class Plugin(object):
             if stat.S_ISDIR(st.st_mode) and os.access(srcpath, os.R_OK):
                 # copy empty directory
                 if not os.listdir(srcpath):
-                    self.archive.add_dir(srcpath)
+                    self.archive.add_dir(dest)
                     return
-                self._copy_dir(srcpath)
+                self._copy_dir(dest)
                 return
 
         # handle special nodes (block, char, fifo, socket)
@@ -808,7 +808,7 @@ class Plugin(object):
             ntype = _node_type(st)
             self._log_debug("creating %s node at archive:'%s'"
                             % (ntype, dest))
-            self._copy_node(srcpath, st)
+            self._copy_node(dest, st)
             return
 
         # if we get here, it's definitely a regular file (not a symlink or dir)

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -731,7 +731,7 @@ class Plugin(object):
 
         # skip recursive copying of symlink pointing to itself.
         if (absdest != srcpath):
-            self._do_copy_path(self.strip_sysroot(absdest))
+            self._do_copy_path(absdest)
         else:
             self._log_debug("link '%s' points to itself, skipping target..."
                             % linkdest)
@@ -758,8 +758,6 @@ class Plugin(object):
         return None
 
     def _is_forbidden_path(self, path):
-        if self.use_sysroot():
-            path = self.join_sysroot(path)
         return _path_in_path_list(path, self.forbidden_paths)
 
     def _copy_node(self, path, st):

--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -89,9 +89,9 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         self.add_forbidden_path([
             '/sys/kernel/debug/tracing/trace_pipe',
             '/sys/kernel/debug/tracing/README',
-            '/sys/kernel/debug/tracing/trace_stat/*',
-            '/sys/kernel/debug/tracing/per_cpu/*',
-            '/sys/kernel/debug/tracing/events/*',
+            '/sys/kernel/debug/tracing/trace_stat',
+            '/sys/kernel/debug/tracing/per_cpu',
+            '/sys/kernel/debug/tracing/events',
             '/sys/kernel/debug/tracing/free_buffer',
             '/sys/kernel/debug/tracing/trace_marker',
             '/sys/kernel/debug/tracing/trace_marker_raw',

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -81,6 +81,7 @@ class ForbiddenMockPlugin(Plugin):
     plugin_name = "forbidden"
 
     def setup(self):
+        self.add_copy_spec("tests")
         self.add_forbidden_path("tests")
 
 
@@ -235,7 +236,7 @@ class PluginTests(unittest.TestCase):
         })
         p.archive = MockArchive()
         p.setup()
-        p._do_copy_path("tests")
+        p.collect()
         self.assertEquals(p.archive.m, {})
 
 


### PR DESCRIPTION
Fix several aspects of path handling that affect container environments using an alternate sysroot (`-s/--sysroot`):

  * Invalid handling of symlink and directory paths, leading to `/host` paths appearing in the archive
  * Incorrect  {strip,join}_sysroot() use in `_do_copy_path()` and `_is_forbidden_path()` leading to `/host` paths leaking into the archive and mis-blacklisting of plugin paths
  * Forbidden path glob styles in the `kernel` plugin that conflict with the change to forbidden path checking in #1695 that cause forbidden paths to be incorrectly added to the archive

This addresses current and urgent issues that make sos unusable in this environment: further problems may exist (especially in the `FileCacheArchive` link follow-up handling used when intermediate path components contain symlinks), and these need to be reviewed and addressed appropriately but this set of changes represents a minimum needed to successfully collect a report from this type of system.

This supersedes pull #1842.
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
