### PR TITLE
[policies] Take care of empty lines while parsing /etc/os-release

### DIFF
--- a/sos/policies/cos.py
+++ b/sos/policies/cos.py
@@ -27,7 +27,8 @@ class CosPolicy(LinuxPolicy):
 
         try:
             with open('/etc/os-release', 'r') as fp:
-                os_release = dict(line.strip().split('=') for line in fp)
+                os_release = dict(line.strip().split('=') for line in fp
+                                  if line.strip())
                 id = os_release.get('ID')
                 return id == 'cos'
         except IOError:


### PR DESCRIPTION
The check function in CozPolicy class hits the ValueError exception
if we have empty lines in /etc/os-release file.

Updated the list comprehension used to parse the /etc/os-release file
with a if condition to take care of empty lines.

Fixes: #2045

Signed-off-by: Sourabh Jain <sourabhjain@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
