### PR TITLE
[policies] Detect systemd use instead of hardcoding it

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -842,7 +842,8 @@ class LinuxPolicy(Policy):
     def __init__(self, sysroot=None):
         super(LinuxPolicy, self).__init__(sysroot=sysroot)
         self.init_kernel_modules()
-        if self.init == 'systemd':
+
+        if os.path.isdir("/run/systemd/system/"):
             self.init_system = SystemdInit()
         else:
             self.init_system = InitSystem()

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -36,7 +36,6 @@ class RedHatPolicy(LinuxPolicy):
     _host_sysroot = '/'
     default_scl_prefix = '/opt/rh'
     name_pattern = 'friendly'
-    init = 'systemd'
 
     def __init__(self, sysroot=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot)


### PR DESCRIPTION
This just has us the builtin option to determine if we are on
systemd or not.
https://www.freedesktop.org/software/systemd/man/sd_booted.html

Resolves: #1936

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
