### PR TITLE
[foreman] collects stats of some tables from foreman DB

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -205,6 +205,15 @@ class Foreman(Plugin):
             % quote(months)
         )
 
+        # counts of fact_names prefixes/types: much of one type suggests
+        # performance issues
+        factnamescmd = (
+            'WITH prefix_counts AS (SELECT split_part(name,\'::\',1) FROM '
+            'fact_names) SELECT COUNT(*), split_part AS "fact_name_prefix" '
+            'FROM prefix_counts GROUP BY split_part ORDER BY count DESC '
+            'LIMIT 100'
+        )
+
         # Populate this dict with DB queries that should be saved directly as
         # postgres formats them. The key will be the filename in the foreman
         # plugin directory, with the value being the DB query to run
@@ -214,6 +223,9 @@ class Foreman(Plugin):
             'foreman_auth_table': authcmd,
             'dynflow_schema_info': 'select * from dynflow_schema_info',
             'foreman_tasks_tasks': 'select * from foreman_tasks_tasks',
+            'audits_table_count': 'select count(*) from audits',
+            'logs_table_count': 'select count(*) from logs',
+            'fact_names_prefixes': factnamescmd,
             'smart_proxies': 'select sp.name, sp.url, ' +
                              'sp.download_policy,n.ip from smart_proxies ' +
                              'as sp left join hosts as h on h.name=sp.name ' +


### PR DESCRIPTION
Too many logs, audits or fact_names suggest performance problems,
so it is worth collecting stats/counts of them.

Resolves: #2117

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
