### PR TITLE
[Plugin] Add default tags and methods for applying tags via regex

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -66,9 +66,11 @@ class Logs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         journal = any([os.path.exists(p + "/log/journal/")
                       for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
-            self.add_journal(since=since)
-            self.add_journal(boot="this", catalog=True, since=since)
-            self.add_journal(boot="last", catalog=True, since=since)
+            self.add_journal(since=since, tags='journal_full')
+            self.add_journal(boot="this", catalog=True, since=since,
+                             tags='journal_since_boot')
+            self.add_journal(boot="last", catalog=True, since=since,
+                             tags='journal_last_boot')
             if self.get_option("all_logs"):
                 self.add_copy_spec([
                     "/var/log/journal/*",

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -65,6 +65,21 @@ class Networking(Plugin):
 
     def setup(self):
         super(Networking, self).setup()
+
+        self.add_cmd_tags({
+            'ethtool -a .*': 'ethool_a',
+            'ethtool -i .*': 'ethtool_i',
+            'ethtool -k .*': 'ethtool_k',
+            'ethtool -S .*': 'ethtool_S',
+            'ethtool -g .*': 'ethtool_g',
+            'ethtool -T .*': 'ethtool_T',
+            'ethtool -c .*': 'ethtool_c'
+        })
+
+        self.add_file_tags({
+            '/proc/net/bonding/bond.*': 'bond'
+        })
+
         self.add_copy_spec([
             "/proc/net/",
             "/etc/nsswitch.conf",
@@ -189,7 +204,7 @@ class Networking(Plugin):
                 "ethtool --phy-statistics " + eth,
                 "ethtool --show-priv-flags " + eth,
                 "ethtool --show-eee " + eth
-            ])
+            ], tags=eth)
 
         # Collect information about bridges (some data already collected via
         # "ip .." commands)

--- a/sos/report/plugins/openshift.py
+++ b/sos/report/plugins/openshift.py
@@ -236,8 +236,9 @@ class Openshift(Plugin, RedHatPlugin):
 
         for resource in global_resources:
             _subdir = "cluster_resources/%s" % resource
+            _tag = ["ocp_%s" % resource]
             _res = self.collect_cmd_output("%s %s" % (self.oc_cmd, resource),
-                                           subdir=_subdir)
+                                           subdir=_subdir, tags=_tag)
             if _res['status'] == 0:
                 for _res_name in _res['output'].splitlines()[1:]:
                     self.add_cmd_output(
@@ -297,11 +298,17 @@ class Openshift(Plugin, RedHatPlugin):
 
         for res in resources:
             _subdir = "%s/%s" % (subdir, res)
+            _tags = [
+                "ocp_%s" % res,
+                "ocp_%s_%s" % (namespace, res),
+                namespace
+            ]
             _get_cmd = "%s --namespace=%s %s" % (self.oc_cmd, namespace, res)
             # get the 'normal' output first
             _res_out = self.collect_cmd_output(
                 _get_cmd,
-                subdir=_subdir
+                subdir=_subdir,
+                tags=_tags
             )
 
             # then get specific detail on each instance of the resource

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -41,7 +41,8 @@ class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         if self.get_option("smaps"):
             self.add_copy_spec("/proc/[0-9]*/smaps")
 
-        self.add_cmd_output("ps auxwww", root_symlink="ps")
+        self.add_cmd_output("ps auxwww", root_symlink="ps",
+                            tags=['ps_aux', 'ps_auxww', 'ps_auxwww'])
         self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
             self.add_cmd_output("lsof -b +M -n -l -c ''", root_symlink="lsof")

--- a/sos/report/plugins/release.py
+++ b/sos/report/plugins/release.py
@@ -9,7 +9,7 @@
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Release(Plugin, RedHatPlugin, UbuntuPlugin):
+class Release(Plugin, UbuntuPlugin):
 
     short_desc = 'Linux release information'
 
@@ -32,5 +32,12 @@ class DebianRelease(Release, DebianPlugin):
     def setup(self):
         super(DebianRelease, self).setup()
         self.add_copy_spec('/etc/debian_version')
+
+
+class RedHatRelease(Release, RedHatPlugin):
+
+    def setup(self):
+        self.add_file_tags({'/etc/redhat-release': 'redhat_release'})
+        super(RedHatRelease, self).setup()
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -26,13 +26,14 @@ class Rpm(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_spec("/var/log/rpmpkgs")
 
-        def add_rpm_cmd(query_fmt, filter_cmd, symlink, suggest):
+        def add_rpm_cmd(query_fmt, filter_cmd, symlink, suggest, tags=[]):
             rpmq_cmd = 'rpm --nodigest -qa --qf=%s' % query_fmt
             shell_cmd = rpmq_cmd
             if filter_cmd:
                 shell_cmd = "sh -c '%s'" % (rpmq_cmd + "|" + filter_cmd)
             self.add_cmd_output(shell_cmd, root_symlink=symlink,
-                                suggest_filename=suggest)
+                                suggest_filename=suggest,
+                                tags=tags)
 
         if self.get_option("rpmq"):
             # basic installed-rpms
@@ -42,7 +43,8 @@ class Rpm(Plugin, RedHatPlugin):
             filter_cmd = 'awk -F "~~" ' \
                 r'"{printf \"%-59s %s\n\",\$1,\$2}"|sort -V'
 
-            add_rpm_cmd(query_fmt, filter_cmd, "installed-rpms", None)
+            add_rpm_cmd(query_fmt, filter_cmd, "installed-rpms", None,
+                        ['installed_rpms'])
 
             # extended package data
             query_fmt = '"%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\\t'
@@ -50,7 +52,8 @@ class Rpm(Plugin, RedHatPlugin):
             query_fmt = query_fmt + '%{VENDOR}\\t%{BUILDHOST}\\t'
             query_fmt = query_fmt + '%{SIGPGP}\\t%{SIGPGP:pgpsig}\\n"'
 
-            add_rpm_cmd(query_fmt, None, None, "package-data")
+            add_rpm_cmd(query_fmt, None, None, "package-data",
+                        ['installed_rpms', 'package_data'])
 
         if self.get_option("rpmva"):
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",

--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -39,7 +39,7 @@ class Yum(Plugin, RedHatPlugin):
         ])
 
         # Get a list of channels the machine is subscribed to.
-        self.add_cmd_output("yum -C repolist")
+        self.add_cmd_output("yum -C repolist", tags="yum_repolist")
 
         # Get the same list, but with various statistics related to its
         # contents such as package count.


### PR DESCRIPTION
This patchset adds a few mechanisms to `Plugin` for adding tags to `manifest.json`.

1. All commands will now by default add a tag of the binary being run
2. Files collected by a copyspec that matches exactly one file collection will now be tagged with the filename minus any extensions, save for `.conf`, which will be changed to `_conf`. E.G. `httpd.conf` will be tagged with `httpd_conf`.
3. Added `add_cmd_tags()` and `add_file_tags()` that will apply tags to cmds/files based on regex matches of the command being run or the file collected respectively.
4. Commands collected via `add_device_cmd()` will be tagged also with the device name
5. Adds specific tagging to several plugins based on requests from the Red Hat Insights team

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
