### PR TITLE
[autofs]: obsfucate password in `automount -m` cmd

### DIFF
--- a/sos/report/plugins/autofs.py
+++ b/sos/report/plugins/autofs.py
@@ -54,6 +54,11 @@ class Autofs(Plugin):
             r"(password=)[^,\s]*",
             r"\1********"
         )
+        self.do_cmd_output_sub(
+            "automount -m",
+            r"(password=)[^,\s]*",
+            r"\1********"
+        )
 
 
 class RedHatAutofs(Autofs, RedHatPlugin):


### PR DESCRIPTION
This patch adds scrubbing of plain text password
from the output of `automount -m` command.

Before Patch :
test | -fstype=cifs,username=user,password=pass //server/sambashare

After Patch :
test | -fstype=cifs,username=user,password=**** //server/sambashare

Resolves : #2165 

Signed-off-by: Rohan Sable <rohanjsable@yahoo.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
