### PR TITLE
[ovirt] Include oVirt engine truststore

### DIFF
--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -140,8 +140,7 @@ class Ovirt(Plugin, RedHatPlugin):
         # Copying host certs.
         self.add_forbidden_path([
             "/etc/pki/ovirt-engine/keys",
-            "/etc/pki/ovirt-engine/private",
-            "/etc/pki/ovirt-engine/.truststore"
+            "/etc/pki/ovirt-engine/private"
         ])
         self.add_copy_spec("/etc/pki/ovirt-engine/")
 


### PR DESCRIPTION
Include the truststore used by the oVirt engine
as it is supposed to contain CA certificates only

Closes: #2122

Signed-off-by: Miguel Martín <mmartinv@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
