### PR TITLE
[plugins] Support for directory specification in add_copy_spec()

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1425,7 +1425,14 @@ class Plugin(object):
             self._add_cmd_output(cmd='%s %s' % (udev_cmd, dev))
 
     def _expand_copy_spec(self, copyspec):
-        return glob.glob(copyspec)
+        if os.path.isdir(copyspec):
+            paths = []
+            for root, dirs, files in os.walk(copyspec):
+                for _file in files:
+                    paths.append(os.path.join(root, _file))
+            return paths
+        else:
+            return glob.glob(copyspec)
 
     def _collect_copy_specs(self):
         for path in self.copy_paths:


### PR DESCRIPTION
Previously, when a directory was specified in add_copy_spec(),
stat.ST_SIZE returned the size of the directory.
As a result, the limitation by --log-size did not work.

When a directory is specified in add_copy_spec(),
use os.walk() to find out the files under the directory.
From this, the limitation by --log-size work correctly.

Resolves: #1863

Signed-off-by: MIZUTA Takeshi <mizuta.takeshi@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
