### PR TITLE
[memory] Collect slabtop info

### DIFF
--- a/sos/plugins/memory.py
+++ b/sos/plugins/memory.py
@@ -36,4 +36,7 @@ class Memory(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "lsmem -a -o RANGE,SIZE,STATE,REMOVABLE,ZONES,NODE,BLOCK"
         ])
 
+        # slabtop -o will hang if not handed a tty via stdin
+        self.add_cmd_output("slabtop -o", foreground=True)
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of `slabtop -o` to show the top consumers of SLAB.

Note that currently there is an issue with this command that will cause
it to hang if stdin does not receive a tty - which is exactly what
happens when commands are run via `timeout`. As such, this command is
for the moment being run with `timeout=None`, and is run in a separate
`add_cmd_output()` call at the end of the plugin.

Resolves: #1895

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
