### PR TITLE
[sosreport] Fix noreport to be available in sos.conf

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -223,7 +223,7 @@ class SoSOptions(object):
         no_value = (
             "alloptions", "allow-system-changes", "all-logs", "batch", "build",
             "debug", "experimental", "list-plugins", "list-presets",
-            "list-profiles", "noreport", "no-env-vars", "quiet", "verify"
+            "list-profiles", "no-report", "no-env-vars", "quiet", "verify"
         )
         count = ("verbose",)
         if opt in no_value:


### PR DESCRIPTION
In _opt_to_args(), no_value had noreport.
However, the list is used for converting option name in sos.conf
to command-line option. It means that noreport needs to be no-report
for aligning command-line option.

Signed-off-by: Keigo Noha <knoha@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
