### PR TITLE
[apt] Forbid /etc/apt/auth.conf.d/ directory collection.

### DIFF
--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -24,6 +24,7 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
         ])
 
         self.add_forbidden_path("/etc/apt/auth.conf")
+        self.add_forbidden_path("/etc/apt/auth.conf.d/")
 
         self.add_cmd_output([
             "apt-get check",


### PR DESCRIPTION
sos/report/plugins/apt.py currently forbids the collection of /etc/apt/auth.conf
on a client system.
However, /etc/apt/auth.conf.d/ can also be used to store apt authentication.
This will prevent keys from being collected.
See apt_auth.conf(5).

Resolves: #2197

Signed-off-by: Adam R Bell <adam.bell@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
