### PR TITLE
[powerpc] Add "ppc64_cpu --info" to the list of commands

### DIFF
--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -45,6 +45,7 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
                 "/var/lib/lsvpd/"
             ])
             self.add_cmd_output([
+                "ppc64_cpu --info",
                 "ppc64_cpu --smt",
                 "ppc64_cpu --cores-present",
                 "ppc64_cpu --cores-on",


### PR DESCRIPTION
The command `ppc64_cpu --info` produces a handy output to easily determine which
threads are online and which ones are offline. For example:

```
$ ppc64_cpu --info
Core   0:    0*    1*    2     3
Core   1:    4*    5*    6     7
Core   2:    8*    9*   10    11
Core   3:   12*   13*   14    15
Core   4:   16*   17*   18    19
Core   5:   20*   21*   22    23
Core   6:   24    25    26    27
Core   7:   28    29    30    31
Core   8:   32*   33*   34    35
Core   9:   36*   37*   38    39
Core  10:   40*   41*   42    43
Core  11:   44*   45*   46    47
Core  12:   48*   49*   50    51
Core  13:   52*   53*   54    55
Core  14:   56    57    58    59
Core  15:   60    61    62    63
Core  16:   64*   65*   66    67
Core  17:   68*   69*   70    71
Core  18:   72*   73*   74    75
Core  19:   76*   77*   78    79
Core  20:   80*   81*   82    83
Core  21:   84*   85*   86    87
Core  22:   88*   89*   90    91
Core  23:   92*   93*   94    95
Core  24:   96*   97*   98    99
Core  25:  100*  101*  102   103
Core  26:  104*  105*  106   107
Core  27:  108*  109*  110   111
Core  28:  112*  113*  114   115
Core  29:  116*  117*  118   119
Core  30:  120*  121*  122   123
Core  31:  124*  125*  126   127
```

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
