### PR TITLE
[haproxy] enable the plugin when puppet-generated subdir exists

### DIFF
--- a/sos/report/plugins/haproxy.py
+++ b/sos/report/plugins/haproxy.py
@@ -25,12 +25,13 @@ class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
     profiles = ('webserver',)
 
     packages = ('haproxy',)
+    var_puppet_gen = '/var/lib/config-data/puppet-generated/haproxy'
+    files = (var_puppet_gen, )
 
     def setup(self):
-        var_puppet_gen = "/var/lib/config-data/puppet-generated/haproxy"
         self.add_copy_spec([
             "/etc/haproxy/haproxy.cfg",
-            var_puppet_gen + "/etc/haproxy/haproxy.cfg"
+            self.var_puppet_gen + "/etc/haproxy/haproxy.cfg"
         ])
         self.add_copy_spec("/etc/haproxy/conf.d/*")
         self.add_cmd_output("haproxy -f /etc/haproxy/haproxy.cfg -c")


### PR DESCRIPTION
The plugin should be enabled also in containers where haproxy package
is missing but thevar_puppet_gen directory exists.

Resolves: #2163

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
