### PR TITLE
[openvswitch] Collect ovs threads list in ps and in procfs

### DIFF
--- a/sos/plugins/openvswitch.py
+++ b/sos/plugins/openvswitch.py
@@ -41,6 +41,18 @@ class OpenVSwitch(Plugin):
             "/run/openvswitch/ovsdb-server.pid",
             "/run/openvswitch/ovs-vswitchd.pid"
         ])
+        proc_files = ["environ", "cgroup", "maps", "numa_maps", "limits",
+                      "status"]
+        with open("/var/run/openvswitch/ovs-vswitchd.pid", 'r') as pidfile:
+            pid = pidfile.readline().splitlines()[0]
+            # List TID & thread command name.
+            self.add_copy_spec(["/proc/%s/task/*/%s"
+                                % (pid, pf) for pf in proc_files])
+
+        ps_Lo = "ps -p %s -Lo" % pid
+        ps_sched_opts = "pid,tid,user,pcpu,psr,trs,rss,size,sz,drs,vsz,"
+        ps_sched_opts += "maj_flt,min_flt,class,rtprio,ni,pri,stat,wchan:20,"
+        ps_sched_opts += "flags,comm"
 
         self.add_cmd_output([
             # The '-s' option enables dumping of packet counters on the
@@ -95,7 +107,9 @@ class OpenVSwitch(Plugin):
             # Capture DPDK pmd stats
             "ovs-appctl dpif-netdev/pmd-stats-show",
             # Capture DPDK pmd performance counters
-            "ovs-appctl dpif-netdev/pmd-perf-show"
+            "ovs-appctl dpif-netdev/pmd-perf-show",
+            # Collect ovs-vswitchd thread details in ps command.
+            "%s %s" % (ps_Lo, ps_sched_opts)
         ])
 
         # Gather systemd services logs


### PR DESCRIPTION
Get detailed ps output of all ovs-vswitchd threads including last cpu
known to run on, priority etc from ps. Also copy 
/proc/<ovs-vswitchd thread id>/{environ,cgroup,maps,numa_maps,limits,
status} to indicate configured cpu affinity and other details.
These information are critical for troubleshooting NFVi openstack
deployments.

Fixes: #1687
Signed-off-by: Jaison Raju <jraju@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ x] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
