### PR TITLE
[apport] List var crash recursively

### DIFF
--- a/sos/plugins/apport.py
+++ b/sos/plugins/apport.py
@@ -32,7 +32,7 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
             "gdbus call -y -d com.ubuntu.WhoopsiePreferences \
             -o /com/ubuntu/WhoopsiePreferences \
             -m com.ubuntu.WhoopsiePreferences.GetIdentifier")
-        self.add_cmd_output("ls -alh /var/crash/")
+        self.add_cmd_output("ls -alhR /var/crash/")
         self.add_cmd_output("bash -c 'grep -B 50 -m 1 ProcMaps /var/crash/*'")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Listing /var/crash recursively will provide
not only the root of /var/crash as current
state, but also data found in subdirectories
if any as follow:

$ ls /var/crash/201911131119/
dmesg.201911131119  dump.201911131119

Signed-by-off: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
