### PR TITLE
[collect] Allow collect to upload via policy

### DIFF
--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -60,7 +60,7 @@ class Cluster():
         self.master = None
         self.cluster_ssh_key = None
         self.tmpdir = commons['tmpdir']
-        self.opts = commons['opts']
+        self.opts = commons['cmdlineopts']
         self.cluster_type = [self.__class__.__name__]
         for cls in self.__class__.__bases__:
             if cls.__name__ != 'Cluster':

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -36,7 +36,7 @@ class SosNode():
                  load_facts=True):
         self.address = address.strip()
         self.commons = commons
-        self.opts = commons['opts']
+        self.opts = commons['cmdlineopts']
         self.tmpdir = commons['tmpdir']
         self.hostlen = commons['hostlen']
         self.need_sudo = commons['need_sudo']

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1387,7 +1387,7 @@ class LinuxPolicy(Policy):
                                            "that you are generating this "
                                            "report for [%s]: ") % caseid)
                 # Policies will need to handle the prompts for user information
-                if cmdline_opts.upload or self.upload_url:
+                if cmdline_opts.upload and self.get_upload_url():
                     self.prompt_for_upload_user()
                     self.prompt_for_upload_password()
                 self._print()


### PR DESCRIPTION
Extends the upload functionality to `sos collect`, to work the same way
that it does for `report`. Uploads will default to policy definitions,
then user provided overrides.

Resolves: #2210

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
