### PR TITLE
[global] Drop use of __future__

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 import re
 import platform

--- a/sos/policies/amazon.py
+++ b/sos/policies/amazon.py
@@ -8,9 +8,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-# This enables the use of with syntax in python 2.5 (e.g. jython)
-from __future__ import print_function
-
 from sos.policies.redhat import RedHatPolicy, OS_RELEASE
 import os
 

--- a/sos/policies/ibmkvm.py
+++ b/sos/policies/ibmkvm.py
@@ -10,8 +10,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from __future__ import print_function
-
 from sos.report.plugins import PowerKVMPlugin, ZKVMPlugin, RedHatPlugin
 from sos.policies.redhat import RedHatPolicy
 

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -8,8 +8,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-# This enables the use of with syntax in python 2.5 (e.g. jython)
-from __future__ import print_function
 import os
 import sys
 import re

--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -7,8 +7,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-# This enables the use of with syntax in python 2.5 (e.g. jython)
-from __future__ import print_function
 import os
 import sys
 

--- a/sos/policies/ubuntu.py
+++ b/sos/policies/ubuntu.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 from sos.report.plugins import UbuntuPlugin, DebianPlugin
 from sos.policies.debian import DebianPolicy
 

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -10,8 +10,6 @@
 
 """ This exports methods available for use by plugins for sos """
 
-from __future__ import with_statement
-
 from sos.utilities import (sos_get_command_output, import_module, grep,
                            fileobj, tail, is_executable)
 import os

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -6,8 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from __future__ import with_statement
-
 import os
 import re
 import inspect


### PR DESCRIPTION
This was used either to
 * get the print function
 * get the with function (for py2.5)

Resolves: #2005

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
