### PR TITLE
[kubernetes] Call setup method from child classes

### DIFF
--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -197,6 +197,9 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
     if path.exists('/etc/origin/master/admin.kubeconfig'):
         kube_cmd = 'oc'
 
+    def setup(self):
+        super(RedHatKubernetes, self).setup()
+
 
 class UbuntuKubernetes(Kubernetes, UbuntuPlugin):
 
@@ -206,5 +209,8 @@ class UbuntuKubernetes(Kubernetes, UbuntuPlugin):
         kube_cmd = "kubectl --kubeconfig=/root/cdk/kubeproxyconfig"
     elif path.exists('/etc/kubernetes/admin.conf'):
         kube_cmd = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+
+    def setup(self):
+        super(UbuntuKubernetes, self).setup()
 
 # vim: et ts=5 sw=4


### PR DESCRIPTION
With no setup() method, RedHatKubernetes or UbuntuKubernetes
are no-op plugins.

Resolves: #2128

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
