### PR TITLE
[plugins] Convert docstrings to class attrs

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1709,9 +1709,7 @@ class Plugin(object):
     def get_description(self):
         """ This function will return the description for the plugin"""
         try:
-            if hasattr(self, '__doc__') and self.__doc__:
-                return self.__doc__.strip()
-            return super(self.__class__, self).__doc__.strip()
+            return self.short_desc
         except Exception:
             return "<no description available>"
 

--- a/sos/report/plugins/abrt.py
+++ b/sos/report/plugins/abrt.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Abrt(Plugin, RedHatPlugin):
-    """Automatic Bug Reporting Tool
-    """
+
+    short_desc = 'Automatic Bug Reporting Tool'
 
     plugin_name = "abrt"
     profiles = ('system', 'debug')

--- a/sos/report/plugins/acpid.py
+++ b/sos/report/plugins/acpid.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Acpid(Plugin):
-    """ACPI daemon information"""
+
+    short_desc = 'ACPI daemon information'
     plugin_name = "acpid"
     profiles = ('hardware',)
     packages = ('acpid',)

--- a/sos/report/plugins/activemq.py
+++ b/sos/report/plugins/activemq.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class ActiveMq(Plugin, DebianPlugin):
-    """ActiveMQ message broker
-    """
+
+    short_desc = 'ActiveMQ message broker'
 
     plugin_name = 'activemq'
     profiles = ('openshift',)

--- a/sos/report/plugins/alternatives.py
+++ b/sos/report/plugins/alternatives.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Alternatives(Plugin, RedHatPlugin):
-    """System alternatives
-    """
+
+    short_desc = 'System alternatives'
 
     packages = ('chkconfig',)
     commands = ('alternatives',)

--- a/sos/report/plugins/anaconda.py
+++ b/sos/report/plugins/anaconda.py
@@ -11,8 +11,8 @@ import os
 
 
 class Anaconda(Plugin, RedHatPlugin):
-    """Anaconda installer
-    """
+
+    short_desc = 'Anaconda installer'
 
     plugin_name = 'anaconda'
     profiles = ('system',)

