### PR TITLE
[Policy] Wrap json.load() in with clause

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -768,10 +768,11 @@ any third party.
         for preset_path in os.listdir(presets_path):
             preset_path = os.path.join(presets_path, preset_path)
 
-            try:
-                preset_data = json.load(open(preset_path))
-            except ValueError:
-                continue
+            with open(preset_path) as pf:
+                try:
+                    preset_data = json.load(pf)
+                except ValueError:
+                    continue
 
             for preset in preset_data.keys():
                 pd = PresetDefaults(preset, opts=SoSOptions())


### PR DESCRIPTION
Wraps naked opens for `json.load()` calls in `with` statements to ensure
the file object gets closed properly.

Closes: #1322
Resolves: #1902

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
