### PR TITLE
[kdump] Show current parameters and the saved kexec from last kdump-c…

### DIFF
--- a/sos/plugins/kdump.py
+++ b/sos/plugins/kdump.py
@@ -85,6 +85,8 @@ class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
         if os.path.exists(initramfs_img):
             self.add_cmd_output("lsinitrd %s" % initramfs_img)
 
+        self.add_cmd_output("kdump-config show")
+
         self.add_copy_spec([
             "/etc/default/kdump-tools"
         ])


### PR DESCRIPTION
…onfig load.

This command can be used to confirm that kdump is correctly configured.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
