### PR TITLE
[sar] Don't truncate sa file even if --log-size limit is reached

### DIFF
--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -24,7 +24,8 @@ class Sar(Plugin,):
 
     def setup(self):
         self.add_copy_spec(self.sa_path,
-                           sizelimit=0 if self.get_option("all_sar") else None)
+                           sizelimit=0 if self.get_option("all_sar") else None,
+                           tailit=False)
 
         try:
             dir_list = os.listdir(self.sa_path)


### PR DESCRIPTION
When sa file is truncated, it cannot be read correctly.
Fix tailit specified in add_copy_spec() to False
so that the sa file is not truncated.

Resolves: #1871

Signed-off-by: MIZUTA Takeshi <mizuta.takeshi@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
