### PR TITLE
[pci] Update gating for lspci commands

### DIFF
--- a/sos/report/plugins/pci.py
+++ b/sos/report/plugins/pci.py
@@ -17,6 +17,16 @@ class Pci(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     plugin_name = "pci"
     profiles = ('hardware', 'system')
 
+    def check_for_bus_devices(self):
+        if not os.path.isdir('/proc/bus/pci'):
+            return False
+        # ensure that more than just the 'devices' file, which can be empty,
+        # exists in the pci directory. This implies actual devices are present
+        content = os.listdir('/proc/bus/pci')
+        if 'devices' in content:
+            content.remove('devices')
+        return len(content) > 0
+
     def setup(self):
         self.add_copy_spec([
             "/proc/ioports",
@@ -24,7 +34,7 @@ class Pci(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
             "/proc/bus/pci"
         ])
 
-        if os.path.isdir("/proc/bus/pci/00"):
+        if self.check_for_bus_devices():
             self.add_cmd_output("lspci -nnvv", root_symlink="lspci")
             self.add_cmd_output("lspci -tv")
 


### PR DESCRIPTION
It was reported that certain arches may create subdir structures under
/proc/bus/pci differently than others - most notably that the first
device subdir could be '0000:00' instead of just '00'.

Rather than chase these different layouts, update the gating check for
running `lspci` commands to being that /proc/bus/pci exists and it has
more than just the `devices` file present, as this file may be present
but empty when nothing else exists under `/proc/bus/pci`.

Resolves: #2138

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
