### PR TITLE
[Plugin|Predicate] Do not collect empty files and add arch sensitivity to Plugin/Predicate

### DIFF
--- a/sos/plugins/__init__.py
+++ b/sos/plugins/__init__.py
@@ -1256,6 +1256,10 @@ class Plugin(object):
                         poller=self.check_timeout
                     )
             self._log_debug("could not run '%s': command not found" % cmd)
+            # Exit here if the command was not found in the chroot check above
+            # as otherwise we will create a blank file in the archive
+            if result['status'] in [126, 127]:
+                return result
 
         self._log_debug("collected output of '%s' in %s (changes=%s)"
                         % (cmd.split()[0], time() - start, changes))

--- a/sos/plugins/iprconfig.py
+++ b/sos/plugins/iprconfig.py
@@ -10,7 +10,6 @@
 
 import re
 from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
-from sos.utilities import is_executable
 
 
 class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
@@ -18,12 +17,11 @@ class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     """
 
     plugin_name = 'iprconfig'
-
-    def check_enabled(self):
-        arch = self.policy.get_arch()
-        return "ppc64" in arch and is_executable("iprconfig")
+    packages = ('iprutils',)
+    architectures = ('ppc64.*',)
 
     def setup(self):
+
         self.add_cmd_output([
             "iprconfig -c show-config",
             "iprconfig -c show-alt-config",

--- a/sos/plugins/pci.py
+++ b/sos/plugins/pci.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+import os
 
 
 class Pci(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
@@ -23,7 +24,8 @@ class Pci(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "/proc/bus/pci"
         ])
 
-        self.add_cmd_output("lspci -nnvv", root_symlink="lspci")
-        self.add_cmd_output("lspci -tv")
+        if os.path.isdir("/proc/bus/pci/00"):
+            self.add_cmd_output("lspci -nnvv", root_symlink="lspci")
+            self.add_cmd_output("lspci -tv")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/plugins/powerpc.py
+++ b/sos/plugins/powerpc.py
@@ -19,9 +19,7 @@ class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     plugin_name = 'powerpc'
     profiles = ('system', 'hardware')
-
-    def check_enabled(self):
-        return "ppc64" in self.policy.get_arch()
+    architectures = ('ppc.*',)
 
     def setup(self):
         try:


### PR DESCRIPTION
One of our support engineers found that sos was writing empty `lspci` and similar files to the archive when sos was run on ppc/s390 systems.

The command does not exist on those systems, so normally we should have just skipped any output writing, however it was found that if a suggest_filename or root_symlink was specified, we'd write an empty file.

Fixing that led to some architecture fixups in plugins, which in turn then led me to extend `SoSPredicate` to not only allow for architecture checks, but also to include _negative_ predicate checks to allow plugins to specify architectures specific commands can't run on, rather than having to whitelist the ones it can run on.

That then got me thinking of extending the `Plugin` enablement checks to be architecture sensitive as well.

In other words, I went down the rabbit hole on an otherwise straight forward patch and this patchset now:

* Fixes writing empty files to the archive when a command is not found.
* Extends `SoSPredicate` to allow for architecture restraints
* Extends `SoSPredicate` to allow negative checks, I.E. 'collect this only if $thing is **not** present/true'
* Extends `Plugin` to allow an `architectures` tuple to specify what arches to enable on, just like `packages`, `services`, `files`, etc...
* Updates the `powerpc`, `pci`, and `iprconfig` plugins to take advantage of the above.


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
