### PR TITLE
[kubernetes] Set plugin_name

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -19,6 +19,7 @@ class Kubernetes(Plugin):
     """Kubernetes plugin
     """
 
+    plugin_name = "kubernetes"
     profiles = ('container',)
 
     option_list = [


### PR DESCRIPTION
Without setting plugin_name in parent class, "sosreport --list-plugins"
prints plugin name based on the child class name (redhatkubernetes,
ubuntukubernetes). Trying to refer that plugin name fails.

Setting plugin_name to "kubernetes" in the parent Kubernetes class
prevents this confusion.

Resolves: #1858

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
