### PR TITLE
[general] set file logging only when initialized

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -182,6 +182,7 @@ class SoSComponent():
         # main soslog
         self.soslog = logging.getLogger('sos')
         self.soslog.setLevel(logging.DEBUG)
+        flog = None
         if not self.check_listing_options():
             self.sos_log_file = self.get_temp_file()
             flog = logging.StreamHandler(self.sos_log_file)
@@ -195,10 +196,12 @@ class SoSComponent():
             console.setFormatter(logging.Formatter('%(message)s'))
             if self.opts.verbosity and self.opts.verbosity > 1:
                 console.setLevel(logging.DEBUG)
-                flog.setLevel(logging.DEBUG)
+                if flog:
+                    flog.setLevel(logging.DEBUG)
             elif self.opts.verbosity and self.opts.verbosity > 0:
                 console.setLevel(logging.INFO)
-                flog.setLevel(logging.DEBUG)
+                if flog:
+                    flog.setLevel(logging.DEBUG)
             else:
                 console.setLevel(logging.WARNING)
             self.soslog.addHandler(console)


### PR DESCRIPTION
To fix regression in 8a2a765:

Could not initialize 'report':
  local variable 'flog' referenced before assignment

Resolves: #2057

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
