### PR TITLE
[foreman] obfuscate storepass and candlepin password

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -241,8 +241,8 @@ class Foreman(Plugin):
         return _dbcmd % (self.dbhost, csvformat, quote(query))
 
     def postproc(self):
-        satreg = r"((foreman.*)?(\"::(foreman(.*?)|katello).*)?(::(.*)::.*" \
-              r"(passw|cred|token|secret|key).*(\")?:))(.*)"
+        satreg = r"((foreman.*)?(\"::(foreman(.*?)|katello).*)?((::(.*)::.*" \
+              r"(passw|cred|token|secret|key).*(\")?:)|(storepass )))(.*)"
         self.do_path_regex_sub(
             "/var/log/foreman-installer/sat*",
             satreg,
@@ -265,7 +265,7 @@ class Foreman(Plugin):
             r"\1********")
         self.do_path_regex_sub(
             "/var/log/foreman-maintain/foreman-maintain.log*",
-            r"((passw|cred|token|secret)=)(.*)",
+            r"(((passw|cred|token|secret)=)|(password ))(.*)",
             r"\1********")
         self.do_path_regex_sub(
             "/var/log/%s*/foreman-ssl_access_ssl.log*" % self.apachepkg,


### PR DESCRIPTION
cpdb --password '..' needs to be obfuscated in foreman-maintain.log

-[src|]storepass .. on few places in satellite.log needs the same

Resolves: #1901

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
