### PR TITLE
[redis] Collection of redis from scl

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1950,8 +1950,9 @@ class SCLPlugin(RedHatPlugin):
         scl_prefix = self.policy.get_default_scl_prefix()
         for rootdir in ['etc', 'var']:
             p = re.compile('^/%s/' % rootdir)
-            copyspec = p.sub('/%s/%s/%s/' % (rootdir, scl_prefix, scl),
-                             copyspec)
+            copyspec = os.path.abspath(p.sub('/%s/%s/%s/' %
+                                       (rootdir, scl_prefix, scl),
+                                       copyspec))
         return copyspec
 
     def add_copy_spec_scl(self, scl, copyspecs):

--- a/sos/report/plugins/redis.py
+++ b/sos/report/plugins/redis.py
@@ -9,23 +9,19 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, SCLPlugin
 
 
-class Redis(Plugin, RedHatPlugin):
+class Redis(Plugin, SCLPlugin):
 
     short_desc = 'Redis, in-memory data structure store'
 
     plugin_name = 'redis'
     profiles = ('services',)
 
-    packages = ('redis',)
+    packages = ('redis', 'rh-redis32', 'rh-redis5')
+
     var_puppet_gen = "/var/lib/config-data/puppet-generated/redis"
-    files = (
-        '/etc/redis.conf',
-        '/var/log/redis',
-        var_puppet_gen + '/etc/redis.conf'
-    )
 
     def setup(self):
         self.add_copy_spec([
@@ -34,6 +30,17 @@ class Redis(Plugin, RedHatPlugin):
             self.var_puppet_gen + "/etc/redis/",
             self.var_puppet_gen + "/etc/security/limits.d/"
         ])
+
+        for pkg in self.packages[1:]:
+            scl = pkg.split('rh-redis*-')[0]
+            self.add_copy_spec_scl(scl, [
+                '/etc/redis.conf',
+                '/etc/redis.conf.puppet',
+                '/etc/redis-sentinel.conf',
+                '/etc/redis-sentinel.conf.puppet',
+                '/var/log/redis/sentinel.log',
+                '/var/log/redis/redis.log'
+            ])
 
         self.add_cmd_output("redis-cli info")
         if self.get_option("all_logs"):
@@ -46,26 +53,19 @@ class Redis(Plugin, RedHatPlugin):
             ])
 
     def postproc(self):
-        self.do_file_sub(
-            "/etc/redis.conf",
-            r"(masterauth\s).*",
-            r"\1********"
-        )
-        self.do_file_sub(
-            "/etc/redis.conf",
-            r"(requirepass\s).*",
-            r"\1********"
-        )
-        self.do_path_regex_sub(
-            self.var_puppet_gen + "/etc/redis.conf*",
-            r"(masterauth\s).*",
-            r"\1*********"
-        )
-        self.do_path_regex_sub(
-            self.var_puppet_gen + "/etc/redis.conf*",
-            r"(requirepass\s).*",
-            r"\1*********"
-        )
-
+        for path in ["/etc/",
+                     self.var_puppet_gen + "/etc/",
+                     "/etc/opt/rh/rh-redis32/",
+                     "/etc/opt/rh/rh-redis5/"]:
+            self.do_file_sub(
+                path + "redis.conf",
+                r"(masterauth\s).*",
+                r"\1********"
+            )
+            self.do_file_sub(
+                path + "redis.conf",
+                r"(requirepass\s).*",
+                r"requirepass = ********"
+            )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
As preparation for Satellite 7 configuration and log
collection adding collection of rh-redis32 from scl.

Also adding fix to __init__.py convert_copyspec_scl
method which prevented of postproc due to
"//" instead of "/".

Resolves: #2016

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
