### PR TITLE
[hardware] Add output of lshw

### DIFF
--- a/sos/plugins/hardware.py
+++ b/sos/plugins/hardware.py
@@ -29,6 +29,7 @@ class Hardware(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         ])
 
         self.add_cmd_output("dmidecode", root_symlink="dmidecode")
+        self.add_cmd_output("lshw")
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This plugin adds the output of the command
lshw, and its output complements what we
already collect with dmidecode.

Resolves: #1994
Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
