### PR TITLE
[corosync] Add 'corosync-cmapctl -m stats' output

### DIFF
--- a/sos/plugins/corosync.py
+++ b/sos/plugins/corosync.py
@@ -32,7 +32,8 @@ class Corosync(Plugin):
             "corosync-cfgtool -s",
             "corosync-blackbox",
             "corosync-objctl -a",
-            "corosync-cmapctl"
+            "corosync-cmapctl",
+            "corosync-cmapctl -m stats"
         ])
         self.exec_cmd("killall -USR2 corosync")
 


### PR DESCRIPTION
Information stored in CMAP got split in Corosync 3.x to
configuration and statistics part.

Calling 'corosync-cmapctl' command output only configuration part. To
output statistics part, 'corosync-cmapctl -m stats' has to be called.

Patch adds call of 'corosync-cmapctl -m stats'.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
