### PR TITLE
[selinux] Increase default size limit for /var/lib/selinux

### DIFF
--- a/sos/report/plugins/selinux.py
+++ b/sos/report/plugins/selinux.py
@@ -23,9 +23,11 @@ class SELinux(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_spec([
             '/etc/sestatus.conf',
-            '/etc/selinux',
-            '/var/lib/selinux'
+            '/etc/selinux'
         ])
+        # capture this with a higher log limit since #2035 may limit this
+        # collection
+        self.add_copy_spec('/var/lib/selinux', sizelimit=50)
         self.add_cmd_output('sestatus')
 
         state = self.exec_cmd('getenforce')['output']


### PR DESCRIPTION
Increase the default size limit for /var/lib/selinux, as the global
default of 25 MB is too small to collect both the 'active' and
'targeted' subdirs in many test scenarios. Previously this had been
copied in full due to the size limiting bug that #2035 resolved, so now
we need to properly scope the size limit for this collection.

Resolves: #2090

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
