### PR TITLE
[utilities] Run timeout with --foreground

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1043,7 +1043,7 @@ class Plugin(object):
                        root_symlink=None, timeout=300, stderr=True,
                        chroot=True, runat=None, env=None, binary=False,
                        sizelimit=None, pred=None, subdir=None,
-                       changes=False):
+                       changes=False, foreground=False):
         """Run a program or a list of programs and collect the output"""
         if isinstance(cmds, six.string_types):
             cmds = [cmds]
@@ -1059,7 +1059,7 @@ class Plugin(object):
                                  stderr=stderr, chroot=chroot, runat=runat,
                                  env=env, binary=binary, sizelimit=sizelimit,
                                  pred=pred, subdir=subdir,
-                                 changes=changes)
+                                 changes=changes, foreground=foreground)
 
     def get_cmd_output_path(self, name=None, make=True):
         """Return a path into which this module should store collected
@@ -1149,7 +1149,7 @@ class Plugin(object):
                             root_symlink=False, timeout=300, stderr=True,
                             chroot=True, runat=None, env=None,
                             binary=False, sizelimit=None, subdir=None,
-                            changes=False):
+                            changes=False, foreground=False):
         """Execute a command and save the output to a file for inclusion in the
         report.
 
@@ -1189,7 +1189,7 @@ class Plugin(object):
         result = sos_get_command_output(
             cmd, timeout=timeout, stderr=stderr, chroot=root,
             chdir=runat, env=env, binary=binary, sizelimit=sizelimit,
-            poller=self.check_timeout
+            poller=self.check_timeout, foreground=foreground
         )
 
         if result['status'] == 124:
@@ -1263,7 +1263,7 @@ class Plugin(object):
         )
 
     def exec_cmd(self, cmd, timeout=300, stderr=True, chroot=True, runat=None,
-                 env=None, binary=False, pred=None):
+                 env=None, binary=False, pred=None, foreground=False):
         """Execute a command right now and return the output and status, but
         do not save the output within the archive.
 
@@ -1282,7 +1282,8 @@ class Plugin(object):
             root = None
 
         return sos_get_command_output(cmd, timeout=timeout, chroot=root,
-                                      chdir=runat, binary=binary, env=env)
+                                      chdir=runat, binary=binary, env=env,
+                                      foreground=foreground)
 
     def is_module_loaded(self, module_name):
         """Return whether specified module as module_name is loaded or not"""

--- a/sos/plugins/ovn_central.py
+++ b/sos/plugins/ovn_central.py
@@ -26,8 +26,7 @@ class OVNCentral(Plugin):
         if self._container_name:
             cmd = "%s exec %s cat %s" % (
                 self._container_runtime, self._container_name, filename)
-            # the timeout=None is just a workaround for "podman ps" hung bug
-            res = self.exec_cmd(cmd, timeout=None)
+            res = self.exec_cmd(cmd, foreground=True)
             if res['status'] != 0:
                 self._log_error("Could not retrieve DB schema file from "
                                 "container %s" % self._container_name)
@@ -119,8 +118,7 @@ class OVNCentral(Plugin):
                                        self._container_name,
                                        cmd) for cmd in cmds]
 
-        # the timeout=None is just a workaround for "podman ps" hung bug
-        self.add_cmd_output(cmds, timeout=None)
+        self.add_cmd_output(cmds, foreground=True)
 
         self.add_copy_spec("/etc/sysconfig/ovn-northd")
 

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -106,7 +106,7 @@ def is_executable(command):
 
 
 def sos_get_command_output(command, timeout=300, stderr=False,
-                           chroot=None, chdir=None, env=None,
+                           chroot=None, chdir=None, env=None, foreground=False,
                            binary=False, sizelimit=None, poller=None):
     """Execute a command and return a dictionary of status and output,
     optionally changing root or current working directory before
@@ -133,7 +133,11 @@ def sos_get_command_output(command, timeout=300, stderr=False,
                 cmd_env.pop(key, None)
     # use /usr/bin/timeout to implement a timeout
     if timeout and is_executable("timeout"):
-        command = "timeout %ds %s" % (timeout, command)
+        command = "timeout %s %ds %s" % (
+            '--foreground' if foreground else '',
+            timeout,
+            command
+        )
 
     # shlex.split() reacts badly to unicode on older python runtimes.
     if not six.PY3:


### PR DESCRIPTION
This is a two-patch set. 

The first commit makes the use of `--foreground` in our `timeout` command the default.
The second commit updates the `ovn_central` plugin to no longer use the `timeout=None` workaround.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
