### PR TITLE
Skipping py2 only decorated test if condition is true

### DIFF
--- a/tests/utilities_tests.py
+++ b/tests/utilities_tests.py
@@ -56,6 +56,7 @@ class ExecutableTest(unittest.TestCase):
     def test_exe_file_abs_path(self):
         self.assertTrue(is_executable("/usr/bin/timeout"))
 
+    @unittest.skipIf(six.PY3, "Python2 test")
     def test_output(self):
         path = os.path.join(TEST_DIR, 'test_exe.py')
         result = sos_get_command_output(path)
@@ -75,6 +76,7 @@ class ExecutableTest(unittest.TestCase):
         self.assertEquals(result['status'], 0)
         self.assertEquals(result['output'].strip(), TEST_DIR)
 
+    @unittest.skipIf(six.PY3, "Python2 test")
     def test_shell_out(self):
         path = os.path.join(TEST_DIR, 'test_exe.py')
         self.assertEquals("executed\n", shell_out(path))


### PR DESCRIPTION
Debian/Ubuntu latest release are python3 only by default.

Causing the following during unittest run:

```
$ nosetests3 -v --with-cover --cover-package=sos --cover-html
======================================================================
FAIL: test_output (utilities_tests.ExecutableTest)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/tmp/gh/sos-3.9/tests/utilities_tests.py", line 62, in test_output
self.assertEquals(result['status'], 0)
AssertionError: 127 != 0

======================================================================
FAIL: test_shell_out (utilities_tests.ExecutableTest)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/tmp/gh/sos-3.9/tests/utilities_tests.py", line 80, in test_shell_out
self.assertEquals("executed\n", shell_out(path))
AssertionError: 'executed\n' != ''
- executed
```

Closes: #1949 

Co-authored-by: Louis Bouchard <louis@ubuntu.com>
Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
