### PR TITLE
[hyperv] Add plugin for Hyper-V clients

### DIFF
--- a/sos/report/plugins/hyperv.py
+++ b/sos/report/plugins/hyperv.py
@@ -1,0 +1,28 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+
+
+class Hyperv(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+    """Hyper-V client information"""
+
+    plugin_name = "hyperv"
+    files = ('/sys/bus/vmbus/',)
+
+    def setup(self):
+
+        self.add_copy_spec([
+            "/sys/bus/vmbus/drivers/",
+            # copy devices/*/* instead of devices/ to follow link files
+            "/sys/bus/vmbus/devices/*/*"
+        ])
+
+        self.add_cmd_output("lsvmbus -vv")
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The hyperv plugin collects config files specific to Hyper-V and runs
commands for debugging the vmbus.

Signed-off-by: Kameron Carr <kameroncarrcollege@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
