### PR TITLE
[Policy|Plugin] Provide a Container Runtime Abstraction

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1309,27 +1309,119 @@ class Plugin(object):
 
     def exec_cmd(self, cmd, timeout=cmd_timeout, stderr=True, chroot=True,
                  runat=None, env=None, binary=False, pred=None,
-                 foreground=False):
+                 foreground=False, container=False):
         """Execute a command right now and return the output and status, but
         do not save the output within the archive.
 
         Use this method in a plugin's setup() if command output is needed to
         build subsequent commands added to a report via add_cmd_output().
         """
+        _default = {'status': None, 'output': ''}
         if not self.test_predicate(cmd=True, pred=pred):
-            return {
-                'status': None,
-                'output': ''
-            }
+            return _default
 
         if chroot or self.commons['cmdlineopts'].chroot == 'always':
             root = self.sysroot
         else:
             root = None
 
+        if container:
+            if self._get_container_runtime() is None:
+                self._log_info("Cannot run cmd '%s' in container %s: no "
+                               "runtime detected on host." % (cmd, container))
+                return _default
+            if self.container_exists(container):
+                cmd = self.fmt_container_cmd(container, cmd)
+            else:
+                self._log_info("Cannot run cmd '%s' in container %s: no such "
+                               "container is running." % (cmd, container))
+
         return sos_get_command_output(cmd, timeout=timeout, chroot=root,
                                       chdir=runat, binary=binary, env=env,
                                       foreground=foreground)
+
+    def _get_container_runtime(self, runtime=None):
+        """Based on policy and request by the plugin, return a usable
+        ContainerRuntime if one exists
+        """
+        if runtime is None:
+            if 'default' in self.policy.runtimes.keys():
+                return self.policy.runtimes['default']
+        else:
+            for pol_runtime in list(self.policy.runtimes.keys()):
+                if runtime == pol_runtime:
+                    return self.policy.runtimes[pol_runtime]
+        return None
+
+    def container_exists(self, name):
+        """If a container runtime is present, check to see if a container with
+        a given name is currently running
+        """
+        _runtime = self._get_container_runtime()
+        if _runtime is not None:
+            con = _runtime.get_container_by_name(name)
+            return con is not None
+        return False
+
+    def get_container_by_name(self, name):
+        _runtime = self._get_container_runtime()
+        if _runtime is not None:
+            return _runtime.get_container_by_name(name)
+        return None
+
+    def get_containers(self, runtime=None, get_all=False):
+        """Return a list of all container IDs from the Policy's
+        ContainerRuntime.
+
+        If `runtime` is not provided, use the Policy default. If the specified
+        `runtime is not loaded, return empty.
+        """
+        _runtime = self._get_container_runtime(runtime=runtime)
+        if _runtime is not None:
+            if get_all:
+                return _runtime.get_containers(get_all=True)
+            else:
+                return _runtime.containers
+        return []
+
+    def get_container_images(self, runtime=None):
+        """Return a list of all image names from the Policy's
+        ContainerRuntime
+
+        If `runtime` is not provided, use the Policy default. If the specified
+        `runtime is not loaded, return empty.
+        """
+        _runtime = self._get_container_runtime(runtime=runtime)
+        if _runtime is not None:
+            return _runtime.images
+        return []
+
+    def get_container_volumes(self, runtime=None):
+        """Return a list of all volume names from the Policy's
+        ContainerRuntime
+
+        If `runtime` is not provided, use the Policy default. If the specified
+        `runtime is not loaded, return empty.
+        """
+        _runtime = self._get_container_runtime(runtime=runtime)
+        if _runtime is not None:
+            return _runtime.volumes
+        return []
+
+    def get_container_logs(self, container, **kwargs):
+        """Helper to get the `logs` output for a given container
+
+        Supports passthru of add_cmd_output() options
+        """
+        _runtime = self._get_container_runtime()
+        if _runtime is not None:
+            self.add_cmd_output(_runtime.get_logs_command(container), **kwargs)
+
+    def fmt_container_cmd(self, container, cmd):
+        if self.container_exists(container):
+            _runtime = self._get_container_runtime()
+            return _runtime.fmt_container_cmd(container, cmd)
+        return cmd
 
     def is_module_loaded(self, module_name):
         """Return whether specified module as module_name is loaded or not"""

--- a/sos/plugins/openstack_cinder.py
+++ b/sos/plugins/openstack_cinder.py
@@ -37,7 +37,7 @@ class OpenStackCinder(Plugin):
             if in_ps:
                 break
 
-        in_container = self.running_in_container()
+        in_container = self.container_exists('cinder_api')
         if in_container:
             cinder_config = cinder_config_opt % self.var_puppet_gen
 
