### PR TITLE
[pcp] Fix FileNotFoundError exception while gathering pmlogger log files

### DIFF
--- a/sos/plugins/pcp.py
+++ b/sos/plugins/pcp.py
@@ -129,7 +129,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
                                 self.pcp_hostname, '*')
             pmlogger_ls = self.exec_cmd("ls -t1 %s" % path)
             if pmlogger_ls['status'] == 0:
-                for line in open(pmlogger_ls['output']).read().splitlines():
+                for line in pmlogger_ls['output'].splitlines():
                     self.add_copy_spec(line, sizelimit=0)
                     files_collected = files_collected + 1
                     if self.countlimit and files_collected == self.countlimit:


### PR DESCRIPTION
After API command consolidation via commits 
e8bb94c84a75d9a992e0dce9446d1731cbefb608
and  e51d3e6d5b5c084a3289751dbca559ba134bace8,
 pcp started throwing a FileNotFound exception. 
This patch attemps to fix this exception.

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
