### PR TITLE
[travis] drop 16.04/py3.5 and fix build to use python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,12 @@ jobs:
       arch: s390x
       language: shell
       script: "sudo ./tests/simple.sh"
-    - name: "16.04 native run (py3.5)"
-      os: linux
-      dist: xenial
-      language: shell
-      script: "sudo ./tests/simple.sh"
-    - name: "nosetests and travis Python 3.5"
-      os: linux
-      dist: bionic
-      language: python
-      python: "3.5"
-      install: pip install -r requirements.txt; python setup.py install;
-      script:
-        - "nosetests -v --with-cover --cover-package=sos --cover-html"
-        - "sudo ./tests/simple.sh ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python"
     - name: "nosetests and travis Python 3.6"
       os: linux
       dist: bionic
       language: python
       python: "3.6"
-      install: pip install -r requirements.txt; python setup.py install;
+      install: pip install -r requirements.txt; python3 setup.py install;
       script:
         - "nosetests -v --with-cover --cover-package=sos --cover-html"
         - "sudo ./tests/simple.sh ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python"
@@ -48,7 +34,7 @@ jobs:
       dist: bionic
       language: python
       python: "3.7"
-      install: pip install -r requirements.txt; python setup.py install;
+      install: pip install -r requirements.txt; python3 setup.py install;
       script:
         - "nosetests -v --with-cover --cover-package=sos --cover-html"
         - "sudo ./tests/simple.sh ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python"
@@ -57,7 +43,7 @@ jobs:
       dist: bionic
       language: python
       python: "3.8"
-      install: pip install -r requirements.txt; python setup.py install;
+      install: pip install -r requirements.txt; python3 setup.py install;
       script:
         - "nosetests -v --with-cover --cover-package=sos --cover-html"
         - "sudo ./tests/simple.sh ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/python"


### PR DESCRIPTION
Was determined we can drop Ubuntu 16.04 and python3.5 support.
Also broke build cause we are trying only python3 now.

Signed-off-by: Bryan Quigley <code@bryanquigley.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
