### PR TITLE
[canonical-livepatch] No longer need to hardcode absolute path

### DIFF
--- a/sos/plugins/canonical_livepatch.py
+++ b/sos/plugins/canonical_livepatch.py
@@ -17,13 +17,13 @@ class CanonicaLivepatch(Plugin, UbuntuPlugin):
 
     plugin_name = 'canonical_livepatch'
     profiles = ('system', 'kernel')
-    files = ('/snap/bin/canonical-livepatch')
+    commands = ('canonical-livepatch',)
 
     def setup(self):
         self.add_cmd_output([
             "systemctl status snap.canonical-livepatch.canonical-livepatchd",
-            "snap run canonical-livepatch status --verbose",
-            "snap run canonical-livepatch --version"
+            "canonical-livepatch status --verbose",
+            "canonical-livepatch --version"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
