### PR TITLE
[global] PEP 257 docstring fixes

### DIFF
--- a/example_plugins/example.py
+++ b/example_plugins/example.py
@@ -12,7 +12,7 @@ from sos.plugins import Plugin, RedHatPlugin
 # if you want to override it simply provide a @classmethod name()
 # that returns the name you want
 class example(Plugin, RedHatPlugin):
-    '''This is the description for the example plugin'''
+    """This is the description for the example plugin"""
     # Plugin developers want to override setup() from which they will call
     # add_copy_spec() to collect files and collectExtOutput() to collect programs
     # output.
@@ -27,13 +27,13 @@ class example(Plugin, RedHatPlugin):
                   ('color', 'Gathers toenail polish color', 'fast', 0)]
 
     def setup(self):
-        ''' First phase - Collect all the information we need.
+        """ First phase - Collect all the information we need.
         Directories are copied recursively. arbitrary commands may be
         executed using the collectExtOutput() method. Information is
         automatically saved, and links are presented in the report to each
         file or directory which has been copied to the saved tree. Also, links
         are provided to the output from each command.
-        '''
+        """
         # Here's how to copy files and directory trees
         self.add_copy_spec("/etc/hosts")
 

--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -47,7 +47,7 @@ def _to_u(s):
 
 
 def regex_findall(regex, fname):
-    '''Return a list of all non overlapping matches in the string(s)'''
+    """Return a list of all non overlapping matches in the string(s)"""
     try:
         with fileobj(fname) as f:
             return re.findall(regex, f.read(), re.MULTILINE)
@@ -205,7 +205,7 @@ class SoSPredicate(object):
             return all(_pkgs)
 
     def _eval_cmd_output(self, cmd_output):
-        '''Does 'cmd' output contain string 'output'?'''
+        """Does 'cmd' output contain string 'output'?"""
         if 'cmd' not in cmd_output or 'output' not in cmd_output:
             return False
         result = sos_get_command_output(cmd_output['cmd'])
@@ -367,10 +367,10 @@ class Plugin(object):
 
     @property
     def timeout(self):
-        '''Returns either the default plugin timeout value, the value as
+        """Returns either the default plugin timeout value, the value as
         provided on the commandline via -k plugin.timeout=value, or the value
         of the global --plugin-timeout option.
-        '''
+        """
         _timeout = None
         try:
             opt_timeout = self.get_option('plugin_timeout')
@@ -390,7 +390,7 @@ class Plugin(object):
         return self.plugin_timeout
 
     def check_timeout(self):
-        '''
+        """
         Checks to see if the plugin has hit its timeout.
 
         This is set when the sos.collect_plugin() method hits a timeout and
@@ -404,7 +404,7 @@ class Plugin(object):
 
         Returns True if timeout has been hit, else False.
 
-        '''
+        """
         return self._timeout_hit
 
     @classmethod
@@ -451,27 +451,27 @@ class Plugin(object):
         return os.path.commonprefix(paths) == self.sysroot
 
     def is_installed(self, package_name):
-        '''Is the package $package_name installed?'''
+        """Is the package $package_name installed?"""
         return self.policy.pkg_by_name(package_name) is not None
 
     def is_service(self, name):
-        '''Does the service $name exist on the system?'''
+        """Does the service $name exist on the system?"""
         return self.policy.init_system.is_service(name)
 
     def is_service_enabled(self, name):
-        '''Is the service $name enabled?'''
+        """Is the service $name enabled?"""
         return self.policy.init_system.is_enabled(name)
 
     def is_service_disabled(self, name):
-        '''Is the service $name disabled?'''
+        """Is the service $name disabled?"""
         return self.policy.init_system.is_disabled(name)
 
     def is_service_running(self, name):
-        '''Is the service $name currently running?'''
+        """Is the service $name currently running?"""
         return self.policy.init_system.is_running(name)
 
     def get_service_status(self, name):
-        '''Return the reported status for service $name'''
+        """Return the reported status for service $name"""
         return self.policy.init_system.get_service_status(name)['status']
 
     def set_predicate(self, pred):
