### PR TITLE
[sar] Fix the parameter specified in add_copy_spec() to wildcard

### DIFF
--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -18,7 +18,7 @@ class Sar(Plugin,):
     profiles = ('system', 'performance')
 
     packages = ('sysstat',)
-    sa_path = '/var/log/sa'
+    sa_path = '/var/log/sa/*'
     option_list = [("all_sar", "gather all system activity records",
                     "", False)]
 
@@ -55,11 +55,11 @@ class Sar(Plugin,):
 
 class RedHatSar(Sar, RedHatPlugin):
 
-    sa_path = '/var/log/sa'
+    sa_path = '/var/log/sa/*'
 
 
 class DebianSar(Sar, DebianPlugin, UbuntuPlugin):
 
-    sa_path = '/var/log/sysstat'
+    sa_path = '/var/log/sysstat/*'
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
"/var/log/sa" is specified in add_copy_spec() in sar.py.
However, if a directory is specified in the parameter of
add_copy_spec(), --log-size does not work properly.
Therefore, fix "/var/log/sa" to wildcardso that --log-size
works correctly.

Resolves: #1863

Signed-off-by: MIZUTA Takeshi <mizuta.takeshi@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
