### PR TITLE
[global] Update config file location and layout

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -116,6 +116,9 @@ Note: to set a description for the preset that is displayed with \fB--list-prese
 use the \fB--desc\fR option.
 
 Note: to set a behaviour note of the preset, use --note option.
+
+Note: The root filesystem, as seen by sos if running within a container, must be
+writable to save presets using this option.
 .TP
 .B \--del-preset DEL_PRESET
 Deletes the preset with name DEL_PRESET from the filesystem so that it can no

--- a/man/en/sos.conf.5
+++ b/man/en/sos.conf.5
@@ -3,7 +3,76 @@
 sos.conf \- sosreport configuration
 .SH DESCRIPTION
 .sp
-sosreport uses a configuration file at /etc/sos/sos.conf.
+sosreport uses a configuration file at /etc/sos/sos.conf, and there are
+subdirectories under /etc/sos that are used for specific purposes.
+
+Note that non-root users may override options set in /etc/sos/sos.conf by creating
+their own sos.conf under $HOME/.config/sos.
+
+The order in which options are loaded is as follows:
+
+  1. System configuration file at /etc/sos/sos.conf
+  2. User-specific configuration file at $HOME/.config/sos/sos.conf (for sos
+     components that support non-root)
+  3. In the case of running \fBsos report\fR, presets either automatically loaded
+     due to system configuration, or specified via \fB--preset\fR
+  4. Command line values
+
+
+In other words, config files will override defaults, presets override config files,
+and command line values override presets and config files.
+
+.SH SUBDIRECTORIES
+The following subdirectories exist under /etc/sos and are used as noted below
+
+.TP
+\fBextras.d\fP
+This directory is used to store configuration files used by the sos_extras plugin.
+
+The plugin traverses this directory and for each file there it executes commands
+or collects files optionally with sizelimit.
+
+Expected content of an extras file is as follows:
+    - empty lines or those starting with '#' are ignored
+    - add_copy_spec called to lines starting by ':', optionally followed by
+      sizelimit
+    - otherwise, whole line will be executed as a command.
+    Example:
+    command1 --arg1 val1
+    command2
+    :/path/to/file
+    :/path/to/files* sizelimit
+
+    WARNING: be careful what files to collect or what commands to execute:
+    - avoid calling potentially dangerous or system altering commands, like:
+      - using multiple commands on a line (via pipes, semicolon etc.)
+      - executing commands on background
+      - setting env.variables (as those will be ignored)
+      - altering a system (not only by "rm -rf")
+    - be aware, no secret obfuscation is made
+.TP
+\fBgroups.d\fP
+This directory is used to store host group configuration files for \fBsos collect\fP.
+
+These files can specify any/all of the \fBmaster\fP, \fBnodes\fP, and \fBcluster-type\fP
+options.
+
+Users may create their own private host groups in $HOME/.config/sos/groups.d/. If
+a host group of the same name is saved in both the user's homedir and this directory,
+the homedir configuration file will have precedence. When run as non-root, \fBsos collect\fP
+will save host groups to the user's home dir, and create the necessary directory structure
+if required.
+
+Note that non-root users may load host groups defined under /etc/sos/groups.d/, but they
+may not write new groups or update existing groups saved there.
+
+.TP
+\fBpresets.d\fP
+This directory is used to store preset configuration files for \fBsos report\fP.
+
+Presets may be used to save standard sets of options. See \fBman sos-report\fP for
+more information.
+
 .SH PARAMETERS
 .sp
 There are sections for each sos component, as well as global values and
@@ -53,7 +122,7 @@ To disable the 'host' and 'filesys' plugins:
 .LP
 [report]
 .br
-noplugins = host,filesys
+skip-plugins = host,filesys
 .sp
 To disable rpm package verification in the RPM plugin:
 .LP
@@ -64,6 +133,8 @@ rpm.rpmva = off
 .SH FILES
 .sp
 /etc/sos/sos.conf
+.br
+$HOME/.config/sos/sos.conf (optional)
 .SH SEE ALSO
 .sp
 sos-report(1)

--- a/man/en/sos.conf.5
+++ b/man/en/sos.conf.5
@@ -3,11 +3,11 @@
 sos.conf \- sosreport configuration
 .SH DESCRIPTION
 .sp
-sosreport uses a configuration file at /etc/sos.conf.
+sosreport uses a configuration file at /etc/sos/sos.conf.
 .SH PARAMETERS
 .sp
