### PR TITLE
[collect] Pass SoSNode object for remote policy loading

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -340,7 +340,7 @@ class SosNode():
             return self.commons['policy']
         host = load(cache={}, sysroot=self.opts.sysroot, init=InitSystem(),
                     probe_runtime=False, remote_exec=self.ssh_cmd,
-                    remote_check=self.read_file('/etc/os-release'))
+                    remote_node=self)
         if host:
             self.log_info("loaded policy %s for host" % host.distro)
             return host

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -49,7 +49,7 @@ def import_policy(name):
 
 
 def load(cache={}, sysroot=None, init=None, probe_runtime=True,
-         remote_exec=None, remote_check=''):
+         remote_exec=None, remote_node=None):
     if 'policy' in cache:
         return cache.get('policy')
 
@@ -57,7 +57,7 @@ def load(cache={}, sysroot=None, init=None, probe_runtime=True,
     helper = ImporterHelper(sos.policies)
     for module in helper.get_modules():
         for policy in import_policy(module):
-            if policy.check(remote=remote_check):
+            if policy.check(remote=remote_node):
                 cache['policy'] = policy(sysroot=sysroot, init=init,
                                          probe_runtime=probe_runtime,
                                          remote_exec=remote_exec)

--- a/sos/policies/amazon.py
+++ b/sos/policies/amazon.py
@@ -25,10 +25,9 @@ class AmazonPolicy(RedHatPolicy):
                                            remote_exec=remote_exec)
 
     @classmethod
-    def check(cls, remote=''):
-
+    def check(cls, remote=None):
         if remote:
-            return cls.distro in remote
+            return cls.distro in remote.read_file(OS_RELEASE)
 
         if not os.path.exists(OS_RELEASE):
             return False

--- a/sos/policies/cos.py
+++ b/sos/policies/cos.py
@@ -34,9 +34,9 @@ class CosPolicy(LinuxPolicy):
     PATH = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
         if remote:
-            return cls.distro in remote
+            return cls.distro in remote.read_file('/etc/os-release')
 
         try:
             with open('/etc/os-release', 'r') as fp:

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -39,12 +39,12 @@ class DebianPolicy(LinuxPolicy):
         }.get(binary, binary)
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
         """This method checks to see if we are running on Debian.
            It returns True or False."""
 
         if remote:
-            return cls.distro in remote
+            return remote.file_exists('/etc/debian_version')
 
         return os.path.isfile('/etc/debian_version')
 

--- a/sos/policies/ibmkvm.py
+++ b/sos/policies/ibmkvm.py
@@ -29,12 +29,12 @@ class PowerKVMPolicy(RedHatPolicy):
         self.valid_subclasses = [PowerKVMPlugin, RedHatPlugin]
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
         """This method checks to see if we are running on PowerKVM.
            It returns True or False."""
 
         if remote:
-            return cls.distro in remote
+            return remote.file_exists('/etc/ibm_powerkvm-release')
 
         return os.path.isfile('/etc/ibm_powerkvm-release')
 
@@ -57,12 +57,12 @@ class ZKVMPolicy(RedHatPolicy):
         self.valid_subclasses = [ZKVMPlugin, RedHatPlugin]
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
         """This method checks to see if we are running on IBM Z KVM. It
         returns True or False."""
 
         if remote:
-            return cls.distro in remote
+            return remote.file_exists('/etc/base-release')
 
         return os.path.isfile('/etc/base-release')
 

--- a/sos/policies/osx.py
+++ b/sos/policies/osx.py
@@ -7,10 +7,10 @@ class OSXPolicy(Policy):
     distro = "Mac OS X"
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
 
         if remote:
-            return cls.distro in remote
+            return cls.distro in remote.read_file('/etc/os-release')
 
         try:
             return "Mac OS X" in shell_out("sw_vers")

--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -44,7 +44,7 @@ class SuSEPolicy(LinuxPolicy):
         self.set_exec_path()
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
         """This method checks to see if we are running on SuSE. It must be
         overriden by concrete subclasses to return True when running on an
         OpenSuSE, SLES or other Suse distribution and False otherwise."""
@@ -103,11 +103,10 @@ No changes will be made to system configuration.
                                              probe_runtime=probe_runtime)
 
     @classmethod
-    def check(cls, remote):
+    def check(cls, remote=None):
         """This method checks to see if we are running on SuSE.
         """
-
         if remote:
-            return cls.distro in remote
+            return remote.file_exists('/etc/SuSE-release')
 
         return (os.path.isfile('/etc/SuSE-release'))

--- a/sos/policies/ubuntu.py
+++ b/sos/policies/ubuntu.py
@@ -23,12 +23,12 @@ class UbuntuPolicy(DebianPolicy):
         self.valid_subclasses = [UbuntuPlugin, DebianPlugin]
 
     @classmethod
-    def check(cls, remote=''):
+    def check(cls, remote=None):
         """This method checks to see if we are running on Ubuntu.
            It returns True or False."""
 
         if remote:
-            return cls.distro in remote
+            return cls.distro in remote.read_file('/etc/lsb-release')
 
         try:
             with open('/etc/lsb-release', 'r') as fp:


### PR DESCRIPTION
Rather than read `/etc/os-release` indiscriminately and pass the entire
contents as a single string to each policy's `check()` method, now just
pass the actual `SoSNode()` object and allow the policy to determine
what to do with it, if provided.

This allows policies to mimic their local checks for remote nodes, be
that substring presence in a file, a file's presence, or anything else.

Resolves: #2111

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
