### PR TITLE
[rabbitmq] emulate TTY via timeout foreground

### DIFF
--- a/sos/plugins/rabbitmq.py
+++ b/sos/plugins/rabbitmq.py
@@ -38,8 +38,8 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             for container in container_names:
                 self.add_cmd_output('docker logs {0}'.format(container))
                 self.add_cmd_output(
-                    'docker exec -t {0} rabbitmqctl report'
-                    .format(container)
+                    'docker exec {0} rabbitmqctl report'
+                    .format(container), foreground=True
                 )
         else:
             self.add_cmd_output("rabbitmqctl report")


### PR DESCRIPTION
"docker exec -t" might hang without a terminal. Let emulate TTY via
timeout --foreground instead.

Resolves: #2083

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
