### PR TITLE
[redhat] Update CoreOS release line match

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -503,7 +503,7 @@ support representative.
         host_release = os.environ[ENV_HOST_SYSROOT] + cls._redhat_release
         try:
             for line in open(host_release, 'r').read().splitlines():
-                coreos |= 'Red Hat CoreOS' in line
+                coreos |= 'Red Hat Enterprise Linux CoreOS' in line
         except IOError:
             pass
         return coreos


### PR DESCRIPTION
Updates the release line we try to match against for identifying CoreOS
hosts to the syntax now used by Red Hat CoreOS.

Resolves: #2042

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
