### PR TITLE
[sapnw] implement collect_cmd_output API change

### DIFF
--- a/sos/plugins/sapnw.py
+++ b/sos/plugins/sapnw.py
@@ -32,14 +32,13 @@ class sapnw(Plugin, RedHatPlugin):
             "/usr/sap/hostctrl/exe/saphostctrl -function ListInstances",
             suggest_filename="SAPInstances"
         )
-        if not inst_out:
+        if inst_out['status'] != 0:
             return
 
         sidsunique = set()
         # Cycle through all the instances, get 'sid', 'instance_number'
         # and 'vhost' to determine the proper profile
-        p = open(inst_out, "r").read().splitlines()
-        for inst_line in p:
+        for inst_line in inst_out['output'].splitlines():
             if "DAA" not in inst_line:
                 fields = inst_line.strip().split()
                 sid = fields[3]
@@ -99,11 +98,10 @@ class sapnw(Plugin, RedHatPlugin):
             suggest_filename="SAPDatabases"
         )
 
-        if not db_out:
+        if db_out['status'] != 0:
             return
 
-        dbl = open(db_out, "r").read().splitlines()
-        for line in dbl:
+        for line in db_out['output'].splitlines():
             if "Instance name" in line:
                 fields = line.strip().split()
                 dbadm = fields[2][:-1]


### PR DESCRIPTION
Since e8bb94c, collect_cmd_output returns a dict instead of filename.
Reflect the change in testing command output and accessing filename.

Resolves: #1859

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
