### PR TITLE
[selinux] collect /var/lib/selinux

### DIFF
--- a/sos/plugins/selinux.py
+++ b/sos/plugins/selinux.py
@@ -23,7 +23,8 @@ class SELinux(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_spec([
             '/etc/sestatus.conf',
-            '/etc/selinux'
+            '/etc/selinux',
+            '/var/lib/selinux'
         ])
         self.add_cmd_output('sestatus')
 


### PR DESCRIPTION
On RHEL 8, modules and contexts are not in /etc/selinux/<policy>
directory anymore, but in /var/lib/selinux/<policy> directory.

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
