### PR TITLE
[build] Remove sos.conf from setup.py, make config file optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
     license="GPLv2+",
     scripts=['bin/sos', 'bin/sosreport', 'bin/sos-collector'],
     data_files=[
-        ('/', ['sos.conf']),
         ('share/man/man1', ['man/en/sosreport.1', 'man/en/sos-report.1',
                             'man/en/sos.1', 'man/en/sos-collect.1',
                             'man/en/sos-collector.1', 'man/en/sos-clean.1',

--- a/sos/options.py
+++ b/sos/options.py
@@ -214,8 +214,10 @@ class SoSOptions():
                 raise exit('Failed to parse configuration file %s'
                            % config_file)
         except (OSError, IOError) as e:
-            raise exit('Unable to read configuration file %s : %s'
-                       % (config_file, e.args[1]))
+            print(
+                'WARNING: Unable to read configuration file %s : %s'
+                % (config_file, e.args[1])
+            )
 
         _update_from_section("global", config)
         _update_from_section(component, config)


### PR DESCRIPTION
In the recent packaging update (#2160), sos.conf was added to `setup.py`
to include it in the source distribution tarball produced. That was the
wrong approach, as setuptools explicitly tries to prevent files from
being written outside of the package directory.

Instead, the correct approach is to make the config file effectively
optional, by producing a warning message when it doesn't exist, but
still continue on with the defaults rather than aborting.

Note that parsing errors and duplicate entries will still cause sos to
abort execution.

Resolves: #2174

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
