### PR TITLE
[ubuntu] support status command update

### DIFF
--- a/sos/report/plugins/ubuntu.py
+++ b/sos/report/plugins/ubuntu.py
@@ -18,7 +18,7 @@ class Ubuntu(Plugin, UbuntuPlugin):
 
     def setup(self):
         self.add_cmd_output([
-            "ubuntu-support-status --show-all",
+            "ubuntu-security-status --thirdparty --unavailable",
             "hwe-support-status --verbose",
             "ubuntu-advantage status"
         ])


### PR DESCRIPTION
Dropping 'ubuntu-support-status' as
is it confusing and not very useful
in favor of 'ubuntu-security-status'
which, for now, is only available
starting with Focal/20.04LTS.

Ubuntu bug report:
https://launchpad.net/bugs/1873362

Closes: #2139

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
