### PR TITLE
[options] Fix dict order py38 incompatibility

### DIFF
--- a/sos/options.py
+++ b/sos/options.py
@@ -186,7 +186,7 @@ class SoSOptions():
                 if 'verbose' in odict.keys():
                     odict['verbosity'] = int(odict.pop('verbose'))
                 # convert options names
-                for key in odict.keys():
+                for key in list(odict):
                     if '-' in key:
                         odict[key.replace('-', '_')] = odict.pop(key)
                 # set the values according to the config file


### PR DESCRIPTION
Could not initialize 'report': dictionary keys changed during iteration
Traceback (most recent call last):
  File "/usr/bin/sos", line 21, in <module>
    sos = SoS(sys.argv[1:])
  File "/usr/lib/python3/dist-packages/sos/__init__.py", line 121, in __init__
    self._init_component()
  File "/usr/lib/python3/dist-packages/sos/__init__.py", line 181, in _init_component
    raise err
  File "/usr/lib/python3/dist-packages/sos/__init__.py", line 176, in _init_component
    self._component = _to_load(self.parser, self.args, self.cmdline)
  File "/usr/lib/python3/dist-packages/sos/report/__init__.py", line 120, in __init__
    super(SoSReport, self).__init__(parser, args, cmdline)
  File "/usr/lib/python3/dist-packages/sos/component.py", line 86, in __init__
    self.opts = self.load_options()
  File "/usr/lib/python3/dist-packages/sos/component.py", line 208, in load_options
    opts.update_from_conf(self.args.config_file, self.args.component)
  File "/usr/lib/python3/dist-packages/sos/options.py", line 222, in update_from_conf
    _update_from_section("global", config)
  File "/usr/lib/python3/dist-packages/sos/options.py", line 189, in _update_from_section
    for key in odict.keys():
RuntimeError: dictionary keys changed during iteration

Closes: #2206
Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
