### PR TITLE
[collectd] grab collectd.log whenever it is present

### DIFF
--- a/sos/plugins/collectd.py
+++ b/sos/plugins/collectd.py
@@ -18,12 +18,18 @@ class Collectd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     plugin_name = "collectd"
     profiles = ('services', 'webserver')
 
+    # enable the plugin either when collectd package is installed
+    # or being inside Super Proviledged Container that does not have
+    # the package but logs to the host's logfile
     packages = ('collectd',)
+    files = ('/var/log/containers/collectd/collectd.log')
 
     def setup(self):
         self.add_copy_spec([
             '/etc/collectd.conf',
             '/etc/collectd.d/*.conf',
+            '/var/log/containers/collectd/collectd.log',
+            '/var/lib/config-data/collectd',
         ])
 
         p = re.compile('^LoadPlugin.*')


### PR DESCRIPTION
The plugin should be enabled also in a Super Privileged Container that
does not have the collectd package installed, but it has access and logs
to the host's collectd.log.

This logfile should be grabbed, alongside with config-data dir to ensure
the right configs were properly copied to /etc during deployment.

Resolves: #1917

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
