### PR TITLE
[containers_common] Call machinectl on foreground and fix a typo

### DIFF
--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -51,6 +51,6 @@ class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
                 for cmd in user_subcmds:
                     self.add_cmd_output([
                         'machinectl -q shell %s@ %s %s' % (user, binary, cmd)
-                    ])
+                    ], foreground=True)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -45,7 +45,7 @@ class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
         for user in users_list:
             # collect user's containers' config
             self.add_copy_spec(
-                '%s/.config/containers/' % (os.path.expanduser('~%s') % user))
+                '%s/.config/containers/' % (os.path.expanduser('~%s' % user)))
             # collect the user's podman/buildah info and uid/guid maps
             for binary in ['/usr/bin/podman', '/usr/bin/buildah']:
                 for cmd in user_subcmds:


### PR DESCRIPTION
Commands like:
    
    machinectl -q shell user1@ ..
    
hang if not called on foreground / with terminal.

Further, fix user's home expansion typo.
    
Resolves: #2082

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