@@ -537,13 +537,13 @@ class Plugin(object):
         self._log_warn(msg % (cmd, needs))
 
     def do_cmd_private_sub(self, cmd, desc=""):
-        '''Remove certificate and key output archived by sosreport. cmd
+        """Remove certificate and key output archived by sosreport. cmd
         is the command name from which output is collected (i.e. exlcuding
         parameters). Any matching instances are replaced with: '-----SCRUBBED'
         and this function does not take a regexp or substituting string.
 
         This function returns the number of replacements made.
-        '''
+        """
         if not self.executed_commands:
             return 0
 
@@ -555,7 +555,7 @@ class Plugin(object):
         return self.do_cmd_output_sub(cmd, _certmatch, replace)
 
     def do_cmd_output_sub(self, cmd, regexp, subst):
-        '''Apply a regexp substitution to command output archived by sosreport.
+        """Apply a regexp substitution to command output archived by sosreport.
         cmd is the command name from which output is collected (i.e. excluding
         parameters). The regexp can be a string or a compiled re object. The
         substitution string, subst, is a string that replaces each occurrence
@@ -564,7 +564,7 @@ class Plugin(object):
         the current module's command list is subjected to the replacement.
 
         This function returns the number of replacements made.
-        '''
+        """
         globstr = '*' + cmd + '*'
         pattern = regexp.pattern if hasattr(regexp, "pattern") else regexp
         self._log_debug("substituting '%s' for '%s' in commands matching '%s'"
@@ -599,7 +599,7 @@ class Plugin(object):
         return replacements
 
     def do_file_private_sub(self, pathregex, desc=""):
-        '''Scrub certificate/key/etc information from files collected by sos.
+        """Scrub certificate/key/etc information from files collected by sos.
 
         Files matching the provided pathregex are searched for content that
         resembles certificate, ssh keys, or similar information. Any matches
@@ -611,7 +611,7 @@ class Plugin(object):
         Positional arguments:
             :param pathregex: A string or regex of a filename to match against
             :param desc: A description of the replaced content
-        '''
+        """
         self._log_debug("Scrubbing certs and keys for paths matching %s"
                         % pathregex)
         match = re.compile(pathregex).match
@@ -624,13 +624,13 @@ class Plugin(object):
             self.do_file_sub(path, _certmatch, replace)
 
     def do_file_sub(self, srcpath, regexp, subst):
-        '''Apply a regexp substitution to a file archived by sosreport.
+        """Apply a regexp substitution to a file archived by sosreport.
         srcpath is the path in the archive where the file can be found.  regexp
         can be a regexp string or a compiled re object.  subst is a string to
         replace each occurance of regexp in the content of srcpath.
 
         This function returns the number of replacements made.
-        '''
+        """
         try:
             path = self._get_dest_for_srcpath(srcpath)
             pattern = regexp.pattern if hasattr(regexp, "pattern") else regexp
@@ -661,12 +661,12 @@ class Plugin(object):
         return replacements
 
     def do_path_regex_sub(self, pathexp, regexp, subst):
-        '''Apply a regexp substituation to a set of files archived by
+        """Apply a regexp substituation to a set of files archived by
         sos. The set of files to be substituted is generated by matching
         collected file pathnames against pathexp which may be a regular
         expression string or compiled re object. The portion of the file
         to be replaced is specified via regexp and the replacement string
-        is passed in subst.'''
+        is passed in subst."""
         if not hasattr(pathexp, "match"):
             pathexp = re.compile(pathexp)
         match = pathexp.match
@@ -773,10 +773,10 @@ class Plugin(object):
 
     # Methods for copying files and shelling out
     def _do_copy_path(self, srcpath, dest=None):
-        '''Copy file or directory to the destination tree. If a directory, then
+        """Copy file or directory to the destination tree. If a directory, then
         everything below it is recursively copied. A list of copied files are
         saved for use later in preparing a report.
-        '''
+        """
         if self._timeout_hit:
             return
 
@@ -895,9 +895,9 @@ class Plugin(object):
         return default
 
     def get_option_as_list(self, optionname, delimiter=",", default=None):
