### PR TITLE
[plugins] improve heuristic for applying --since to logarchives

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -158,8 +158,11 @@ and including logs in non-default locations. This option may significantly
 increase the size of reports.
 .TP
 .B \--since YYYYMMDD[HHMMSS]
-Limits the collection to logs newer than this date.
+Limits the collection of log archives(*) to those newer than this date.
 This also affects \--all-logs. Will pad with 0s if HHMMSS isn't specified.
+(*) Sos interprets as a log archive any file not found in /etc, that has
+either a numeric or compression-type extension for example '.zip'. '.1', '.gz'
+ etc.)
 .TP
 .B \--allow-system-changes
 Run commands even if they can change the system (e.g. load kernel modules).

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -917,6 +917,7 @@ class Plugin(object):
             since = self.get_option('since')
 
         logarchive_pattern = re.compile(r'.*((\.(zip|gz|bz2|xz))|[-.][\d]+)$')
+        configfile_pattern = re.compile(r"^%s/*" % self.join_sysroot("etc"))
 
         if not self.test_predicate(pred=pred):
             self._log_info("skipped copy spec '%s' due to predicate (%s)" %
@@ -962,7 +963,9 @@ class Plugin(object):
                 """ When --since is passed, or maxage is coming from the
                 plugin, we need to filter out older files """
 
-                if logarchive_pattern.search(path) is None:
+                # skip config files or not-logarchive files from the filter
+                if ((logarchive_pattern.search(path) is None) or
+                   (configfile_pattern.search(path) is not None)):
                     return True
                 filetime = datetime.fromtimestamp(getmtime(path))
                 if ((since and filetime < since) or


### PR DESCRIPTION
logarchive_pattern treats some configs (e.g. /etc/dbus-1) as log
archives, causing --since option will skip collecting them.

This patch just improves the heuristic by claiming nothing under /etc
is a logarchive, and adds a warning to sosreport help.

Improves: #1847

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
