### PR TITLE
[tests] Make simple.sh consistent

### DIFF
--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -11,7 +11,6 @@
 # * look into using a framework..
 # * why --dry-run fails?
 # * why --experimental fails?
-# * https://github.com/sosreport/sos/issues/1921
 # * make it better validate archives and contents
 
 PYTHON=${1:-/usr/bin/python3}
@@ -93,14 +92,7 @@ run_expecting_sucess " --batch   --build   --no-env-vars "  # Only --build test
 run_expecting_sucess " --batch   --no-report   -o hardware " extract
 run_expecting_sucess " --batch   --label TEST   -a  -c never" extract
 run_expecting_sucess " --batch   --debug  --log-size 0  -c always" extract
-
-# Workaround Travis bug (requires -n lxd)
-if [ $TRAVIS = true ]; then
-    run_expecting_sucess " --batch   -z xz   --log-size 1 -n lxd" extract
-else
-    run_expecting_sucess " --batch   -z xz   --log-size 1" extract
-fi
-
+run_expecting_sucess " --batch   -z xz   --log-size 1" extract
 run_expecting_sucess " --batch   -z gzip" extract
 run_expecting_sucess " --batch   -z bzip2   -t 1 -n hardware" extract
 run_expecting_sucess " --batch   --quiet    -e opencl -k kernel.with-timer" extract


### PR DESCRIPTION
We no longer have to workaround an odd LXD/Travis interaction
so make simple.sh not treat Travis special.

Closes: #1921
Resolves: #1983

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
