### PR TITLE
[docs] Small fixes for RTD online generation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/sosreport/sos.svg?branch=master)](https://travis-ci.org/sosreport/sos) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/sosreport/sos.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sosreport/sos/context:python)
+[![Build Status](https://travis-ci.org/sosreport/sos.svg?branch=master)](https://travis-ci.org/sosreport/sos) [![Documentation Status](https://readthedocs.org/projects/sos/badge/?version=master)](https://sos.readthedocs.io/en/master/?badge=master) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/sosreport/sos.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sosreport/sos/context:python)
 
 # SoS
 
@@ -116,6 +116,6 @@ sudo apt install sosreport
  [3]: https://github.com/sosreport/sos/wiki/Plugin-options
  [4]: https://www.redhat.com/mailman/listinfo/sos-devel
  [5]: https://github.com/sosreport/sos/issues?state=open
- [6]: https://sos.readthedocs.org/en/latest/index.html
+ [6]: https://sos.readthedocs.org/
  [7]: https://www.sphinx-doc.org/
  [8]: https://www.readthedocs.org/

--- a/docs/clusters.rst
+++ b/docs/clusters.rst
@@ -1,5 +1,5 @@
-``sos.collector.clusters`` ---  Cluster Profiles
-================================================
+``sos.collector.clusters`` ---  Cluster Interface
+=================================================
 
 .. automodule:: sos.collector.clusters
     :noindex:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,9 +58,7 @@ Manual Installation
 
 .. code::
 
-    to install locally (as root) ==> make install
-    to build an rpm ==> make rpm
-    to build a deb ==> make deb
+    python3 setup.py install
 
 Pre-built Packaging
 ^^^^^^^^^^^^^^^^^^^
@@ -80,16 +78,6 @@ Ubuntu (14.04 LTS and above) users install via apt:
 API
 ===
 
-Plugin Reference
-^^^^^^^^^^^^^^^^
-
-.. toctree::
-   :maxdepth: 2
-
-   plugins
-   clusters
-   parsers
-
 Core Reference
 ^^^^^^^^^^^^^^
 
@@ -97,6 +85,8 @@ Core Reference
    :maxdepth: 4
 
    archive
+   clusters
+   parsers
    policies
    plugins
    reporting

--- a/docs/parsers.rst
+++ b/docs/parsers.rst
@@ -1,5 +1,5 @@
-``sos.cleaner.parsers`` ---  Cleaning Parser Definition
-=======================================================
+``sos.cleaner.parsers`` ---  Parser Interface
+=============================================
 
 .. automodule:: sos.cleaner.parsers
     :noindex:


### PR DESCRIPTION
A few changes on the RTD side in turn need us to slightly adjust some
parts of our docs in-tree so that RTD can successfully build the docs
online based on current master branch.

Resolves: #2209

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
