### PR TITLE
[kubernetes] Add detailed node information and use oc when available

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -89,13 +89,23 @@ class Kubernetes(Plugin):
         # these are not namespaced, must pull separately.
         global_resources = [
             'namespaces',
-            'nodes',
             'projects',
             'pvs'
         ]
         self.add_cmd_output([
             "%s get %s" % (self.kube_cmd, res) for res in global_resources
         ])
+
+        # Get detailed node information
+        nodes = self.collect_cmd_output("%s get nodes" % self.kube_cmd)
+        if nodes['status'] == 0:
+            for line in nodes['output'].splitlines()[1:]:
+                node = line.split()[0]
+                self.add_cmd_output(
+                    "%s describe node %s" % (self.kube_cmd, node),
+                    subdir='nodes'
+                )
+
         # Also collect master metrics
         self.add_cmd_output("%s get --raw /metrics" % self.kube_cmd)
 

--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -188,8 +188,11 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
     )
 
     kube_cmd = "kubectl"
+    # Rather than loading the config file, use the OCP command directly that
+    # wraps kubectl, so we don't have to manually account for any other changes
+    # the `oc` binary may implement
     if path.exists('/etc/origin/master/admin.kubeconfig'):
-        kube_cmd += ' --kubeconfig=/etc/origin/master/admin.kubeconfig'
+        kube_cmd = 'oc'
 
 
 class UbuntuKubernetes(Kubernetes, UbuntuPlugin):


### PR DESCRIPTION
Two patch set that first adds collection of `describe node <node>` output for each node returned by `get nodes`. Secondly, for RH OCP installations, rather than using `kubectl` with an updated config file, use the existing `oc` binary that performs the wrapping. This will allow us to be completely sure that the information collected by sos is the same information that would be seen when an end user runs the same commands manually.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
