### PR TITLE
[virsh] add new path collection of virt-manager logs

### DIFF
--- a/sos/plugins/virsh.py
+++ b/sos/plugins/virsh.py
@@ -20,10 +20,10 @@ class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     def setup(self):
         # virt-manager logs
-        if not self.get_option("all_logs"):
-            self.add_copy_spec("/root/.virt-manager/*", sizelimit=5)
-        else:
-            self.add_copy_spec("/root/.virt-manager/*")
+        self.add_copy_spec([
+            "/root/.cache/virt-manager/*.log",
+            "/root/.virt-manager/*.log"
+        ])
 
         cmd = 'virsh -r'
 


### PR DESCRIPTION
The path of virt-manager logs was changed from
"/root/.virt-manager/" to "/root/.cache/virt-manager".
New path collection is added to virsh plugin.

Signed-off-by: MORISHIMA Shigeki <s.morishima@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
