### PR TITLE
[vhostmd] Capture the output of vhostmd

### DIFF
--- a/sos/report/plugins/vhostmd.py
+++ b/sos/report/plugins/vhostmd.py
@@ -20,7 +20,7 @@ class vhostmd(Plugin, RedHatPlugin):
     packages = ['virt-what']
 
     def setup(self):
-        vw = self.exec_cmd("virt-what")['output'].splitlines()
+        vw = self.collect_cmd_output("virt-what")['output'].splitlines()
 
         if not vw:
             return


### PR DESCRIPTION
Currently we only use the output of vhostmd temporarily
to check if the machine is a vm or not. With this
patch we also capture its output.

Resolves: #2135 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
