### PR TITLE
[rpm] increase timeout of "rpm -Va"

### DIFF
--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -53,8 +53,9 @@ class Rpm(Plugin, RedHatPlugin):
             add_rpm_cmd(query_fmt, None, None, "package-data")
 
         if self.get_option("rpmva"):
+            self.plugin_timeout = 1000
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",
-                                timeout=180)
+                                timeout=900)
 
         if self.get_option("rpmdb"):
             self.add_cmd_output("lsof +D /var/lib/rpm",


### PR DESCRIPTION
Since "rpm -Va" takes often more time than the current timeout,
let increase it accordingly.

Resolves: #1369

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
