### PR TITLE
[sos] Don't double log error level messages

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -202,7 +202,9 @@ class SoSComponent():
             else:
                 console.setLevel(logging.WARNING)
             self.soslog.addHandler(console)
-            # log ERROR or higher logs to stderr instead
+        # still log ERROR level message to console, but only setup this handler
+        # when --quiet is used, as otherwise we'll double log
+        else:
             console_err = logging.StreamHandler(sys.stderr)
             console_err.setFormatter(logging.Formatter('%(message)s'))
             console_err.setLevel(logging.ERROR)


### PR DESCRIPTION
Only set the logging handler that prints ERROR level messages to console
if we're running in quiet mode, as otherwise we'll double log from the
normal console handler.

Closes: #1999
Resolves: #2033

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
