### PR TITLE
[abrt] Add /var/tmp/abrt into the collection

### DIFF
--- a/sos/report/plugins/abrt.py
+++ b/sos/report/plugins/abrt.py
@@ -36,7 +36,8 @@ class Abrt(Plugin, RedHatPlugin):
         self.add_copy_spec([
             "/etc/abrt/abrt.conf",
             "/etc/abrt/abrt-action-save-package-data.conf",
-            "/etc/abrt/plugins"
+            "/etc/abrt/plugins",
+            "/var/tmp/abrt"
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Files generated under /var/tmp/abrt should be collected
as well.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1644646
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
