### PR TITLE
[networking] Updated uwf to gather numbered status, removed aboslute path

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -314,8 +314,8 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/run/systemd/network"
         ])
         self.add_cmd_output([
-            "/usr/sbin/ufw status",
-            "/usr/sbin/ufw app list"
+            "ufw status numbered",
+            "ufw app list"
         ])
         if self.get_option("traceroute"):
             self.add_cmd_output("/usr/sbin/traceroute -n %s" % self.trace_host)


### PR DESCRIPTION
Minor change to make the ufw status more verbose in its output, to include the rules in numbered order, which makes debugging precedence much easier.  