### PR TITLE
[sosreport] Allow automatic uploading to policy or user defined locations

### DIFF
--- a/man/en/sosreport.1
+++ b/man/en/sosreport.1
@@ -30,6 +30,8 @@ sosreport \- Collect and package diagnostic and support data
           [-z|--compression-type method]\fR
           [--encrypt-key KEY]\fR
           [--encrypt-pass PASS]\fR
+          [--upload] [--upload-url url] [--upload-user user]\fR
+          [--upload-directory dir] [--upload-pass pass]\fR
           [--experimental]\fR
           [-h|--help]\fR
 
@@ -257,6 +259,60 @@ Execute plugins as normal, but do not collect any file content, command
 output, or string data from the system. The resulting logs may be used
 to understand the actions that sos would have taken without the dry run
 option.
+.TP
+.B \--upload
+If specified, attempt to upload the resulting archive to a vendor defined location.
+
+This option is implied if --upload-url is used.
+
+You may be prompted for a username and password if these are not defined by the vendor
+as well. If these credentials are not provided, sos will still run and create an archive
+but will not attempt an automatic upload, instead relying on the end user to upload it
+as needed.
+
+The sosreport archive will still remain on the local filesystem even after a successful
+upload.
+
+Note that depending on the distribution sos is being run on, or the vendor policy detected during
+execution, there may be dependencies that are not strictly required by the package
+at installation time.
+
+For example, for HTTPS uploads the python-requests library must be available. If this
+library is not available, HTTPS uploads will not be attempted.
+.TP
+.B \--upload-url URL
+If a vendor does not provide a default upload location, or if you would like to upload
+the archive to a different location, specify the address here.
+
+A support protocol MUST be specified in this URL. Currently uploading is supported
+for HTTPS, SFTP, and FTP protocols.
+
+If your destination server listens on a non-standard port, specify the listening
+port in the URL.
+.TP
+.B \-\-upload-user USER
+If a vendor does not provide a default user for uploading, specify the username here.
+
+If this option is unused and upload is request, and a vendor default is not set, you
+will be prompted for one. If --batch is used and this option is omitted, no username will
+be collected and thus uploads will fail if no vendor default is set.
+.TP
+.B \-\-upload-pass PASS
+Specify the password to use for authentication with the destination server.
+
+If this option is omitted and upload is requested, you will be prompted for one.
+
+If --batch is used, this prompt will not occur, so any uploads are likely to fail unless
+this option is used.
+
+Note that this will result in the plaintext string appearing in `ps` output that may
+be collected by sos and be in the archive. If a password must be provided by you
+for uploading, it is strongly recommended to not use --batch and enter the password
+when prompted rather than using this option.
+.TP
+.B \--upload-directory DIR
+Specify a directory to upload to, if one is not specified by a vendor default location
+or if your destination server does not allow writes to '/'.
 .TP
 .B \--experimental
 Enable plugins marked as experimental. Experimental plugins may not have

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -57,6 +57,7 @@ _arg_names = [
     'list_profiles', 'log_size', 'noplugins', 'noreport', 'no_env_vars',
     'no_postproc', 'note', 'onlyplugins', 'plugin_timeout', 'plugopts',
     'preset', 'profiles', 'quiet', 'since', 'sysroot', 'threads', 'tmp_dir',
+    'upload', 'upload_url', 'upload_directory', 'upload_user', 'upload_pass',
     'verbosity', 'verify'
 ]
 
@@ -194,6 +195,11 @@ class SoSOptions(object):
         self.sysroot = None
         self.threads = 4
         self.tmp_dir = ""
+        self.upload = False
+        self.upload_url = ""
+        self.upload_directory = ""
+        self.upload_user = ""
+        self.upload_pass = ""
         self.verbosity = _arg_defaults["verbosity"]
         self.verify = False
         self._nondefault = set()

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -9,8 +9,9 @@ import fnmatch
 import tempfile
 import random
 import string
-from pwd import getpwuid
 
