### PR TITLE
[pacemaker] Fix scrubbing when password contains an equal sign

### DIFF
--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -55,14 +55,14 @@ class Pacemaker(Plugin):
     def postproc_crm_shell(self):
         self.do_cmd_output_sub(
             "crm configure show",
-            r"passw(\S*)=\S+",
+            r"passw([^\s=]*)=\S+",
             r"passw\1=********"
         )
 
     def postproc_pcs(self):
         self.do_cmd_output_sub(
             "pcs config",
-            r"passw(\S*)=\S+",
+            r"passw([^\s=]*)=\S+",
             r"passw\1=********"
         )
 


### PR DESCRIPTION
If the password contains one or more equal signs ('='), only the substring
after the final equal sign is scrubbed. The rest of the password appears in
plain text.

This patch modifies the scrub regex to scrub all characters after the first
equal sign.

Related to RHBZ#1845386.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
