### PR TITLE
[kubernetes] ignore blank+empty lines in "kubectl get nodes" output

### DIFF
--- a/sos/plugins/kubernetes.py
+++ b/sos/plugins/kubernetes.py
@@ -100,7 +100,11 @@ class Kubernetes(Plugin):
         nodes = self.collect_cmd_output("%s get nodes" % self.kube_cmd)
         if nodes['status'] == 0:
             for line in nodes['output'].splitlines()[1:]:
-                node = line.split()[0]
+                # find first word in the line and ignore empty+blank lines
+                words = line.split()
+                if not words:
+                    continue
+                node = words[0]
                 self.add_cmd_output(
                     "%s describe node %s" % (self.kube_cmd, node),
                     subdir='nodes'


### PR DESCRIPTION
In a theoretical case when the command output contains empty or blank
line, we must skip them before finding the first word there.

Related: #2162
Resolves: #2164

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
