### PR TITLE
[ovn_central] call podman exec without a timeout

### DIFF
--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -26,7 +26,8 @@ class OVNCentral(Plugin):
         if self._container_name:
             cmd = "%s exec %s cat %s" % (
                 self._container_runtime, self._container_name, filename)
-            res = self.exec_cmd(cmd)
+            # the timeout=None is just a workaround for "podman ps" hung bug
+            res = self.exec_cmd(cmd, timeout=None)
             if res['status'] != 0:
                 self._log_error("Could not retrieve DB schema file from "
                                 "container %s" % self._container_name)
@@ -118,7 +119,8 @@ class OVNCentral(Plugin):
                                        self._container_name,
                                        cmd) for cmd in cmds]
 
-        self.add_cmd_output(cmds)
+        # the timeout=None is just a workaround for "podman ps" hung bug
+        self.add_cmd_output(cmds, timeout=None)
 
         self.add_copy_spec("/etc/sysconfig/ovn-northd")
 


### PR DESCRIPTION
This is a workaround fix of a podman bug (see rhbz1732525) where "podman ps"
can hang when "podman exec .." is invoked in detached mode under "timeout".

Calling it without timeout works fine.

This commit can be reverted once the podman bug is fixed.

Resolves: #1875

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
