### PR TITLE
[ceph] Add 'ceph insights' command output

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -67,6 +67,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph osd crush show-tunables",
             "ceph-disk list",
             "ceph versions",
+            "ceph insights",
             "ceph osd crush dump",
             "ceph -v"
         ])


### PR DESCRIPTION
This change adds the output of the recently added 'ceph insights'
command.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
