### PR TITLE
[lxd] Adapt the plugin for lxd snap installation

### DIFF
--- a/sos/plugins/lxd.py
+++ b/sos/plugins/lxd.py
@@ -34,7 +34,9 @@ class LXD(Plugin, UbuntuPlugin):
             "/var/lib/lxd/lxd.db",
             "/var/lib/lxd/database/local.db",
             "/var/lib/lxd/database/global/*",
-            "/var/log/lxd/*"
+            "/var/log/lxd/*",
+            "/var/snap/lxd/common/lxd/database/local.db",
+            "/var/snap/lxd/common/lxd/database/global/*"
         ])
 
         self.add_cmd_output([
@@ -48,5 +50,9 @@ class LXD(Plugin, UbuntuPlugin):
         self.add_cmd_output([
             "find /var/lib/lxd -maxdepth 2 -type d -ls",
         ], suggest_filename='var-lxd-dirs.txt')
+
+        self.add_cmd_output([
+            "find /var/snap/lxd/common -maxdepth 2 -type d -ls",
+        ], suggest_filename='snap-var-lxd-dirs.txt')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Nowadays, starting with Disco release, lxd deb package
is only use as a transitionning package converting
DEB to SNAP.

This fix adds the snap locations while still keeping
the plugin backward compatibility for 2.X and 3.X
DEB packages installation that are still exist,used
and supported by Canonical.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
