### PR TITLE
[maas] use maas-region instead of deprecated maas-region-admin

### DIFF
--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -104,7 +104,7 @@ class Maas(Plugin, UbuntuPlugin):
 
         if self.is_installed("maas-region-controller"):
             self.add_cmd_output([
-                "maas-region-admin dumpdata",
+                "maas-region dumpdata",
             ])
 
         if self._has_login_options():


### PR DESCRIPTION
Signed-off-by: Alberto Donato <alberto.donato@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