--- a/sos/report/plugins/anacron.py
+++ b/sos/report/plugins/anacron.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Anacron(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Anacron job scheduling service"""
+
+    short_desc = 'Anacron job scheduling service'
 
     plugin_name = 'anacron'
     profiles = ('system',)

--- a/sos/report/plugins/ansible.py
+++ b/sos/report/plugins/ansible.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class Ansible(Plugin, RedHatPlugin, UbuntuPlugin):
-    """Ansible configuration management
-    """
+
+    short_desc = 'Ansible configuration management'
 
     plugin_name = 'ansible'
     profiles = ('system',)

--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Apache(Plugin):
-    """Apache http daemon
-    """
+
+    short_desc = 'Apache http daemon'
     plugin_name = "apache"
     profiles = ('webserver', 'openshift')
     packages = ('httpd',)

--- a/sos/report/plugins/apparmor.py
+++ b/sos/report/plugins/apparmor.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class Apparmor(Plugin, UbuntuPlugin):
-    """Apparmor mandatory access control
-    """
+
+    short_desc = 'Apparmor mandatory access control'
 
     plugin_name = 'apparmor'
     profiles = ('security',)

--- a/sos/report/plugins/apport.py
+++ b/sos/report/plugins/apport.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, DebianPlugin, UbuntuPlugin
 
 
 class Apport(Plugin, DebianPlugin, UbuntuPlugin):
-    """Apport crash reporting tool
-    """
+
+    short_desc = 'Apport crash reporting tool'
 
     plugin_name = 'apport'
     profiles = ('debug',)

--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin, DebianPlugin
 
 
 class Apt(Plugin, DebianPlugin, UbuntuPlugin):
-    """ APT - advanced packaging tool
-    """
+
+    short_desc = 'APT - advanced packaging tool'
 
     plugin_name = 'apt'
     profiles = ('system', 'sysmgmt', 'packagemanager')

--- a/sos/report/plugins/ata.py
+++ b/sos/report/plugins/ata.py
@@ -11,8 +11,8 @@ import os
 
 
 class Ata(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """ ATA and IDE information
-    """
+
+    short_desc = 'ATA and IDE information'
 
     plugin_name = "ata"
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/atomichost.py
+++ b/sos/report/plugins/atomichost.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class AtomicHost(Plugin, RedHatPlugin):
-    """ Atomic Host """
+
+    short_desc = 'Atomic Host'
 
     plugin_name = "atomichost"
     profiles = ('container',)

--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Auditd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Audit daemon information
-    """
+
+    short_desc = 'Audit daemon information'
 
     plugin_name = 'auditd'
     profiles = ('system', 'security')

--- a/sos/report/plugins/autofs.py
+++ b/sos/report/plugins/autofs.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Autofs(Plugin):
-    """Autofs on-demand automounter
-    """
+
+    short_desc = 'Autofs on-demand automounter'
 
     plugin_name = "autofs"
     profiles = ('storage', 'nfs')

--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin, RedHatPlugin
 
 
 class Azure(Plugin, UbuntuPlugin):
-    """ Microsoft Azure client
-    """
+
+    short_desc = 'Microsoft Azure client'
 
     plugin_name = 'azure'
     profiles = ('virt',)

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Block device information
-    """
+
+    short_desc = 'Block device information'
 
     plugin_name = 'block'
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/boom.py
+++ b/sos/report/plugins/boom.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Boom(Plugin, RedHatPlugin):
-    """Configuration data for the boom boot manager.
-    """
+
+    short_desc = 'Configuration data for the boom boot manager.'
 
     plugin_name = 'boom'
     profiles = ('boot', 'system')

--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -11,8 +11,8 @@ from glob import glob
 
 
 class Boot(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Bootloader information
-    """
+
+    short_desc = 'Bootloader information'
 
     plugin_name = 'boot'
     profiles = ('system', 'boot')

--- a/sos/report/plugins/btrfs.py
+++ b/sos/report/plugins/btrfs.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Btrfs(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """Btrfs filesystem
-    """
+
+    short_desc = 'Btrfs filesystem'
 
     plugin_name = 'btrfs'
     profiles = ('storage',)

--- a/sos/report/plugins/buildah.py
+++ b/sos/report/plugins/buildah.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Buildah(Plugin, RedHatPlugin):
-    """Buildah container and image builder
-    """
+
+    short_desc = 'Buildah container and image builder'
 
     plugin_name = 'buildah'
     packages = ('buildah',)

--- a/sos/report/plugins/candlepin.py
+++ b/sos/report/plugins/candlepin.py
@@ -14,7 +14,8 @@ from re import match
 
 
 class Candlepin(Plugin, RedHatPlugin):
-    """Candlepin entitlement management"""
+
+    short_desc = 'Candlepin entitlement management'
 
     plugin_name = 'candlepin'
     packages = ('candlepin',)

--- a/sos/report/plugins/canonical_livepatch.py
+++ b/sos/report/plugins/canonical_livepatch.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class CanonicaLivepatch(Plugin, UbuntuPlugin):
-    """Canonical Livepatch Service
-    """
+
+    short_desc = 'Canonical Livepatch Service'
 
     plugin_name = 'canonical_livepatch'
     profiles = ('system', 'kernel')

--- a/sos/report/plugins/ceph.py
+++ b/sos/report/plugins/ceph.py
@@ -11,8 +11,8 @@ from socket import gethostname
 
 
 class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
-    """CEPH distributed storage
-    """
+
+    short_desc = 'CEPH distributed storage'
 
     plugin_name = 'ceph'
     profiles = ('storage', 'virt')

--- a/sos/report/plugins/ceph_ansible.py
+++ b/sos/report/plugins/ceph_ansible.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class CephAnsible(Plugin, RedHatPlugin, DebianPlugin):
-    """CEPH distributed storage - Ansible installer
-    """
+
+    short_desc = 'CEPH distributed storage - Ansible installer'
 
     plugin_name = 'ceph_ansible'
     profiles = ('storage',)

--- a/sos/report/plugins/cgroups.py
+++ b/sos/report/plugins/cgroups.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Cgroups(Plugin, DebianPlugin, UbuntuPlugin):
-    """Control groups subsystem
-    """
+
+    short_desc = 'Control groups subsystem'
 
     plugin_name = "cgroups"
     profiles = ('container', 'system')

--- a/sos/report/plugins/chrony.py
+++ b/sos/report/plugins/chrony.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Chrony(Plugin):
-    """Chrony clock (for Network time protocol)
-    """
+
+    short_desc = 'Chrony clock (for Network time protocol)'
 
     plugin_name = "chrony"
     profiles = ('system', 'services')

--- a/sos/report/plugins/cifs.py
+++ b/sos/report/plugins/cifs.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Cifs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """SMB file system information
-    """
+
+    short_desc = 'SMB file system information'
     plugin_name = 'cifs'
     profiles = ('storage', 'network', 'cifs')
     packages = ['cifs-utils']

--- a/sos/report/plugins/clear_containers.py
+++ b/sos/report/plugins/clear_containers.py
@@ -14,8 +14,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 class ClearContainers(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin,
                       SuSEPlugin):
-    """Intel(R) Clear Containers configuration
-    """
+
+    short_desc = 'Intel(R) Clear Containers configuration'
 
     plugin_name = 'clear_containers'
     profiles = ('system', 'virt', 'container')

--- a/sos/report/plugins/cloud_init.py
+++ b/sos/report/plugins/cloud_init.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class CloudInit(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """cloud-init instance configurations
-    """
+
+    short_desc = 'cloud-init instance configurations'
 
     plugin_name = 'cloud_init'
     packages = ('cloud-init',)

--- a/sos/report/plugins/cman.py
+++ b/sos/report/plugins/cman.py
@@ -11,8 +11,8 @@ from glob import glob
 
 
 class Cman(Plugin, RedHatPlugin):
-    """cman based Red Hat Cluster High Availability
-    """
+
+    short_desc = 'cman based Red Hat Cluster High Availability'
 
     plugin_name = "cman"
     profiles = ("cluster",)

--- a/sos/report/plugins/cobbler.py
+++ b/sos/report/plugins/cobbler.py
@@ -14,8 +14,8 @@ class Cobbler(Plugin):
 
 
 class RedHatCobbler(Cobbler, RedHatPlugin):
-    """Cobbler installation server
-    """
+
+    short_desc = 'Cobbler installation server'
 
     packages = ('cobbler',)
     profiles = ('cluster', 'sysmgmt')

--- a/sos/report/plugins/cockpit.py
+++ b/sos/report/plugins/cockpit.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Cockpit(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Cockpit Web Service"""
+
+    short_desc = 'Cockpit Web Service'
 
     plugin_name = 'cockpit'
     packages = ('cockpit-ws', 'cockpit-system')

--- a/sos/report/plugins/collectd.py
+++ b/sos/report/plugins/collectd.py
@@ -12,9 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Collectd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """
-    Collectd config collector
-    """
+
+    short_desc = 'Collectd config collector'
     plugin_name = "collectd"
     profiles = ('services', 'webserver')
 

--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -2,8 +2,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Composer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Lorax Composer
-    """
+
+    short_desc = 'Lorax Composer'
 
     plugin_name = 'composer'
     profiles = ('sysmgmt', 'virt', )

--- a/sos/report/plugins/conntrackd.py
+++ b/sos/report/plugins/conntrackd.py
@@ -12,8 +12,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class Conntrackd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
-    """conntrackd - netfilter connection tracking user-space daemon
-    """
+
+    short_desc = 'conntrackd - netfilter connection tracking user-space daemon'
 
     plugin_name = 'conntrackd'
     profiles = ('network', 'cluster')

--- a/sos/report/plugins/console.py
+++ b/sos/report/plugins/console.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class Console(Plugin, RedHatPlugin, UbuntuPlugin):
-    """Console and keyboard information
-    """
+
+    short_desc = 'Console and keyboard information'
 
     plugin_name = 'console'
     profiles = ('system',)

--- a/sos/report/plugins/container_log.py
+++ b/sos/report/plugins/container_log.py
@@ -13,8 +13,8 @@ import os
 
 
 class ContainerLog(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """All container logs
-    """
+
+    short_desc = 'All logs under /var/log/containers'
     plugin_name = 'container_log'
     logdir = '/var/log/containers/'
     files = (logdir, )

--- a/sos/report/plugins/convert2rhel.py
+++ b/sos/report/plugins/convert2rhel.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class convert2rhel(Plugin, RedHatPlugin):
-    """Convert2RHEL
-    """
+
+    short_desc = 'Convert2RHEL'
     plugin_name = 'convert2rhel'
     profiles = ('system')
     packages = ('convert2rhel')

--- a/sos/report/plugins/corosync.py
+++ b/sos/report/plugins/corosync.py
@@ -12,8 +12,8 @@ import re
 
 
 class Corosync(Plugin):
-    """ Corosync cluster engine
-    """
+
+    short_desc = 'Corosync cluster engine'
 
     plugin_name = "corosync"
     profiles = ('cluster',)

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -13,9 +13,7 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, SoSPredicate
 
 class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
 
-    """CRI-O containers
-    """
-
+    short_desc = 'CRI-O containers'
     plugin_name = 'crio'
     profiles = ('container',)
     packages = ('cri-o', 'cri-tools')

--- a/sos/report/plugins/cron.py
+++ b/sos/report/plugins/cron.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Cron(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Cron job scheduler
-    """
+
+    short_desc = 'Cron job scheduler'
 
     plugin_name = "cron"
     profiles = ('system',)

--- a/sos/report/plugins/crypto.py
+++ b/sos/report/plugins/crypto.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Crypto(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """ System crypto services information
-    """
+
+    short_desc = 'System crypto services information'
 
     plugin_name = 'crypto'
     profiles = ('system', 'hardware')

--- a/sos/report/plugins/cs.py
+++ b/sos/report/plugins/cs.py
@@ -16,8 +16,8 @@ from glob import glob
 
 
 class CertificateSystem(Plugin, RedHatPlugin):
-    """Certificate System and Dogtag
-    """
+
+    short_desc = 'Certificate System and Dogtag'
 
     plugin_name = 'cs'
     profiles = ('identity', 'security')

--- a/sos/report/plugins/ctdb.py
+++ b/sos/report/plugins/ctdb.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ctdb(Plugin, DebianPlugin, UbuntuPlugin):
-    """Samba Clustered TDB
-    """
+
+    short_desc = 'Samba Clustered TDB'
     packages = ('ctdb',)
     profiles = ('cluster', 'storage')
     plugin_name = "ctdb"

--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Cups(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """CUPS IPP print service
-    """
+
+    short_desc = 'CUPS IPP print service'
 
     plugin_name = 'cups'
     profiles = ('hardware',)

--- a/sos/report/plugins/date.py
+++ b/sos/report/plugins/date.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class Date(Plugin, RedHatPlugin, DebianPlugin):
-    """Basic system time information
-    """
+
+    short_desc = 'Basic system time information'
 
     plugin_name = 'date'
 

--- a/sos/report/plugins/dbus.py
+++ b/sos/report/plugins/dbus.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Dbus(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """D-Bus message bus"""
+
+    short_desc = 'D-Bus message bus'
 
     plugin_name = "dbus"
     profiles = ('system',)

--- a/sos/report/plugins/devicemapper.py
+++ b/sos/report/plugins/devicemapper.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class DeviceMapper(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """device-mapper framework
-    """
+
+    short_desc = 'device-mapper framework'
 
     plugin_name = 'devicemapper'
     profiles = ('storage',)

--- a/sos/report/plugins/devices.py
+++ b/sos/report/plugins/devices.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Devices(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """ devices specific commands
-    """
+
+    short_desc = 'devices specific commands'
 
     plugin_name = 'devices'
     profiles = ('system', 'hardware', 'boot')

--- a/sos/report/plugins/dhcp.py
+++ b/sos/report/plugins/dhcp.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class Dhcp(Plugin):
-    """DHCP daemon
-    """
+
+    short_desc = 'DHCP daemon'
 
     plugin_name = "dhcp"
     profiles = ('network',)

--- a/sos/report/plugins/distupgrade.py
+++ b/sos/report/plugins/distupgrade.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class DistUpgrade(Plugin):
-    """ Distribution upgrade data """
+
+    short_desc = 'Distribution upgrade data'
 
     plugin_name = "distupgrade"
     profiles = ('system', 'sysmgmt')

--- a/sos/report/plugins/dlm.py
+++ b/sos/report/plugins/dlm.py
@@ -11,7 +11,8 @@ import re
 
 
 class Dlm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """DLM (Distributed lock manager)"""
+
+    short_desc = 'DLM (Distributed lock manager)'
 
     plugin_name = "dlm"
     profiles = ("cluster", )

--- a/sos/report/plugins/dmraid.py
+++ b/sos/report/plugins/dmraid.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Dmraid(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """dmraid software RAID
-    """
+
+    short_desc = 'dmraid software RAID'
 
     plugin_name = 'dmraid'
     profiles = ('hardware', 'storage')

--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class DNFPlugin(Plugin, RedHatPlugin):
-    """dnf package manager"""
+
+    short_desc = 'dnf package manager'
     plugin_name = "dnf"
     profiles = ('system', 'packagemanager', 'sysmgmt')
 

--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -13,9 +13,7 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, SoSPredicate
 
 class Docker(Plugin):
 
-    """Docker containers
-    """
-
+    short_desc = 'Docker containers'
     plugin_name = 'docker'
     profiles = ('container',)
 

--- a/sos/report/plugins/docker_distribution.py
+++ b/sos/report/plugins/docker_distribution.py
@@ -13,8 +13,7 @@ import os
 
 class DockerDistribution(Plugin):
 
-    """Docker Distribution"""
-
+    short_desc = 'Docker Distribution'
     plugin_name = "docker_distribution"
     profiles = ('container',)
 

--- a/sos/report/plugins/dovecot.py
+++ b/sos/report/plugins/dovecot.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Dovecot(Plugin):
-    """Dovecot IMAP and POP3
-    """
+
+    short_desc = 'Dovecot IMAP and POP3'
 
     plugin_name = "dovecot"
     profiles = ('mail',)
@@ -22,8 +22,7 @@ class Dovecot(Plugin):
 
 
 class RedHatDovecot(Dovecot, RedHatPlugin):
-    """dovecot server related information
-    """
+
     def setup(self):
         super(RedHatDovecot, self).setup()
 
@@ -32,8 +31,7 @@ class RedHatDovecot(Dovecot, RedHatPlugin):
 
 
 class DebianDovecot(Dovecot, DebianPlugin, UbuntuPlugin):
-    """dovecot server related information for Debian based distribution
-    """
+
     def setup(self):
         super(DebianDovecot, self).setup()
 

--- a/sos/report/plugins/dpkg.py
+++ b/sos/report/plugins/dpkg.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, DebianPlugin, UbuntuPlugin
 
 
 class Dpkg(Plugin, DebianPlugin, UbuntuPlugin):
-    """Debian Package Management
-    """
+
+    short_desc = 'Debian Package Management'
 
     plugin_name = 'dpkg'
     profiles = ('sysmgmt', 'packagemanager')

--- a/sos/report/plugins/dracut.py
+++ b/sos/report/plugins/dracut.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Dracut(Plugin, RedHatPlugin):
-    """ Dracut initramfs generator """
+
+    short_desc = 'Dracut initramfs generator'
 
     plugin_name = "dracut"
     packages = ("dracut",)

--- a/sos/report/plugins/ds.py
+++ b/sos/report/plugins/ds.py
@@ -14,8 +14,8 @@ import os
 
 
 class DirectoryServer(Plugin, RedHatPlugin):
-    """Directory Server
-    """
+
+    short_desc = 'Directory Server'
 
     plugin_name = 'ds'
     profiles = ('identity',)

--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -11,8 +11,8 @@ import json
 
 
 class Ebpf(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """eBPF tool
-    """
+
+    short_desc = 'eBPF tool'
     plugin_name = 'ebpf'
     profiles = ('system', 'kernel', 'network')
 

--- a/sos/report/plugins/elastic.py
+++ b/sos/report/plugins/elastic.py
@@ -13,9 +13,8 @@ import re
 
 
 class Elastic(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """
-    ElasticSearch service
-    """
+
+    short_desc = 'ElasticSearch service'
     plugin_name = 'elastic'
     profiles = ('services', )
 

--- a/sos/report/plugins/etcd.py
+++ b/sos/report/plugins/etcd.py
@@ -14,8 +14,8 @@ from os import path
 
 
 class etcd(Plugin, RedHatPlugin):
-    """etcd plugin
-    """
+
+    short_desc = 'etcd plugin'
 
     plugin_name = 'etcd'
     packages = ('etcd',)

--- a/sos/report/plugins/fcoe.py
+++ b/sos/report/plugins/fcoe.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class fcoe(Plugin, RedHatPlugin):
-    """Fibre Channel over Ethernet
-    """
+
+    short_desc = 'Fibre Channel over Ethernet'
 
     plugin_name = 'fcoe'
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Fibrechannel(Plugin, RedHatPlugin):
-    """Collects information on fibrechannel devices, if present"""
+
+    short_desc = 'Collect information on fibrechannel devices'
 
     plugin_name = 'fibrechannel'
     profiles = ('hardware', 'storage', 'system')

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Filesys(Plugin, DebianPlugin, UbuntuPlugin):
-    """Local file systems
-    """
+
+    short_desc = 'Local file systems'
 
     plugin_name = 'filesys'
     profiles = ('storage',)

--- a/sos/report/plugins/firewalld.py
+++ b/sos/report/plugins/firewalld.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, SoSPredicate
 
 
 class FirewallD(Plugin, RedHatPlugin):
-    """Firewall daemon
-    """
+
+    short_desc = 'Firewall daemon'
 
     plugin_name = 'firewalld'
     profiles = ('network',)

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -16,8 +16,8 @@ from re import match
 
 
 class Foreman(Plugin):
-    """Foreman/Satellite 6 systems management
-    """
+
+    short_desc = 'Foreman/Satellite 6 systems management'
 
     plugin_name = 'foreman'
     plugin_timeout = 1800

--- a/sos/report/plugins/freeipmi.py
+++ b/sos/report/plugins/freeipmi.py
@@ -12,9 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class Freeipmi(Plugin, UbuntuPlugin):
-    """Freeipmi hardware information.
-    """
 
+    short_desc = 'Freeipmi hardware information'
     plugin_name = 'freeipmi'
     profiles = ('hardware', 'system', )
 

--- a/sos/report/plugins/frr.py
+++ b/sos/report/plugins/frr.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Frr(Plugin, RedHatPlugin):
-    """Frr routing service
-    """
+
+    short_desc = 'Frr routing service'
 
     plugin_name = 'frr'
     profiles = ('network',)

--- a/sos/report/plugins/fwupd.py
+++ b/sos/report/plugins/fwupd.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Fwupd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """fwupd information
-    """
+
+    short_desc = 'fwupd information'
 
     plugin_name = 'fwupd'
     profiles = ('system', )

--- a/sos/report/plugins/gdm.py
+++ b/sos/report/plugins/gdm.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Gdm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """GNOME display manager
-    """
+
+    short_desc = 'GNOME display manager'
 
     plugin_name = 'gdm'
     profiles = ('desktop',)

--- a/sos/report/plugins/gfs2.py
+++ b/sos/report/plugins/gfs2.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Gfs2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """GFS2 (Global Filesystem 2)"""
+
+    short_desc = 'GFS2 (Global Filesystem 2)'
 
     plugin_name = "gfs2"
     profiles = ("cluster", )

--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -15,7 +15,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Gluster(Plugin, RedHatPlugin):
-    """GlusterFS storage"""
+
+    short_desc = 'GlusterFS storage'
 
     plugin_name = 'gluster'
     profiles = ('storage', 'virt')

--- a/sos/report/plugins/gluster_block.py
+++ b/sos/report/plugins/gluster_block.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class GlusterBlock(Plugin, RedHatPlugin):
-    """Gluster Block"""
+
+    short_desc = 'Gluster Block'
 
     plugin_name = 'gluster_block'
     profiles = ('storage',)

--- a/sos/report/plugins/gnocchi.py
+++ b/sos/report/plugins/gnocchi.py
@@ -14,7 +14,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Gnocchi(Plugin):
-    """Gnocchi - Metric as a service"""
+
+    short_desc = 'Gnocchi - Metric as a service'
     plugin_name = "gnocchi"
 
     profiles = ('openstack', 'openstack_controller')

--- a/sos/report/plugins/grafana.py
+++ b/sos/report/plugins/grafana.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Grafana(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Fetch Grafana configuration, logs and CLI output
-    """
+
+    short_desc = 'Fetch Grafana configuration, logs and CLI output'
     plugin_name = "grafana"
     profiles = ('services', 'openstack', 'openstack_controller')
 

--- a/sos/report/plugins/grub.py
+++ b/sos/report/plugins/grub.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Grub(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """GRUB bootloader
-    """
+
+    short_desc = 'GRUB bootloader'
 
     plugin_name = 'grub'
     profiles = ('boot',)

--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -11,8 +11,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class Grub2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """GRUB2 bootloader
-    """
+
+    short_desc = 'GRUB2 bootloader'
 
     plugin_name = 'grub2'
     profiles = ('boot',)

--- a/sos/report/plugins/gssproxy.py
+++ b/sos/report/plugins/gssproxy.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class GSSProxy(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """GSSAPI Proxy
-    """
+
+    short_desc = 'GSSAPI Proxy'
 
     plugin_name = "gssproxy"
     profiles = ('services', 'security', 'identity')

--- a/sos/report/plugins/haproxy.py
+++ b/sos/report/plugins/haproxy.py
@@ -18,8 +18,8 @@ except ImportError:
 
 
 class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
-    """HAProxy load balancer
-    """
+
+    short_desc = 'HAProxy load balancer'
 
     plugin_name = 'haproxy'
     profiles = ('webserver',)

--- a/sos/report/plugins/hardware.py
+++ b/sos/report/plugins/hardware.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Hardware(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """General hardware information
-    """
+
+    short_desc = 'General hardware information'
 
     plugin_name = "hardware"
     profiles = ('system', 'hardware')

--- a/sos/report/plugins/host.py
+++ b/sos/report/plugins/host.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class Host(Plugin, RedHatPlugin, DebianPlugin):
-    """Host information
-    """
+
+    short_desc = 'Host information'
 
     plugin_name = 'host'
     profiles = ('system',)

--- a/sos/report/plugins/hpasm.py
+++ b/sos/report/plugins/hpasm.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Hpasm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """HP Advanced Server Management
-    """
+
+    short_desc = 'HP Advanced Server Management'
 
     plugin_name = 'hpasm'
     profiles = ('system', 'hardware')

--- a/sos/report/plugins/hts.py
+++ b/sos/report/plugins/hts.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class HardwareTestSuite(Plugin, RedHatPlugin):
-    """Red Hat Hardware Test Suite
-    """
+
+    short_desc = 'Red Hat Hardware Test Suite'
 
     plugin_name = 'hts'
     profiles = ('debug',)

--- a/sos/report/plugins/i18n.py
+++ b/sos/report/plugins/i18n.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class I18n(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Internationalization
-    """
+
+    short_desc = 'Internationalization'
 
     plugin_name = 'i18n'
     profiles = ('system',)

--- a/sos/report/plugins/infiniband.py
+++ b/sos/report/plugins/infiniband.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Infiniband(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Infiniband data
-    """
+
+    short_desc = 'Infiniband information'
 
     plugin_name = 'infiniband'
     profiles = ('hardware',)

--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class RedHatInsights(Plugin, RedHatPlugin):
-    """Collect config and log for Red Hat Insights
-    """
+
+    short_desc = 'Collect config and logs for Red Hat Insights'
     plugin_name = 'insights'
     packages = ['redhat-access-insights', 'insights-client']
     profiles = ('system', 'sysmgmt')

--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -14,8 +14,8 @@ from os.path import exists
 
 
 class Ipa(Plugin, RedHatPlugin):
-    """ Identity, policy, audit
-    """
+
+    short_desc = 'Identity, policy, audit'
 
     plugin_name = 'ipa'
     profiles = ('identity', 'apache')

--- a/sos/report/plugins/ipmitool.py
+++ b/sos/report/plugins/ipmitool.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class IpmiTool(Plugin, RedHatPlugin, DebianPlugin):
-    """IpmiTool hardware information.
-    """
+
+    short_desc = 'IpmiTool hardware information'
 
     plugin_name = 'ipmitool'
     profiles = ('hardware', 'system', )

--- a/sos/report/plugins/iprconfig.py
+++ b/sos/report/plugins/iprconfig.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """IBM Power RAID storage adapter configuration information
-    """
+
+    short_desc = 'IBM Power RAID storage adapter configuration information'
 
     plugin_name = 'iprconfig'
     packages = ('iprutils',)

--- a/sos/report/plugins/ipvs.py
+++ b/sos/report/plugins/ipvs.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, SoSPredicate
 
 
 class Ipvs(Plugin, RedHatPlugin, DebianPlugin):
-    """Linux IP virtual server
-    """
+
+    short_desc = 'Linux IP virtual server'
 
     plugin_name = 'ipvs'
     profiles = ('cluster', 'network')

--- a/sos/report/plugins/iscsi.py
+++ b/sos/report/plugins/iscsi.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Iscsi(Plugin):
-    """iSCSI initiator
-    """
+
+    short_desc = 'iSCSI initiator'
 
     plugin_name = "iscsi"
     profiles = ('storage',)

--- a/sos/report/plugins/iscsitarget.py
+++ b/sos/report/plugins/iscsitarget.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class IscsiTarget(Plugin):
-    """iSCSI target
-    """
+
+    short_desc = 'iSCSI target'
 
     plugin_name = "iscsitarget"
     profiles = ('storage',)

--- a/sos/report/plugins/jars.py
+++ b/sos/report/plugins/jars.py
@@ -18,7 +18,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Jars(Plugin, RedHatPlugin):
-    """Collect information about available Java archives."""
+
+    short_desc = 'Collect information about available Java archives'
 
     plugin_name = "jars"
     version = "1.0.0"

--- a/sos/report/plugins/java.py
+++ b/sos/report/plugins/java.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Java(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """Java runtime"""
+
+    short_desc = 'Java runtime'
 
     plugin_name = "java"
     profiles = ('webserver', 'java')

--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class Juju(Plugin, UbuntuPlugin):
-    """ Juju orchestration tool
-    """
+
+    short_desc = 'Juju orchestration tool'
 
     plugin_name = 'juju'
     profiles = ('virt', 'sysmgmt')

--- a/sos/report/plugins/kata_containers.py
+++ b/sos/report/plugins/kata_containers.py
@@ -12,8 +12,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 class KataContainers(Plugin, RedHatPlugin, DebianPlugin,
                      UbuntuPlugin, SuSEPlugin):
-    """Kata Containers configuration
-    """
+
+    short_desc = 'Kata Containers configuration'
 
     plugin_name = 'kata_containers'
     profiles = ('system', 'virt', 'container')

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class KDump(Plugin):
-    """Kdump crash dumps
-    """
+
+    short_desc = 'Kdump crash dumps'
 
     plugin_name = "kdump"
     profiles = ('system', 'debug')

--- a/sos/report/plugins/keepalived.py
+++ b/sos/report/plugins/keepalived.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Keepalived(Plugin, RedHatPlugin):
-    """Keepalived routing server
-    """
+
+    short_desc = 'Keepalived routing server'
 
     plugin_name = 'keepalived'
     profiles = ('webserver', 'network', 'cluster')

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -12,8 +12,8 @@ import glob
 
 
 class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Linux kernel
-    """
+
+    short_desc = 'Linux kernel'
 
     plugin_name = 'kernel'
     profiles = ('system', 'hardware', 'kernel')

--- a/sos/report/plugins/kernelrt.py
+++ b/sos/report/plugins/kernelrt.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class KernelRT(Plugin, RedHatPlugin):
-    """Realtime kernel variant
-    """
+
+    short_desc = 'Realtime kernel variant'
 
     plugin_name = 'kernelrt'
     profiles = ('system', 'hardware', 'kernel', 'mrg')

--- a/sos/report/plugins/keyutils.py
+++ b/sos/report/plugins/keyutils.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Keyutils(Plugin, RedHatPlugin):
-    """Kernel key ring
-    """
+
+    short_desc = 'Kernel key ring'
 
     plugin_name = 'keyutils'
     profiles = ('system', 'kernel', 'security', 'storage')

--- a/sos/report/plugins/kimchi.py
+++ b/sos/report/plugins/kimchi.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Kimchi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """kimchi-related information
-    """
+
+    short_desc = 'kimchi-related information'
 
     plugin_name = 'kimchi'
     packages = ('kimchi',)

--- a/sos/report/plugins/kpatch.py
+++ b/sos/report/plugins/kpatch.py
@@ -13,8 +13,8 @@ import re
 
 
 class Kpatch(Plugin, RedHatPlugin):
-    """Kpatch information
-    """
+
+    short_desc = 'Kpatch information'
 
     plugin_name = 'kpatch'
 

--- a/sos/report/plugins/krb5.py
+++ b/sos/report/plugins/krb5.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Krb5(Plugin):
-    """Kerberos authentication
-    """
+
+    short_desc = 'Kerberos authentication'
     plugin_name = 'krb5'
     profiles = ('identity', 'system')
     packages = ('krb5-libs', 'krb5-user')

--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -16,8 +16,8 @@ import re
 
 
 class Kubernetes(Plugin):
-    """Kubernetes plugin
-    """
+
+    short_desc = 'Kubernetes container orchestration platform'
 
     plugin_name = "kubernetes"
     profiles = ('container',)
@@ -175,8 +175,6 @@ class Kubernetes(Plugin):
 
 
 class RedHatKubernetes(Kubernetes, RedHatPlugin):
-    """Red Hat Kubernetes plugin
-    """
 
     # OpenShift Container Platform uses the atomic-openshift-master package
     # to provide kubernetes
@@ -196,13 +194,9 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
 
 
 class UbuntuKubernetes(Kubernetes, UbuntuPlugin):
-    """Ubuntu Kubernetes plugin
-    """
 
     packages = ('kubernetes',)
-
     files = ('/root/cdk/kubeproxyconfig',)
-
     kube_cmd = "kubectl --kubeconfig=/root/cdk/kubeproxyconfig"
 
 # vim: et ts=5 sw=4

--- a/sos/report/plugins/kvm.py
+++ b/sos/report/plugins/kvm.py
@@ -14,8 +14,8 @@ import os
 
 
 class Kvm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Kernel virtual machine
-    """
+
+    short_desc = 'Kernel virtual machine'
 
     plugin_name = 'kvm'
     profiles = ('system', 'virt')

--- a/sos/report/plugins/landscape.py
+++ b/sos/report/plugins/landscape.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class Landscape(Plugin, UbuntuPlugin):
-    """Ubuntu Landscape client
-    """
+
+    short_desc = 'Ubuntu Landscape client'
 
     plugin_name = 'landscape'
     profiles = ('sysmgmt',)

--- a/sos/report/plugins/ldap.py
+++ b/sos/report/plugins/ldap.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ldap(Plugin):
-    """LDAP configuration
-    """
+
+    short_desc = 'LDAP configuration'
 
     plugin_name = "ldap"
     profiles = ('identity', 'sysmgmt', 'system')

--- a/sos/report/plugins/leapp.py
+++ b/sos/report/plugins/leapp.py
@@ -12,9 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Leapp(Plugin, RedHatPlugin):
-    """
-    Leapp upgrade handling tool
-    """
+
+    short_desc = 'Leapp upgrade handling tool'
 
     plugin_name = 'leapp'
     packages = ('leapp', 'leapp-repository')

--- a/sos/report/plugins/libraries.py
+++ b/sos/report/plugins/libraries.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class Libraries(Plugin, RedHatPlugin, UbuntuPlugin):
-    """Dynamic shared libraries
-    """
+
+    short_desc = 'Dynamic shared libraries'
 
     plugin_name = 'libraries'
     profiles = ('system',)

--- a/sos/report/plugins/libreswan.py
+++ b/sos/report/plugins/libreswan.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Libreswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Libreswan IPsec
-    """
+
+    short_desc = 'Libreswan IPsec'
 
     plugin_name = 'libreswan'
     profiles = ('network', 'security', 'openshift')

--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -12,8 +12,8 @@ import os
 
 
 class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """libvirt virtualization API
-    """
+
+    short_desc = 'libvirt virtualization API'
 
     plugin_name = 'libvirt'
     profiles = ('system', 'virt')

--- a/sos/report/plugins/lightdm.py
+++ b/sos/report/plugins/lightdm.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class LightDm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Light Display Manager
-    """
+
+    short_desc = 'Light Display Manager'
     packages = ('lightdm', )
     profiles = ('desktop', )
     plugin_name = 'lightdm'

--- a/sos/report/plugins/lilo.py
+++ b/sos/report/plugins/lilo.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class Lilo(Plugin, RedHatPlugin, UbuntuPlugin):
-    """Lilo bootloader
-    """
+
+    short_desc = 'Lilo bootloader'
 
     plugin_name = 'lilo'
     profiles = ('system', 'boot')

--- a/sos/report/plugins/login.py
+++ b/sos/report/plugins/login.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Login(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """login information
-    """
+
+    short_desc = 'login information'
 
     plugin_name = 'login'
     profiles = ('system', 'identity')

--- a/sos/report/plugins/logrotate.py
+++ b/sos/report/plugins/logrotate.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class LogRotate(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """LogRotate service
-    """
+
+    short_desc = 'LogRotate service'
 
     plugin_name = 'logrotate'
     profiles = ('system',)

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Logs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """System logs"""
+
+    short_desc = 'System logs'
 
     plugin_name = "logs"
     profiles = ('system', 'hardware', 'storage')

--- a/sos/report/plugins/lstopo.py
+++ b/sos/report/plugins/lstopo.py
@@ -11,8 +11,8 @@ from sos.utilities import is_executable
 
 
 class Lstopo(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """lstopo / machine topology/numa node information
-    """
+
+    short_desc = 'Machine topology information'
 
     plugin_name = "lstopo"
     profiles = ("system", "hardware")

--- a/sos/report/plugins/lustre.py
+++ b/sos/report/plugins/lustre.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Lustre(Plugin, RedHatPlugin):
-    """Lustre filesystem"""
+
+    short_desc = 'Lustre filesystem'
 
     plugin_name = 'lustre'
     profiles = ('storage', 'network', 'cluster', )

--- a/sos/report/plugins/lvm2.py
+++ b/sos/report/plugins/lvm2.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Lvm2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """LVM2 volume manager
-    """
+
+    short_desc = 'Logical Volume Manager 2'
 
     plugin_name = 'lvm2'
     profiles = ('storage',)

--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class LXD(Plugin, UbuntuPlugin):
-    """LXD is a containers hypervisor.
-    """
+
+    short_desc = 'LXD container hypervisor'
     plugin_name = 'lxd'
     profiles = ('container',)
     packages = ('lxd',)

--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class Maas(Plugin, UbuntuPlugin):
-    """Ubuntu Metal-As-A-Service
-    """
+
+    short_desc = 'Ubuntu Metal-As-A-Service'
 
     plugin_name = 'maas'
     profiles = ('sysmgmt',)

--- a/sos/report/plugins/manageiq.py
+++ b/sos/report/plugins/manageiq.py
@@ -17,8 +17,8 @@ import os.path
 
 
 class ManageIQ(Plugin, RedHatPlugin):
-    """ManageIQ/CloudForms related information
-    """
+
+    short_desc = 'ManageIQ/CloudForms related information'
 
     plugin_name = 'manageiq'
 

--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Md(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """MD RAID subsystem
-    """
+
+    short_desc = 'MD RAID subsystem'
 
     plugin_name = 'md'
     profiles = ('storage',)

--- a/sos/report/plugins/megacli.py
+++ b/sos/report/plugins/megacli.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class MegaCLI(Plugin, RedHatPlugin):
-    """LSI MegaRAID devices
-    """
+
+    short_desc = 'LSI MegaRAID devices'
 
     plugin_name = 'megacli'
     profiles = ('system', 'storage', 'hardware')

--- a/sos/report/plugins/memcached.py
+++ b/sos/report/plugins/memcached.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Memcached(Plugin):
-    """memcached distributed memory caching system"""
+
+    short_desc = 'memcached distributed memory caching system'
 
     plugin_name = 'memcached'
     profiles = ('webserver',)

--- a/sos/report/plugins/memory.py
+++ b/sos/report/plugins/memory.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Memory(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Memory configuration and use
-    """
+
+    short_desc = 'Memory configuration and use'
 
     plugin_name = 'memory'
     profiles = ('system', 'hardware', 'memory')

--- a/sos/report/plugins/mongodb.py
+++ b/sos/report/plugins/mongodb.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class MongoDb(Plugin, DebianPlugin, UbuntuPlugin):
-    """MongoDB document database
-    """
+
+    short_desc = 'MongoDB document database'
 
     plugin_name = 'mongodb'
     profiles = ('services',)

--- a/sos/report/plugins/monit.py
+++ b/sos/report/plugins/monit.py
@@ -14,8 +14,8 @@ from glob import glob
 
 
 class Monit(Plugin, RedHatPlugin):
-    """Monit monitoring daemon
-    """
+
+    short_desc = 'Monit monitoring daemon'
     packages = ('monit',)
     profiles = ('system',)
     plugin_name = 'monit'

--- a/sos/report/plugins/mpt.py
+++ b/sos/report/plugins/mpt.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Mpt(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """ LSI Message Passing Technology
-    """
+
+    short_desc = 'LSI Message Passing Technology'
     files = ('/proc/mpt',)
     profiles = ('storage', )
     plugin_name = 'mpt'

--- a/sos/report/plugins/mssql.py
+++ b/sos/report/plugins/mssql.py
@@ -13,8 +13,8 @@ import os
 
 
 class MsSQL(Plugin, RedHatPlugin):
-    """Microsoft SQL Server on Linux
-    """
+
+    short_desc = 'Microsoft SQL Server on Linux'
 
     plugin_name = "mssql"
     profiles = ('services',)

--- a/sos/report/plugins/multipath.py
+++ b/sos/report/plugins/multipath.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Multipath(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Device-mapper multipath tools
-    """
+
+    short_desc = 'Device-mapper multipath tools'
 
     plugin_name = 'multipath'
     profiles = ('system', 'storage', 'hardware')

--- a/sos/report/plugins/mysql.py
+++ b/sos/report/plugins/mysql.py
@@ -11,8 +11,8 @@ import os
 
 
 class Mysql(Plugin):
-    """MySQL and MariaDB RDBMS
-    """
+
+    short_desc = 'MySQL and MariaDB RDBMS'
 
     plugin_name = "mysql"
     profiles = ('services',)

--- a/sos/report/plugins/named.py
+++ b/sos/report/plugins/named.py
@@ -11,8 +11,8 @@ from os.path import exists, join, normpath
 
 
 class Named(Plugin):
-    """BIND named server
-    """
+
+    short_desc = 'BIND named server'
 
     plugin_name = "named"
     profiles = ('system', 'services', 'network')

--- a/sos/report/plugins/navicli.py
+++ b/sos/report/plugins/navicli.py
@@ -14,8 +14,8 @@ from sos.utilities import is_executable
 
 
 class Navicli(Plugin, RedHatPlugin):
-    """ EMC Navicli
-    """
+
+    short_desc = 'EMC Navicli'
 
     plugin_name = 'navicli'
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -13,8 +13,9 @@ from re import match
 
 
 class Networking(Plugin):
-    """network and device configuration
-    """
+
+    short_desc = 'Network and networking devices configuration'
+
     plugin_name = "networking"
     profiles = ('network', 'hardware', 'system')
     trace_host = "www.example.com"

--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -11,8 +11,8 @@ import os
 
 
 class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
-    """NetworkManager service configuration
-    """
+
+    short_desc = 'NetworkManager service configuration'
 
     plugin_name = 'networkmanager'
     profiles = ('network', 'hardware', 'system')

--- a/sos/report/plugins/nfs.py
+++ b/sos/report/plugins/nfs.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Network file system information
-    """
+
+    short_desc = 'Network file system information'
     plugin_name = 'nfs'
     profiles = ('storage', 'network', 'nfs')
     packages = ['nfs-utils']

--- a/sos/report/plugins/nfsganesha.py
+++ b/sos/report/plugins/nfsganesha.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """NFS-Ganesha file server information
-    """
+
+    short_desc = 'NFS-Ganesha file server information'
     plugin_name = 'nfsganesha'
     profiles = ('storage', 'network', 'nfs')
     packages = ('nfs-ganesha',)

--- a/sos/report/plugins/nfsserver.py
+++ b/sos/report/plugins/nfsserver.py
@@ -14,9 +14,8 @@ from stat import ST_SIZE
 
 
 class NfsServer(Plugin, RedHatPlugin):
-    """NFS server information
-    """
 
+    short_desc = 'NFS Server information'
     plugin_name = 'nfsserver'
     profiles = ('storage', 'network', 'services', 'nfs')
 

--- a/sos/report/plugins/nginx.py
+++ b/sos/report/plugins/nginx.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nginx(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """nginx http daemon
-    """
+
+    short_desc = 'nginx http daemon'
     plugin_name = "nginx"
     profiles = ('webserver',)
     packages = ('nginx',)

--- a/sos/report/plugins/nis.py
+++ b/sos/report/plugins/nis.py
@@ -10,9 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nis(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Network information service
-    """
 
+    short_desc = 'Network Information Service'
     plugin_name = 'nis'
     profiles = ('identity', 'services')
 

--- a/sos/report/plugins/nodejs.py
+++ b/sos/report/plugins/nodejs.py
@@ -13,7 +13,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class NodeJS(Plugin, RedHatPlugin, SuSEPlugin):
-    """ Get runtime version of NodeJS """
+
+    short_desc = 'NodeJS runtime version'
 
     plugin_name = 'nodejs'
     profiles = ('system',)

--- a/sos/report/plugins/npm.py
+++ b/sos/report/plugins/npm.py
@@ -15,10 +15,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class Npm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
-    """
-    Get info about available npm modules
-    """
 
+    short_desc = 'Information from available npm modules'
     plugin_name = 'npm'
     profiles = ('system',)
     option_list = [("project_path",

--- a/sos/report/plugins/nscd.py
+++ b/sos/report/plugins/nscd.py
@@ -12,9 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nscd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Name service caching daemon
-    """
 
+    short_desc = 'Name service caching daemon'
     plugin_name = 'nscd'
     profiles = ('services', 'identity', 'system')
 

--- a/sos/report/plugins/nss.py
+++ b/sos/report/plugins/nss.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class NSS(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Network Security Services configuration
-    """
+
+    short_desc = 'Network Security Services configuration'
 
     plugin_name = "nss"
     profiles = ('network', 'security')

--- a/sos/report/plugins/ntb.py
+++ b/sos/report/plugins/ntb.py
@@ -10,9 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Ntb(Plugin, RedHatPlugin):
-    """Linux PCI-Express Non-Transparent Bridge
-    """
 
+    short_desc = 'Linux PCI-Express Non-Transparent Bridge'
     plugin_name = 'ntb'
     profiles = ('hardware', )
 

--- a/sos/report/plugins/ntp.py
+++ b/sos/report/plugins/ntp.py
@@ -10,9 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ntp(Plugin):
-    """Network time protocol
-    """
 
+    short_desc = 'Network Time Protocol'
     plugin_name = "ntp"
     profiles = ('system', 'services')
 

--- a/sos/report/plugins/numa.py
+++ b/sos/report/plugins/numa.py
@@ -13,8 +13,8 @@ import os.path
 
 
 class Numa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """NUMA state and configuration
-    """
+
+    short_desc = 'NUMA state and configuration'
 
     plugin_name = 'numa'
     profiles = ('hardware', 'system', 'memory', 'performance')

--- a/sos/report/plugins/nvidia.py
+++ b/sos/report/plugins/nvidia.py
@@ -13,7 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nvidia(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Nvidia GPU information"""
+
+    short_desc = 'Nvidia GPU information'
 
     commands = ('nvidia-smi',)
 

--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Nvme(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Collect config and system information about NVMe devices"""
+
+    short_desc = 'Collect config and system information about NVMe devices'
 
     plugin_name = "nvme"
     packages = ('nvme-cli',)

--- a/sos/report/plugins/oddjob.py
+++ b/sos/report/plugins/oddjob.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Oddjob(Plugin, RedHatPlugin):
-    """OddJob task scheduler
-    """
+
+    short_desc = 'OddJob task scheduler'
 
     plugin_name = 'oddjob'
     profiles = ('services', 'sysmgmt')

--- a/sos/report/plugins/omnipath_client.py
+++ b/sos/report/plugins/omnipath_client.py
@@ -19,8 +19,8 @@ from os.path import join
 
 
 class OmnipathClient(Plugin, RedHatPlugin):
-    """OmniPath Tools and Fast Fabric Client
-    """
+
+    short_desc = 'OmniPath Tools and Fast Fabric Client'
 
     plugin_name = 'omnipath_client'
     profiles = ('hardware',)

--- a/sos/report/plugins/omnipath_manager.py
+++ b/sos/report/plugins/omnipath_manager.py
@@ -18,8 +18,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OmnipathManager(Plugin, RedHatPlugin):
-    """OmniPath Fabric Manager
-    """
+
+    short_desc = 'OmniPath Fabric Manager'
 
     plugin_name = 'omnipath_manager'
     profiles = ('hardware',)

--- a/sos/report/plugins/omsa.py
+++ b/sos/report/plugins/omsa.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class omsa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Dell OpenManage Server Administrator (OMSA)
-    """
+
+    short_desc = 'Dell OpenManage Server Administrator (OMSA)'
 
     plugin_name = 'omsa'
     profiles = ('hardware', 'debug')

--- a/sos/report/plugins/opencl.py
+++ b/sos/report/plugins/opencl.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenCL(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """OpenCL
-    """
+
+    short_desc = 'OpenCL'
 
     plugin_name = 'opencl'
     profiles = ('hardware', 'desktop', 'gpu')

--- a/sos/report/plugins/opendaylight.py
+++ b/sos/report/plugins/opendaylight.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OpenDaylight(Plugin, RedHatPlugin):
-    """OpenDaylight network manager
-    """
+
+    short_desc = 'OpenDaylight network manager'
 
     plugin_name = 'opendaylight'
     profiles = ('openstack', 'openstack_controller')

--- a/sos/report/plugins/opengl.py
+++ b/sos/report/plugins/opengl.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenGL(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """OpenGL
-    """
+
+    short_desc = 'OpenGL'
 
     plugin_name = 'opengl'
     profiles = ('hardware', 'desktop', 'gpu')

--- a/sos/report/plugins/openhpi.py
+++ b/sos/report/plugins/openhpi.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OpenHPI(Plugin, RedHatPlugin):
-    """Open Hardware Platform Interface
-    """
+
+    short_desc = 'Open Hardware Platform Interface'
 
     plugin_name = 'openhpi'
     profiles = ('system', 'hardware')

--- a/sos/report/plugins/openshift.py
+++ b/sos/report/plugins/openshift.py
@@ -17,7 +17,8 @@ import os.path
 # For later of OpenShift Origin based on: https://github.com/openshift/origin
 # like OpenShift Enterprise 3.x see the origin.py plugin
 class Openshift(Plugin, RedHatPlugin):
-    """Openshift 2.x node and broker"""
+
+    short_desc = 'Openshift 2.x node and broker'
 
     plugin_name = "openshift"
     profiles = ('virt', 'openshift')

--- a/sos/report/plugins/openssl.py
+++ b/sos/report/plugins/openssl.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenSSL(Plugin):
-    """OpenSSL configuration
-    """
+
+    short_desc = 'OpenSSL configuration'
 
     plugin_name = "openssl"
     profiles = ('network', 'security')
@@ -37,8 +37,6 @@ class OpenSSL(Plugin):
 
 
 class RedHatOpenSSL(OpenSSL, RedHatPlugin):
-    """openssl related information
-    """
 
     files = ('/etc/pki/tls/openssl.cnf',)
 
@@ -48,8 +46,6 @@ class RedHatOpenSSL(OpenSSL, RedHatPlugin):
 
 
 class DebianOpenSSL(OpenSSL, DebianPlugin, UbuntuPlugin):
-    """openssl related information for Debian distributions
-    """
 
     files = ('/etc/ssl/openssl.cnf',)
 

--- a/sos/report/plugins/openstack_ansible.py
+++ b/sos/report/plugins/openstack_ansible.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackAnsible(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """OpenStack-Ansible sos plugin."""
+
+    short_desc = 'OpenStack-Ansible'
 
     plugin_name = "openstack_ansible"
     profiles = ('openstack',)

--- a/sos/report/plugins/openstack_aodh.py
+++ b/sos/report/plugins/openstack_aodh.py
@@ -14,7 +14,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OpenStackAodh(Plugin, RedHatPlugin):
-    """OpenStack Alarm service"""
+
+    short_desc = 'OpenStack Alarm service'
     plugin_name = "openstack_aodh"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_ceilometer.py
+++ b/sos/report/plugins/openstack_ceilometer.py
@@ -16,7 +16,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackCeilometer(Plugin):
-    """Openstack Ceilometer"""
+
+    short_desc = 'Openstack Ceilometer'
     plugin_name = "openstack_ceilometer"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 

--- a/sos/report/plugins/openstack_cinder.py
+++ b/sos/report/plugins/openstack_cinder.py
@@ -16,8 +16,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackCinder(Plugin):
-    """OpenStack cinder
-    """
+
+    short_desc = 'OpenStack cinder'
     plugin_name = "openstack_cinder"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_glance.py
+++ b/sos/report/plugins/openstack_glance.py
@@ -17,7 +17,8 @@ import os
 
 
 class OpenStackGlance(Plugin):
-    """OpenStack Glance"""
+
+    short_desc = 'OpenStack Glance'
     plugin_name = "openstack_glance"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_heat.py
+++ b/sos/report/plugins/openstack_heat.py
@@ -14,8 +14,8 @@ import os
 
 
 class OpenStackHeat(Plugin):
-    """OpenStack Heat
-    """
+
+    short_desc = 'OpenStack Heat'
     plugin_name = "openstack_heat"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_horizon.py
+++ b/sos/report/plugins/openstack_horizon.py
@@ -15,8 +15,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackHorizon(Plugin):
-    """OpenStack Horizon
-    """
+
+    short_desc = 'OpenStack Horizon'
 
     plugin_name = "openstack_horizon"
     profiles = ('openstack', 'openstack_controller')

--- a/sos/report/plugins/openstack_instack.py
+++ b/sos/report/plugins/openstack_instack.py
@@ -31,8 +31,8 @@ CONTAINERIZED_DEPLOY = [
 
 
 class OpenStackInstack(Plugin):
-    """OpenStack Instack
-    """
+
+    short_desc = 'OpenStack Instack'
     plugin_name = "openstack_instack"
     profiles = ('openstack', 'openstack_undercloud')
 

--- a/sos/report/plugins/openstack_ironic.py
+++ b/sos/report/plugins/openstack_ironic.py
@@ -14,8 +14,8 @@ import os
 
 
 class OpenStackIronic(Plugin):
-    """OpenStack Ironic
-    """
+
+    short_desc = 'OpenStack Ironic'
     plugin_name = "openstack_ironic"
     profiles = ('openstack', 'openstack_undercloud')
 

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -14,8 +14,8 @@ import os
 
 
 class OpenStackKeystone(Plugin):
-    """OpenStack Keystone
-    """
+
+    short_desc = 'OpenStack Keystone'
     plugin_name = "openstack_keystone"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_manila.py
+++ b/sos/report/plugins/openstack_manila.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackManila(Plugin):
-    """OpenStack Manila
-    """
+
+    short_desc = 'OpenStack Manila'
     plugin_name = "openstack_manila"
     profiles = ('openstack', 'openstack_controller')
     option_list = []
@@ -71,8 +71,8 @@ class OpenStackManila(Plugin):
 
 
 class DebianManila(OpenStackManila, DebianPlugin, UbuntuPlugin):
-    """OpenStackManila related information for Debian based distributions."""
 
+    short_desc = 'OpenStack Manila information for Debian based distributions'
     packages = (
         'python-manila',
         'manila-common',
@@ -83,8 +83,8 @@ class DebianManila(OpenStackManila, DebianPlugin, UbuntuPlugin):
 
 
 class RedHatManila(OpenStackManila, RedHatPlugin):
-    """OpenStackManila related information for Red Hat distributions."""
 
+    short_desc = 'OpenStack Manila information for Red Hat distributions'
     packages = ('openstack-selinux',)
 
     def setup(self):

--- a/sos/report/plugins/openstack_neutron.py
+++ b/sos/report/plugins/openstack_neutron.py
@@ -14,8 +14,8 @@ import os
 
 
 class OpenStackNeutron(Plugin):
-    """OpenStack Networking
-    """
+
+    short_desc = 'OpenStack Networking'
     plugin_name = "openstack_neutron"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -18,8 +18,8 @@ import os
 
 
 class OpenStackNova(Plugin):
-    """OpenStack Nova
-    """
+
+    short_desc = 'OpenStack Nova'
     plugin_name = "openstack_nova"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
 

--- a/sos/report/plugins/openstack_novajoin.py
+++ b/sos/report/plugins/openstack_novajoin.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OpenStackNovajoin(Plugin):
-    """OpenStack Novajoin
-    """
+
+    short_desc = 'OpenStack Novajoin'
     plugin_name = "openstack_novajoin"
     profiles = ('openstack', 'openstack_undercloud')
 

--- a/sos/report/plugins/openstack_octavia.py
+++ b/sos/report/plugins/openstack_octavia.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackOctavia(Plugin):
-    """Openstack Octavia"""
+
+    short_desc = 'Openstack Octavia'
 
     plugin_name = "openstack_octavia"
     profiles = ('openstack', 'openstack_controller')

--- a/sos/report/plugins/openstack_placement.py
+++ b/sos/report/plugins/openstack_placement.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackPlacement(Plugin):
-    """OpenStack Placement
-    """
+
+    short_desc = 'OpenStack Placement'
     plugin_name = "openstack_placement"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_sahara.py
+++ b/sos/report/plugins/openstack_sahara.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackSahara(Plugin):
-    """OpenStack Sahara"""
+
+    short_desc = 'OpenStack Sahara'
     plugin_name = 'openstack_sahara'
     profiles = ('openstack', 'openstack_controller')
 
@@ -64,8 +65,8 @@ class OpenStackSahara(Plugin):
 
 
 class DebianSahara(OpenStackSahara, DebianPlugin, UbuntuPlugin):
-    """OpenStackSahara related information for Debian based distributions."""
 
+    short_desc = 'OpenStack Sahara information for Debian based distributions'
     packages = (
         'sahara-api',
         'sahara-common',
@@ -79,8 +80,8 @@ class DebianSahara(OpenStackSahara, DebianPlugin, UbuntuPlugin):
 
 
 class RedHatSahara(OpenStackSahara, RedHatPlugin):
-    """OpenStack sahara related information for Red Hat distributions."""
 
+    short_desc = 'OpenStack Sahara information for Red Hat distributions'
     packages = ('openstack-selinux',)
 
     def setup(self):

--- a/sos/report/plugins/openstack_swift.py
+++ b/sos/report/plugins/openstack_swift.py
@@ -15,7 +15,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackSwift(Plugin):
-    """OpenStack Swift"""
+
+    short_desc = 'OpenStack Swift'
     plugin_name = "openstack_swift"
     profiles = ('openstack', 'openstack_controller')
 

--- a/sos/report/plugins/openstack_tripleo.py
+++ b/sos/report/plugins/openstack_tripleo.py
@@ -13,8 +13,8 @@ import re
 
 
 class OpenStackTripleO(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Fetch installation informations from OpenStack Installer
-    """
+
+    short_desc = 'Installation information from OpenStack Installer'
 
     plugin_name = 'openstack_tripleo'
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')

--- a/sos/report/plugins/openstack_trove.py
+++ b/sos/report/plugins/openstack_trove.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class OpenStackTrove(Plugin):
-    """OpenStack Trove
-    """
+
+    short_desc = 'OpenStack Trove'
 
     plugin_name = "openstack_trove"
     profiles = ('openstack', 'openstack_controller')

--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -15,8 +15,8 @@ from os import environ
 
 
 class OpenVSwitch(Plugin):
-    """ OpenVSwitch networking
-    """
+
+    short_desc = 'OpenVSwitch networking'
     plugin_name = "openvswitch"
     profiles = ('network', 'virt')
 

--- a/sos/report/plugins/origin.py
+++ b/sos/report/plugins/origin.py
@@ -33,7 +33,8 @@ import os.path
 
 
 class OpenShiftOrigin(Plugin):
-    """ OpenShift Origin """
+
+    short_desc = 'OpenShift Origin'
 
     plugin_name = "origin"
     files = None  # file lists assigned after path setup below
@@ -224,8 +225,8 @@ class OpenShiftOrigin(Plugin):
 
 
 class AtomicOpenShift(OpenShiftOrigin, RedHatPlugin):
-    """ OpenShift Enterprise / OpenShift Container Platform
-    """
+
+    short_desc = 'OpenShift Enterprise / OpenShift Container Platform'
 
     packages = ('atomic-openshift',)
 

--- a/sos/report/plugins/os_net_config.py
+++ b/sos/report/plugins/os_net_config.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class OsNetConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """OpenStack Net Config"""
+
+    short_desc = 'OpenStack Net Config'
 
     plugin_name = "os_net_config"
     profiles = ('openstack')

--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -21,7 +21,8 @@ from sos.utilities import is_executable
 
 # Class name must be the same as file name and method names must not change
 class Ovirt(Plugin, RedHatPlugin):
-    """oVirt Engine"""
+
+    short_desc = 'oVirt Engine'
 
     plugin_name = "ovirt"
     profiles = ('virt',)

--- a/sos/report/plugins/ovirt_engine_backup.py
+++ b/sos/report/plugins/ovirt_engine_backup.py
@@ -14,7 +14,8 @@ from datetime import datetime
 
 
 class oVirtEngineBackup(Plugin, RedHatPlugin):
-    """oVirt Engine database backup"""
+
+    short_desc = 'oVirt Engine database backup'
 
     packages = ("ovirt-engine-tools-backup",)
     plugin_name = "ovirt_engine_backup"

--- a/sos/report/plugins/ovirt_hosted_engine.py
+++ b/sos/report/plugins/ovirt_hosted_engine.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OvirtHostedEngine(Plugin, RedHatPlugin):
-    """oVirt Hosted Engine"""
+
+    short_desc = 'oVirt Hosted Engine'
 
     packages = (
         'ovirt-hosted-engine-setup',

--- a/sos/report/plugins/ovirt_imageio.py
+++ b/sos/report/plugins/ovirt_imageio.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OvirtImageIO(Plugin, RedHatPlugin):
-    """oVirt Image I/O Daemon / Proxy"""
+
+    short_desc = 'oVirt Image I/O Daemon / Proxy'
 
     packages = (
         'ovirt-imageio-daemon',

--- a/sos/report/plugins/ovirt_node.py
+++ b/sos/report/plugins/ovirt_node.py
@@ -11,7 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OvirtNode(Plugin, RedHatPlugin):
-    """oVirt Node specific information"""
+
+    short_desc = 'oVirt Node specific information'
 
     packages = (
         'imgbased',

--- a/sos/report/plugins/ovirt_provider_ovn.py
+++ b/sos/report/plugins/ovirt_provider_ovn.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class OvirtProviderOvn(Plugin, RedHatPlugin):
-    """oVirt OVN Provider
-    """
+
+    short_desc = 'oVirt OVN Provider'
 
     packages = ('ovirt-provider-ovn',)
     plugin_name = 'ovirt_provider_ovn'

--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -14,8 +14,8 @@ import os
 
 
 class OVNCentral(Plugin):
-    """ OVN Northd
-    """
+
+    short_desc = 'OVN Northd'
     plugin_name = "ovn_central"
     profiles = ('network', 'virt')
 

--- a/sos/report/plugins/ovn_host.py
+++ b/sos/report/plugins/ovn_host.py
@@ -21,8 +21,8 @@ pid_paths = [
 
 
 class OVNHost(Plugin):
-    """ OVN Controller
-    """
+
+    short_desc = 'OVN Controller'
     plugin_name = "ovn_host"
     profiles = ('network', 'virt')
 

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -13,8 +13,8 @@ import os.path
 
 
 class Pacemaker(Plugin):
-    """Pacemaker high-availability cluster resource manager
-    """
+
+    short_desc = 'Pacemaker high-availability cluster resource manager'
 
     plugin_name = "pacemaker"
     version = "1.0"

--- a/sos/report/plugins/pam.py
+++ b/sos/report/plugins/pam.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Pam(Plugin):
-    """Pluggable Authentication Modules
-    """
+
+    short_desc = 'Pluggable Authentication Modules'
 
     plugin_name = "pam"
     profiles = ('security', 'identity', 'system')

--- a/sos/report/plugins/pci.py
+++ b/sos/report/plugins/pci.py
@@ -11,8 +11,8 @@ import os
 
 
 class Pci(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """PCI devices
-    """
+
+    short_desc = 'PCI devices'
 
     plugin_name = "pci"
     profiles = ('hardware', 'system')

--- a/sos/report/plugins/pcp.py
+++ b/sos/report/plugins/pcp.py
@@ -15,8 +15,8 @@ from socket import gethostname
 
 
 class Pcp(Plugin, RedHatPlugin, DebianPlugin):
-    """Performance Co-Pilot data
-    """
+
+    short_desc = 'Performance Co-Pilot data'
 
     plugin_name = 'pcp'
     profiles = ('system', 'performance')

--- a/sos/report/plugins/peripety.py
+++ b/sos/report/plugins/peripety.py
@@ -14,7 +14,8 @@ import glob
 
 
 class Peripety(Plugin, RedHatPlugin):
-    """Peripety Storage Event Monitor"""
+
+    short_desc = 'Peripety Storage Event Monitor'
 
     packages = ('peripety',)
     services = ('peripetyd',)

--- a/sos/report/plugins/perl.py
+++ b/sos/report/plugins/perl.py
@@ -10,7 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Perl(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """Perl runtime"""
+
+    short_desc = 'Perl runtime'
 
     plugin_name = "perl"
     profiles = ('webserver', 'perl')

--- a/sos/report/plugins/pmem.py
+++ b/sos/report/plugins/pmem.py
@@ -10,12 +10,11 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class pmem(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """Persistent Memory Devices
+    """This plugin collects data from Persistent Memory devices,
+    commonly referred to as NVDIMM's or Storage Class Memory (SCM)
     """
 
-    # This plugin collects data from Persistent Memory devices,
-    # commonly referred to as NVDIMM's or Storage Class Memory (SCM).
-
+    short_desc = 'Persistent Memory Devices'
     plugin_name = 'pmem'
     profiles = ('storage', 'hardware', 'memory')
     # Utilities can be installed by package or self compiled

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -13,9 +13,7 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
-    """Podman containers
-    """
-
+    short_desc = 'Podman containers'
     plugin_name = 'podman'
     profiles = ('container',)
     packages = ('podman')

--- a/sos/report/plugins/postfix.py
+++ b/sos/report/plugins/postfix.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Postfix(Plugin):
-    """Postfix smtp server
-    """
+
+    short_desc = 'Postfix smtp server'
     plugin_name = "postfix"
     profiles = ('mail', 'services')
 

--- a/sos/report/plugins/postgresql.py
+++ b/sos/report/plugins/postgresql.py
@@ -19,7 +19,8 @@ from sos.utilities import find
 
 
 class PostgreSQL(Plugin):
-    """PostgreSQL RDBMS"""
+
+    short_desc = 'PostgreSQL RDBMS'
 
     plugin_name = "postgresql"
     profiles = ('services',)

--- a/sos/report/plugins/powerpath.py
+++ b/sos/report/plugins/powerpath.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, os
 
 
 class PowerPath(Plugin, RedHatPlugin):
-    """ EMC PowerPath
-    """
+
+    short_desc = 'EMC PowerPath'
 
     plugin_name = 'powerpath'
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -14,8 +14,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """IBM Power systems
-    """
+
+    short_desc = 'IBM Power systems'
 
     plugin_name = 'powerpc'
     profiles = ('system', 'hardware')

--- a/sos/report/plugins/ppp.py
+++ b/sos/report/plugins/ppp.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ppp(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Point-to-point protocol
-    """
+
+    short_desc = 'Point-to-point protocol'
 
     plugin_name = 'ppp'
     profiles = ('system', 'network')

--- a/sos/report/plugins/procenv.py
+++ b/sos/report/plugins/procenv.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, DebianPlugin, UbuntuPlugin
 
 
 class Procenv(Plugin, DebianPlugin, UbuntuPlugin):
-    """Process environment
-    """
+
+    short_desc = 'Process environment'
 
     plugin_name = 'procenv'
     profiles = ('system',)

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """process information
-    """
+
+    short_desc = 'process information'
 
     plugin_name = 'process'
     profiles = ('system',)

--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Processor(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """CPU information
-    """
+
+    short_desc = 'CPU information'
 
     plugin_name = 'processor'
     profiles = ('system', 'hardware', 'memory')

--- a/sos/report/plugins/psacct.py
+++ b/sos/report/plugins/psacct.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Psacct(Plugin):
-    """Process accounting information
-    """
+
+    short_desc = 'Process accounting information'
     plugin_name = "psacct"
     profiles = ('system',)
 

--- a/sos/report/plugins/ptp.py
+++ b/sos/report/plugins/ptp.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ptp(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Precision time protocol
-    """
+
+    short_desc = 'Precision time protocol'
 
     plugin_name = "ptp"
     profiles = ('system', 'services')

--- a/sos/report/plugins/pulp.py
+++ b/sos/report/plugins/pulp.py
@@ -14,7 +14,8 @@ from re import match
 
 
 class Pulp(Plugin, RedHatPlugin):
-    """Pulp platform"""
+
+    short_desc = 'Pulp platform'
 
     plugin_name = "pulp"
     packages = ("pulp-server", "pulp-katello")

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -11,8 +11,8 @@ from glob import glob
 
 
 class Puppet(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Puppet service
-    """
+
+    short_desc = 'Puppet service'
 
     plugin_name = 'puppet'
     profiles = ('services',)

--- a/sos/report/plugins/pxe.py
+++ b/sos/report/plugins/pxe.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Pxe(Plugin):
-    """PXE service
-    """
+
+    short_desc = 'PXE service'
     plugin_name = "pxe"
     profiles = ('sysmgmt', 'network')
     option_list = [("tftpboot", 'gathers content from the tftpboot path',

--- a/sos/report/plugins/python.py
+++ b/sos/report/plugins/python.py
@@ -16,8 +16,8 @@ import hashlib
 
 
 class Python(Plugin, DebianPlugin, UbuntuPlugin):
-    """Python runtime
-    """
+
+    short_desc = 'Python runtime'
 
     plugin_name = 'python'
     profiles = ('system',)

--- a/sos/report/plugins/qpid.py
+++ b/sos/report/plugins/qpid.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Qpid(Plugin, RedHatPlugin):
-    """Qpid messaging
-    """
+
+    short_desc = 'Qpid messaging'
 
     plugin_name = 'qpid'
     profiles = ('services',)

--- a/sos/report/plugins/qpid_dispatch.py
+++ b/sos/report/plugins/qpid_dispatch.py
@@ -13,8 +13,8 @@ from socket import gethostname
 
 
 class QpidDispatch(Plugin, RedHatPlugin):
-    """Qpid dispatch router
-    """
+
+    short_desc = 'Qpid dispatch router'
 
     plugin_name = 'qpid_dispatch'
     profiles = ('services',)

--- a/sos/report/plugins/qt.py
+++ b/sos/report/plugins/qt.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Qt(Plugin, RedHatPlugin):
-    """QT widget toolkit"""
+
+    short_desc = 'QT widget toolkit'
 
     plugin_name = 'qt'
     packages = ('qt', )

--- a/sos/report/plugins/quagga.py
+++ b/sos/report/plugins/quagga.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Quagga(Plugin, RedHatPlugin):
-    """Quagga routing service
-    """
+
+    short_desc = 'Quagga routing service'
 
     plugin_name = 'quagga'
     profiles = ('network',)

--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """RabbitMQ messaging service
-    """
+
+    short_desc = 'RabbitMQ messaging service'
     plugin_name = 'rabbitmq'
     profiles = ('services',)
     var_puppet_gen = "/var/lib/config-data/puppet-generated/rabbitmq"

--- a/sos/report/plugins/radius.py
+++ b/sos/report/plugins/radius.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Radius(Plugin):
-    """RADIUS service information
-    """
+
+    short_desc = 'RADIUS service information'
 
     plugin_name = "radius"
     profiles = ('network', 'identity')

--- a/sos/report/plugins/rasdaemon.py
+++ b/sos/report/plugins/rasdaemon.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Rasdaemon(Plugin, RedHatPlugin):
-    """rasdaemon kernel trace event monitor
-    """
+
+    short_desc = 'rasdaemon kernel trace event monitor'
 
     plugin_name = 'rasdaemon'
     packages = ('rasdaemon', )

--- a/sos/report/plugins/rear.py
+++ b/sos/report/plugins/rear.py
@@ -13,9 +13,7 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 class Rear(Plugin, RedHatPlugin):
 
-    """Relax and Recover
-    """
-
+    short_desc = 'Relax and Recover'
     plugin_name = "rear"
     packages = ('rear',)
 

--- a/sos/report/plugins/redis.py
+++ b/sos/report/plugins/redis.py
@@ -13,8 +13,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Redis(Plugin, RedHatPlugin):
-    """Redis, in-memory data structure store
-    """
+
+    short_desc = 'Redis, in-memory data structure store'
 
     plugin_name = 'redis'
     profiles = ('services',)

--- a/sos/report/plugins/release.py
+++ b/sos/report/plugins/release.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Release(Plugin, RedHatPlugin, UbuntuPlugin):
-    """Linux release information
-    """
+
+    short_desc = 'Linux release information'
 
     plugin_name = 'release'
     profiles = ('system',)

--- a/sos/report/plugins/rhcos.py
+++ b/sos/report/plugins/rhcos.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class RHCoreOS(Plugin, RedHatPlugin):
-    """Red Hat CoreOS"""
+
+    short_desc = 'Red Hat CoreOS'
 
     plugin_name = 'rhcos'
     packages = ('redhat-release-coreos', 'coreos-metadata')

--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Rhui(Plugin, RedHatPlugin):
-    """Red Hat Update Infrastructure
-    """
+
+    short_desc = 'Red Hat Update Infrastructure'
 
     plugin_name = 'rhui'
     profiles = ('sysmgmt',)

--- a/sos/report/plugins/rhv_analyzer.py
+++ b/sos/report/plugins/rhv_analyzer.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Rhv_Analyzer(Plugin, RedHatPlugin):
-    """RHV Log Collector Analyzer"""
+
+    short_desc = 'RHV Log Collector Analyzer'
 
     packages = ('rhv-log-collector-analyzer',)
 

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Rpm(Plugin, RedHatPlugin):
-    """RPM Package Manager
-    """
+
+    short_desc = 'RPM Package Manager'
 
     plugin_name = 'rpm'
     profiles = ('system', 'packagemanager')

--- a/sos/report/plugins/rpmostree.py
+++ b/sos/report/plugins/rpmostree.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Rpmostree(Plugin, RedHatPlugin):
-    """rpm-ostree image/package system"""
+
+    short_desc = 'rpm-ostree image/package system'
 
     plugin_name = 'rpmostree'
     packages = ('rpm-ostree',)

--- a/sos/report/plugins/ruby.py
+++ b/sos/report/plugins/ruby.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ruby(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Ruby runtime"""
+
+    short_desc = 'Ruby runtime'
 
     plugin_name = 'ruby'
     packages = ('ruby', 'ruby-irb')

--- a/sos/report/plugins/runc.py
+++ b/sos/report/plugins/runc.py
@@ -13,8 +13,7 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 class Runc(Plugin):
 
-    """runC container runtime"""
-
+    short_desc = 'runC container runtime'
     plugin_name = 'runc'
     profiles = ('container',)
 

--- a/sos/report/plugins/s390.py
+++ b/sos/report/plugins/s390.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """IBM S/390
-    """
+
+    short_desc = 'IBM S/390'
 
     plugin_name = 's390'
     profiles = ('system', 'hardware')

--- a/sos/report/plugins/salt.py
+++ b/sos/report/plugins/salt.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class Salt(Plugin, RedHatPlugin, DebianPlugin):
-    """Salt
-    """
+
+    short_desc = 'Salt'
 
     plugin_name = 'salt'
     profiles = ('sysmgmt',)

--- a/sos/report/plugins/saltmaster.py
+++ b/sos/report/plugins/saltmaster.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class SaltMaster(Plugin, RedHatPlugin, DebianPlugin):
-    """Salt Master
-    """
+
+    short_desc = 'Salt Master'
 
     plugin_name = 'saltmaster'
     profiles = ('sysmgmt',)

--- a/sos/report/plugins/samba.py
+++ b/sos/report/plugins/samba.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Samba Windows interoperability
-    """
+
+    short_desc = 'Samba Windows interoperability'
     packages = ('samba-common',)
     plugin_name = "samba"
     profiles = ('services',)

--- a/sos/report/plugins/sanlock.py
+++ b/sos/report/plugins/sanlock.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class SANLock(Plugin):
-    """SANlock daemon
-    """
+
+    short_desc = 'SANlock daemon'
     plugin_name = "sanlock"
     profiles = ('cluster', 'virt')
     packages = ["sanlock"]

--- a/sos/report/plugins/saphana.py
+++ b/sos/report/plugins/saphana.py
@@ -11,7 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class saphana(Plugin, RedHatPlugin):
-    """SAP HANA"""
+
+    short_desc = 'SAP HANA'
 
     plugin_name = 'saphana'
     profiles = ['sap']

--- a/sos/report/plugins/sapnw.py
+++ b/sos/report/plugins/sapnw.py
@@ -19,7 +19,8 @@ def get_directory_listing(path):
 
 
 class sapnw(Plugin, RedHatPlugin):
-    """SAP NetWeaver"""
+
+    short_desc = 'SAP NetWeaver'
 
     plugin_name = 'sapnw'
     profiles = ['sap']

--- a/sos/report/plugins/sar.py
+++ b/sos/report/plugins/sar.py
@@ -11,8 +11,8 @@ import os
 
 
 class Sar(Plugin,):
-    """System Activity Reporter
-    """
+
+    short_desc = 'System Activity Reporter'
 
     plugin_name = 'sar'
     profiles = ('system', 'performance')

--- a/sos/report/plugins/sas3ircu.py
+++ b/sos/report/plugins/sas3ircu.py
@@ -14,8 +14,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class SAS3ircu(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """SAS-3 Integrated RAID adapter information
-    """
+
+    short_desc = 'SAS-3 Integrated RAID adapter information'
 
     plugin_name = "sas3ircu"
     commands = ("sas3ircu",)

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Scsi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """SCSI devices
-    """
+
+    short_desc = 'SCSI devices'
 
     plugin_name = 'scsi'
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/selinux.py
+++ b/sos/report/plugins/selinux.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class SELinux(Plugin, RedHatPlugin):
-    """SELinux access control
-    """
+
+    short_desc = 'SELinux access control'
 
     plugin_name = 'selinux'
     profiles = ('container', 'system', 'security', 'openshift')

--- a/sos/report/plugins/sendmail.py
+++ b/sos/report/plugins/sendmail.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Sendmail(Plugin):
-    """sendmail service
-    """
+
+    short_desc = 'sendmail service'
 
     plugin_name = "sendmail"
     profiles = ('services', 'mail')

--- a/sos/report/plugins/services.py
+++ b/sos/report/plugins/services.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Services(Plugin):
-    """System services
-    """
+
+    short_desc = 'System services'
 
     plugin_name = "services"
     profiles = ('system', 'boot')

--- a/sos/report/plugins/skydive.py
+++ b/sos/report/plugins/skydive.py
@@ -13,8 +13,8 @@ import os
 
 
 class Skydive(Plugin, RedHatPlugin):
-    """Skydive, a network topology and protocols analyzer
-    """
+
+    short_desc = 'Skydive network topology and protocol analyzer'
 
     plugin_name = "skydive"
     profiles = ('network', )

--- a/sos/report/plugins/smartcard.py
+++ b/sos/report/plugins/smartcard.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Smartcard(Plugin, RedHatPlugin):
-    """PKCS#11 smart cards
-    """
+
+    short_desc = 'PKCS#11 smart cards'
 
     plugin_name = 'smartcard'
     profiles = ('security', 'identity', 'hardware')

--- a/sos/report/plugins/snappy.py
+++ b/sos/report/plugins/snappy.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin
 
 
 class Snappy(Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin):
-    """Snap packages
-    """
+
+    short_desc = 'Snap packages'
 
     plugin_name = 'snappy'
     profiles = ('system', 'sysmgmt', 'packagemanager')

--- a/sos/report/plugins/snmp.py
+++ b/sos/report/plugins/snmp.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Snmp(Plugin):
-    """Simple network management protocol
-    """
+
+    short_desc = 'Simple network management protocol'
     plugin_name = "snmp"
     profiles = ('system', 'sysmgmt')
 

--- a/sos/report/plugins/sos_extras.py
+++ b/sos/report/plugins/sos_extras.py
@@ -12,8 +12,8 @@ import stat
 
 
 class SosExtras(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """Collect extra data defined in /etc/sos.extras.d/ .
-    """
+
+    short_desc = 'Collect extra data defined in /etc/sos.extras.d'
 
     """The plugin traverses 'extras_dir' directory and for each file there,
     it executes commands or collects files optionally with sizelimit. Expected

--- a/sos/report/plugins/soundcard.py
+++ b/sos/report/plugins/soundcard.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Soundcard(Plugin):
-    """ Sound devices
-    """
+
+    short_desc = 'Sound devices'
 
     plugin_name = "soundcard"
     profiles = ('desktop', 'hardware')

--- a/sos/report/plugins/squid.py
+++ b/sos/report/plugins/squid.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Squid(Plugin):
-    """Squid caching proxy
-    """
+
+    short_desc = 'Squid caching proxy'
 
     plugin_name = 'squid'
     profiles = ('webserver', 'services', 'sysmgmt')

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Ssh(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Secure shell service
-    """
+
+    short_desc = 'Secure shell service'
 
     plugin_name = 'ssh'
     profiles = ('services', 'security', 'system', 'identity')

--- a/sos/report/plugins/ssmtp.py
+++ b/sos/report/plugins/ssmtp.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Ssmtp(Plugin, RedHatPlugin):
-    """sSMTP information
-    """
+
+    short_desc = 'sSMTP information'
 
     plugin_name = 'ssmtp'
     profiles = ('mail', 'system')

--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -13,8 +13,8 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class Sssd(Plugin):
-    """System security service daemon
-    """
+
+    short_desc = 'System security service daemon'
 
     plugin_name = "sssd"
     profiles = ('services', 'security', 'identity')

--- a/sos/report/plugins/storageconsole.py
+++ b/sos/report/plugins/storageconsole.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 
 
 class StorageConsole(Plugin, RedHatPlugin, DebianPlugin):
-    """Red Hat Storage Console
-    """
+
+    short_desc = 'Red Hat Storage Console'
 
     plugin_name = 'storageconsole'
     profiles = ('storage',)

--- a/sos/report/plugins/stratis.py
+++ b/sos/report/plugins/stratis.py
@@ -12,7 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Stratis(Plugin, RedHatPlugin):
-    """Stratis Storage"""
+
+    short_desc = 'Stratis Storage'
 
     packages = ('stratis-cli', 'stratisd')
     services = ('stratisd',)

--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -11,8 +11,8 @@ import glob
 
 
 class SubscriptionManager(Plugin, RedHatPlugin):
-    """subscription-manager information
-    """
+
+    short_desc = 'subscription-manager information'
 
     plugin_name = 'subscription_manager'
     profiles = ('system', 'packagemanager', 'sysmgmt')

--- a/sos/report/plugins/sudo.py
+++ b/sos/report/plugins/sudo.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Sudo(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Sudo command execution
-    """
+
+    short_desc = 'Sudo command execution'
     plugin_name = 'sudo'
     profiles = ('identity', 'system')
     packages = ('sudo')

--- a/sos/report/plugins/sunrpc.py
+++ b/sos/report/plugins/sunrpc.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class SunRPC(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Sun RPC service
-    """
+
+    short_desc = 'Sun RPC service'
 
     plugin_name = "sunrpc"
     profiles = ('system', 'storage', 'network', 'nfs')

--- a/sos/report/plugins/symcli.py
+++ b/sos/report/plugins/symcli.py
@@ -14,8 +14,8 @@ from sos.utilities import is_executable
 
 
 class Symcli(Plugin, RedHatPlugin):
-    """ EMC Symcli
-    """
+
+    short_desc = 'EMC Symcli'
 
     plugin_name = 'symcli'
     profiles = ('storage', 'hardware')

--- a/sos/report/plugins/system.py
+++ b/sos/report/plugins/system.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class System(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """core system information
-    """
+
+    short_desc = 'core system information'
 
     plugin_name = "system"
     profiles = ('system', 'kernel')

--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """ System management daemon
-    """
+
+    short_desc = 'System management daemon'
 
     plugin_name = "systemd"
     profiles = ('system', 'services', 'boot')

--- a/sos/report/plugins/systemtap.py
+++ b/sos/report/plugins/systemtap.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class SystemTap(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """SystemTap dynamic instrumentation
-    """
+
+    short_desc = 'SystemTap dynamic instrumentation'
 
     plugin_name = 'systemtap'
     profiles = ('debug', 'performance')

--- a/sos/report/plugins/sysvipc.py
+++ b/sos/report/plugins/sysvipc.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class SysVIPC(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """SysV IPC
-    """
+
+    short_desc = 'SysV IPC'
 
     plugin_name = "sysvipc"
     profiles = ('system', 'services')

--- a/sos/report/plugins/targetcli.py
+++ b/sos/report/plugins/targetcli.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class TargetCli(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """TargetCLI TCM/LIO configuration
-    """
+
+    short_desc = 'TargetCLI TCM/LIO configuration'
     packages = ('targetcli', 'python-rtslib')
     profiles = ('storage', )
     plugin_name = 'targetcli'

--- a/sos/report/plugins/teamd.py
+++ b/sos/report/plugins/teamd.py
@@ -11,9 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Teamd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Network interface teaming
-    """
 
+    short_desc = 'Network Interface Teaming'
     plugin_name = 'teamd'
     profiles = ('network', 'hardware', )
 

--- a/sos/report/plugins/tftpserver.py
+++ b/sos/report/plugins/tftpserver.py
@@ -12,9 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class TftpServer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """TFTP server
-    """
 
+    short_desc = 'TFTP Server information'
     plugin_name = 'tftpserver'
     profiles = ('sysmgmt', 'network')
 

--- a/sos/report/plugins/tomcat.py
+++ b/sos/report/plugins/tomcat.py
@@ -11,9 +11,8 @@ from datetime import datetime
 
 
 class Tomcat(Plugin, RedHatPlugin):
-    """Apache Tomcat server
-    """
 
+    short_desc = 'Apache Tomcat Server'
     plugin_name = 'tomcat'
     profiles = ('webserver', 'java', 'services', 'sysmgmt')
 

--- a/sos/report/plugins/tuned.py
+++ b/sos/report/plugins/tuned.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Tuned(Plugin, RedHatPlugin):
-    """Tuned system tuning daemon
-    """
+
+    short_desc = 'Tuned system tuning daemon'
     packages = ('tuned',)
     profiles = ('system', 'performance')
     plugin_name = 'tuned'

--- a/sos/report/plugins/ubuntu.py
+++ b/sos/report/plugins/ubuntu.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class Ubuntu(Plugin, UbuntuPlugin):
-    """ Ubuntu specific information
-    """
+
+    short_desc = 'Ubuntu specific information'
 
     plugin_name = 'ubuntu'
     profiles = ('system',)

--- a/sos/report/plugins/udev.py
+++ b/sos/report/plugins/udev.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Udev(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """udev dynamic device management
-    """
+
+    short_desc = 'udev dynamic device management'
 
     plugin_name = 'udev'
     profiles = ('system', 'hardware', 'boot')

--- a/sos/report/plugins/unity.py
+++ b/sos/report/plugins/unity.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, UbuntuPlugin
 
 
 class unity(Plugin, UbuntuPlugin):
-    """Unity
-    """
+
+    short_desc = 'Unity'
 
     plugin_name = 'unity'
     profiles = ('hardware', 'desktop')

--- a/sos/report/plugins/unpackaged.py
+++ b/sos/report/plugins/unpackaged.py
@@ -13,10 +13,9 @@ import stat
 
 
 class Unpackaged(Plugin, RedHatPlugin):
-    """
-    Collects a list of files that are not handled by the package
-    manager
-    """
+
+    short_desc = ('Collects a list of files that are not handled by the '
+                  'package manager')
 
     def setup(self):
 

--- a/sos/report/plugins/upstart.py
+++ b/sos/report/plugins/upstart.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Upstart(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Upstart init system
-    """
+
+    short_desc = 'Upstart init system'
 
     plugin_name = 'upstart'
     profiles = ('system', 'services', 'boot')

--- a/sos/report/plugins/usb.py
+++ b/sos/report/plugins/usb.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Usb(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """USB devices
-    """
+
+    short_desc = 'USB devices'
 
     plugin_name = "usb"
     profiles = ('hardware',)

--- a/sos/report/plugins/validation_framework.py
+++ b/sos/report/plugins/validation_framework.py
@@ -17,8 +17,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 #   this plugin has a generic name.
 # - The Framework is targeted at Red Hat products, at least for now.
 class ValidationFramework(Plugin, RedHatPlugin):
-    """Fetch run logs provided by the Validation Framework
-    """
+
+    short_desc = 'Logs provided by the Validation Framework'
 
     plugin_name = 'validation_framework'
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')

--- a/sos/report/plugins/vdo.py
+++ b/sos/report/plugins/vdo.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Vdo(Plugin, RedHatPlugin):
-    """Virtual Data Optimizer
-    """
+
+    short_desc = 'Virtual Data Optimizer'
 
     plugin_name = 'vdo'
     profiles = ('storage',)

--- a/sos/report/plugins/vdsm.py
+++ b/sos/report/plugins/vdsm.py
@@ -50,8 +50,8 @@ LVM_CONFIG = re.sub(r"\s+", " ", LVM_CONFIG).strip()
 
 
 class Vdsm(Plugin, RedHatPlugin):
-    """vdsm plugin"""
 
+    short_desc = 'VDSM - Virtual Desktop and Server Manager'
     packages = (
         'vdsm',
         'vdsm-client',

--- a/sos/report/plugins/veritas.py
+++ b/sos/report/plugins/veritas.py
@@ -11,8 +11,8 @@ import os
 
 
 class Veritas(Plugin, RedHatPlugin):
-    """Veritas software
-    """
+
+    short_desc = 'Veritas software'
 
     plugin_name = 'veritas'
     profiles = ('cluster', 'storage')

--- a/sos/report/plugins/vhostmd.py
+++ b/sos/report/plugins/vhostmd.py
@@ -11,8 +11,8 @@ import os
 
 
 class vhostmd(Plugin, RedHatPlugin):
-    """vhostmd virtualization metrics collection
-    """
+
+    short_desc = 'vhostmd virtualization metrics collection'
 
     plugin_name = 'vhostmd'
     profiles = ['sap', 'virt', 'system']

--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """client for libvirt virtualization API
-    """
+
+    short_desc = 'client for libvirt virtualization API'
 
     plugin_name = 'virsh'
     profiles = ('system', 'virt')

--- a/sos/report/plugins/virtwho.py
+++ b/sos/report/plugins/virtwho.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class VirtWho(Plugin, RedHatPlugin):
-    """Virt-Who agent
-    """
+
+    short_desc = 'Virt-Who agent'
 
     plugin_name = 'virtwho'
     profiles = ('virt', 'system')

--- a/sos/report/plugins/vmware.py
+++ b/sos/report/plugins/vmware.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class VMWare(Plugin, RedHatPlugin):
-    """VMWare client information
-    """
+
+    short_desc = 'VMWare client information'
 
     plugin_name = 'vmware'
     profiles = ('virt',)

--- a/sos/report/plugins/vsftpd.py
+++ b/sos/report/plugins/vsftpd.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Vsftpd(Plugin, RedHatPlugin):
-    """Vsftpd server
-    """
+
+    short_desc = 'Vsftpd server'
 
     plugin_name = 'vsftpd'
     profiles = ('services',)

--- a/sos/report/plugins/vulkan.py
+++ b/sos/report/plugins/vulkan.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Vulkan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """Vulkan
-    """
+
+    short_desc = 'Vulkan'
 
     plugin_name = 'vulkan'
     profiles = ('hardware', 'desktop', 'gpu')

--- a/sos/report/plugins/watchdog.py
+++ b/sos/report/plugins/watchdog.py
@@ -15,7 +15,8 @@ import os
 
 
 class Watchdog(Plugin, RedHatPlugin):
-    """Watchdog information."""
+
+    short_desc = 'Watchdog information.'
     plugin_name = 'watchdog'
     profiles = ('system',)
     packages = ('watchdog',)

--- a/sos/report/plugins/wireless.py
+++ b/sos/report/plugins/wireless.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Wireless(Plugin, DebianPlugin, UbuntuPlugin):
-    """Wireless
-    """
+
+    short_desc = 'Wireless'
 
     plugin_name = 'wireless'
     profiles = ('hardware', 'desktop', 'network')
@@ -27,8 +27,8 @@ class Wireless(Plugin, DebianPlugin, UbuntuPlugin):
 
 
 class RedHatWireless(Wireless, RedHatPlugin):
-    """Wireless
-    """
+
+    short_desc = 'Wireless'
 
     files = ('/usr/sbin/iw', '/usr/sbin/iwlist')
     packages = ('iw', 'wireless-tools')

--- a/sos/report/plugins/x11.py
+++ b/sos/report/plugins/x11.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """X windowing system
-    """
+
+    short_desc = 'X windowing system'
 
     plugin_name = 'x11'
     profiles = ('hardware', 'desktop')

--- a/sos/report/plugins/xen.py
+++ b/sos/report/plugins/xen.py
@@ -12,8 +12,8 @@ import re
 
 
 class Xen(Plugin, RedHatPlugin):
-    """Xen virtualization
-    """
+
+    short_desc = 'Xen virtualization'
 
     plugin_name = 'xen'
     profiles = ('virt',)

--- a/sos/report/plugins/xfs.py
+++ b/sos/report/plugins/xfs.py
@@ -10,8 +10,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Xfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """XFS filesystem
-    """
+
+    short_desc = 'XFS filesystem'
 
     plugin_name = 'xfs'
     profiles = ('storage',)

--- a/sos/report/plugins/xinetd.py
+++ b/sos/report/plugins/xinetd.py
@@ -12,8 +12,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Xinetd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
-    """xinetd information
-    """
+
+    short_desc = 'xinetd information'
 
     plugin_name = 'xinetd'
     profiles = ('services', 'network', 'boot')

--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -13,8 +13,8 @@ YUM_PLUGIN_PATH = "/usr/lib/yum-plugins/"
 
 
 class Yum(Plugin, RedHatPlugin):
-    """yum information
-    """
+
+    short_desc = 'yum information'
 
     plugin_name = 'yum'
     profiles = ('system', 'packagemanager', 'sysmgmt')

--- a/sos/report/plugins/zfs.py
+++ b/sos/report/plugins/zfs.py
@@ -11,8 +11,8 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
 
 
 class Zfs(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
-    """ZFS filesystem
-    """
+
+    short_desc = 'ZFS filesystem'
 
     plugin_name = 'zfs'
     profiles = ('storage',)

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -69,8 +69,8 @@ class MockPlugin(Plugin):
 
 
 class NamedMockPlugin(Plugin):
-    """This plugin has a description."""
 
+    short_desc = "This plugin has a description."
     plugin_name = "testing"
 
     def setup(self):


### PR DESCRIPTION
Converts all current plugin docstrings into a `short_desc` attribute,
that is now referenced by `Plugin.get_description()`.

Closes: #1960
Resolves: #2036

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
