### PR TITLE
[landscape] Substitute oidc conf in service file

### DIFF
--- a/sos/report/plugins/landscape.py
+++ b/sos/report/plugins/landscape.py
@@ -61,6 +61,16 @@ class Landscape(Plugin, UbuntuPlugin):
             r"secret-token = [********]"
         )
         self.do_file_sub(
+            "/etc/landscape/service.conf",
+            r"oidc-client-secret = (.*)",
+            r"oidc-client-secret = [********]"
+        )
+        self.do_file_sub(
+            "/etc/landscape/service.conf",
+            r"oidc-client-id = (.*)",
+            r"oidc-client-id = [********]"
+        )
+        self.do_file_sub(
             "/etc/landscape/service.conf.old",
             r"password = (.*)",
             r"password = [********]"
@@ -74,6 +84,16 @@ class Landscape(Plugin, UbuntuPlugin):
             "/etc/landscape/service.conf.old",
             r"secret-token = (.*)",
             r"secret-token = [********]"
+        )
+        self.do_file_sub(
+            "/etc/landscape/service.conf.old",
+            r"oidc-client-secret = (.*)",
+            r"oidc-client-secret = [********]"
+        )
+        self.do_file_sub(
+            "/etc/landscape/service.conf.old",
+            r"oidc-client-id = (.*)",
+            r"oidc-client-id = [********]"
         )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Substitute sensitive informations about oidc
found in landscape service configuration file.

From release 19.10, Landscape can use OpenID-Connect
(OIDC) to authenticate users. To enable OpenID-Connect
support, please add oidc-issuer, oidc-client-id and
oidc-client-secret to /etc/landscape/service.conf in
the [landscape] section.

Reference:
https://docs.ubuntu.com/landscape/en/onprem-auth#openid-connect-support

Resolves: #2023

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
