### PR TITLE
[networkmanager] catch states when nmcli status fails

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -43,7 +43,8 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
                 "general"    # >= 0.9.9
             ]
             status = self.exec_cmd(status_template % obj_table[version])
-            return status['output'].lower().startswith("running")
+            return (status['status'] == 0 and
+                    status['output'].lower().startswith("running"))
 
         # NetworkManager >= 0.9.9 (Use short name of objects for nmcli)
         if test_nm_status(version=1):


### PR DESCRIPTION
Catch situations when nmcli is not installed or returns nonzero;
status['output'] is then empty.

Resolves: #2191

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
