### PR TITLE
[sos] Write to host filesystem if in container with HOST env var set

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -77,7 +77,7 @@ class SoSComponent():
         self.opts = self.load_options()
 
         if self.configure_logging:
-            tmpdir = self.opts.tmp_dir or '/var/tmp'
+            tmpdir = self.get_tmpdir_default()
 
             if not os.path.isdir(tmpdir) \
                     or not os.access(tmpdir, os.W_OK):
@@ -108,6 +108,21 @@ class SoSComponent():
 
     def _exit(self, error=0):
         raise SystemExit(error)
+
+    def get_tmpdir_default(self):
+        """If --tmp-dir is not specified, provide a default location.
+        Normally this is /var/tmp, but if we detect we are in a container, then
+        use a standardized env var to redirect to the host's filesystem instead
+        """
+        if self.opts.tmp_dir:
+            return self.opts.tmp_dir
+
+        tmpdir = '/var/tmp'
+
+        if os.getenv('HOST', None) and os.getenv('container', None):
+            tmpdir = os.path.join(os.getenv('HOST'), tmpdir.lstrip('/'))
+
+        return tmpdir
 
     def check_listing_options(self):
         opts = [o for o in self.opts.dict().keys() if o.startswith('list')]


### PR DESCRIPTION
Moving tmpdir specifications out of policy gave us the ability to have
logging within `Policy`, however it was unnoticed before that this
stopped the redirection from container filesystem to host filesystem
when sos was running in a container (and we wanted to save the archive
to the host and not the container).

Fix this by standardizing a check for a `HOST` environment variable,
when a `container` env var is set as well. This has been used by the Red
Hat policy for some time to determine chroot locations for when we're
running in a container, and has been working well. The `container`
environment variable should be set at container setup by modern
container runtimes.

If either the `container` or `HOST` environment variable is not set, but
we are running in a container, then we will continue to write to the
container's filesystem (while policy will still determine any chroot
requirements separately).

Resolves: #2041

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
