### PR TITLE
[policy] Change Satellite preset from verify to more logs

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -211,7 +211,7 @@ RH_CFME_DESC = "Red Hat CloudForms"
 
 RH_SATELLITE = "satellite"
 RH_SATELLITE_DESC = "Red Hat Satellite"
-SAT_OPTS = SoSOptions(verify=True, plugopts=['apache.log=on'])
+SAT_OPTS = SoSOptions(log_size=100, plugopts=['apache.log=on'])
 
 CB = "cantboot"
 CB_DESC = "For use when normal system startup fails"


### PR DESCRIPTION
As Satellite deployments get more stable, it is less important to verify
packages installed.

Further, as Satellite produces much logs worth to collect, the preset should
increase log size to 100 MB.

Resolves: #2112

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