-There are three sections in the sosreport configuration file:
-general, plugins and tunables. Options are set using 'ini'-style
+There are sections for each sos component, as well as global values and
+those for plugin options. Options are set using 'ini'-style
 \fBname = value\fP pairs. Disabling/enabling a boolean option
 is done the same way like on command line (e.g. process.lsof=off).
 
@@ -18,30 +18,30 @@ will result in enabling those options, regardless of value set.
 
 Sections are parsed in the ordering:
 .br
-- \fB[general]\fP
+- \fB[global]\fP
 .br
-- \fB[plugins]\fP (disable)
+- \fB[component]\fP
 .br
-- \fB[plugins]\fP (enable)
-.br
-- \fB[tunables]\fP
+- \fB[plugin_options]\fP
 
 .TP
-\fB[general]\fP
+\fB[global]\fP
 <option>      Sets (long) option value. Short options (i.e. z=auto)
               are not supported.
 .TP
-\fB[plugins]\fP
-disable       Comma separated list of plugins to disable.
-.br
-enable        Comma separated list of plugins to enable.
+\fB[component]\fP
+Each component will have a separate section, and it will support the options
+that particular component provides. These are readily identifiable in the
+\fB--help\fP output for each component, E.G. \fBsos report --help\fP.
 .TP
-\fB[tunables]\fP
-plugin.option Alter available options for defined plugin.
+\fB[plugin_options]\fP
+Alter available options for defined (and loaded) plugins.
+
+Takes the form plugin.option = value, for example \fBrpm.rpmva = true\fP.
 .SH EXAMPLES
 To use quiet and batch mode with 10 threads:
 .LP
-[general]
+[global]
 .br
 batch=yes
 .br
@@ -51,19 +51,21 @@ threads=10
 .sp
 To disable the 'host' and 'filesys' plugins:
 .LP
-[plugins]
+[report]
 .br
-disable = host, filesys
+noplugins = host,filesys
 .sp
 To disable rpm package verification in the RPM plugin:
 .LP
-[tunables]
+[plugin_options]
 .br
 rpm.rpmva = off
 .br
 .SH FILES
 .sp
-/etc/sos.conf
+/etc/sos/sos.conf
 .SH SEE ALSO
 .sp
-sosreport(1)
+sos-report(1)
+sos-collect(1)
+sos-clean(1)

--- a/sos.conf
+++ b/sos.conf
@@ -1,11 +1,36 @@
-[general]
+[global]
+# Set global options here that are not component specific
+# If you would like one global default value to be specifically overridden for
+# just one component, but not others, you may override that value in the
+# component specific section below
 #verbose = 3
 #verify = yes
 #batch = yes
 #log-size = 15
 
-[plugins]
-#disable = rpm, selinux, dovecot
+[report]
+# Options that will apply to any `sos report` run should be listed here.
+# Note that the option names *must* be the long-form name as seen in --help
+# output. Use a comma for list delimitations.
+#skip-plugins = rpm, selinux, dovecot
+#enable-plugins = host,logs
 