+from getpass import getpass
+from pwd import getpwuid
 from sos.utilities import (ImporterHelper,
                            import_module,
                            shell_out,
@@ -1182,7 +1183,7 @@ class LinuxPolicy(Policy):
         except socket.gaierror:
             raise Exception("unable to connect to %s" % url)
         except ftplib.error_perm as err:
-            errno = err.split()[0]
+            errno = str(err).split()[0]
             if errno == 503:
                 raise Exception("could not login as '%s'" % user)
             if errno == 550:

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -24,6 +24,12 @@ from six.moves import input
 
 PRESETS_PATH = "/var/lib/sos/presets"
 
+try:
+    import requests
+    REQUESTS_LOADED = True
+except ImportError:
+    REQUESTS_LOADED = False
+
 
 def get_human_readable(size, precision=2):
     # Credit to Pavan Gupta https://stackoverflow.com/questions/5194057/
@@ -836,8 +842,21 @@ class LinuxPolicy(Policy):
     vendor = "None"
     PATH = "/bin:/sbin:/usr/bin:/usr/sbin"
     init = None
-
+    # _ prefixed class attrs are used for storing any vendor-defined defaults
+    # the non-prefixed attrs are used by the upload methods, and will be set
+    # to the cmdline/config file values, if provided. If not provided, then
+    # those attrs will be set to the _ prefixed values as a fallback.
+    # TL;DR Use _upload_* for policy default values, use upload_* when wanting
+    # to actual use the value in a method/override
+    _upload_url = None
+    _upload_directory = '/'
+    _upload_user = None
+    _upload_password = None
+    _use_https_streaming = False
     _preferred_hash_name = None
+    upload_url = None
+    upload_user = None
+    upload_password = None
 
     def __init__(self, sysroot=None):
         super(LinuxPolicy, self).__init__(sysroot=sysroot)
@@ -907,12 +926,25 @@ class LinuxPolicy(Policy):
         cmdline_opts = self.commons['cmdlineopts']
         caseid = cmdline_opts.case_id if cmdline_opts.case_id else ""
 
+        # Set the cmdline settings to the class attrs that are referenced later
+        # The policy default '_' prefixed versions of these are untouched to
+        # allow fallback
+        self.upload_url = cmdline_opts.upload_url
+        self.upload_user = cmdline_opts.upload_user
+        self.upload_directory = cmdline_opts.upload_directory
+        self.upload_password = cmdline_opts.upload_pass
+
         if not cmdline_opts.batch and not \
                 cmdline_opts.quiet:
             try:
                 self.case_id = input(_("Please enter the case id "
                                        "that you are generating this "
                                        "report for [%s]: ") % caseid)
+                # Policies will need to handle the prompts for user information
+                if cmdline_opts.upload or self.upload_url:
+                    self.prompt_for_upload_user()
+                    self.prompt_for_upload_password()
+
                 self._print()
             except KeyboardInterrupt:
                 self._print()
@@ -923,5 +955,249 @@ class LinuxPolicy(Policy):
 
         return
 
+    def prompt_for_upload_user(self):
+        """Should be overridden by policies to determine if a user needs to
+        be provided or not
+        """
+        if not self.upload_user and not self._upload_user:
+            msg = "Please provide upload user for %s: " % self.get_upload_url()
+            self.upload_user = input(_(msg))
+
+    def prompt_for_upload_password(self):
+        """Should be overridden by policies to determine if a password needs to
+        be provided for upload or not
+        """
+        if ((not self.upload_password and not self._upload_password) and
+                self.upload_user):
+            msg = (
+                "Please provide the upload password for %s: "
+                % self.upload_user
+            )
+            self.upload_password = getpass(msg)
+
+    def upload_archive(self, archive):
+        """Entry point for sos attempts to upload the generated archive to a
+        policy or user specified location.
+
+        Curerntly there is support for HTTPS, SFTP, and FTP. HTTPS uploads are
+        preferred for policy-defined defaults.
+
+        Policies that need to override uploading methods should override the
+        respective upload_https(), upload_sftp(), and/or upload_ftp() methods
+        and should NOT override this method.
+
+        In order to enable this for a policy, that policy needs to implement
+        the following:
+
+        Required:
+            Class Attrs:
+                _upload_url                 The default location to use. Note
+                                            these MUST include protocol header
+                _upload_user                Default username, if any else None
+                _upload_password            Default password, if any else None
+                _use_https_streaming        Set to True if the HTTPS endpoint
+                                            supports streaming data
+
+        Optional:
+            Class Attrs:
+                _upload_directory   Default FTP server directory, if any
+
+            Methods:
+                prompt_for_upload_user()    Determines if sos should prompt
+                                            for a username or not.
+                get_upload_user()           Determines if the default or a
+                                            different username should be used
+                get_upload_https_auth()     Format authentication data for
+                                            HTTPS uploads
+                get_upload_url_string()     If you want your policy to print
+                                            a string other than the default URL
+                                            for your vendor/distro, override
+                                            this method
+
+        """
+        self.upload_archive = archive
+        self.upload_url = self.get_upload_url()
+        if not self.upload_url:
+            raise Exception("No upload destination provided by policy or by "
+                            "--upload-url")
+        upload_func = self._determine_upload_type()
+        print(_("Attempting upload to %s" % self.get_upload_url_string()))
+        return upload_func()
+
+    def _determine_upload_type(self):
+        """Based on the url provided, determine what type of upload to attempt.
+
+        Note that this requires users to provide a FQDN address, such as
+        https://myvendor.com/api or ftp://myvendor.com instead of
+        myvendor.com/api or myvendor.com
+        """
+        prots = {
+            'ftp': self.upload_ftp,
+            'sftp': self.upload_sftp,
+            'https': self.upload_https
+        }
+        if '://' not in self.upload_url:
+            raise Exception("Must provide protocol in upload URL")
+        prot, url = self.upload_url.split('://')
+        if prot not in prots.keys():
+            raise Exception("Unsupported or unrecognized protocol: %s" % prot)
+        return prots[prot]
+
+    def get_upload_https_auth(self, user=None, password=None):
+        """Formats the user/password credentials using basic auth
+        """
+        if not user:
+            user = self.get_upload_user()
+        if not password:
+            password = self.get_upload_password()
+
+        return requests.auth.HTTPBasicAuth(user, password)
+
+    def get_upload_url(self):
+        """Helper function to determine if we should use the policy default
+        upload url or one provided by the user
+        """
+        return self.upload_url or self._upload_url
+
+    def get_upload_url_string(self):
+        """Used by distro policies to potentially change the string used to
+        report upload location from the URL to a more human-friendly string
+        """
+        return self.get_upload_url()
+
+    def get_upload_user(self):
+        """Helper function to determine if we should use the policy default
+        upload user or one provided by the user
+        """
+        return self.upload_user or self._upload_user
+
+    def get_upload_password(self):
+        """Helper function to determine if we should use the policy default
+        upload password or one provided by the user
+        """
+        return self.upload_password or self._upload_password
+
+    def upload_sftp(self):
+        """Attempts to upload the archive to an SFTP location.
+
+        Due to the lack of well maintained, secure, and generally widespread
+        python libraries for SFTP, sos will shell-out to the system's local ssh
+        installation in order to handle these uploads.
+
+        Do not override this method with one that uses python-paramiko, as the
+        upstream sos team will reject any PR that includes that dependency.
+        """
+        raise NotImplementedError("SFTP support is not yet implemented")
+
+    def _upload_https_streaming(self, archive):
+        """If upload_https() needs to use requests.put(), this method is used
+        to provide streaming functionality
+
+        Policies should override this method instead of the base upload_https()
+
+        Positional arguments:
+            :param archive:     The open archive file object
+        """
+        return requests.put(self.get_upload_url(), data=archive,
+                            auth=self.get_upload_https_auth())
+
+    def _get_upload_headers(self):
+        """Define any needed headers to be passed with the POST request here
+        """
+        return {}
+
+    def _upload_https_no_stream(self, archive):
+        """If upload_https() needs to use requests.post(), this method is used
+        to provide non-streaming functionality
+
+        Policies should override this method instead of the base upload_https()
+
+        Positional arguments:
+            :param archive:     The open archive file object
+        """
+        files = {
+            'file': (archive.name.split('/')[-1], archive,
+                     self._get_upload_headers())
+        }
+        return requests.post(self.get_upload_url(), files=files,
+                             auth=self.get_upload_https_auth())
+
+    def upload_https(self):
+        """Attempts to upload the archive to an HTTPS location.
+
+        Policies may define whether this upload attempt should use streaming
+        or non-streaming data by setting the `use_https_streaming` class
+        attr to True
+        """
+        if not REQUESTS_LOADED:
+            raise Exception("Unable to upload due to missing python requests "
+                            "library")
+
+        with open(self.upload_archive, 'rb') as arc:
+            if not self._use_https_streaming:
+                r = self._upload_https_no_stream(arc)
+            else:
+                r = self._upload_https_streaming(arc)
+            if r.status_code != 201:
+                if r.status_code == 401:
+                    raise Exception(
+                        "Authentication failed: invalid user credentials"
+                    )
+                raise Exception("POST request returned %s: %s"
+                                % (r.status_code, r.reason))
+            return True
+
+    def upload_ftp(self, url=None, directory=None, user=None, password=None):
+        """Attempts to upload the archive to either the policy defined or user
+        provided FTP location.
+        """
+        try:
+            import ftplib
+            import socket
+        except ImportError:
+            # socket is part of the standard library, should only fail here on
+            # ftplib
+            raise Exception("missing python ftplib library")
+
+        if not url:
+            url = self.get_upload_url()
+        if url is None:
+            raise Exception("no FTP server specified by policy, use --upload-"
+                            "url to specify a location")
+
+        url = url.replace('ftp://', '')
+
+        if not user:
+            user = self.get_upload_user()
+
+        if not password:
+            password = self.get_upload_password()
+
+        if not directory:
+            directory = self._upload_directory
+
+        try:
+            session = ftplib.FTP(url, user, password)
+            session.cwd(directory)
+        except socket.gaierror:
+            raise Exception("unable to connect to %s" % url)
+        except ftplib.error_perm as err:
+            errno = err.split()[0]
+            if errno == 503:
+                raise Exception("could not login as '%s'" % user)
+            if errno == 550:
+                raise Exception("could not set upload directory to %s"
+                                % directory)
+
+        try:
+            with open(self.upload_archive, 'rb') as _arcfile:
+                session.storbinary(
+                    "STOR %s" % self.upload_archive.split('/')[-1],
+                    _arcfile
+                )
+            session.quit()
+            return True
+        except IOError:
+            raise Exception("could not open archive file")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -938,14 +938,16 @@ class LinuxPolicy(Policy):
         if not cmdline_opts.batch and not \
                 cmdline_opts.quiet:
             try:
-                self.case_id = input(_("Please enter the case id "
-                                       "that you are generating this "
-                                       "report for [%s]: ") % caseid)
+                if caseid:
+                    self.case_id = caseid
+                else:
+                    self.case_id = input(_("Please enter the case id "
+                                           "that you are generating this "
+                                           "report for [%s]: ") % caseid)
                 # Policies will need to handle the prompts for user information
                 if cmdline_opts.upload or self.upload_url:
                     self.prompt_for_upload_user()
                     self.prompt_for_upload_password()
-
                 self._print()
             except KeyboardInterrupt:
                 self._print()

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -21,6 +21,14 @@ from sos import SoSOptions
 
 OS_RELEASE = "/etc/os-release"
 
+# In python2.7, input() will not properly return strings, and on python3.x
+# raw_input() was renamed to input(). So, if we're running on python2.7, map
+# input() to raw_input() to match the behavior
+try:
+    input = raw_input
+except NameError:
+    pass
+
 
 class RedHatPolicy(LinuxPolicy):
     distro = "Red Hat"
@@ -37,9 +45,6 @@ class RedHatPolicy(LinuxPolicy):
     default_scl_prefix = '/opt/rh'
     name_pattern = 'friendly'
     init = 'systemd'
-    upload_url = 'dropbox.redhat.com'
-    upload_user = 'anonymous'
-    upload_directory = '/incoming'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)
@@ -241,6 +246,9 @@ organization before being passed to any third party.
 No changes will be made to system configuration.
 """
 
+RH_API_HOST = "https://access.redhat.com"
+RH_FTP_HOST = "ftp://dropbox.redhat.com"
+
 
 class RHELPolicy(RedHatPolicy):
     distro = RHEL_RELEASE_STR
@@ -255,6 +263,9 @@ An archive containing the collected information will be \
 generated in %(tmpdir)s and may be provided to a %(vendor)s \
 support representative.
 """ + disclaimer_text + "%(vendor_text)s\n")
