### PR TITLE
[logs] collect also non-persistent journal logs

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -59,13 +59,21 @@ class Logs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         self.add_cmd_output("journalctl --disk-usage")
         self.add_cmd_output('ls -alRh /var/log/')
 
-        journal = os.path.exists("/var/log/journal/")
-        if journal and self.is_installed("systemd"):
+        # collect journal logs if:
+        # - there is some data present, either persistent or runtime only
+        # - systemd-journald service exists
+        # otherwise fallback to collecting few well known logfiles directly
+        journal = any([os.path.exists(p + "/log/journal/")
+                      for p in ["/var", "/run"]])
+        if journal and self.is_service("systemd-journald"):
             self.add_journal(since=since)
-            self.add_journal(boot="this", catalog=True)
-            self.add_journal(boot="last", catalog=True)
+            self.add_journal(boot="this", catalog=True, since=since)
+            self.add_journal(boot="last", catalog=True, since=since)
             if self.get_option("all_logs"):
-                self.add_copy_spec("/var/log/journal/*")
+                self.add_copy_spec([
+                    "/var/log/journal/*",
+                    "/run/log/journal/*"
+                ])
         else:  # If not using journal
             if not self.get_option("all_logs"):
                 self.add_copy_spec([


### PR DESCRIPTION
Collect journalctl logs also when journal is configured to store logs
in memory only.

Further, when --all-logs is provided, collect the transient logs in
/var/log/journal dir as well.

Resolves: #2130

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
