### PR TITLE
[report] Immediately exit on first fatal error from plugins

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -977,9 +977,11 @@ class SoSReport(SoSComponent):
             pass
         except (OSError, IOError) as e:
             if e.errno in fatal_fs_errors:
-                self.ui_log.error("\n %s while collecting plugin data\n"
+                self.ui_log.error("\n %s while collecting plugin data"
                                   % e.strerror)
-                self._exit(1)
+                self.ui_log.error(" Data collected still available at %s\n"
+                                  % self.tmpdir)
+                os._exit(1)
             self.handle_exception(plugname, "collect")
         except Exception:
             self.handle_exception(plugname, "collect")


### PR DESCRIPTION
Updates our exit path when we encounter a fatal filesystem error
(ENOSPC, EROFS) to use `os._exit(1)` rather than our own `_exit()`
method so that we can properly exit from the ThreadPool.

This does leave the temporary directory in place on the filesystem, so
the exit message has been updated to highlight that fact to the end
user.

Closes: #2071
Resolves: #2108

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
