### PR TITLE
[xdp] Add XDP plugin

### DIFF
--- a/sos/report/plugins/xdp.py
+++ b/sos/report/plugins/xdp.py
@@ -1,0 +1,21 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, \
+    UbuntuPlugin
+
+
+class Xdp(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+
+    short_desc = 'XDP program information'
+    plugin_name = 'xdp'
+    profiles = ('system', 'kernel', 'network')
+    packages = ('xdp-tools',)
+
+    def setup(self):
+        self.add_cmd_output('xdp-loader status')


### PR DESCRIPTION
This adds a plugin for gathering information about the loaded XDP programs
on a system, using the xdp-loader tool in the xdp-tools package. This is
complementary with the existing eBPF plugin, because this plugin supports
getting status for multiple XDP programs on each interface as supported by
libxdp.

For now, this just prints the output of 'xdp-loader status' which will list
any XDP programs attached. We don't currently support structured
output (such as JSON) from xdp-tools, but should we add that in the future
we can of course update this plugin.



---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?