### PR TITLE
[Plugin] Detect copy operations without the adequate access rights

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -744,6 +744,10 @@ class Plugin(object):
                 path = os.path.join(srcpath, name)
                 self._do_copy_path(path)
         except OSError as e:
+            if e.errno == errno.EPERM or errno.EACCES:
+                msg = "Permission denied"
+                self._log_warn("_copy_dir: '%s' %s" % (srcpath, msg))
+                return
             if e.errno == errno.ELOOP:
                 msg = "Too many levels of symbolic links copying"
                 self._log_error("_copy_dir: %s '%s'" % (msg, srcpath))


### PR DESCRIPTION
Likely due to Linux Security Modules such as apparmor, selinux, ...

Fix: #1662

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
