### PR TITLE
[drbd] Add new plugin for DRBD

### DIFF
--- a/sos/report/plugins/drbd.py
+++ b/sos/report/plugins/drbd.py
@@ -1,0 +1,33 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+
+
+class drbd(Plugin, RedHatPlugin, UbuntuPlugin):
+
+    short_desc = 'Distributed Replicated Block Device (DRBD)'
+
+    plugin_name = 'drbd'
+    profiles = ('storage')
+    packages = ('drbd.*-utils',)
+
+    def setup(self):
+        self.add_cmd_output([
+            "drbd-overview",
+            "drbdadm dump-xml",
+            "drbdsetup status",
+            "drbdsetup show"
+        ])
+        self.add_copy_spec([
+            "/etc/drbd.conf",
+            "/etc/drbd.d/*",
+            "/proc/drbd"
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch implements a new plugin
to capture information about Distributed
Replicated Block Device (DRBD) setups.

Closes: #2102
Resolves: #2120 
Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
