### PR TITLE
[insights] collect insights dump output in deterministic filename

### DIFF
--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -33,7 +33,8 @@ class RedHatInsights(Plugin, RedHatPlugin):
 
         # Collect insights-client report data into given dump dir
         path = self.get_cmd_output_path(name="insights-client-dump")
-        self.add_cmd_output("insights-client --offline --output-dir %s" % path)
+        self.add_cmd_output("insights-client --offline --output-dir %s" % path,
+                            suggest_filename="insights-client-dump.log")
 
     def postproc(self):
         for conf in self.config:
@@ -44,3 +45,5 @@ class RedHatInsights(Plugin, RedHatPlugin):
             self.do_file_sub(
                 conf, r'(proxy[\t\ ]*=.*)(:)(.*)(@.*)', r'\1\2********\4'
             )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Currently, "insights-client --offline" stdout is stored in filename like
insights-client_--offline_--output-dir_.var.tmp.sos.cbl0ox16. (and so on)

Let make the filename unified and deterministic.

Also add the trailing vim expand tabs comment.

Resolves: #2058

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?