-        '''Will try to return the option as a list separated by the
+        """Will try to return the option as a list separated by the
         delimiter.
-        '''
+        """
         option = self.get_option(optionname)
         try:
             opt_list = [opt.strip() for opt in option.split(delimiter)]
@@ -1302,13 +1302,13 @@ class Plugin(object):
         self.custom_text += text
 
     def add_service_status(self, services, timeout=None, pred=None):
-        '''Collect service status information based on the InitSystem used.
+        """Collect service status information based on the InitSystem used.
 
         :param services: A string, or list of strings, specifying the services
                           to collect
         :param timeout:  Optional timeout in seconds
         :param pred:     An optional predicate to gate collection
-        '''
+        """
         if isinstance(services, six.string_types):
             services = [services]
 

--- a/sos/plugins/cloud_init.py
+++ b/sos/plugins/cloud_init.py
@@ -12,8 +12,8 @@ from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class CloudInit(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    '''cloud-init instance configurations
-    '''
+    """cloud-init instance configurations
+    """
 
     plugin_name = 'cloud_init'
     packages = ('cloud-init',)

--- a/sos/plugins/cockpit.py
+++ b/sos/plugins/cockpit.py
@@ -12,7 +12,7 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Cockpit(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    '''Cockpit Web Service'''
+    """Cockpit Web Service"""
 
     plugin_name = 'cockpit'
     packages = ('cockpit-ws', 'cockpit-system')

--- a/sos/plugins/collectd.py
+++ b/sos/plugins/collectd.py
@@ -12,9 +12,9 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Collectd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    '''
+    """
     Collectd config collector
-    '''
+    """
     plugin_name = "collectd"
     profiles = ('services', 'webserver')
 

