### PR TITLE
[cups] Call add_journal() with output set to 'verbose'

### DIFF
--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -39,6 +39,6 @@ class Cups(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "lpstat -d"
         ])
 
-        self.add_journal(units="cups")
+        self.add_journal(units="cups", output="verbose")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Cups now stores the Job ID as a journal field JID. Unless the journalctl
is captured with the 'verbose' output option the information will not be
available in the report..

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
