### PR TITLE
[kdump] Switch lsinitrd in favor of lsinitramfs

### DIFF
--- a/sos/plugins/kdump.py
+++ b/sos/plugins/kdump.py
@@ -83,7 +83,7 @@ class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
 
         initramfs_img = "/var/lib/kdump/initrd.img-" + platform.release()
         if os.path.exists(initramfs_img):
-            self.add_cmd_output("lsinitrd %s" % initramfs_img)
+            self.add_cmd_output("lsinitramfs -l %s" % initramfs_img)
 
         self.add_copy_spec([
             "/etc/default/kdump-tools"


### PR DESCRIPTION
lsinitramfs is more likely to be present and useful

lsinitramfs come with package iniramfs-tools-core (main)
lsinitrd comes with package dracut-core (universe)

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
