### PR TITLE
[ubuntu] Collect /var/log/ubuntu-advantage.log file(s).

### DIFF
--- a/sos/report/plugins/ubuntu.py
+++ b/sos/report/plugins/ubuntu.py
@@ -20,5 +20,15 @@ class Ubuntu(Plugin, UbuntuPlugin):
         self.add_cmd_output([
             "ubuntu-security-status --thirdparty --unavailable",
             "hwe-support-status --verbose",
-            "ubuntu-advantage status"
         ])
+
+        if self.is_installed('ubuntu-advantage-tools'):
+            self.add_cmd_output("ubuntu-advantage status")
+            if not self.get_option("all_logs"):
+                self.add_copy_spec([
+                    "/var/log/ubuntu-advantage.log",
+                    "/var/log/ubuntu-advantage.log.1",
+                    "/var/log/ubuntu-advantage.log.2*",
+                ])
+            else:
+                self.add_copy_spec("/var/log/ubuntu-advantage.log*")


### PR DESCRIPTION
This log file is not being collected.
Canonical engineers have needed to ask for the file outside of sosreport.
This addition will collect the log file, as applicable, as part of sosreport.

Resolves: #2199

Signed-off-by: Adam R Bell <adam.bell@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
