### PR TITLE
[navicli] replace interactive prompt by plugin option

### DIFF
--- a/sos/report/plugins/navicli.py
+++ b/sos/report/plugins/navicli.py
@@ -19,6 +19,8 @@ class Navicli(Plugin, RedHatPlugin):
 
     plugin_name = 'navicli'
     profiles = ('storage', 'hardware')
+    option_list = [("ipaddrs", "list of space separated CLARiiON IP addresses",
+                    '', "")]
 
     def check_enabled(self):
         return is_executable("navicli")
@@ -57,30 +59,8 @@ class Navicli(Plugin, RedHatPlugin):
 
     def setup(self):
         self.get_navicli_config()
-        CLARiiON_IP_address_list = []
-        CLARiiON_IP_loop = "stay_in"
-        while CLARiiON_IP_loop == "stay_in":
-            try:
-                ans = input("CLARiiON SP IP Address or [Enter] to exit: ")
-            except Exception:
-                return
-            if self.exec_cmd("navicli -h %s getsptime" % (ans,))['status']:
-                CLARiiON_IP_address_list.append(ans)
-            else:
-                if ans != "":
-                    print("The IP address you entered, %s, is not to an "
-                          "active CLARiiON SP." % ans)
-                if ans == "":
-                    CLARiiON_IP_loop = "get_out"
-        # Sort and dedup the list of CLARiiON IP Addresses
-        CLARiiON_IP_address_list.sort()
-        for SP_address in CLARiiON_IP_address_list:
-            if CLARiiON_IP_address_list.count(SP_address) > 1:
-                CLARiiON_IP_address_list.remove(SP_address)
-        for SP_address in CLARiiON_IP_address_list:
-            if SP_address != "":
-                print(" Gathering NAVICLI information for %s..." %
-                      SP_address)
-                self.get_navicli_SP_info(SP_address)
+        for ip in set(self.get_option("ipaddrs").split()):
+            if self.exec_cmd("navicli -h %s getsptime" % (ip))['status'] == 0:
+                self.get_navicli_SP_info(ip)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
List of ClariiOn IP addresses should be provided via
-k navicli.ipaddrs plugopt, as a space separated list.

Resolves: #2020

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
