### PR TITLE
[rabbitmq] Do not run exec for stopped containers

### DIFF
--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -23,7 +23,7 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         container_status = self.exec_cmd(
-            "docker ps -a --format='{{ .Names }}'"
+            "docker ps --format='{{ .Names }}'"
         )
 
         in_container = False


### PR DESCRIPTION
Currently rabbitmq plugin invokes rabbitmqctl command by docker exec
for all containers whose name start with rabbitmq, but it always tries
to run commands agaist stopped containers, which can never succeed.

This patch makes sure that the plugin only use running containers,
to avoid useless trial with stopped containers.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X ] Is the subject and message clear and concise?
- [ X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ X ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
