### PR TITLE
[s390] Correctly capture s390dbf

### DIFF
--- a/sos/plugins/s390.py
+++ b/sos/plugins/s390.py
@@ -41,17 +41,22 @@ class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "/sys/bus/ccw/drivers/zfcp/0.*/*",
             "/sys/bus/ccw/drivers/zfcp/0.*/0x*/*",
             "/sys/bus/ccw/drivers/zfcp/0.*/0x*/0x*/*",
+            "/sys/kernel/debug/s390dbf",
             "/etc/zipl.conf",
             "/etc/zfcp.conf",
             "/etc/sysconfig/dumpconf",
             "/etc/src_vipa.conf",
             "/etc/ccwgroup.conf",
-            "/etc/chandev.conf"])
+            "/etc/chandev.conf"
+        ])
+
+        # skip flush as it is useless for sos collection
+        self.add_forbidden_path("/sys/kernel/debug/s390dbf/*/flush")
+
         self.add_cmd_output([
             "lscss",
             "lsdasd",
             "lstape",
-            "find /proc/s390dbf -type f",
             "qethconf list_all",
             "lsqeth",
             "lszfcp",
@@ -59,6 +64,7 @@ class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "icainfo",
             "icastats"
         ])
+
         r = self.exec_cmd("ls /dev/dasd?")
         dasd_dev = r['output']
         for x in dasd_dev.split('\n'):


### PR DESCRIPTION
Captures the content under /sys/kernel/debug/s390dbf rather than just
listing the file names.

Also included are trivial stylistic fixes.

Closes: #905
Resolves: #1926

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
