### PR TITLE
[Plugin] Align service check method names with other checks

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -186,7 +186,7 @@ class SoSPredicate(object):
         if not self.services:
             return True
 
-        _svcs = [self._owner.service_is_running(s) for s in self.services]
+        _svcs = [self._owner.is_service_running(s) for s in self.services]
 
         if self.required['services'] == 'any':
             return any(_svcs)
@@ -458,15 +458,15 @@ class Plugin(object):
         '''Does the service $name exist on the system?'''
         return self.policy.init_system.is_service(name)
 
-    def service_is_enabled(self, name):
+    def is_service_enabled(self, name):
         '''Is the service $name enabled?'''
         return self.policy.init_system.is_enabled(name)
 
-    def service_is_disabled(self, name):
+    def is_service_disabled(self, name):
         '''Is the service $name disabled?'''
         return self.policy.init_system.is_disabled(name)
 
-    def service_is_running(self, name):
+    def is_service_running(self, name):
         '''Is the service $name currently running?'''
         return self.policy.init_system.is_running(name)
 

--- a/sos/plugins/openstack_glance.py
+++ b/sos/plugins/openstack_glance.py
@@ -44,7 +44,7 @@ class OpenStackGlance(Plugin):
         # is running
         in_container = self.running_in_container()
 
-        if self.service_is_running('openstack-glance-api') or in_container:
+        if self.is_service_running('openstack-glance-api') or in_container:
             glance_config = ""
             # if containerized we need to pass the config to the cont.
             if in_container:

--- a/sos/plugins/openstack_heat.py
+++ b/sos/plugins/openstack_heat.py
@@ -28,7 +28,7 @@ class OpenStackHeat(Plugin):
         # is running
         in_container = self.running_in_container()
 
-        if self.service_is_running('openstack-heat-api') or in_container:
+        if self.is_service_running('openstack-heat-api') or in_container:
             heat_config = ""
             # if containerized we need to pass the config to the cont.
             if in_container:

--- a/sos/plugins/openstack_nova.py
+++ b/sos/plugins/openstack_nova.py
@@ -31,7 +31,7 @@ class OpenStackNova(Plugin):
         # is running
         in_container = self.running_in_container()
 
-        if self.service_is_running('openstack-nova-api') or in_container:
+        if self.is_service_running('openstack-nova-api') or in_container:
             nova_config = ""
             # if containerized we need to pass the config to the cont.
             if in_container:

--- a/sos/plugins/openstack_placement.py
+++ b/sos/plugins/openstack_placement.py
@@ -26,7 +26,7 @@ class OpenStackPlacement(Plugin):
 
         in_container = self.running_in_container()
 
-        if self.service_is_running('openstack-placement-api') or in_container:
+        if self.is_service_running('openstack-placement-api') or in_container:
             placement_config = ""
             # if containerized we need to pass the config to the cont.
             if in_container:

--- a/sos/plugins/postgresql.py
+++ b/sos/plugins/postgresql.py
@@ -95,7 +95,7 @@ class RedHatPostgreSQL(PostgreSQL, SCLPlugin):
             # The scl name, package name, and service name all differ slightly
             # but is at least consistent in doing so across versions, so we
             # need to do some mangling here
-            if self.service_is_running(pkg.replace('-server', '')):
+            if self.is_service_running(pkg.replace('-server', '')):
                 scl = pkg.split('-postgresql-')[0]
 
         # Copy PostgreSQL log files.


### PR DESCRIPTION
The historic name pattern for `Plugin` checks is `is_$thing()`, such as
`is_executable`, `is_installed`, etc...

The service checks for a loaded `InitSystem` exposed via the `Plugin`
API however did not follow this convention. Re-name the `service_is_*`
methods to `is_service_*` to better align with the rest of the API.

Resolves: #1891

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
