### PR TITLE
[openstack_horizon] fix useless forbidden paths

### DIFF
--- a/sos/plugins/openstack_horizon.py
+++ b/sos/plugins/openstack_horizon.py
@@ -41,7 +41,9 @@ class OpenStackHorizon(Plugin):
             self.var_puppet_gen + "/horizon/etc/httpd/conf.modules.d/*.conf",
             self.var_puppet_gen + "/memcached/etc/sysconfig/memcached"
         ])
-        self.add_forbidden_path("*.py[co]")
+        self.add_forbidden_path(
+            "/etc/openstack-dashboard/local_settings.d/*.py[co]"
+        )
 
     def postproc(self):
         var_puppet_gen = self.var_puppet_gen + "/horizon"


### PR DESCRIPTION
The code has currently the following line:

        self.add_forbidden_path("*.py[co]")

But add_forbidden_path() needs a directory prefix, so this won't
work. This line was introduced via commit 4d75385ad to solve
issue #856, that discussed the postproc method in
openstack_horizon. It seems that the python object and source
files are present in /etc/openstack-dashboard/local_settings.d/
used to customize the dashboard. This patch adds that directory
to the add_forbidden_path() line.

Closes: #1846

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
