### PR TITLE
[rabbitmq] Call containerised rabbitmqctl report on foreground

### DIFF
--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -34,7 +34,8 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             for container in container_names:
                 self.get_container_logs(container)
                 self.add_cmd_output(
-                    self.fmt_container_cmd(container, 'rabbitmqctl report')
+                    self.fmt_container_cmd(container, 'rabbitmqctl report'),
+                    foreground=True
                 )
         else:
             self.add_cmd_output("rabbitmqctl report")


### PR DESCRIPTION
In some use cases, "rabbitmqctl report" run in a container can hung
due to missing terminal. Let workaround it for now by running the
command with --foreground timeout option.

Resolves: #2047

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
