### PR TITLE
[foreman] scrub cpdb password in installer logs

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -268,6 +268,11 @@ class Foreman(Plugin):
             "/var/log/foreman-installer/sat*",
             sat_debug_reg,
             r"\1 \2 ********")
+        # also hide passwords in yet different format
+        self.do_path_regex_sub(
+            "/var/log/foreman-installer/sat*",
+            r"--password=(\S*)",
+            r"--password=********")
         self.do_path_regex_sub(
             "/var/log/foreman-installer/foreman-proxy*",
             r"(\s*proxy_password\s=) (.*)",


### PR DESCRIPTION
Obfuscate passwords in logs like

..'cpdb --create .. --password='Qg6Fej9wekDGiWrMDR9j8WWgwcq4dyP3' ..

Resolves: #2115

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
