### PR TITLE
[man] update references to 'general' plugin

### DIFF
--- a/man/en/sos.conf.5
+++ b/man/en/sos.conf.5
@@ -49,11 +49,11 @@ build=true
 .br
 threads=10
 .sp
-To disable the 'general' and 'filesys' plugins:
+To disable the 'host' and 'filesys' plugins:
 .LP
 [plugins]
 .br
-disable = general, filesys
+disable = host, filesys
 .sp
 To disable rpm package verification in the RPM plugin:
 .LP


### PR DESCRIPTION
'general' plugin was replaced by 'host' plugin years ago.

Let update an example in man pages accordingly.

Resolves: #2072

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?