### PR TITLE
[Plugin|390] Fix architecture-only enablement checks

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1775,6 +1775,11 @@ class Plugin(object):
         return True
 
     def _check_plugin_triggers(self, files, packages, commands, services):
+
+        if not any([files, packages, commands, services]):
+            # no checks beyond architecture restrictions
+            return self.check_is_architecture()
+
         return ((any(os.path.exists(fname) for fname in files) or
                 any(self.is_installed(pkg) for pkg in packages) or
                 any(is_executable(cmd) for cmd in commands) or

--- a/sos/report/plugins/s390.py
+++ b/sos/report/plugins/s390.py
@@ -17,13 +17,7 @@ class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     plugin_name = 's390'
     profiles = ('system', 'hardware')
-
-    # Check for s390 arch goes here
-
-    def check_enabled(self):
-        return ("s390" in self.policy.get_arch())
-
-    # Gather s390 specific information
+    architectures = ('s390.*',)
 
     def setup(self):
         self.add_copy_spec([


### PR DESCRIPTION
First commit fixes the enablement checks for plugins that only specify an `architectures` tuple, and no others like `packages`, `files`, etc...

Second commit updates the s390 plugin to use that style of trigger, like the powerpc plugin.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