+    _upload_url = RH_FTP_HOST
+    _upload_user = 'anonymous'
+    _upload_directory = '/incoming'
 
     def __init__(self, sysroot=None):
         super(RHELPolicy, self).__init__(sysroot=sysroot)
@@ -283,6 +294,49 @@ support representative.
                     if value.startswith(cls.distro):
                         return True
         return False
+
+    def prompt_for_upload_user(self):
+        if self.commons['cmdlineopts'].upload_user:
+            return
+        # Not using the default, so don't call this prompt for RHCP
+        if self.commons['cmdlineopts'].upload_url:
+            super(RHELPolicy, self).prompt_for_upload_user()
+            return
+        if self.case_id:
+            self.upload_user = input(_(
+                "Enter your Red Hat Customer Portal username (empty to use "
+                "public dropbox): ")
+            )
+
+    def get_upload_url(self):
+        if self.commons['cmdlineopts'].upload_url:
+            return self.commons['cmdlineopts'].upload_url
+        if (not self.case_id or not self.upload_user or not
+                self.upload_password):
+            # Cannot use the RHCP. Use anonymous dropbox
+            self.upload_user = self._upload_user
+            self.upload_directory = self._upload_directory
+            self.upload_password = None
+            return RH_FTP_HOST
+        else:
+            rh_case_api = "/hydra/rest/cases/%s/attachments"
+            return RH_API_HOST + rh_case_api % self.case_id
+
+    def _get_upload_headers(self):
+        if self.get_upload_url().startswith(RH_API_HOST):
+            return {'isPrivate': 'false', 'cache-control': 'no-cache'}
+        return {}
+
+    def get_upload_url_string(self):
+        if self.get_upload_url().startswith(RH_API_HOST):
+            return "Red Hat Customer Portal"
+        return self.upload_url or RH_FTP_HOST
+
+    def get_upload_user(self):
+        # if this is anything other than dropbox, annonymous won't work
+        if self.upload_url != RH_FTP_HOST:
+            return self.upload_user
+        return self._upload_user
 
     def dist_version(self):
         try:

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -37,6 +37,9 @@ class RedHatPolicy(LinuxPolicy):
     default_scl_prefix = '/opt/rh'
     name_pattern = 'friendly'
     init = 'systemd'
