### PR TITLE
[networking] remove 'ethtool -e' option for bnx2x NICs

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -183,13 +183,23 @@ class Networking(Plugin):
                 "ethtool -a " + eth,
                 "ethtool -c " + eth,
                 "ethtool -g " + eth,
-                "ethtool -e " + eth,
                 "ethtool -P " + eth,
                 "ethtool -l " + eth,
                 "ethtool --phy-statistics " + eth,
                 "ethtool --show-priv-flags " + eth,
                 "ethtool --show-eee " + eth
             ])
+
+            # skip EEPROM collection for 'bnx2x' NICs as this command
+            # can pause the NIC and is not production safe.
+            bnx_output = {
+                "cmd": "ethtool -i %s" % eth,
+                "output": "bnx2x"
+            }
+            bnx_pred = SoSPredicate(self,
+                                    cmd_outputs=bnx_output,
+                                    required={'cmd_outputs': 'none'})
+            self.add_cmd_output("ethtool -e %s" % eth, pred=bnx_pred)
 
         # Collect information about bridges (some data already collected via
         # "ip .." commands)


### PR DESCRIPTION
Running EEPROM dump (ethtool -e) can result in bnx2x driver NICs to
pause for few seconds and is not recommended in production environment.

Signed-off-by: suresh2514 <suresh2514@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [x ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
