### PR TITLE
[freeipmi] Add freeipmi support

### DIFF
--- a/sos/report/plugins/freeipmi.py
+++ b/sos/report/plugins/freeipmi.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2020 Canonical Ltd. Arif Ali <arif.ali@canonical.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, UbuntuPlugin
+
+
+class Freeipmi(Plugin, UbuntuPlugin):
+    """Freeipmi hardware information.
+    """
+
+    plugin_name = 'freeipmi'
+    profiles = ('hardware', 'system', )
+
+    packages = ('freeipmi-tools',)
+
+    def setup(self):
+
+        self.add_cmd_output([
+            "bmc-info",
+            "ipmi-sel",
+            "ipmi-sensors",
+            "ipmi-chassis --get-status",
+            "ipmi-fru",
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add freeipmi support, as freeipmi is in main for Ubuntu, and ipmitool is in universe

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