-[tunables]
+[collect]
+# Options that will apply to any `sos collect` run should be listed here.
+# Note that the option names *must* be the long-form name as seen in --help
+# output. Use a comma for list delimitations
+#master = myhost.example.com
+#ssh-key = /home/user/.ssh/mykey
+#password = true
+
+[clean]
+# Options that will apply to any `sos clean|mask` run should be listed here.
+# Note that the option names *must* be the long-form name as seen in --help
+# output. Use a comma for list delimitations
+#domains = mydomain.com
+#no-update = true
+
+[plugin_options]
+# Specify any plugin options and their values here. These options take the form
+# plugin_name.option_name = value
 #rpm.rpmva = off

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -127,7 +127,8 @@ class SoS():
         global_grp.add_argument("--batch", default=False, action="store_true",
                                 help="Do not prompt interactively")
         global_grp.add_argument("--config-file", type=str, action="store",
-                                dest="config_file", default="/etc/sos.conf",
+                                dest="config_file",
+                                default="/etc/sos/sos.conf",
                                 help="specify alternate configuration file")
         global_grp.add_argument("--debug", action="store_true", dest="debug",
                                 help="enable interactive debugging using the "
@@ -173,6 +174,7 @@ class SoS():
             if _to_load.root_required and not os.getuid() == 0:
                 raise Exception("Component must be run with root privileges")
             self._component = _to_load(self.parser, self.args, self.cmdline)
+
         except Exception as err:
             print("Could not initialize '%s': %s" % (_com, err))
             if self.args.debug:

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -22,7 +22,7 @@ from sos import _sos as _
 from textwrap import fill
 from pipes import quote
 
-PRESETS_PATH = "/var/lib/sos/presets"
+PRESETS_PATH = "/etc/sos/presets.d"
 
 try:
     import requests
@@ -931,9 +931,8 @@ any third party.
                 pd.note = data[NOTE] if NOTE in data else ""
 
                 if OPTS in data:
-                    for arg in _arg_names:
-                        if arg in data[OPTS]:
-                            setattr(pd.opts, arg, data[OPTS][arg])
+                    for arg in data[OPTS]:
+                        setattr(pd.opts, arg, data[OPTS][arg])
                 pd.builtin = False
                 self.presets[preset] = pd
 

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -751,8 +751,8 @@ class SoSReport(SoSComponent):
             return False
 
         # Filter --add-preset <name> from arguments list
-        arg_index = self._args.index("--add-preset")
-        args = self._args[0:arg_index] + self._args[arg_index + 2:]
+        arg_index = self.cmdline.index("--add-preset")
+        args = self.cmdline[0:arg_index] + self.cmdline[arg_index + 2:]
 
         self.ui_log.info("Added preset '%s' with options %s\n" %
                          (name, " ".join(args)))

--- a/sos/report/plugins/host.py
+++ b/sos/report/plugins/host.py
@@ -20,6 +20,8 @@ class Host(Plugin, RedHatPlugin, DebianPlugin):
 
     def setup(self):
 
+        self.add_forbidden_path('/etc/sos/cleaner/default_mapping')
+
         self.add_cmd_output('hostname', root_symlink='hostname')
         self.add_cmd_output('uptime', root_symlink='uptime')
 
@@ -30,7 +32,7 @@ class Host(Plugin, RedHatPlugin, DebianPlugin):
         ])
 
         self.add_copy_spec([
-            '/etc/sos.conf',
+            '/etc/sos',
             '/etc/hostid',
         ])
 

--- a/sos/report/plugins/sos_extras.py
+++ b/sos/report/plugins/sos_extras.py
@@ -13,7 +13,7 @@ import stat
 
 class SosExtras(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
-    short_desc = 'Collect extra data defined in /etc/sos.extras.d'
+    short_desc = 'Collect extra data defined in /etc/sos/extras.d'
 
     """The plugin traverses 'extras_dir' directory and for each file there,
     it executes commands or collects files optionally with sizelimit. Expected
@@ -39,7 +39,7 @@ class SosExtras(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     plugin_name = "sos_extras"
 
-    extras_dir = '/etc/sos.extras.d/'
+    extras_dir = '/etc/sos/extras.d/'
 
     files = (extras_dir)
 
@@ -55,8 +55,6 @@ class SosExtras(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             self._log_warn("can't stat %s, skipping sos extras" %
                            self.extras_dir)
             return
-
-        self.add_copy_spec(self.extras_dir)
 
         for path, dirlist, filelist in os.walk(self.extras_dir):
             for f in filelist:

--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -82,12 +82,13 @@ run_expecting_sucess () {
     fi
 }
 
-# If /etc/sos.conf doesn't exist let's just make it..
-if [ -f /etc/sos.conf ]; then
-   echo "/etc/sos.conf already exists"
+# If /etc/sos/sos.conf doesn't exist let's just make it..
+if [ -f /etc/sos/sos.conf ]; then
+   echo "/etc/sos/sos.conf already exists"
 else
    echo "Creating /etc/sos.conf"
-   touch /etc/sos.conf
+   mkdir /etc/sos
+   touch /etc/sos/sos.conf
 fi
 
 # Runs not generating sosreports


### PR DESCRIPTION
Moves the default config file we look for to /etc/sos/sos.conf instead
of /etc/sos.conf. Extends the config file to look for a section matching
the name of the component being used. Renames the "general" section to
"global" and the "tunables" section to "plugin_options".

Updates the default sos.conf to this style and adds some comments to the
file. Update the man page for sos.conf.

Note that this commit does NOT update sos.spec to drop the default
configuration file in the new location, as that will be handled by a
later commit to update the specfile wholesale.

Closes: #2125
Resolves: #2136

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
