### PR TITLE
[networking] options to limit namespaces

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -174,7 +174,6 @@ ENV_HOST_SYSROOT = 'HOST'
 _opts_verify = SoSOptions(verify=True)
 _opts_all_logs = SoSOptions(all_logs=True)
 _opts_all_logs_verify = SoSOptions(all_logs=True, verify=True)
-_opts_no_lsof = SoSOptions(plugopts=['process.lsof=off'])
 _cb_profiles = ['boot', 'storage', 'system']
 _cb_plugopts = ['boot.all-images=on', 'rpm.rpmva=on', 'rpm.rpmdb=on']
 
@@ -191,6 +190,10 @@ RHOSP_DESC = "Red Hat OpenStack Platform"
 
 RHOCP = "ocp"
 RHOCP_DESC = "OpenShift Container Platform by Red Hat"
+RHOSP_OPTS = SoSOptions(plugopts=[
+                             'process.lsof=off',
+                             'networking.ethtool_namespaces=False',
+                             'networking.namespaces=200'])
 
 RH_CFME = "cfme"
 RH_CFME_DESC = "Red Hat CloudForms"
@@ -215,7 +218,7 @@ rhel_presets = {
     RHV: PresetDefaults(name=RHV, desc=RHV_DESC, note=NOTE_TIME,
                         opts=_opts_verify),
     RHEL: PresetDefaults(name=RHEL, desc=RHEL_DESC),
-    RHOSP: PresetDefaults(name=RHOSP, desc=RHOSP_DESC, opts=_opts_no_lsof),
+    RHOSP: PresetDefaults(name=RHOSP, desc=RHOSP_DESC, opts=RHOSP_OPTS),
     RHOCP: PresetDefaults(name=RHOCP, desc=RHOCP_DESC, note=NOTE_SIZE_TIME,
                           opts=_opts_all_logs_verify),
     RH_CFME: PresetDefaults(name=RH_CFME, desc=RH_CFME_DESC, note=NOTE_TIME,


### PR DESCRIPTION
* Added posibility to define namespaces with
parameter namespaces = "". Posible regexp
like "eth* ens4".
* Added inspect_namespaces which defines how
many namespaces should be inspected, by
default unlimited
* Added ethtool_namespaces variable which
is by default true and if set to false it
will not execute ethtool commands for
namespaces
* Changed options for OpenStack environment
where ethtool_namespaces=False and
inspect_namespaces = 200

Closes: sosreport#1916

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
