### PR TITLE
[foreman] cast dynflow_execution_plans.uuid as varchar

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -176,22 +176,24 @@ class Foreman(Plugin):
         dyncmd = (
             'select dynflow_execution_plans.* from foreman_tasks_tasks join '
             'dynflow_execution_plans on (foreman_tasks_tasks.external_id = '
-            'dynflow_execution_plans.uuid) where foreman_tasks_tasks.'
+            'dynflow_execution_plans.uuid::varchar) where foreman_tasks_tasks.'
             'started_at > NOW() - interval %s' % quote(months)
         )
 
         dactioncmd = (
              'select dynflow_actions.* from foreman_tasks_tasks join '
              'dynflow_actions on (foreman_tasks_tasks.external_id = '
-             'dynflow_actions.execution_plan_uuid) where foreman_tasks_tasks.'
-             'started_at > NOW() - interval %s' % quote(months)
+             'dynflow_actions.execution_plan_uuid::varchar) where '
+             'foreman_tasks_tasks.started_at > NOW() - interval %s'
+             % quote(months)
         )
 
         dstepscmd = (
             'select dynflow_steps.* from foreman_tasks_tasks join '
             'dynflow_steps on (foreman_tasks_tasks.external_id = '
-            'dynflow_steps.execution_plan_uuid) where foreman_tasks_tasks.'
-            'started_at > NOW() - interval %s' % quote(months)
+            'dynflow_steps.execution_plan_uuid::varchar) where '
+            'foreman_tasks_tasks.started_at > NOW() - interval %s'
+            % quote(months)
         )
 
         # Populate this dict with DB queries that should be saved directly as


### PR DESCRIPTION
Due to a change in foreman DB scheme, we must explicitly cast
dynflow_execution_plans.uuid as a varchar since foreman-tasks
0.15.5 .

The explicit casting works well on older versions as well.

Resolves: #1882

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