+    upload_url = 'dropbox.redhat.com'
+    upload_user = 'anonymous'
+    upload_directory = '/incoming'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)

--- a/sos/policies/ubuntu.py
+++ b/sos/policies/ubuntu.py
@@ -3,6 +3,8 @@ from __future__ import with_statement
 from sos.plugins import UbuntuPlugin, DebianPlugin
 from sos.policies.debian import DebianPolicy
 
+import os
+
 
 class UbuntuPolicy(DebianPolicy):
     distro = "Ubuntu"
@@ -10,6 +12,10 @@ class UbuntuPolicy(DebianPolicy):
     vendor_url = "https://www.ubuntu.com/"
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin:/snap/bin"
+    _upload_url = "https://files.support.canonical.com/uploads/"
+    _upload_user = "ubuntu"
+    _upload_password = "ubuntu"
+    _use_https_streaming = True
 
     def __init__(self, sysroot=None):
         super(UbuntuPolicy, self).__init__(sysroot=sysroot)
@@ -37,5 +43,23 @@ class UbuntuPolicy(DebianPolicy):
             return False
         except IOError:
             return False
+
+    def get_upload_https_auth(self):
+        if self.upload_url.startswith(self._upload_url):
+            return (self._upload_user, self._upload_password)
+        else:
+            return super(UbuntuPolicy, self).get_upload_https_auth()
+
+    def get_upload_url_string(self):
+        if self.upload_url.startswith(self._upload_url):
+            return "Canonical Support File Server"
+        else:
+            return self.get_upload_url()
+
+    def get_upload_url(self):
+        if not self.upload_url or self.upload_url.startswith(self._upload_url):
+            fname = os.path.basename(self.upload_archive)
+            return self._upload_url + fname
+        super(UbuntuPolicy, self).get_upload_url()
 
 # vim: set et ts=4 sw=4 :

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -245,6 +245,17 @@ def _get_parser():
                         help="Run commands even if they can change the "
                              "system (e.g. load kernel modules)")
 
