### PR TITLE
[insights] collect insights-client dump

### DIFF
--- a/sos/plugins/insights.py
+++ b/sos/plugins/insights.py
@@ -31,6 +31,10 @@ class RedHatInsights(Plugin, RedHatPlugin):
         else:
             self.add_copy_spec("/var/log/insights-client/insights-client.log")
 
+        # Collect insights-client report data into given dump dir
+        path = self.get_cmd_output_path(name="insights-client-dump")
+        self.add_cmd_output("insights-client --offline --output-dir %s" % path)
+
     def postproc(self):
         for conf in self.config:
             self.do_file_sub(


### PR DESCRIPTION
Collect data of "insights-client --offline" into
sos_commands/insights/insights-client-dump directory.

Related: #2030

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
