### PR TITLE
[plugins, logs] Apply --since option to journal logs

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1366,6 +1366,7 @@ class Plugin(object):
 
         journal_size = 100
         all_logs = self.get_option("all_logs")
+        since = since or self.get_option("since")
         log_size = sizelimit or self.get_option("log_size")
         log_size = max(log_size, journal_size) if not all_logs else 0
 

--- a/sos/plugins/logs.py
+++ b/sos/plugins/logs.py
@@ -51,8 +51,7 @@ class Logs(Plugin):
                 self.add_copy_spec(i)
 
         if self.get_option('all_logs'):
-            self.add_journal(boot="this", since=self.get_option("since"),
-                             allfields=True, output="verbose")
+            self.add_journal(boot="this", allfields=True, output="verbose")
             self.add_journal(boot="last", allfields=True, output="verbose")
 
     def postproc(self):


### PR DESCRIPTION
journalctl / add_journal should apply --since command line option
the same way like collecting logfiles / add_copy_spec does.

Resolves: #1848

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
