### PR TITLE
[gluster] fix gluster volume splitlines iteration

### DIFF
--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -104,10 +104,10 @@ class Gluster(Plugin, RedHatPlugin):
 
         volume_cmd = self.collect_cmd_output("gluster volume info")
         if volume_cmd['status'] == 0:
-            for line in volume_cmd['output']:
+            for line in volume_cmd['output'].splitlines():
                 if not line.startswith("Volume Name:"):
                     continue
-                volname = line[12:-1]
+                volname = line[12:]
                 self.add_cmd_output([
                     "gluster volume get %s all" % volname,
                     "gluster volume geo-replication %s status" % volname,


### PR DESCRIPTION
Iterate via "gluster volue info" output split to lines,
and dont truncate the trailing character (a relict from past different
content parsing).

Resolves: #2106

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
