### PR TITLE
[rpm] Increase the timeout of rpm -Va

### DIFF
--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -54,7 +54,7 @@ class Rpm(Plugin, RedHatPlugin):
 
         if self.get_option("rpmva"):
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",
-                                timeout=180)
+                                timeout=600)
 
         if self.get_option("rpmdb"):
             self.add_cmd_output("lsof +D /var/lib/rpm",


### PR DESCRIPTION
The current timeout of 3 minutes is
insufficient for most systems. This patch
increases the timeout to 10 minutes, which
should cover the majority of cases.

Closes: #1369

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
