### PR TITLE
[Plugin] Collect plugin service status by default

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1604,6 +1604,17 @@ class Plugin(object):
         only if manually specified in the command line."""
         return True
 
+    def add_default_collections(self):
+        """Based on the class attrs defined for plugin enablement, add a
+        standardized set of collections before we call the plugin's own setup()
+        method.
+        """
+        # For any service used for enablement checks, collect its current
+        # status if it exists
+        for service in self.services:
+            if self.is_service(service):
+                self.add_service_status(service)
+
     def setup(self):
         """Collect the list of files declared by the plugin. This method
         may be overridden to add further copy_specs, forbidden_paths, and

--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -116,7 +116,6 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph %s --format json-pretty" % s for s in ceph_cmds
         ], subdir="json_output")
 
-        self.add_service_status(self.services)
         for service in self.services:
             self.add_journal(units=service)
 

--- a/sos/plugins/maas.py
+++ b/sos/plugins/maas.py
@@ -66,8 +66,6 @@ class Maas(Plugin, UbuntuPlugin):
             "apt-cache policy python-django-*",
         ])
 
-        self.add_service_status(self.services)
-
         for service in self.services:
             self.add_journal(units=service)
 

--- a/sos/sosreport.py
+++ b/sos/sosreport.py
@@ -977,6 +977,7 @@ class SoSReport(object):
         for plugname, plug in self.loaded_plugins:
             try:
                 plug.archive = self.archive
+                plug.add_default_collections()
                 plug.setup()
                 self.env_vars.update(plug._env_vars)
                 if self.opts.verify:


### PR DESCRIPTION
By default, plugins will now capture service status information from the
init system for any services defined in the plugin's `services` member,
provided that that service actually exists on the system.

This is done by calling a new method, `add_default_collections()` before
we call `Plugin.setup()` for each plugin. This will allow us to more
easily extend default collection behaviors going forward.

Resolves: #1965

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
