### PR TITLE
[snappy] Adds root symlink to installed snaps.

### DIFF
--- a/sos/report/plugins/snappy.py
+++ b/sos/report/plugins/snappy.py
@@ -19,8 +19,8 @@ class Snappy(Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin):
     packages = ('snapd',)
 
     def setup(self):
+        self.add_cmd_output("snap list --all", root_symlink="installed-snaps")
         self.add_cmd_output([
-            "snap list --all",
             "snap --version",
             "snap changes"
         ])


### PR DESCRIPTION
This is to mirror the "installed-debs" root symlink from the "dpkg" plugin.
Support engineers prefer the quick access of "installed-debs", but that only
covers dpkg packages.
Therefore, this additional root symlink will provide engineers with the snappy
packages installed.
It is a somewhat Ubuntu-specific change since few other systems use snappy.
Like "installed-debs" in the "dpkg" plugin, this will only show up when the
snappy plugin executes.

Resolves: #2198

Signed-off-by: Adam R Bell <adam.bell@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
