### PR TITLE
[component|collect|report] Add metadata collection

### DIFF
--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -153,7 +153,9 @@ class Cluster():
         """Used by SosNode() to retrieve the appropriate label from the cluster
         as set by set_node_label() in the cluster profile.
         """
-        return self.set_node_label(node)
+        label = self.set_node_label(node)
+        node.manifest.add_field('label', label)
+        return label
 
     def set_node_label(self, node):
         """This may be overridden by clusters.

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -143,7 +143,10 @@ class ovirt(Cluster):
         db_sos = self.exec_master_cmd(cmd, need_root=True)
         for line in db_sos['stdout'].splitlines():
             if fnmatch.fnmatch(line, '*sosreport-*tar*'):
-                return line.strip()
+                _pg_dump = line.strip()
+                self.master.manifest.add_field('postgresql_dump',
+                                               _pg_dump.split('/')[-1])
+                return _pg_dump
         self.log_error('Failed to gather database dump')
         return False
 

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -107,6 +107,14 @@ class SosNode():
     def _fmt_msg(self, msg):
         return '{:<{}} : {}'.format(self._hostname, self.hostlen + 1, msg)
 
+    def set_node_manifest(self, manifest):
+        """Set the manifest section that this node will write to
+        """
+        self.manifest = manifest
+        self.manifest.add_field('hostname', self._hostname)
+        self.manifest.add_field('policy', self.host.distro)
+        self.manifest.add_field('sos_version', self.sos_info['version'])
+
     def check_in_container(self):
         """
         Tries to identify if we are currently running in a container or not.
@@ -692,7 +700,9 @@ class SosNode():
                 self.log_debug('Requested to enable preset %s but preset does '
                                'not exist on node' % self.opts.preset)
 
-        return "%s %s" % (sos_cmd, ' '.join(sos_opts))
+        _sos_cmd = "%s %s" % (sos_cmd, ' '.join(sos_opts))
+        self.manifest.add_field('final_sos_command', _sos_cmd)
+        return _sos_cmd
 
     def determine_sos_label(self):
         """Determine what, if any, label should be added to the sosreport"""
@@ -724,6 +734,7 @@ class SosNode():
         self.log_info('Final sos path: %s' % path)
         self.sos_path = path
         self.archive = path.split('/')[-1]
+        self.manifest.add_field('collected_archive', self.archive)
 
     def determine_sos_error(self, rc, stdout):
         if rc == -1:


### PR DESCRIPTION
Adds facilities to capture metadata information about a particular sos
run, and save it to any resulting archive as `manifest.json`. This
manifest will include component-specific information that should assist
in analysis of sos runs.

For `report`, this is an extension of existing reporting functionality,
that records information on a per-plugin basis regarding command output
and file collection. However, more information is recorded in this
collection than the JSON or HTML reporting structures that review a
finished archive.

Manifest data is added at the time of collection; for commands this includes
a breakout of command, parameters, full execution syntax, filepath relative
to archive root, and the actual return code of the command, even if non-zero.
For files, the copied files are grouped by the specification set in
`add_copy_spec()` calls, I.E. for any file pattern regex that collects
at least one file, all files collected by that regex are listed.

Additionally, this adds a `tags` parameter to `add_copy_spec()`,
`add_cmd_output()`, and `collect_cmd_output()` that if used will add
tagging information to the manifest entries for those collections. This
is intended to assist in future sos work (E.G. `sos examine`) and third
party utilities in identifying relevant/connected data that is present
in the archive. Note that all collections specified by a single call to
any of these collection methods will inherit the same tags.

For `collect` we now record the cluster type, node list, and a separate
entry for each node in the node list that includes the sos version, node
sos policy, and the archive within the collect tarball that was
collected for that host.

Closes: #1990
Resolves: #2050

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
