### PR TITLE
[ebpf] Add new plugin for eBPF commands

### DIFF
--- a/sos/plugins/ebpf.py
+++ b/sos/plugins/ebpf.py
@@ -1,0 +1,78 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+import json
+
+
+class eBPF(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+
+    plugin_name = 'ebpf'
+    profiles = ('system', 'kernel', 'network')
+
+    def get_bpftool_prog_ids(self, prog_json):
+        out = []
+        try:
+            prog_data = json.loads(prog_json)
+        except Exception as e:
+            self._log_info("Could not parse bpftool prog list as JSON: %s" % e)
+            return out
+        for item in range(len(prog_data)):
+            if "id" in prog_data[item]:
+                out.append(prog_data[item]["id"])
+        return out
+
+    def get_bpftool_map_ids(self, map_json):
+        out = []
+        try:
+            map_data = json.loads(map_json)
+        except Exception as e:
+            self._log_info("Could not parse bpftool map list as JSON: %s" % e)
+            return out
+        for item in range(len(map_data)):
+            if "id" in map_data[item]:
+                out.append(map_data[item]["id"])
+        return out
+
+    def setup(self):
+        # collect list of eBPF programs and maps and their dumps
+        progs = self.collect_cmd_output("bpftool -j prog list")
+        for prog_id in self.get_bpftool_prog_ids(progs['output']):
+            for dumpcmd in ["xlated", "jited"]:
+                self.add_cmd_output("bpftool prog dump %s id %s" %
+                                    (dumpcmd, prog_id))
+        maps = self.collect_cmd_output("bpftool -j map list")
+        for map_id in self.get_bpftool_map_ids(maps['output']):
+            self.add_cmd_output("bpftool map dump id %s" % map_id)
+
+        # Iterate over all cgroups and list all attached programs
+        self.add_cmd_output("bpftool cgroup tree")
+
+        # collect list of bpf program attachments in the kernel
+        # networking subsystem
+        self.add_cmd_output("bpftool net list")
+
+        # Capture list of bpf program attachments from namespaces
+        ip_netns = self.exec_cmd("ip netns")
+        cmd_prefix = "ip netns exec "
+        if ip_netns['status'] == 0:
+            out_ns = []
+            for line in ip_netns['output'].splitlines():
+                # If there's no namespaces, no need to continue
+                if line.startswith("Object \"netns\" is unknown") \
+                        or line.isspace() \
+                        or line[:1].isspace():
+                    continue
+                out_ns.append(line.partition(' ')[0])
+            for namespace in out_ns:
+                ns_cmd_prefix = cmd_prefix + namespace + " "
+                self.add_cmd_output([
+                    ns_cmd_prefix + "bpftool net list",
+                ])
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -191,10 +191,6 @@ class Networking(Plugin):
         if self.get_option("traceroute"):
             self.add_cmd_output("/bin/traceroute -n %s" % self.trace_host)
 
-        # collect list of bpf program attachments in the kernel
-        # networking subsystem
-        self.add_cmd_output("bpftool net list")
-
         # Capture additional data from namespaces; each command is run
         # per-namespace.
         ip_netns = self.exec_cmd("ip netns")
@@ -217,7 +213,6 @@ class Networking(Plugin):
                     ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
                     ns_cmd_prefix + "netstat -s",
                     ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,
-                    ns_cmd_prefix + "bpftool net list",
                 ])
 
                 ss_cmd = ns_cmd_prefix + "ss -peaonmi"


### PR DESCRIPTION
This plugin groups all bpftool commands from
plugins kernel and networking, and adds a new
one command 'bpftool cgroup tree', as requested
by rhbz#1787586.

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
