### PR TITLE
[containers_common] collect rootless containers info

### DIFF
--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -9,6 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+import os
 
 
 class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -17,11 +18,39 @@ class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'containers_common'
     profiles = ('container', )
     packages = ('containers-common', )
+    option_list = [
+        ('rootlessusers', 'colon-separated list of users\' containers info',
+         '', ''),
+    ]
 
     def setup(self):
         self.add_copy_spec([
             '/etc/containers/*',
             '/usr/share/containers/*',
+            '/etc/subuid',
+            '/etc/subgid',
         ])
+        self.add_cmd_output(['loginctl user-status'])
+
+        users_opt = self.get_option('rootlessusers')
+        users_list = []
+        if users_opt:
+            users_list = [x for x in users_opt.split(':') if x]
+
+        user_subcmds = [
+            'info',
+            'unshare cat /proc/self/uid_map',
+            'unshare cat /proc/self/gid_map'
+        ]
+        for user in users_list:
+            # collect user's containers' config
+            self.add_copy_spec(
+                '%s/.config/containers/' % (os.path.expanduser('~%s') % user))
+            # collect the user's podman/buildah info and uid/guid maps
+            for binary in ['/usr/bin/podman', '/usr/bin/buildah']:
+                for cmd in user_subcmds:
+                    self.add_cmd_output([
+                        'machinectl -q shell %s@ %s %s' % (user, binary, cmd)
+                    ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add the ability to collect data/info about rootless podman/buildah
containers, in particular:

- containers_common plugopt 'rootlessusers' as a list of users to inspect
- for each user, collect its containers config and [podman|buildah] info
- collect user-status and few user-related config files
- collect UID and GID mapping in buildah and podman

Resolves: #2055

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
