### PR TITLE
[landscape] simplify and remove deprecated log dir

### DIFF
--- a/sos/report/plugins/landscape.py
+++ b/sos/report/plugins/landscape.py
@@ -19,21 +19,25 @@ class Landscape(Plugin, UbuntuPlugin):
     packages = ('landscape-client', 'landscape-server')
 
     def setup(self):
-        self.add_copy_spec("/etc/landscape/client.conf")
-        self.add_copy_spec("/etc/default/landscape-client")
-        self.add_copy_spec("/etc/landscape/service.conf")
-        self.add_copy_spec("/etc/landscape/service.conf.old")
-        self.add_copy_spec("/etc/default/landscape-server")
-        self.add_copy_spec("/var/lib/landscape/landscape-oops/*/OOPS-*")
+        self.add_copy_spec([
+            "/etc/default/landscape-client",
+            "/etc/default/landscape-server",
+            "/etc/landscape/client.conf",
+            "/etc/landscape/service.conf",
+            "/etc/landscape/service.conf.old",
+            "/var/lib/landscape/landscape-oops/*/OOPS-*"
+        ])
+
         if not self.get_option("all_logs"):
             self.add_copy_spec("/var/log/landscape/*.log")
-            self.add_copy_spec("/var/log/landscape-server/*.log")
         else:
             self.add_copy_spec("/var/log/landscape")
-            self.add_copy_spec("/var/log/landscape-server")
-        self.add_cmd_output("gpg --verify /etc/landscape/license.txt")
-        self.add_cmd_output("head -n 5 /etc/landscape/license.txt")
-        self.add_cmd_output("lsctl status")
+
+        self.add_cmd_output([
+            "gpg --verify /etc/landscape/license.txt",
+            "head -n 5 /etc/landscape/license.txt",
+            "lsctl status"
+        ])
 
     def postproc(self):
         self.do_file_sub(


### PR DESCRIPTION
* Make add_copy_spec & add_cmd_output method
to accept a list.

* Log directory "/var/log/landscape-server" is
now fully deprecated. Nowadays, all supported
versions are logging inside "/var/log/landscape".

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
