### PR TITLE
[snappy] Check for presence of the snapd pkg instead of its binary

### DIFF
--- a/sos/plugins/snappy.py
+++ b/sos/plugins/snappy.py
@@ -16,7 +16,7 @@ class Snappy(Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin):
 
     plugin_name = 'snappy'
     profiles = ('system', 'sysmgmt', 'packagemanager')
-    files = ('/usr/bin/snap')
+    packages = ('snapd',)
 
     def setup(self):
         self.add_cmd_output([


### PR DESCRIPTION
To perform snap command, 'snapd' debian package must be installed:
https://snapcraft.io/docs/installing-snap-on-ubuntu
https://launchpad.net/ubuntu/+source/snapd

$ apt-file search /usr/bin/snap
snapd: /usr/bin/snap

$ dpkg -S /usr/bin/snap
snapd: /usr/bin/snap

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
