### PR TITLE
[leapp] Add preupgrade log to the leapp sos plugin

### DIFF
--- a/sos/report/plugins/leapp.py
+++ b/sos/report/plugins/leapp.py
@@ -21,6 +21,7 @@ class Leapp(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_spec([
             '/var/log/leapp/dnf-debugdata/',
+            '/var/log/leapp/leapp-preupgrade.log',
             '/var/log/leapp/leapp-upgrade.log',
             '/var/log/leapp/leapp-report.txt',
             '/var/log/leapp/dnf-plugin-data.txt'


### PR DESCRIPTION
- `leapp` generates not only leapp-upgrade.log (when running `leapp upgrade`) but also leapp-preupgrade.log (when running `leapp preupgrade`)
- when customers send us a sos report after running `leapp preupgrade`, we don't have the log in the report archive and it makes the investigation of issues harded
- related report that is missing the log: https://bugzilla.redhat.com/show_bug.cgi?id=1846677#c3

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
