### PR TITLE
[ebpf] Add the output of bpftool struct_ops dump

### DIFF
--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -61,7 +61,9 @@ class Ebpf(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "bpftool cgroup tree",
             # collect list of bpf program attachments in the kernel
             # networking subsystem
-            "bpftool net list"
+            "bpftool net list",
+            # collect all struct_ops currently existing in the system
+            "bpftool struct_ops dump"
         ])
 
         # Capture list of bpf program attachments from namespaces


### PR DESCRIPTION
This patch dumps all struct_ops currently existing in
the system via the commant 'bpftool struct_ops dump'.

Resolves: #2116

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
