### PR TITLE
[tmpfiles.d] Provide a tmpfiles.d conf example

### DIFF
--- a/tmpfilesd-sos.conf
+++ b/tmpfilesd-sos.conf
@@ -1,0 +1,4 @@
+# Cleaning the contents of extracted sosreport directories.
+#
+# Type Path Mode User Group Age Argument
+e /var/tmp/sosreport* - - - 30d


### PR DESCRIPTION
sos will now enforce /var/tmp to store its content.

This example is for vendors such as Debian/Ubuntu
without a current /var/tmp systemd-tmpfiles
cleaning directive in place.

Debian bug reference: #966621

Closes: #2178

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
