### PR TITLE
[sar] Fix "sar: could not list /var/log/sa/*" warning

### DIFF
--- a/sos/plugins/sar.py
+++ b/sos/plugins/sar.py
@@ -18,12 +18,12 @@ class Sar(Plugin,):
     profiles = ('system', 'performance')
 
     packages = ('sysstat',)
-    sa_path = '/var/log/sa/*'
+    sa_path = '/var/log/sa'
     option_list = [("all_sar", "gather all system activity records",
                     "", False)]
 
     def setup(self):
-        self.add_copy_spec(self.sa_path,
+        self.add_copy_spec(os.path.join(self.sa_path, '*'),
                            sizelimit=0 if self.get_option("all_sar") else None,
                            tailit=False)
 
@@ -56,11 +56,11 @@ class Sar(Plugin,):
 
 class RedHatSar(Sar, RedHatPlugin):
 
-    sa_path = '/var/log/sa/*'
+    sa_path = '/var/log/sa'
 
 
 class DebianSar(Sar, DebianPlugin, UbuntuPlugin):
 
-    sa_path = '/var/log/sysstat/*'
+    sa_path = '/var/log/sysstat'
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Commit d334c5dedbcf ("[sar] Fix the parameter specified in
add_copy_spec() to wildcard") appended the wildcard to the sa_path.
But since it is passed to os.listdir() as is, the following warning
is printed and later commands are not collected.

  [plugin:sar] sar: could not list /var/log/sa/*

Resolves: #1978

Signed-off-by: Kazuhito Hagio <k-hagio-ab@nec.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
