### PR TITLE
[block] Avoid loop devices to be queried

### DIFF
--- a/sos/plugins/block.py
+++ b/sos/plugins/block.py
@@ -41,7 +41,7 @@ class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         if os.path.isdir("/sys/block"):
             for disk in os.listdir("/sys/block"):
-                if disk.startswith("ram"):
+                if disk.startswith("ram") or disk.startswith("loop"):
                     continue
                 disk_path = os.path.join('/dev/', disk)
                 queue_path = os.path.join('/sys/block/', disk, 'queue')


### PR DESCRIPTION
Loop devices can be used or unused. Querying
a unused device may lead to kernel block
errors for instance.

Fix: #1897

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
