### PR TITLE
[ceph] collect ceph-volume lvm list

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -68,7 +68,8 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph-disk list",
             "ceph versions",
             "ceph osd crush dump",
-            "ceph -v"
+            "ceph -v",
+            "ceph-volume lvm list"
         ])
 
         ceph_cmds = [


### PR DESCRIPTION
Ceph is moving from managing disks with ceph-disk to using ceph-volume
which uses LVM. So now collect the 'ceph-volume lvm list' output.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