@@ -68,15 +68,6 @@ class OpenStackCinder(Plugin):
                 "/var/log/cinder/*.log",
                 "/var/log/httpd/cinder*.log",
             ])
-
-    def running_in_container(self):
-        for runtime in ["docker", "podman"]:
-            container_status = self.exec_cmd(runtime + " ps")
-            if container_status['status'] == 0:
-                for line in container_status['output'].splitlines():
-                    if line.endswith("cinder_api"):
-                        return True
-        return False
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/cinder/*", regexp, subst)

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -42,7 +42,7 @@ class OpenStackGlance(Plugin):
 
         # collect commands output only if the openstack-glance-api service
         # is running
-        in_container = self.running_in_container()
+        in_container = self.container_exists('glance_api')
 
         if self.is_service_running('openstack-glance-api') or in_container:
             glance_config = ""
@@ -69,15 +69,6 @@ class OpenStackGlance(Plugin):
                                     "environment.")
             else:
                 self.add_cmd_output("openstack image list --long")
-
-    def running_in_container(self):
-        for runtime in ["docker", "podman"]:
-            container_status = self.exec_cmd(runtime + " ps")
-            if container_status['status'] == 0:
-                for line in container_status['output'].splitlines():
-                    if line.endswith("glance_api"):
-                        return True
-        return False
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/glance/*", regexp, subst)

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -26,7 +26,7 @@ class OpenStackHeat(Plugin):
 
         # collect commands output only if the openstack-heat-api service
         # is running
-        in_container = self.running_in_container()
+        in_container = self.container_exists('heat_api')
 
         if self.is_service_running('openstack-heat-api') or in_container:
             heat_config = ""
@@ -78,15 +78,6 @@ class OpenStackHeat(Plugin):
             self.var_puppet_gen + "_api_cfn/etc/httpd/conf.modules.d/*.conf",
             self.var_puppet_gen + "_api_cfn/var/spool/cron/heat",
         ])
-
-    def running_in_container(self):
-        for runtime in ["docker", "podman"]:
-            container_status = self.exec_cmd(runtime + " ps")
-            if container_status['status'] == 0:
-                for line in container_status['output'].splitlines():
-                    if line.endswith("heat_api"):
-                        return True
-        return False
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub(

--- a/sos/plugins/openstack_manila.py
+++ b/sos/plugins/openstack_manila.py
@@ -23,7 +23,7 @@ class OpenStackManila(Plugin):
     def setup(self):
 
         config_dir = "%s/etc/manila" % (
-            self.var_puppet_gen if self.running_in_container() else ''
+            self.var_puppet_gen if self.container_exists('manila_api') else ''
         )
         manila_cmd = "manila-manage --config-dir %s db version" % config_dir
         self.add_cmd_output(manila_cmd, suggest_filename="manila_db_version")
@@ -45,15 +45,6 @@ class OpenStackManila(Plugin):
             self.add_copy_spec([
                 "/var/log/manila/*.log",
             ])
-
-    def running_in_container(self):
-        for runtime in ["docker", "podman"]:
-            container_status = self.exec_cmd(runtime + " ps")
-            if container_status['status'] == 0:
-                for line in container_status['output'].splitlines():
-                    if line.endswith("manila_api"):
-                        return True
-        return False
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/manila/*", regexp, subst)

--- a/sos/plugins/openstack_placement.py
+++ b/sos/plugins/openstack_placement.py
@@ -24,7 +24,7 @@ class OpenStackPlacement(Plugin):
         # collect commands output only if the openstack-placement-api service
         # is running
 
-        in_container = self.running_in_container()
+        in_container = self.container_exists('placement_api')
 
         if self.is_service_running('openstack-placement-api') or in_container:
             placement_config = ""
@@ -58,15 +58,6 @@ class OpenStackPlacement(Plugin):
             self.var_puppet_gen + "/etc/httpd/conf.d/",
             self.var_puppet_gen + "/etc/httpd/conf.modules.d/*.conf",
         ])
-
-    def running_in_container(self):
-        for runtime in ["docker", "podman"]:
-            container_status = self.exec_cmd(runtime + " ps")
-            if container_status['status'] == 0:
-                for line in container_status['output'].splitlines():
-                    if line.endswith("placement_api"):
-                        return True
-        return False
 
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/placement/*", regexp, subst)

--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -19,14 +19,12 @@ class OVNCentral(Plugin):
     """
     plugin_name = "ovn_central"
     profiles = ('network', 'virt')
-    _container_runtime = None
-    _container_name = None
 
     def get_tables_from_schema(self, filename, skip=[]):
         if self._container_name:
-            cmd = "%s exec %s cat %s" % (
-                self._container_runtime, self._container_name, filename)
-            res = self.exec_cmd(cmd, foreground=True)
+            cmd = "cat %s" % filename
+            res = self.exec_cmd(cmd, timeout=None, foreground=True,
+                                container=self._container_name)
             if res['status'] != 0:
                 self._log_error("Could not retrieve DB schema file from "
                                 "container %s" % self._container_name)
@@ -61,23 +59,12 @@ class OVNCentral(Plugin):
         for table in tables:
             cmds.append('%s list %s' % (ovn_cmd, table))
 
-    def running_in_container(self):
-        for runtime in ["podman", "docker"]:
-            container_status = self.exec_cmd(runtime + " ps")
-            if container_status['status'] == 0:
-                for line in container_status['output'].splitlines():
-                    if "ovn-dbs-bundle" in line:
-                        self._container_name = line.split()[-1]
-                        self._container_runtime = runtime
-                        return True
-        return False
-
     def check_enabled(self):
-        return (self.running_in_container() or
+        return (self.container_exists('ovs-dbs-bundle.*') or
                 super(OVNCentral, self).check_enabled())
 
     def setup(self):
-        containerized = self.running_in_container()
+        self._container_name = self.get_container_by_name('ovs-dbs-bundle.*')
 
         ovs_rundir = os.environ.get('OVS_RUNDIR')
         for pidfile in ['ovnnb_db.pid', 'ovnsb_db.pid', 'ovn-northd.pid']:
@@ -113,10 +100,9 @@ class OVNCentral(Plugin):
 
         # If OVN is containerized, we need to run the above commands inside
         # the container.
-        if containerized:
-            cmds = ['%s exec %s %s' % (self._container_runtime,
-                                       self._container_name,
-                                       cmd) for cmd in cmds]
+        cmds = [
+            self.fmt_container_cmd(self._container_name, cmd) for cmd in cmds
+        ]
 
         self.add_cmd_output(cmds, foreground=True)
 

--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -22,24 +22,19 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     packages = ('rabbitmq-server',)
 
     def setup(self):
-        container_status = self.exec_cmd(
-            "docker ps -a --format='{{ .Names }}'"
-        )
-
         in_container = False
         container_names = []
-        if container_status['status'] == 0:
-            for line in container_status['output'].splitlines():
-                if line.startswith("rabbitmq"):
-                    in_container = True
-                    container_names.append(line)
+        _containers = self.get_containers()
+        for _con in _containers:
+            if _con[1].startswith('rabbitmq'):
+                in_container = True
+                container_names.append(_con[1])
 
         if in_container:
             for container in container_names:
-                self.add_cmd_output('docker logs {0}'.format(container))
+                self.get_container_logs(container)
                 self.add_cmd_output(
-                    'docker exec -t {0} rabbitmqctl report'
-                    .format(container)
+                    self.fmt_container_cmd(container, 'rabbitmqctl report')
                 )
         else:
             self.add_cmd_output("rabbitmqctl report")

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -14,6 +14,7 @@ from getpass import getpass
 from pwd import getpwuid
 from sos.utilities import (ImporterHelper,
                            import_module,
+                           is_executable,
                            shell_out,
                            sos_get_command_output)
 from sos.plugins import IndependentPlugin, ExperimentalPlugin
@@ -22,6 +23,7 @@ from sos import SoSOptions, _arg_names
 from textwrap import fill
 from six import print_
 from six.moves import input
+from pipes import quote
 
 PRESETS_PATH = "/var/lib/sos/presets"
 
@@ -65,6 +67,126 @@ def load(cache={}, sysroot=None):
         cache['policy'] = GenericPolicy()
 
     return cache['policy']
+
+
+class ContainerRuntime(object):
+    """Encapsulates a container runtime that provides the ability to plugins to
+    check runtime status, check for the presence of specific containers, and
+    to format commands to run in those containers
+    """
+
+    name = 'Undefined'
+    containers = []
+    images = []
+    volumes = []
+    binary = ''
+    active = False
+
+    def __init__(self, policy=None):
+        self.policy = policy
+        self.run_cmd = "%s exec " % self.binary
+
+    def load_container_info(self):
+        """If this runtime is found to be active, attempt to load information
+        on the objects existing in the runtime.
+        """
+        self.containers = self.get_containers()
+        self.images = self.get_images()
+        self.volumes = self.get_volumes()
+
+    def check_is_active(self):
+        """Check to see if the container runtime is both present AND active.
+
+        Active in this sense means that the runtime can be used to glean
+        information about the runtime itself and containers that are running.
+        """
+        if is_executable(self.binary):
+            self.active = True
+            return True
+        return False
+
+    def get_containers(self, get_all=False):
+        """Get a list of containers present on the system.
+
+        If `get_all` is `True`, also include non-running containers
+        """
+        containers = []
+        _cmd = "%s ps %s" % (self.binary, '-a' if get_all else '')
+        if self.active:
+            out = sos_get_command_output(_cmd)
+            if out['status'] == 0:
+                for ent in out['output'].splitlines()[1:]:
+                    ent = ent.split()
+                    # takes the form (container_id, container_name)
+                    containers.append((ent[0], ent[-1]))
+        return containers
+
+    def get_container_by_name(self, name):
+        """Get the container ID for the container matching the provided
+        name
+        """
+        if not self.active or name is None:
+            return None
+        for c in self.containers:
+            if re.match(name, c[1]):
+                return c[1]
+        return None
+
+    def get_images(self):
+        """Get a list of images present on the system
+        """
+        images = []
+        fmt = '{{lower .Repository}}:{{lower .Tag}} {{lower .ID}}'
+        if self.active:
+            out = sos_get_command_output("%s images --format '%s'"
+                                         % (self.binary, fmt))
+            if out['status'] == 0:
+                for ent in out['output'].splitlines():
+                    ent = ent.split()
+                    # takes the form (image_name, image_id)
+                    images.append((ent[0], ent[1]))
+        return images
+
+    def get_volumes(self):
+        """Get a list of container volumes present on the system
+        """
+        vols = []
+        if self.active:
+            out = sos_get_command_output("%s volume ls" % self.binary)
+            if out['status'] == 0:
+                for ent in out['output'].splitlines()[1:]:
+                    ent = ent.split()
+                    vols.append(ent[-1])
+        return vols
+
+    def fmt_container_cmd(self, container, cmd):
+        return "%s %s %s" % (self.run_cmd, container, quote(cmd))
+
+    def get_logs_command(self, container):
+        """Return the command string used to dump container logs from the
+        runtime
+        """
+        return "%s logs -t %s" % (self.binary, container)
+
+
+class DockerContainerRuntime(ContainerRuntime):
+
+    name = 'docker'
+    binary = 'docker'
+
+    def check_is_active(self):
+        # the daemon must be running
+        if (is_executable('docker') and
+                self.policy.init_system.is_running('docker')):
+            self.active = True
+            return True
+        return False
+
+
+class PodmanContainerRuntime(ContainerRuntime):
+
+    name = 'podman'
+    binary = 'podman'
 
 
 class InitSystem(object):
@@ -464,7 +586,7 @@ any third party.
     _in_container = False
     _host_sysroot = '/'
 
-    def __init__(self, sysroot=None):
+    def __init__(self, sysroot=None, probe_runtime=True):
         """Subclasses that choose to override this initializer should call
         super() to ensure that they get the required platform bits attached.
         super(SubClass, self).__init__(). Policies that require runtime
@@ -472,6 +594,7 @@ any third party.
         modifying PATH in their own initializer."""
         self._parse_uname()
         self.case_id = None
+        self.probe_runtime = probe_runtime
         self.package_manager = PackageManager()
         self._valid_subclasses = []
         self.set_exec_path()
@@ -861,13 +984,15 @@ class LinuxPolicy(Policy):
     _upload_user = None
     _upload_password = None
     _use_https_streaming = False
+    default_container_runtime = 'docker'
     _preferred_hash_name = None
     upload_url = None
     upload_user = None
     upload_password = None
 
-    def __init__(self, sysroot=None, init=None):
-        super(LinuxPolicy, self).__init__(sysroot=sysroot)
+    def __init__(self, sysroot=None, init=None, probe_runtime=True):
+        super(LinuxPolicy, self).__init__(sysroot=sysroot,
+                                          probe_runtime=probe_runtime)
         self.init_kernel_modules()
 
         if init is not None:
@@ -876,6 +1001,25 @@ class LinuxPolicy(Policy):
             self.init_system = SystemdInit()
         else:
             self.init_system = InitSystem()
+
+        self.runtimes = {}
+        if self.probe_runtime:
+            _crun = [
+                PodmanContainerRuntime(policy=self),
+                DockerContainerRuntime(policy=self)
+            ]
+            for runtime in _crun:
+                if runtime.check_is_active():
+                    self.runtimes[runtime.name] = runtime
+                    if runtime.name == self.default_container_runtime:
+                        self.runtimes['default'] = self.runtimes[runtime.name]
+                    self.runtimes[runtime.name].load_container_info()
+
+            if self.runtimes and 'default' not in self.runtimes.keys():
+                # still allow plugins to query a runtime present on the system
+                # even if that is not the policy default one
+                idx = list(self.runtimes.keys())
+                self.runtimes['default'] = self.runtimes[idx[0]]
 
     def get_preferred_hash_name(self):
 

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -47,6 +47,7 @@ class RedHatPolicy(LinuxPolicy):
     upload_url = 'dropbox.redhat.com'
     upload_user = 'anonymous'
     upload_directory = '/incoming'
+    default_container_runtime = 'podman'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -151,60 +151,86 @@ class PluginTests(unittest.TestCase):
 
     def setUp(self):
         self.mp = MockPlugin({
-            'cmdlineopts': MockOptions(),
-            'policy': LinuxPolicy(init=InitSystem()),
             'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
             'cmdlineopts': MockOptions()
         })
         self.mp.archive = MockArchive()
 
     def test_plugin_default_name(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.name(), "mockplugin")
 
     def test_plugin_set_name(self):
-        p = NamedMockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                             'cmdlineopts': MockOptions()})
+        p = NamedMockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.name(), "testing")
 
     def test_plugin_no_descrip(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_description(), "<no description available>")
 
     def test_plugin_no_descrip(self):
-        p = NamedMockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                             'cmdlineopts': MockOptions()})
+        p = NamedMockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_description(), "This plugin has a description.")
 
     def test_set_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option("opt"), "testing")
 
     def test_set_nonexistant_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertFalse(p.set_option("badopt", "testing"))
 
     def test_get_nonexistant_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_option("badopt"), 0)
 
     def test_get_unset_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_option("opt"), 0)
 
     def test_get_unset_plugin_option_with_default(self):
         # this shows that even when we pass in a default to get,
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_option("opt", True), True)
 
     def test_get_unset_plugin_option_with_default_not_none(self):
@@ -212,24 +238,36 @@ class PluginTests(unittest.TestCase):
         # if the plugin default is not None
         # we'll get the option's default as set in the plugin
         # this might not be what we really want
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_option("opt2", True), False)
 
     def test_get_option_as_list_plugin_option(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         p.set_option("opt", "one,two,three")
         self.assertEquals(p.get_option_as_list("opt"), ['one', 'two', 'three'])
 
     def test_get_option_as_list_plugin_option_default(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         self.assertEquals(p.get_option_as_list("opt", default=[]), [])
 
     def test_get_option_as_list_plugin_option_not_list(self):
-        p = MockPlugin({'sysroot': self.sysroot, 'policy': LinuxPolicy(init=InitSystem()),
-                        'cmdlineopts': MockOptions()})
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions()
+        })
         p.set_option("opt", "testing")
         self.assertEquals(p.get_option_as_list("opt"), ['testing'])
 
@@ -245,7 +283,7 @@ class PluginTests(unittest.TestCase):
         p = ForbiddenMockPlugin({
             'cmdlineopts': MockOptions(),
             'sysroot': self.sysroot,
-            'policy': LinuxPolicy(init=InitSystem())
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False)
         })
         p.archive = MockArchive()
         p.setup()
@@ -269,7 +307,7 @@ class AddCopySpecTests(unittest.TestCase):
     def setUp(self):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
-            'policy': LinuxPolicy(init=InitSystem()),
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
             'sysroot': os.getcwd(),
             'cmdlineopts': MockOptions()
         })
@@ -346,7 +384,7 @@ class CheckEnabledTests(unittest.TestCase):
 
     def setUp(self):
         self.mp = EnablerPlugin({
-            'policy': sos.policies.load(),
+            'policy': LinuxPolicy(probe_runtime=False),
             'sysroot': os.getcwd(),
             'cmdlineopts': MockOptions()
         })
@@ -375,7 +413,7 @@ class RegexSubTests(unittest.TestCase):
     def setUp(self):
         self.mp = MockPlugin({
             'cmdlineopts': MockOptions(),
-            'policy': LinuxPolicy(init=InitSystem()),
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
             'sysroot': os.getcwd()
         })
         self.mp.archive = MockArchive()


### PR DESCRIPTION
Adds a new `ContainerRuntime` abstraction class that should streamline the use/probing of a container runtime by plugins.

Plugins now have access to new methods that allow them to query for the presence of containers, images, and volumes without needing to manually specify different runtime commands to run through.

The OpenStack plugins that were doing these checks have been updated to now use the loaded `ContainerRuntime` initialized with `Policy`, as have the `docker` and `podman` plugins to get their element lists.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
