### PR TITLE
[systemd] gate systemd-resolve commands by systemd-resolved service

### DIFF
--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -9,7 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+                                UbuntuPlugin, CosPlugin, SoSPredicate)
 
 
 class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
@@ -42,12 +42,17 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "systemd-analyze",
             "systemd-analyze blame",
             "systemd-analyze dump",
-            "systemd-resolve --status",
-            "systemd-resolve --statistics",
             "journalctl --list-boots",
             "ls -lR /lib/systemd",
             "timedatectl"
         ])
+
+        # systemd-resolve command starts systemd-resolved service if that
+        # is not running, so gate the commands by this predicate
+        self.add_cmd_output([
+            "systemd-resolve --status",
+            "systemd-resolve --statistics",
+        ], pred=SoSPredicate(self, services=["systemd-resolved"]))
 
         self.add_cmd_output("systemd-analyze plot",
                             suggest_filename="systemd-analyze_plot.svg")


### PR DESCRIPTION
systemd-resolve command starts systemd-resolved service when that is
not running; thus we should call the command only under the relevant
predicate.

Resolves: #2059

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
