### PR TITLE
[sar] Extend command sadf to get more data out of sar

### DIFF
--- a/sos/report/plugins/sar.py
+++ b/sos/report/plugins/sar.py
@@ -50,7 +50,7 @@ class Sar(Plugin,):
             if sar_filename not in dir_list:
                 sar_cmd = 'sh -c "sar -A -f %s"' % sa_data_path
                 self.add_cmd_output(sar_cmd, sar_filename)
-            sadf_cmd = "sadf -x %s" % sa_data_path
+            sadf_cmd = "sadf -x -- -A %s" % sa_data_path
             self.add_cmd_output(sadf_cmd, "%s.xml" % fname)
 
 


### PR DESCRIPTION
Currently, the sadf command translates to a XML
file the content of the CPU data captured in sar.
With this patch, all the data captured via sar
is translated into the XML file.
    
Resolves: #2143
    
Signed-off-by: Jose Castillo <jcastillo@redhat.com>

--
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
