### PR TITLE
[pulp] Fix invalid syntax in collected json files

### DIFF
--- a/sos/plugins/pulp.py
+++ b/sos/plugins/pulp.py
@@ -136,10 +136,20 @@ class Pulp(Plugin, RedHatPlugin):
         return _cmd % quote(_moncmd % (_mondb, query))
 
     def postproc(self):
+
+        # Handle all ".conf" files under /etc/pulp - note that this includes
+        # files nested at several distinct directory levels. For this reason we
+        # use a regex that matches all these path components with ".*", and
+        # ensure that the path ends with ".conf".
         etcreg = r"(([a-z].*(passw|token|cred|secret).*)\:(\s))(.*)"
         repl = r"\1 ********"
-        self.do_path_regex_sub("/etc/pulp/(.*).conf", etcreg, repl)
-        jreg = r"(\s*\".*(passw|cred|token|secret).*\:)(.*)"
+        self.do_path_regex_sub(r"/etc/pulp/(.*)\.conf$", etcreg, repl)
+
+        # Now handle JSON-formatted data in the same /etc/pulp directory
+        # structure. We use a different substitution string here to preserve
+        # the file's JSON syntax.
+        jreg = r"(\s*\".*(passw|cred|token|secret).*\"\s*:\s*\")(.*)(\")"
+        repl = r"\1********\4"
         self.do_path_regex_sub("/etc/pulp(.*)(.json$)", jreg, repl)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Plugin replaces sensitive data in etc/pulp/server/plugins.conf.d/*json
with ******* which is an invalid json value. Also it takes away a ","
and collected file is no longer a valid json. This change modifies the
regex used to get a valid json file.

Also Fixed Regex above it which was consuming any file having "conf"
even in middle of file path.

Closes #1878

Signed-off-by: Rohan Arora <roarora@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
