### PR TITLE
[postfix] collect whole /etc/postfix

### DIFF
--- a/sos/report/plugins/postfix.py
+++ b/sos/report/plugins/postfix.py
@@ -19,12 +19,17 @@ class Postfix(Plugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/etc/postfix/main.cf",
-            "/etc/postfix/master.cf"
+            "/etc/postfix/",
         ])
         self.add_cmd_output([
             'postconf',
             'mailq'
+        ])
+        # don't collect SSL keys or certs or ssl dir
+        self.add_forbidden_path([
+            "/etc/postfix/*.key",
+            "/etc/postfix/*.crt",
+            "/etc/postfix/ssl/",
         ])
 
 
@@ -44,6 +49,5 @@ class DebianPostfix(Postfix, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         super(DebianPostfix, self).setup()
-        self.add_copy_spec("/etc/postfix/dynamicmaps.cf")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Skip just collecting some SSL stuff (not required, potentially sensitive).

Resolves: #2075

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
