### PR TITLE
[process] Update pstree to display PIDs and not truncate lines

### DIFF
--- a/sos/plugins/process.py
+++ b/sos/plugins/process.py
@@ -39,7 +39,7 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             self.add_copy_spec("/proc/[0-9]*/smaps")
 
         self.add_cmd_output("ps auxwww", root_symlink="ps")
-        self.add_cmd_output("pstree", root_symlink="pstree")
+        self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
             self.add_cmd_output("lsof -b +M -n -l -c ''", root_symlink="lsof")
 


### PR DESCRIPTION
By default pstree will truncate long lines, which can make it difficult
to identify processes a support representative is chasing - this is
especially true for container process names.

First, don't truncate long lines anymore. Second, add PID numbers to the
pstree output to allow more accurate analysis of pstree output.

Resolves: #1905

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
