### PR TITLE
[networking] Small change to produce more-useful, numbered ufw rules

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -314,8 +314,8 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/run/systemd/network"
         ])
         self.add_cmd_output([
-            "/usr/sbin/ufw status",
-            "/usr/sbin/ufw app list"
+            "ufw status numbered",
+            "ufw app list"
         ])
         if self.get_option("traceroute"):
             self.add_cmd_output("/usr/sbin/traceroute -n %s" % self.trace_host)


### PR DESCRIPTION
This allows inspection of the rule order, as well as insert/edit/delete of the rules by that numbered id (ufw delete 23).

This commit also removes the need for using the absolute path to the 'ufw' binary, since this is asserted by the Ubuntu vendor policy. 

More details can be found here on the [Ubuntu Community page on UFW](https://help.ubuntu.com/community/UFW). 

Signed-off-by: David A. Desrosiers <setuid@gmail.com>