### PR TITLE
[redhat] fix RH containers without sysroot

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -134,7 +134,7 @@ class RedHatPolicy(LinuxPolicy):
                 self._in_container = True
         if ENV_HOST_SYSROOT in os.environ:
             self._host_sysroot = os.environ[ENV_HOST_SYSROOT]
-        use_sysroot = self._in_container and self._host_sysroot != '/'
+        use_sysroot = self._in_container and self._host_sysroot is not None
         if use_sysroot:
             host_tmp_dir = os.path.abspath(self._host_sysroot + self._tmp_dir)
             self._tmp_dir = host_tmp_dir


### PR DESCRIPTION
Attempting to run sosreport in a container currently will always
traceback unless ENV_HOST_SYSROOT is set to '/'.

Allow default NoneType sysroot to function as well.

Signed off by: Robb Manes <rmanes@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?

Attempting to run sosreport in a RHEL container will fail unless `HOST_ENV_SYSROOT` is explicitly set to `/`; if one desires to run an sosreport inside of a container to get container-specific values, then it will traceback:
```
$ podman run -it --rm --name sosreport registry.redhat.io/rhel8/support-tools bash
[root@9e2c299cf1c4 /]# sosreport 
Traceback (most recent call last):
  File "/usr/sbin/sosreport", line 19, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python3.6/site-packages/sos/sosreport.py", line 1383, in main
    sos = SoSReport(args)
  File "/usr/lib/python3.6/site-packages/sos/sosreport.py", line 287, in __init__
    self.policy = sos.policies.load(sysroot=self.opts.sysroot)
  File "/usr/lib/python3.6/site-packages/sos/policies/__init__.py", line 44, in load
    cache['policy'] = policy(sysroot=sysroot)
  File "/usr/lib/python3.6/site-packages/sos/policies/redhat.py", line 259, in __init__
    super(RHELPolicy, self).__init__(sysroot=sysroot)
  File "/usr/lib/python3.6/site-packages/sos/policies/redhat.py", line 50, in __init__
    sysroot = self._container_init()
  File "/usr/lib/python3.6/site-packages/sos/policies/redhat.py", line 145, in _container_init
    host_tmp_dir = os.path.abspath(self._host_sysroot + self._tmp_dir)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
This is fixed by not just checking for `/` but just allowing `NoneType` default sysroot to function as well.  Let me know if adjustments should be made to this for a scenario I didn't think of, but I can't see why we'd only allow either no sysroot or `/` explicitly, and if we do, we probably shouldn't traceback but fail gracefully.
```
# sosreport 
sosreport (version 3.7)
- - - - 8< - - - -
 Setting up archive ...
 Setting up plugins ...
- - - - 8< - - - -
writing traceback to sos_logs/usb-plugin-errors.txt
caught exception in plugin method "x11.setup()"
writing traceback to sos_logs/x11-plugin-errors.txt
caught exception in plugin method "xfs.setup()"
writing traceback to sos_logs/xfs-plugin-errors.txt
caught exception in plugin method "yum.setup()"
writing traceback to sos_logs/yum-plugin-errors.txt
 Running plugins. Please wait ...

  Finishing plugins              [Running: systemd]                                       
  Finished running plugins                                                               
caught exception in plugin method "filesys.postproc()"
writing traceback to sos_logs/filesys-plugin-errors.txt
caught exception in plugin method "ldap.postproc()"
writing traceback to sos_logs/ldap-plugin-errors.txt
caught exception in plugin method "openhpi.postproc()"
writing traceback to sos_logs/openhpi-plugin-errors.txt
caught exception in plugin method "openshift.postproc()"
writing traceback to sos_logs/openshift-plugin-errors.txt
caught exception in plugin method "openssl.postproc()"
writing traceback to sos_logs/openssl-plugin-errors.txt
Creating compressed archive...
```