### PR TITLE
[ceph] mimic/nautilus data collection update

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -32,7 +32,9 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
         'ceph-nfs@pacemaker',
         'ceph-mds@%s' % ceph_hostname,
         'ceph-mon@%s' % ceph_hostname,
-        'ceph-mgr@%s' % ceph_hostname
+        'ceph-mgr@%s' % ceph_hostname,
+        'ceph-radosgw@*',
+        'ceph-osd@*'
     )
 
     def setup(self):
@@ -62,15 +64,24 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph mon stat",
             "ceph mon_status",
             "ceph quorum_status",
+            "ceph mgr module ls",
+            "ceph mgr metadata",
+            "ceph osd metadata",
             "ceph osd erasure-code-profile ls",
             "ceph report",
             "ceph osd crush show-tunables",
             "ceph-disk list",
             "ceph versions",
+            "ceph features",
             "ceph insights",
             "ceph osd crush dump",
             "ceph -v",
-            "ceph-volume lvm list"
+            "ceph-volume lvm list",
+            "ceph crash stat",
+            "ceph crash ls",
+            "ceph config log",
+            "ceph config generate-minimal-conf",
+            "ceph config-key dump",
         ])
 
         ceph_cmds = [
@@ -81,12 +92,20 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "osd df tree",
             "osd dump",
             "osd df",
+            "osd perf",
+            "osd blocked-by",
+            "osd pool ls detail",
+            "osd numa-status",
+            "device ls",
             "mon dump",
+            "mgr dump",
+            "mds stat",
             "df",
             "df detail",
             "fs ls",
             "fs dump",
             "pg dump",
+            "pg stat",
         ]
 
         self.add_cmd_output([
@@ -97,6 +116,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph %s --format json-pretty" % s for s in ceph_cmds
         ], subdir="json_output")
 
+        self.add_service_status(self.services)
         for service in self.services:
             self.add_journal(units=service)
 


### PR DESCRIPTION
Ceph has been focusing on administrator quality of life in the latest
releases. There are a number of shiny new tools/reports available that
would be great to have when troubleshooting ceph clusters.

This is a first pass at updating the ceph plug-in to bring it inline
with upstream changes.

This fix also addresses several inconsistencies in reports that were
captured between mon/mgr/osd services.

Further improvements are possible here, but I recommend splitting up
the ceph plug-in into service-specific modules. See Issue #1945.

Signed-off-by: Dan Hill <daniel.hill@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
