### PR TITLE
[plugins] Proper apply sizelimit in some corner cases

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1127,8 +1127,9 @@ class Plugin(object):
                         strfile = (
                             file_name.replace(os.path.sep, ".") + ".tailed"
                         )
-                        self.add_string_as_file(tail(_file, sizelimit),
-                                                strfile)
+                        add_size = (sizelimit + filestat[stat.ST_SIZE]
+                                    - current_size)
+                        self.add_string_as_file(tail(_file, add_size), strfile)
                         rel_path = os.path.relpath('/', os.path.dirname(_file))
                         link_path = os.path.join(rel_path, 'sos_strings',
                                                  self.name(), strfile)
@@ -1137,9 +1138,12 @@ class Plugin(object):
                     else:
                         self._log_info("skipping '%s' over size limit" % _file)
                 else:
-                    # size limit not hit, copy the file
+                    # size limit not exceeded, copy the file
                     _manifest_files.append(_file.lstrip('/'))
                     self._add_copy_paths([_file])
+                    # in the corner case we just reached the sizelimit, we
+                    # should collect the whole file and stop
+                    limit_reached = (current_size == sizelimit)
             if self.manifest:
                 self.manifest.files.append({
                     'specification': copyspec,


### PR DESCRIPTION
In case sizelimit on a copysspec is exceeded, we must tail just the
"size till the sizelimit" amount of the file.

In case sizelimit is just exactly reached, we must collect the file
but mark the limit is reached.

Resolves: #2175

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
