### PR TITLE
[lxd] Drop db collection and introduce lxd.buginfo

### DIFF
--- a/sos/plugins/lxd.py
+++ b/sos/plugins/lxd.py
@@ -19,34 +19,26 @@ class LXD(Plugin, UbuntuPlugin):
     packages = ('lxd',)
     commands = ('lxd',)
 
-    # Version 2.0.X:
-    # - /etc/default/lxd-bridge
-    # - /var/lib/lxd/lxd.db
-    #
-    # Version 3.0.X:
-    # - /var/lib/lxd/database/local.db
-    # - /var/lib/lxd/database/global/*
-    # - lxd-bridge no longer exist.
-    #
     def setup(self):
-        self.add_copy_spec([
-            "/etc/default/lxd-bridge",
-            "/var/lib/lxd/lxd.db",
-            "/var/lib/lxd/database/local.db",
-            "/var/lib/lxd/database/global/*",
-            "/var/log/lxd/*"
-        ])
+        snap_list = self.exec_cmd('snap list lxd')
+        if snap_list["status"] == 0:
+            self.add_cmd_output("lxd.buginfo")
+        else:
+            self.add_copy_spec([
+                "/etc/default/lxd-bridge",
+                "/var/log/lxd/*"
+            ])
 
-        self.add_cmd_output([
-            "lxc image list",
-            "lxc list",
-            "lxc network list",
-            "lxc profile list",
-            "lxc storage list"
-        ])
+            self.add_cmd_output([
+                "lxc image list",
+                "lxc list",
+                "lxc network list",
+                "lxc profile list",
+                "lxc storage list"
+            ])
 
-        self.add_cmd_output([
-            "find /var/lib/lxd -maxdepth 2 -type d -ls",
-        ], suggest_filename='var-lxd-dirs.txt')
+            self.add_cmd_output([
+                "find /var/lib/lxd -maxdepth 2 -type d -ls",
+            ], suggest_filename='var-lxd-dirs.txt')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The content of lxd database is rarely useful unless DB corruption
and can get very large.

This can be run manually if needed (outside sosreport).

lxd.buginfo command would have the advantage of not needing
updates whenever lxd upstream add a new feature or find something
new that’s worth capturing.

LXD upstream reference:
https://discuss.linuxcontainers.org/t/what-lxd-information-should-be-collected-by-sosreport/7087

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
