### PR TITLE
[policies] fix missing tmpdir for RedHat distro

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -707,6 +707,7 @@ any third party.
         _msg = self.msg % {'distro': self.distro, 'vendor': self.vendor,
                            'vendor_url': self.vendor_url,
                            'vendor_text': self.vendor_text,
+                           'tmpdir': self.commons['tmpdir'],
                            'changes_text': changes_text}
         _fmt = ""
         for line in _msg.splitlines():


### PR DESCRIPTION
a0e0a52 removed setting 'tmpdir' from Policy get_msg while RedHatPolicy
refers on it.

Resolves: #1881

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
