### PR TITLE
[openstack_keystone] implement exec_cmd API change

### DIFF
--- a/sos/plugins/openstack_keystone.py
+++ b/sos/plugins/openstack_keystone.py
@@ -48,10 +48,11 @@ class OpenStackKeystone(Plugin):
 
         # collect domain config directory, if specified
         # if not, collect default /etc/keystone/domains
-        self.domain_config_dir = self.exec_cmd(
+        exec_out = self.exec_cmd(
                 "crudini --get /etc/keystone/keystone.conf "
                 "identity domain_config_dir")
-        if self.domain_config_dir is None or \
+        self.domain_config_dir = exec_out['output']
+        if exec_out['status'] != 0 or \
                 not(os.path.isdir(self.domain_config_dir)):
             self.domain_config_dir = "/etc/keystone/domains"
         self.add_copy_spec(self.domain_config_dir)


### PR DESCRIPTION
Since e8bb94c, exec_cmd returns a dict instead of command output.
Reflect the change in testing the return value and using the output.

Resolves: #1860

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
