### PR TITLE
[kernel,networking] collect bpftool net list for each namespace

### DIFF
--- a/sos/plugins/kernel.py
+++ b/sos/plugins/kernel.py
@@ -143,10 +143,6 @@ class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         if not self.get_option("trace"):
             self.add_forbidden_path("/sys/kernel/debug/tracing/trace")
 
-        # collect list of bpf program attachments in the kernel
-        # networking subsystem
-        self.add_cmd_output("bpftool net list")
-
         # collect list of eBPF programs and maps and their dumps
         prog_file = self.exec_cmd("bpftool -j prog list")
         for prog_id in self.get_bpftool_prog_ids(prog_file):

--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -191,6 +191,10 @@ class Networking(Plugin):
         if self.get_option("traceroute"):
             self.add_cmd_output("/bin/traceroute -n %s" % self.trace_host)
 
+        # collect list of bpf program attachments in the kernel
+        # networking subsystem
+        self.add_cmd_output("bpftool net list")
+
         # Capture additional data from namespaces; each command is run
         # per-namespace.
         ip_netns = self.exec_cmd("ip netns")
@@ -212,7 +216,8 @@ class Networking(Plugin):
                     ns_cmd_prefix + "iptables-save",
                     ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
                     ns_cmd_prefix + "netstat -s",
-                    ns_cmd_prefix + "netstat %s -agn" % self.ns_wide
+                    ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,
+                    ns_cmd_prefix + "bpftool net list",
                 ])
 
                 ss_cmd = ns_cmd_prefix + "ss -peaonmi"


### PR DESCRIPTION
- move "bpftool net list" command execution from kernel to networking
plugin as it belongs rather to networking.
- collect that output per each net name space as well

Resolves: #1874

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
