### PR TITLE
[openvswitch] Adding nuage-openvswitch to the list of packages for ovs plugin

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -163,12 +163,13 @@ class OpenVSwitch(Plugin):
 
 class RedHatOpenVSwitch(OpenVSwitch, RedHatPlugin):
 
-    packages = ('openvswitch', 'openvswitch2.*', 'openvswitch-dpdk')
+    packages = ('openvswitch', 'openvswitch2.*',
+                'openvswitch-dpdk', 'nuage-openvswitch')
 
 
 class DebianOpenVSwitch(OpenVSwitch, DebianPlugin, UbuntuPlugin):
 
-    packages = ('openvswitch-switch',)
+    packages = ('openvswitch-switch', 'nuage-openvswitch')
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Nokia Nuage has forked upstream OVS but basically, the same
commands should work. When a server is having nuage-ovs installed,
we don't execute the ovs plugin because it doesn't detect the
package.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
