### PR TITLE
[report] Drop non-root framework by adding root_required check

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -16,6 +16,7 @@ gettext to internationalize messages.
 """
 __version__ = "3.9"
 
+import os
 import sys
 
 from argparse import ArgumentParser
@@ -168,8 +169,10 @@ class SoS():
         if _com not in self._components.keys():
             print("Unknown subcommand '%s' specified" % _com)
         try:
-            self._component = self._components[_com][0](self.parser, self.args,
-                                                        self.cmdline)
+            _to_load = self._components[_com][0]
+            if _to_load.root_required and not os.getuid() == 0:
+                raise Exception("Component must be run with root privileges")
+            self._component = _to_load(self.parser, self.args, self.cmdline)
         except Exception as err:
             print("Could not initialize '%s': %s" % (_com, err))
             if self.args.debug:

--- a/sos/component.py
+++ b/sos/component.py
@@ -48,6 +48,7 @@ class SoSComponent():
     arg_defaults = {}
     configure_logging = True
     load_policy = True
+    root_required = False
 
     _arg_defaults = {
         "batch": False,

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -72,6 +72,7 @@ class SoSReport(SoSComponent):
     """
 
     desc = "Collect files and command output in an archive"
+    root_required = True
 
     arg_defaults = {
         'alloptions': False,
@@ -493,12 +494,6 @@ class SoSReport(SoSComponent):
                     if self.opts.verbosity > 0:
                         self._skip(plugin_class, _("does not validate"))
                         continue
-
-                if plugin_class.requires_root and not self._is_root:
-                    self.soslog.info(_("plugin %s requires root permissions"
-                                       "to execute, skipping") % plug)
-                    self._skip(plugin_class, _("requires root"))
-                    continue
 
                 # plug-in is valid, let's decide whether run it or not
                 self.plugin_names.append(plugbase)

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -379,9 +379,6 @@ class Plugin(object):
     this if you are defining multiple plugins that do the same thing on
     different platforms.
 
-    requires_root is a boolean that specifies whether or not sosreport should
-    execute this plugin as a super user.
-
     version is a string representing the version of the plugin. This can be
     useful for post-collection tooling.
 
@@ -396,7 +393,6 @@ class Plugin(object):
     """
 
     plugin_name = None
-    requires_root = True
     version = 'unversioned'
     packages = ()
     files = ()

--- a/sos/report/plugins/openstack_aodh.py
+++ b/sos/report/plugins/openstack_aodh.py
@@ -20,9 +20,6 @@ class OpenStackAodh(Plugin, RedHatPlugin):
     profiles = ('openstack', 'openstack_controller')
 
     packages = ('openstack-selinux',)
-
-    requires_root = False
-
     var_puppet_gen = "/var/lib/config-data/puppet-generated/aodh"
 
     def setup(self):


### PR DESCRIPTION
Adds a check on a per-component basis for if that component requires
root permissions to run. By default, SoSComponent sets this value to
`False`, so set it explicitly to `True` for `SoSReport`.

Closes: #1989
Resolves: #2126

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
