### PR TITLE
[foreman] increase sizelimit for tasks export

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -218,12 +218,12 @@ class Foreman(Plugin):
         for table in foremandb:
             _cmd = self.build_query_cmd(foremandb[table])
             self.add_cmd_output(_cmd, suggest_filename=table, timeout=600,
-                                env=self.env)
+                                sizelimit=100, env=self.env)
 
         for dyn in foremancsv:
             _cmd = self.build_query_cmd(foremancsv[dyn], csv=True)
             self.add_cmd_output(_cmd, suggest_filename=dyn, timeout=600,
-                                env=self.env)
+                                sizelimit=100, env=self.env)
 
         # collect http[|s]_proxy env.variables
         self.add_env_var(["http_proxy", "https_proxy"])


### PR DESCRIPTION
When foreman stores tens to hundreds of thousands of tasks, default
sizelimit causes the dynflow* or foreman_tasks_tasks files are truncated.

Let increase the sizelimit to 100MB.

Resolves: #1899

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
