### PR TITLE
[podman] remove "podman pod ps -a" command

### DIFF
--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -38,7 +38,6 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
             'info',
             'images',
             'pod ps',
-            'pod ps -a',
             'port --all',
             'ps',
             'ps -a',


### PR DESCRIPTION
"-a" option is not used for a while (if ever) and we collect
"podman pod ps" already.

Resolves: #2146

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
