### PR TITLE
[yum] Add "yum -C repolist --verbose" command output

### DIFF
--- a/sos/plugins/yum.py
+++ b/sos/plugins/yum.py
@@ -41,6 +41,10 @@ class Yum(Plugin, RedHatPlugin):
         # Get a list of channels the machine is subscribed to.
         self.add_cmd_output("yum -C repolist")
 
+        # Get the same list, but with various statistics related to its
+        # contents such as package count.
+        self.add_cmd_output("yum -C repolist --verbose")
+
         # Get list of available plugins and their configuration files.
         if os.path.exists(YUM_PLUGIN_PATH) and os.path.isdir(YUM_PLUGIN_PATH):
             plugins = ""


### PR DESCRIPTION
Following the upstream DNF commit below, the "yum -C repolist" command
output will no longer include package count information:

    c4f57476 Do not load metadata for repolist commands...

This information is helpful for those searching for client-side
mismatches to upstream repositories. Such as in the case of two
repositories, where one is missing content that another includes, this
information can be crucial for determining the source of the problem.

This change includes a "yum -C repolist --verbose" command in the
resulting sosreport which includes information such as the following:

>    Repo-id            : repoid
>    Repo-name          : full reponame
>    Repo-revision      : version
>    Repo-updated       : datestamp
>    Repo-pkgs          : total repo package count
>    Repo-available-pkgs: package count
>    Repo-size          : size
>    Repo-baseurl       : url
>    Repo-expire        : datestamp
>    Repo-filename      : path

Signed-off-by: Kyle Walker <kwalker@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
