### PR TITLE
[qpid] adding the consumed storage size

### DIFF
--- a/sos/plugins/qpid.py
+++ b/sos/plugins/qpid.py
@@ -58,7 +58,8 @@ class Qpid(Plugin, RedHatPlugin):
             "qpid-route route list" + options,
             "qpid-cluster" + options,  # applies to pre-0.22 versions
             "qpid-ha query" + options,  # applies since 0.22 version
-            "ls -lanR /var/lib/qpidd"
+            "ls -lanR /var/lib/qpidd",
+            "du -sh /var/lib/qpidd/.qpidd/*"
         ])
 
         self.add_copy_spec([


### PR DESCRIPTION
Here we are collecting the consumed disk area, very useful when doing Satellite troubleshooting.
```
# du -sh /var/lib/qpidd/.qpidd/*
```
Resolves: #1971
