### PR TITLE
[archive] Drop bzip2

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -15,7 +15,6 @@ BuildRequires: gettext
 Requires: libxml2-python
 Requires: rpm-python
 Requires: tar
-Requires: bzip2
 Requires: xz
 Requires: python3-pexpect
 

--- a/sos/archive.py
+++ b/sos/archive.py
@@ -117,7 +117,7 @@ class Archive(object):
         """Finalize an archive object via method. This may involve creating
         An archive that is subsequently compressed or simply closing an
         archive that supports in-line handling. If method is automatic then
-        the following methods are tried in order: xz, bz2 and gzip"""
+        the following methods are tried in order: xz, gzip"""
 
         self.close()
 
@@ -667,7 +667,7 @@ class TarFileArchive(FileCacheArchive):
     def _compress(self):
         methods = []
         # Make sure that valid compression commands exist.
-        for method in ['xz', 'bzip2', 'gzip']:
+        for method in ['xz', 'gzip']:
             if is_executable(method):
                 methods.append(method)
             else:

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -325,7 +325,7 @@ class SoSCollector(SoSComponent):
                                  help='Timeout for sosreport on each node.')
         collect_grp.add_argument('-z', '--compression-type',
                                  dest="compression",
-                                 choices=['auto', 'gzip', 'bzip2', 'xz'],
+                                 choices=['auto', 'gzip', 'xz'],
                                  help="compression technology to use")
 
         # Group to make tarball encryption (via GPG/password) exclusive

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -725,12 +725,10 @@ any third party.
 
     def get_cmd_for_compress_method(self, method, threads):
         cmd = method
-        # use fast compression if using xz or bz2
-        if cmd != "gzip":
-            cmd = "%s -2" % cmd
-        # determine number of threads to use for compressing - applicable
-        # only for xz and of version 5.2 or higher
         if cmd.startswith("xz"):
+            # XZ only determine number of threads to use (for 5.2 only) and
+            # set compression to -2
+            cmd = "%s -2" % cmd
             try:
                 xz_package = self._get_pkg_name_for_binary(method)
                 xz_version = self.package_manager\

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -27,7 +27,6 @@ from sos import _sos as _
 from sos import __version__
 from sos.component import SoSComponent
 import sos.policies
-from sos.archive import TarFileArchive
 from sos.report.reporting import (Report, Section, Command, CopiedFile,
                                   CreatedFile, Alert, Note, PlainTextReport,
                                   JSONReport, HTMLReport)
@@ -254,7 +253,7 @@ class SoSReport(SoSComponent):
                             dest="compression_type",
                             default='auto',
                             help="compression technology to use [auto, "
-                                 "gzip, bzip2, xz] (default=auto)")
+                                 "gzip, xz] (default=auto)")
         parser.add_argument("--allow-system-changes", action="store_true",
                             dest="allow_system_changes", default=False,
                             help="Run commands even if they can change the "

--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -103,7 +103,7 @@ run_expecting_sucess " --batch   --label TEST   -a  -c never" extract
 run_expecting_sucess " --batch   --debug  --log-size 0  -c always" extract
 run_expecting_sucess " --batch   -z xz   --log-size 1" extract
 run_expecting_sucess " --batch   -z gzip" extract
-run_expecting_sucess " --batch   -z bzip2   -t 1 -n hardware" extract
+run_expecting_sucess " --batch   -t 1 -n hardware" extract
 run_expecting_sucess " --batch   --quiet    -e opencl -k kernel.with-timer" extract
 run_expecting_sucess " --batch   --case-id 10101   --all-logs --since=$(date -d "yesterday 13:00" '+%Y%m%d') " extract
 run_expecting_sucess " --batch   --verbose   --no-postproc" extract


### PR DESCRIPTION
This just leaves xz with bzip2 as the automtic backup.
Bzip2 took the most time by far and only does marginally
better than gzip.

time 27 Size 10.72MiB --batch -z xz --log-size 1
time 27 Size 16.32MiB --batch -z gzip --log-size 1
time 40 Size 14.17MiB --batch -z bzip2 --log-size 1
time 43 Size 105.21MiB --batch -z xz --all-logs
time 64 Size 187.38MiB --batch -z gzip --all-logs
time 135 Size 182.86MiB --batch -z bzip2 --all-logs

Resolves: #2053

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
