### PR TITLE
[ovn_central] Execute 'podman' commands with stdin=PIPE

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1256,7 +1256,7 @@ class Plugin(object):
         )
 
     def exec_cmd(self, cmd, timeout=300, stderr=True, chroot=True, runat=None,
-                 env=None, binary=False, pred=None):
+                 env=None, binary=False, pred=None, stdin=None):
         """Execute a command right now and return the output and status, but
         do not save the output within the archive.
 
@@ -1275,7 +1275,8 @@ class Plugin(object):
             root = None
 
         return sos_get_command_output(cmd, timeout=timeout, chroot=root,
-                                      chdir=runat, binary=binary, env=env)
+                                      chdir=runat, binary=binary, env=env,
+                                      stdin=stdin)
 
     def is_module_loaded(self, module_name):
         """Return whether specified module as module_name is loaded or not"""

--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -12,6 +12,7 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 import json
 import os
 import six
+from subprocess import PIPE
 
 
 class OVNCentral(Plugin):
@@ -21,6 +22,12 @@ class OVNCentral(Plugin):
     profiles = ('network', 'virt')
     _container_runtime = None
     _container_name = None
+    _container_stdin = None
+
+    def exec_cmd(self, *args, **kwargs):
+        return super().get_command_output(*args,
+                                          stdin=self._container_stdin,
+                                          **kwargs)
 
     def get_tables_from_schema(self, filename, skip=[]):
         if self._container_name:
@@ -69,6 +76,8 @@ class OVNCentral(Plugin):
                     if "ovn-dbs-bundle" in line:
                         self._container_name = line.split()[-1]
                         self._container_runtime = runtime
+                        if self._container_name == 'podman':
+                            self._container_stdin = PIPE
                         return True
         return False
 

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -107,7 +107,8 @@ def is_executable(command):
 
 def sos_get_command_output(command, timeout=300, stderr=False,
                            chroot=None, chdir=None, env=None,
-                           binary=False, sizelimit=None, poller=None):
+                           binary=False, sizelimit=None, poller=None,
+                           stdin=None):
     """Execute a command and return a dictionary of status and output,
     optionally changing root or current working directory before
     executing command.
@@ -148,7 +149,7 @@ def sos_get_command_output(command, timeout=300, stderr=False,
         else:
             expanded_args.append(arg)
     try:
-        p = Popen(expanded_args, shell=False, stdout=PIPE,
+        p = Popen(expanded_args, shell=False, stdout=PIPE, stdin=stdin,
                   stderr=STDOUT if stderr else PIPE,
                   bufsize=-1, env=cmd_env, close_fds=True,
                   preexec_fn=_child_prep_fn)


### PR DESCRIPTION
When executing commands inside a container with podman, it's
required to use a pipe for stdin or they'll hang.
This patch is accomplishing that and it might be reverted when [0]
is fixed.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1732525

Signed-off-by: Daniel Alvarez <dalvarez@redhat.com>