### PR TITLE
[firewalld] put "nft list ruleset" under kmods predicate

### DIFF
--- a/sos/plugins/firewalld.py
+++ b/sos/plugins/firewalld.py
@@ -9,7 +9,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin, RedHatPlugin
+from sos.plugins import Plugin, RedHatPlugin, SoSPredicate
 
 
 class FirewallD(Plugin, RedHatPlugin):
@@ -33,7 +33,10 @@ class FirewallD(Plugin, RedHatPlugin):
         ])
 
         # collect nftables ruleset
-        self.add_cmd_output("nft list ruleset")
+        nft_pred = SoSPredicate(self,
+                                kmods=['nf_tables', 'nfnetlink'],
+                                required={'kmods': 'all'})
+        self.add_cmd_output("nft list ruleset", pred=nft_pred, changes=True)
 
         # use a 10s timeout to workaround dbus problems in
         # docker containers.


### PR DESCRIPTION
Executing "nft list ruleset" loads kernel modules nf_tables and nfnetlink.

Sosreport should call it only under the kmods=[nf_tables,nfnetlink] predicate.

Resolves: #1919

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
