### PR TITLE
[plugins] set default cmd timeout to add_journal

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -363,6 +363,7 @@ class Plugin(object):
     profiles = ()
     sysroot = '/'
     plugin_timeout = 300
+    cmd_timeout = 300
     _timeout_hit = False
 
     # Default predicates
@@ -1080,7 +1081,7 @@ class Plugin(object):
                                  changes=soscmd.changes)
 
     def add_cmd_output(self, cmds, suggest_filename=None,
-                       root_symlink=None, timeout=300, stderr=True,
+                       root_symlink=None, timeout=cmd_timeout, stderr=True,
                        chroot=True, runat=None, env=None, binary=False,
                        sizelimit=None, pred=None, subdir=None,
                        changes=False, foreground=False):
@@ -1186,8 +1187,8 @@ class Plugin(object):
         self._log_debug("added string ...'%s' as '%s'" % (summary, filename))
 
     def _collect_cmd_output(self, cmd, suggest_filename=None,
-                            root_symlink=False, timeout=300, stderr=True,
-                            chroot=True, runat=None, env=None,
+                            root_symlink=False, timeout=cmd_timeout,
+                            stderr=True, chroot=True, runat=None, env=None,
                             binary=False, sizelimit=None, subdir=None,
                             changes=False, foreground=False):
         """Execute a command and save the output to a file for inclusion in the
@@ -1280,8 +1281,8 @@ class Plugin(object):
         return result
 
     def collect_cmd_output(self, cmd, suggest_filename=None,
-                           root_symlink=False, timeout=300, stderr=True,
-                           chroot=True, runat=None, env=None,
+                           root_symlink=False, timeout=cmd_timeout,
+                           stderr=True, chroot=True, runat=None, env=None,
                            binary=False, sizelimit=None, pred=None,
                            subdir=None):
         """Execute a command and save the output to a file for inclusion in the
@@ -1302,8 +1303,9 @@ class Plugin(object):
             env=env, binary=binary, sizelimit=sizelimit, subdir=subdir
         )
 
-    def exec_cmd(self, cmd, timeout=300, stderr=True, chroot=True, runat=None,
-                 env=None, binary=False, pred=None, foreground=False):
+    def exec_cmd(self, cmd, timeout=cmd_timeout, stderr=True, chroot=True,
+                 runat=None, env=None, binary=False, pred=None,
+                 foreground=False):
         """Execute a command right now and return the output and status, but
         do not save the output within the archive.
 
@@ -1364,8 +1366,9 @@ class Plugin(object):
             self._add_cmd_output(cmd="%s %s" % (query, service), **kwargs)
 
     def add_journal(self, units=None, boot=None, since=None, until=None,
-                    lines=None, allfields=False, output=None, timeout=None,
-                    identifier=None, catalog=None, sizelimit=None, pred=None):
+                    lines=None, allfields=False, output=None,
+                    timeout=cmd_timeout, identifier=None, catalog=None,
+                    sizelimit=None, pred=None):
         """Collect journald logs from one of more units.
 
         :param units: A string, or list of strings specifying the


### PR DESCRIPTION
add_journal calls a sos command underneath that should apply same
command timeout limits like e.g. add_cmd_output method.

Further, define the command timeout value of 300 seconds just on
one place.

Resolves: #1938

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