+    parser.add_argument("--upload", action="store_true", default=False,
+                        help="Upload the archive to a policy-default location")
+    parser.add_argument("--upload-url", default=None,
+                        help="Upload the archive to the specified server")
+    parser.add_argument("--upload-directory", default=None,
+                        help="Specify the directory to upload the archive to")
+    parser.add_argument("--upload-user", default=None,
+                        help="Username to authenticate to upload server with")
+    parser.add_argument("--upload-pass", default=None,
+                        help="Password to authenticate to upload server with")
+
     # Group to make add/del preset exclusive
     preset_grp = parser.add_mutually_exclusive_group()
     preset_grp.add_argument("--add-preset", type=str, action="store",
@@ -1311,6 +1322,18 @@ class SoSReport(object):
                                         archivestat)
         else:
             self.policy.display_results(archive, directory, checksum)
+
+        if self.opts.upload or self.opts.upload_url:
+            if not self.opts.build:
+                try:
+                    self.policy.upload_archive(archive)
+                    self.ui_log.info(_("Uploaded archive successfully"))
+                except Exception as err:
+                    self.ui_log.error("Upload attempt failed: %s" % err)
+            else:
+                msg = ("Unable to upload archive when using --build as no "
+                       "archive is created.")
+                self.ui_log.error(msg)
 
         # clean up
         logging.shutdown()


