### PR TITLE
[dnf] Assume yes for dnf commands

### DIFF
--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -34,7 +34,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
             if "[i]" in line:
                 module = line.split()[0]
                 if module != "Hint:":
-                    self.add_cmd_output("dnf module info " + module)
+                    self.add_cmd_output("dnf -y module info " + module)
 
     def setup(self):
         self.add_copy_spec("/etc/dnf/")
@@ -48,9 +48,9 @@ class DNFPlugin(Plugin, RedHatPlugin):
 
         self.add_cmd_output([
             "dnf --version",
-            "dnf list installed *dnf*",
-            "dnf list extras",
-            "dnf module list",
+            "dnf -y list installed *dnf*",
+            "dnf -y list extras",
+            "dnf -y module list",
             "package-cleanup --dupes",
             "package-cleanup --problems"
         ])
@@ -72,7 +72,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
                 self.add_cmd_output("dnf history info %d" % tr_id)
 
         # Get list of dnf installed modules and their details.
-        modules = self.collect_cmd_output("dnf module list --installed")
+        modules = self.collect_cmd_output("dnf -y module list --installed")
         self.get_modules_info(modules['output'])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
dnf could wait for some interactive input from a user.
For instance, if the GPG fingerprint of a repo has not
been yet accepted.

Signed-off-by: Emmanuel Roullit <emmanuel.roullit@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
