### PR TITLE
[ipa] Collect 'getcert list' only if service certmonger is running

### DIFF
--- a/sos/plugins/ipa.py
+++ b/sos/plugins/ipa.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.plugins import Plugin, RedHatPlugin
+from sos.plugins import Plugin, RedHatPlugin, SoSPredicate
 from glob import glob
 from os.path import exists
 
@@ -152,7 +152,6 @@ class Ipa(Plugin, RedHatPlugin):
 
         self.add_cmd_output([
             "ls -la /etc/dirsrv/slapd-*/schema/",
-            "getcert list",
             "certutil -L -d /etc/httpd/alias/",
             "pki-server cert-find --show-all",
             "pki-server subsystem-cert-validate ca",
@@ -160,6 +159,11 @@ class Ipa(Plugin, RedHatPlugin):
             "klist -ket /etc/httpd/conf/ipa.keytab",
             "klist -ket /var/lib/ipa/gssproxy/http.keytab"
         ])
+
+        getcert_pred = SoSPredicate(self,
+                                    services=['certmonger'])
+
+        self.add_cmd_output("getcert list", pred=getcert_pred)
 
         for certdb_directory in glob("/etc/dirsrv/slapd-*/"):
             self.add_cmd_output("certutil -L -d %s" % certdb_directory)


### PR DESCRIPTION
During collection of 'getcert list' is started certmonger service.
That is not wanted behavior, as result should be 'getcert list'
collected only if certmonger is running.

Resolves: #1920

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
