### PR TITLE
[Plugin|Policy] Only call lsmod once and standardize kmod checks

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1278,11 +1278,8 @@ class Plugin(object):
                                       chdir=runat, binary=binary, env=env)
 
     def is_module_loaded(self, module_name):
-        """Return whether specified moudle as module_name is loaded or not"""
-        if len(grep("^" + module_name + " ", "/proc/modules")) == 0:
-            return False
-        else:
-            return True
+        """Return whether specified module as module_name is loaded or not"""
+        return module_name in self.policy.kernel_mods
 
     # For adding output
     def add_alert(self, alertstring):
@@ -1541,15 +1538,11 @@ class Plugin(object):
         return True
 
     def _check_plugin_triggers(self, files, packages, commands, services):
-        kernel_mods = self.policy.lsmod()
-
-        def have_kmod(kmod):
-            return kmod in kernel_mods
 
         return (any(os.path.exists(fname) for fname in files) or
                 any(self.is_installed(pkg) for pkg in packages) or
                 any(is_executable(cmd) for cmd in commands) or
-                any(have_kmod(kmod) for kmod in self.kernel_mods) or
+                any(self.is_module_loaded(mod) for mod in self.kernel_mods) or
                 any(self.is_service(svc) for svc in services))
 
     def default_enabled(self):

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -822,6 +822,7 @@ class LinuxPolicy(Policy):
 
     def __init__(self, sysroot=None):
         super(LinuxPolicy, self).__init__(sysroot=sysroot)
+        self.init_kernel_modules()
         if self.init == 'systemd':
             self.init_system = SystemdInit()
         else:
@@ -874,11 +875,12 @@ class LinuxPolicy(Policy):
     def sanitize_filename(self, name):
         return re.sub(r"[^-a-z,A-Z.0-9]", "", name)
 
-    def lsmod(self):
-        """Return a list of kernel module names as strings.
+    def init_kernel_modules(self):
+        """Obtain a list of loaded kernel modules to reference later for plugin
+        enablement and SoSPredicate checks
         """
         lines = shell_out("lsmod", timeout=0).splitlines()
-        return [line.split()[0].strip() for line in lines]
+        self.kernel_mods = [line.split()[0].strip() for line in lines]
 
     def pre_work(self):
         # this method will be called before the gathering begins


### PR DESCRIPTION
This commit makes two changes to how sos deals with kernel modules and
their state during a run of sosreport.

First, no longer call `lsmod` for every individual plugin during its
enablement check. Instead, call `Policy.lsmod()` only once during
`load_plugins()` before we begin iterating over the plugins, and save
that information as a policy class attr.

Second, have `Plugin.is_module_loaded()` check for kmod presence in the
saved policy class attr for kernel_mods, rather than checking through
`/proc/modules`. Have the plugin enablement checks now also use
`is_module_loaded()` to standardize with how `SoSPredicate`s are
checked.

Note that this change results in a significant performance increase for
sos initialization times in a RHEL 7 container.

Resolves: #1854

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