--- a/sos/plugins/container_log.py
+++ b/sos/plugins/container_log.py
@@ -13,8 +13,8 @@ import os
 
 
 class ContainerLog(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    '''All container logs
-    '''
+    """All container logs
+    """
     plugin_name = 'container_log'
     logdir = '/var/log/containers/'
     files = (logdir, )
@@ -26,8 +26,8 @@ class ContainerLog(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             self.collect_subdirs()
 
     def collect_subdirs(self, root=logdir):
-        '''Collect *.log files from subdirs of passed root path
-        '''
+        """Collect *.log files from subdirs of passed root path
+        """
         for dirName, _, _ in os.walk(root):
             self.add_copy_spec(os.path.join(dirName, '*.log'))
 

--- a/sos/plugins/date.py
+++ b/sos/plugins/date.py
@@ -12,8 +12,8 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class Date(Plugin, RedHatPlugin, DebianPlugin):
-    '''Basic system time information
-    '''
+    """Basic system time information
+    """
 
     plugin_name = 'date'
 

--- a/sos/plugins/fibrechannel.py
+++ b/sos/plugins/fibrechannel.py
@@ -15,7 +15,7 @@ from os.path import isdir, join
 
 
 class Fibrechannel(Plugin, RedHatPlugin):
-    '''Collects information on fibrechannel devices, if present'''
+    """Collects information on fibrechannel devices, if present"""
 
     plugin_name = 'fibrechannel'
     profiles = ('hardware', 'storage', 'system')

--- a/sos/plugins/host.py
+++ b/sos/plugins/host.py
@@ -12,8 +12,8 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class Host(Plugin, RedHatPlugin, DebianPlugin):
-    '''Host information
-    '''
+    """Host information
+    """
 
     plugin_name = 'host'
     profiles = ('system',)

--- a/sos/plugins/insights.py
+++ b/sos/plugins/insights.py
@@ -10,8 +10,8 @@ from sos.plugins import Plugin, RedHatPlugin
 
 
 class RedHatInsights(Plugin, RedHatPlugin):
-    '''Collect config and log for Red Hat Insights
-    '''
+    """Collect config and log for Red Hat Insights
+    """
     plugin_name = 'insights'
     packages = ['redhat-access-insights', 'insights-client']
     profiles = ('system', 'sysmgmt')

--- a/sos/plugins/kernelrt.py
+++ b/sos/plugins/kernelrt.py
@@ -13,8 +13,8 @@ from sos.plugins import Plugin, RedHatPlugin
 
 
 class KernelRT(Plugin, RedHatPlugin):
-    '''Realtime kernel variant
-    '''
+    """Realtime kernel variant
+    """
 
     plugin_name = 'kernelrt'
     profiles = ('system', 'hardware', 'kernel', 'mrg')

--- a/sos/plugins/lustre.py
+++ b/sos/plugins/lustre.py
@@ -10,17 +10,17 @@ from sos.plugins import Plugin, RedHatPlugin
 
 
 class Lustre(Plugin, RedHatPlugin):
-    '''Lustre filesystem'''
+    """Lustre filesystem"""
 
     plugin_name = 'lustre'
     profiles = ('storage', 'network', 'cluster', )
     packages = ('lustre', 'lustre-client', )
 
     def get_params(self, name, param_list):
-        '''Use lctl get_param to collect a selection of parameters into a
+        """Use lctl get_param to collect a selection of parameters into a
             file.
 
-        '''
+        """
         self.add_cmd_output("lctl get_param %s" % " ".join(param_list),
                             suggest_filename="params-%s" % name,
                             stderr=False)

--- a/sos/plugins/nvidia.py
+++ b/sos/plugins/nvidia.py
@@ -13,7 +13,7 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nvidia(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    '''Nvidia GPU information'''
+    """Nvidia GPU information"""
 
     commands = ('nvidia-smi',)
 

--- a/sos/plugins/omsa.py
+++ b/sos/plugins/omsa.py
@@ -10,8 +10,8 @@ from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class omsa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    '''Dell OpenManage Server Administrator (OMSA)
-    '''
+    """Dell OpenManage Server Administrator (OMSA)
+    """
 
     plugin_name = 'omsa'
     profiles = ('hardware', 'debug')

--- a/sos/plugins/openshift.py
+++ b/sos/plugins/openshift.py
@@ -17,7 +17,7 @@ import os.path
 # For later of OpenShift Origin based on: https://github.com/openshift/origin
 # like OpenShift Enterprise 3.x see the origin.py plugin
 class Openshift(Plugin, RedHatPlugin):
-    '''Openshift 2.x node and broker'''
+    """Openshift 2.x node and broker"""
 
     plugin_name = "openshift"
     profiles = ('virt', 'openshift')

--- a/sos/plugins/origin.py
+++ b/sos/plugins/origin.py
@@ -33,7 +33,7 @@ import os.path
 
 
 class OpenShiftOrigin(Plugin):
-    ''' OpenShift Origin '''
+    """ OpenShift Origin """
 
     plugin_name = "origin"
     files = None  # file lists assigned after path setup below
@@ -68,19 +68,19 @@ class OpenShiftOrigin(Plugin):
     # single instance (at least one must evaluate True if this is an OpenShift
     # installation)
     def is_master(self):
-        '''Determine if we are on a master'''
+        """Determine if we are on a master"""
         return os.path.exists(self.master_cfg)
 
     def is_node(self):
-        '''Determine if we are on a node'''
+        """Determine if we are on a node"""
         return os.path.exists(self.node_cfg)
 
     def is_static_etcd(self):
-        '''Determine if we are on a node running etcd'''
+        """Determine if we are on a node running etcd"""
         return os.path.exists(os.path.join(self.static_pod_dir, "etcd.yaml"))
 
     def is_static_pod_compatible(self):
-        '''Determine if a node is running static pods'''
+        """Determine if a node is running static pods"""
         return os.path.exists(self.static_pod_dir)
 
     def setup(self):
@@ -224,8 +224,8 @@ class OpenShiftOrigin(Plugin):
 
 
 class AtomicOpenShift(OpenShiftOrigin, RedHatPlugin):
-    ''' OpenShift Enterprise / OpenShift Container Platform
-    '''
+    """ OpenShift Enterprise / OpenShift Container Platform
+    """
 
     packages = ('atomic-openshift',)
 

--- a/sos/plugins/peripety.py
+++ b/sos/plugins/peripety.py
@@ -14,7 +14,7 @@ import glob
 
 
 class Peripety(Plugin, RedHatPlugin):
-    '''Peripety Storage Event Monitor'''
+    """Peripety Storage Event Monitor"""
 
     packages = ('peripety',)
     services = ('peripetyd',)

--- a/sos/plugins/qt.py
+++ b/sos/plugins/qt.py
@@ -12,7 +12,7 @@ from sos.plugins import Plugin, RedHatPlugin
 
 
 class Qt(Plugin, RedHatPlugin):
-    '''QT widget toolkit'''
+    """QT widget toolkit"""
 
     plugin_name = 'qt'
     packages = ('qt', )

--- a/sos/plugins/rasdaemon.py
+++ b/sos/plugins/rasdaemon.py
@@ -12,8 +12,8 @@ from sos.plugins import Plugin, RedHatPlugin
 
 
 class Rasdaemon(Plugin, RedHatPlugin):
-    '''rasdaemon kernel trace event monitor
-    '''
+    """rasdaemon kernel trace event monitor
+    """
 
     plugin_name = 'rasdaemon'
     packages = ('rasdaemon', )

--- a/sos/plugins/stratis.py
+++ b/sos/plugins/stratis.py
@@ -12,7 +12,7 @@ from sos.plugins import Plugin, RedHatPlugin
 
 
 class Stratis(Plugin, RedHatPlugin):
-    '''Stratis Storage'''
+    """Stratis Storage"""
 
     packages = ('stratis-cli', 'stratisd')
     services = ('stratisd',)

--- a/sos/plugins/unpackaged.py
+++ b/sos/plugins/unpackaged.py
@@ -13,10 +13,10 @@ import stat
 
 
 class Unpackaged(Plugin, RedHatPlugin):
-    '''
+    """
     Collects a list of files that are not handled by the package
     manager
-    '''
+    """
 
     def setup(self):
 

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -1017,8 +1017,8 @@ class SoSReport(object):
             os._exit(1)
 
     def _collect_plugin(self, plugin):
-        '''Wraps the collect_plugin() method so we can apply a timeout
-        against the plugin as a whole'''
+        """Wraps the collect_plugin() method so we can apply a timeout
+        against the plugin as a whole"""
         with ThreadPoolExecutor(1) as pool:
             try:
                 t = pool.submit(self.collect_plugin, plugin)

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -204,12 +204,12 @@ def shell_out(cmd, timeout=30, chroot=None, runat=None):
 
 
 class AsyncReader(threading.Thread):
-    '''Used to limit command output to a given size without deadlocking
+    """Used to limit command output to a given size without deadlocking
     sos.
 
     Takes a sizelimit value in MB, and will compile stdout from Popen into a
     string that is limited to the given sizelimit.
-    '''
+    """
 
     def __init__(self, channel, sizelimit, binary):
         super(AsyncReader, self).__init__()
@@ -225,14 +225,14 @@ class AsyncReader(threading.Thread):
         self.start()
 
     def run(self):
-        '''Reads from the channel (pipe) that is the output pipe for a
+        """Reads from the channel (pipe) that is the output pipe for a
         called Popen. As we are reading from the pipe, the output is added
         to a deque. After the size of the deque exceeds the sizelimit
         earlier (older) entries are removed.
 
         This means the returned output is chunksize-sensitive, but is not
         really byte-sensitive.
-        '''
+        """
         try:
             while True:
                 line = self.chan.read(self.chunksize)
@@ -246,7 +246,7 @@ class AsyncReader(threading.Thread):
         self.running = False
 
     def get_contents(self):
-        '''Returns the contents of the deque as a string'''
+        """Returns the contents of the deque as a string"""
         # block until command completes or timesout (separate from the plugin
         # hitting a timeout)
         while self.running:


### PR DESCRIPTION
PEP 257 specifies docstrings should always use triple double quotes,
rather than triple single quotes.

This commit corrects the places where triple single quotes are used
incorrectly, most of which were done by yours truly.

Resolves: #1914

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