### PR DESCRIPTION
This patchset allows users to have sos try to upload to an FTP location (which may be defined by `Policy`) after the archive is successfully tar'd.

Users may request this by using `--upload` if the loaded `Policy` specifies a default location and credentials. Additionally, users may request a specific location using `--upload-url`. The `--upload-user`, `--upload-directory`, and `--upload-pass` options have been added to assist with this as well.

For Red Hat systems, the policy defines the long-standing public read-only dropbox location at dropbox.redhat.com for FTP uploads if a case number is not provided. If a case number is provided, users will be prompted for Customer Portal credentials and sos will then try to upload the archive directly to the case. If a case number is provided by credentials are not, sos will fallback to uploading to the public dropbox.

If uploading fails for any reason, sos will still exit the same - as this upload attempt only occurs at the end of a successful execution.

For consideration: for basic FTP uploads, this requires the `ftplib` library to be available, and for Red Hat specifically uploading to the Customer Portal requires the `requests` library. I have not added either of these as hard dependencies for sosreport as this is optional functionality that may not be used (or may not be allowed in secure environments), and so sos does not actually 'require' these libraries to perform its main objectives.

Also included in this patchset is a fix with `policies/__init__.py` where an empty input for a case number when `--case-id` has been used on the cmdline would override the cmdline option.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
