### PR TITLE
[InitSystem|Plugin] Add method to get service names matching regex

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -517,6 +517,10 @@ class Plugin(object):
         """Return the reported status for service $name"""
         return self.policy.init_system.get_service_status(name)['status']
 
+    def get_service_names(self, regex):
+        """Get all service names matching regex"""
+        return self.policy.init_system.get_service_names(regex)
+
     def set_predicate(self, pred):
         """Set or clear the default predicate for this plugin.
         """

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -129,6 +129,13 @@ class InitSystem(object):
         """
         return output
 
+    def get_service_names(self, regex):
+        """Get a list of all services discovered on the system that match the
+        given regex.
+        """
+        reg = re.compile(regex, re.I)
+        return [s for s in self.services.keys() if reg.match(s)]
+
     def get_service_status(self, name):
         """Returns the status for the given service name along with the output
         of the query command
@@ -168,7 +175,7 @@ class SystemdInit(InitSystem):
         return 'unknown'
 
     def load_all_services(self):
-        svcs = shell_out(self.list_cmd).splitlines()
+        svcs = shell_out(self.list_cmd).splitlines()[1:]
         for line in svcs:
             try:
                 name = line.split('.service')[0]


### PR DESCRIPTION
Adds a new `get_service_names()` method to the `InitSystem` class which
is then exposed to plugins via `Plugin.get_service_names()` to allow
plugins to fetch a list of service names discovered on the system that
match a provided regex.

Included in this is a fix to avoid the header line from the discovery
command being entered in the dict of known services, so that we avoid
inadvertent regex matches.

Resolves: #1943

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
