### PR TITLE
[ovirt_hosted_engine] Collect rotated HA logs by default

### DIFF
--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -22,8 +22,6 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
     plugin_name = 'ovirt_hosted_engine'
     profiles = ('virt',)
 
-    HA_LOG_GLOB = '/var/log/ovirt-hosted-engine-ha/*.log'
-
     def setup(self):
         # Add configuration files
         # Collecting the whole directory since it may contain branding
@@ -45,18 +43,14 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
 
         self.add_copy_spec([
             '/var/log/ovirt-hosted-engine-setup',
-            '/var/log/ovirt-hosted-engine-ha/agent.log',
-            '/var/log/ovirt-hosted-engine-ha/broker.log',
+            '/var/log/ovirt-hosted-engine-ha/agent.log*',
+            '/var/log/ovirt-hosted-engine-ha/broker.log*',
         ])
 
         # Add gluster deployment and cleanup log
         self.add_copy_spec([
             '/var/log/cockpit/ovirt-dashboard'
         ])
-
-        # Add older ovirt-hosted-engine-ha log files only if requested
-        if self.get_option('all_logs'):
-            self.add_copy_spec(self.HA_LOG_GLOB)
 
         # Add run-time status
         self.add_cmd_output([


### PR DESCRIPTION
Updates the plugin to collect the rotated agent and broker HA logs by
default. These logs are small and can be rotated faster than other ovirt
components, leading to cases where HA logs do not go back far enough
even though we capture a lot of historical data from VDSM and other
components.

Now we will collect the rotated logs up until the `--log-size` threshold
is reached. Users may use `--all-logs` to remove this size restriction
as usual.

Related: RHBZ#1787119
Resolves: #1906

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
