### PR TITLE
[kubernetes] Adding support for alternate Ubuntu deployments

### DIFF
--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -53,7 +53,12 @@ class Kubernetes(Plugin):
             'kube-apiserver',
             'kube-proxy',
             'kube-scheduler',
-            'kube-controller-manager'
+            'kube-controller-manager',
+            'snap.kubelet.daemon',
+            'snap.kube-apiserver.daemon',
+            'snap.kube-proxy.daemon',
+            'snap.kube-scheduler.daemon',
+            'snap.kube-controller-manager.daemon'
         ]
 
         for svc in svcs:
@@ -196,7 +201,10 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
 class UbuntuKubernetes(Kubernetes, UbuntuPlugin):
 
     packages = ('kubernetes',)
-    files = ('/root/cdk/kubeproxyconfig',)
-    kube_cmd = "kubectl --kubeconfig=/root/cdk/kubeproxyconfig"
+    files = ('/root/cdk/kubeproxyconfig', '/etc/kubernetes')
+    if path.exists('/root/cdk/kubeproxyconfig'):
+        kube_cmd = "kubectl --kubeconfig=/root/cdk/kubeproxyconfig"
+    elif path.exists('/etc/kubernetes/admin.conf'):
+        kube_cmd = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
 
 # vim: et ts=5 sw=4


### PR DESCRIPTION
This plugin is only executed if Kubernetes is deployed using
Canonical's Charmed Distribution of Kubernetes.  The plugin
should also be run if other deployment methods are used.

Also adding service names if the Ubuntu Snaps are used for
the kubernetes control plane.

Closes: #2103

Signed-off-by: Nick Niehoff <nick.niehoff@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X ] Is the subject and message clear and concise?
- [ X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
