### PR TITLE
[kvm] change check_enabled to /dev/kvm

### DIFF
--- a/sos/report/plugins/kvm.py
+++ b/sos/report/plugins/kvm.py
@@ -10,7 +10,6 @@
 
 
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-import os
 
 
 class Kvm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
@@ -19,9 +18,7 @@ class Kvm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
     plugin_name = 'kvm'
     profiles = ('system', 'virt')
-
-    def check_enabled(self):
-        return os.access("/sys/module/kvm", os.R_OK)
+    files = ('/dev/kvm',)
 
     def setup(self):
         self.add_copy_spec([


### PR DESCRIPTION
The KVM plugin get triggered in a container
(e.g lxd) because of inheritance from the
kernel host as follows:

$ systemd-detect-virt
lxc

import os
os.access("/sys/module/kvm", os.R_OK)
True

Not only it's a waste of sosreport time,
but running it inside a container may
unintentionnaly reveal details from its
host. Which is a undesired behaviour.

Switching to /dev/kvm, is more appropriate
and follow current standard as used by
cpu-checker (kvm-ok) for instance.

* Baremetal host (hosting KVM hosts)

systemd-detect-virt
none

import os
os.access("/dev/kvm", os.R_OK)
True

* LXC container hosted on the same host

systemd-detect-virt
lxc

import os
os.access("/dev/kvm", os.R_OK)
False

Closes: #2062

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
