### PR TITLE
[java] Only run java conditionally and collect more

### DIFF
--- a/sos/plugins/java.py
+++ b/sos/plugins/java.py
@@ -15,13 +15,16 @@ class Java(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     plugin_name = "java"
     profiles = ('webserver', 'java')
     verify_packages = ('java.*',)
+    commands = ('java',)
+    files = ('/usr/bin/java',)
+    packages = ('java', 'java-common', )
 
     def setup(self):
-        self.add_copy_spec("/etc/java")
-        self.add_forbidden_path("/etc/java/security")
-        self.add_cmd_output("alternatives --display java",
-                            root_symlink="java")
+        self.add_copy_spec("/etc/java*")
+        self.add_forbidden_path("/etc/java*/security")
+        self.add_cmd_output("alternatives --display java")
         self.add_cmd_output("readlink -f /usr/bin/java")
+        self.add_cmd_output("java -version")
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
As this has been run unconditionaly to this point I choose to
do both commands = java, files=/usr/bin/java and packages.
There are many times Java is installed to /opt/ for say IBM's
java or Oracle's Java, or someone else's java.  To the same
 extent there are many different packages that include java
so do /usr/bin/java in case we miss some.

Add * to /etc/java*/ as some of the names can be different like
/etc/java-13-openjdk/

Remove alternatives from root symlink - I couldn't find a
reason for it to be in root, but happy to revisit.  (doesn't
work on Ubuntu)

Add java --version.  If it's in path we should at least be able
to get this.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
