### PR TITLE
[openstack_designate] Add list command output

### DIFF
--- a/sos/report/plugins/openstack_designate.py
+++ b/sos/report/plugins/openstack_designate.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class OpenStackDesignate(Plugin):
@@ -82,5 +82,10 @@ class OpenStackDesignate(Plugin):
 class RedHatdesignate(OpenStackDesignate, RedHatPlugin):
 
     packages = ('openstack-selinux',)
+
+
+class Ubuntudesignate(OpenStackDesignate, UbuntuPlugin):
+
+    packages = ('designate-common',)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openstack_designate.py
+++ b/sos/report/plugins/openstack_designate.py
@@ -1,0 +1,60 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class OpenStackDesignate(Plugin):
+
+    short_desc = 'Openstack Designate'
+
+    plugin_name = "openstack_designate"
+    profiles = ('openstack', 'openstack_controller')
+
+    var_puppet_gen = "/var/lib/config-data/puppet-generated/designate"
+
+    def setup(self):
+        # configs
+        self.add_copy_spec([
+            "/etc/designate/*",
+            self.var_puppet_gen + "/etc/designate/designate.conf",
+            self.var_puppet_gen + "/etc/designate/pools.yaml",
+        ])
+
+        # logs
+        if self.get_option("all_logs"):
+            self.add_copy_spec([
+                "/var/log/designate/*",
+                "/var/log/containers/designate/*",
+            ])
+        else:
+            self.add_copy_spec([
+                "/var/log/designate/*.log",
+                "/var/log/containers/designate/*.log"
+            ])
+
+    def postproc(self):
+        protect_keys = [
+            "password", "connection", "transport_url", "admin_password",
+            "ssl_key_password", "ssl_client_key_password",
+            "memcache_secret_key"
+        ]
+        regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
+
+        self.do_path_regex_sub("/etc/designate/*", regexp, r"\1*********")
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/designate/*",
+            regexp, r"\1*********"
+        )
+
+
+class RedHatdesignate(OpenStackDesignate, RedHatPlugin):
+
+    packages = ('openstack-selinux',)
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch adds the various "list" command output for OpenStack
designate to the SOS report.
    
Closes: #2150
    
Signed-off-by: Michael Johnson <johnsomor@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
