### PR TITLE
[containers_common] Add plugin for common containers configs

### DIFF
--- a/sos/report/plugins/buildah.py
+++ b/sos/report/plugins/buildah.py
@@ -20,13 +20,6 @@ class Buildah(Plugin, RedHatPlugin):
     profiles = ('container',)
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/containers/registries.conf",
-            "/etc/containers/storage.conf",
-            "/etc/containers/mounts.conf",
-            "/etc/containers/policy.json",
-        ])
-
         subcmds = [
             'containers',
             'containers --all',

--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2020 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+
+
+class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
+
+    short_desc = 'Common container configs under {/etc,/usr/share}/containers'
+    plugin_name = 'containers_common'
+    profiles = ('container', )
+    packages = ('containers-common', )
+
+    def setup(self):
+        self.add_copy_spec([
+            '/etc/containers/*',
+            '/usr/share/containers/*',
+        ])
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -27,13 +27,6 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
     ]
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/containers/registries.conf",
-            "/etc/containers/storage.conf",
-            "/etc/containers/mounts.conf",
-            "/etc/containers/policy.json",
-        ])
-
         self.add_env_var([
             'HTTP_PROXY',
             'HTTPS_PROXY',


### PR DESCRIPTION
Move collection of whole /etc/containers and /usr/share/containers to
one containers_common plugin enabled by the package of the same name.

Since the package is a common dependency for buildah and podman, no regression
in default data collection happens.

Resolves: #2040

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
