### PR TITLE
[dnf] Collect module --list and use collect_cmd_output content

### DIFF
--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -24,20 +24,16 @@ class DNFPlugin(Plugin, RedHatPlugin):
         ("history-info", "detailed transaction history", "slow", False),
     ]
 
-    def get_modules_info(self, module_file):
-        if module_file:
-            try:
-                module_out = open(module_file).read()
-            except IOError:
-                self._log_warn("could not read module list file")
-                return
-            # take just lines with the module names, i.e. containing "[i]" and
-            # not the "Hint: [d]efault, [e]nabled, [i]nstalled,.."
-            for line in module_out.splitlines():
-                if "[i]" in line:
-                    module = line.split()[0]
-                    if module != "Hint:":
-                        self.add_cmd_output("dnf module info " + module)
+    def get_modules_info(self, modules):
+        if not modules:
+            return
+        # take just lines with the module names, i.e. containing "[i]" and
+        # not the "Hint: [d]efault, [e]nabled, [i]nstalled,.."
+        for line in modules.splitlines():
+            if "[i]" in line:
+                module = line.split()[0]
+                if module != "Hint:":
+                    self.add_cmd_output("dnf module info " + module)
 
     def setup(self):
         self.add_copy_spec("/etc/dnf/")
@@ -74,7 +70,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
                 self.add_cmd_output("dnf history info %d" % tr_id)
 
         # Get list of dnf installed modules and their details.
-        module_file = self.collect_cmd_output("dnf module list --installed")
-        self.get_modules_info(module_file['filename'])
+        modules = self.collect_cmd_output("dnf module list --installed")
+        self.get_modules_info(modules['output'])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/dnf.py
+++ b/sos/plugins/dnf.py
@@ -49,6 +49,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
             "dnf --version",
             "dnf list installed *dnf*",
             "dnf list extras",
+            "dnf module list",
             "package-cleanup --dupes",
             "package-cleanup --problems"
         ])


### PR DESCRIPTION
This is a 2-patch set that:

1. Updates `dnf` to use the `output` key of the `collect_cmd_output()` dict instead of re-reading the file into memory.
2. Adds `dnf module list` to collection, not just `dnf module list --installed` as requested in RHBZ#1781819

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
