### PR TITLE
[gluster] remove only dump files

### DIFF
--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -41,15 +41,14 @@ class Gluster(Plugin, RedHatPlugin):
                     ret = string.count(last_line, 'DUMP_END_TIME')
 
     def postproc(self):
-        if not os.path.exists(self.statedump_dir):
-            return
-        try:
-            for dirs in os.listdir(self.statedump_dir):
-                os.remove(os.path.join(self.statedump_dir, dirs))
-            os.rmdir(self.statedump_dir)
-            os.unlink('/tmp/glusterdump.options')
-        except OSError:
-            pass
+        if self.get_option("dump"):
+            if not os.path.exists(self.statedump_dir):
+                return
+            try:
+                for name in glob.glob(self.statedump_dir + '/*.dump.[0-9]*'):
+                    os.remove(name)
+            except OSError:
+                pass
 
     def setup(self):
         self.add_forbidden_path("/var/lib/glusterd/geo-replication/secret.pem")


### PR DESCRIPTION
Removes only dump files and leaving
other files as .socket or sock.

Resolves: #2152

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
