### PR TITLE
[policies] Fix human readable filesizes function

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -25,14 +25,14 @@ from six.moves import input
 PRESETS_PATH = "/var/lib/sos/presets"
 
 
-def GetHumanReadable(size, precision=2):
+def get_human_readable(size, precision=2):
     # Credit to Pavan Gupta https://stackoverflow.com/questions/5194057/
-    suffixes = ['B', 'KB', 'MB', 'GB', 'TB']
-    suffixIndex = 0
-    while size > 1024 and suffixIndex < 4:
-        suffixIndex += 1
+    suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
+    suffixindex = 0
+    while size > 1024 and suffixindex < 4:
+        suffixindex += 1
         size = size/1024.0
-    return "%.*f%s" % (precision, size, suffixes[suffixIndex])
+    return "%.*f%s" % (precision, size, suffixes[suffixindex])
 
 
 def import_policy(name):
@@ -672,7 +672,7 @@ any third party.
             self._print(_("Your sosreport has been generated and saved "
                           "in:\n  %s\n") % archive, always=True)
             self._print(_(" Size\t%s") %
-                        GetHumanReadable(archivestat.st_size))
+                        get_human_readable(archivestat.st_size))
             self._print(_(" Owner\t%s") %
                         getpwuid(archivestat.st_uid).pw_name)
         else:


### PR DESCRIPTION
We should have been using MiB instead of MB.
And as MiB is what ls -alh uses I think that makes
sense.

Also got rid of CapitalNaming.

Discussed in #887

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
