### PR TITLE
[man] describe --allow-system-changes

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -25,6 +25,7 @@ sosreport \- Collect and package diagnostic and support data
           [--log-size]\fR
           [--all-logs]\fR
           [--since YYYYMMDD[HHMMSS]]\fR
+          [--allow-system-changes]\fR
           [-z|--compression-type method]\fR
           [--encrypt-key KEY]\fR
           [--encrypt-pass PASS]\fR
@@ -159,6 +160,9 @@ increase the size of reports.
 .B \--since YYYYMMDD[HHMMSS]
 Limits the collection to logs newer than this date.
 This also affects \--all-logs. Will pad with 0s if HHMMSS isn't specified.
+.TP
+.B \--allow-system-changes
+Run commands even if they can change the system (e.g. load kernel modules).
 .TP
 .B \-z, \--compression-type METHOD
 Override the default compression type specified by the active policy.


### PR DESCRIPTION
In #1435, --allow-system-changes option was added that is documented
in sosreport --help but not in manpages.

Resolves: #1850

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
