### PR TITLE
[Policy] Allow upload username/password provided via environment vars

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -299,6 +299,12 @@ If a vendor does not provide a default user for uploading, specify the username 
 If this option is unused and upload is request, and a vendor default is not set, you
 will be prompted for one. If --batch is used and this option is omitted, no username will
 be collected and thus uploads will fail if no vendor default is set.
+
+You also have the option of providing this value via the SOSUPLOADUSER environment
+variable. If this variable is set, then no username prompt will occur and --batch
+may be used provided all other required values (case number, upload password)
+are provided.
+
 .TP
 .B \-\-upload-pass PASS
 Specify the password to use for authentication with the destination server.
@@ -312,6 +318,11 @@ Note that this will result in the plaintext string appearing in `ps` output that
 be collected by sos and be in the archive. If a password must be provided by you
 for uploading, it is strongly recommended to not use --batch and enter the password
 when prompted rather than using this option.
+
+You also have the option of providing this value via the SOSUPLOADPASSWORD environment
+variable. If this variable is set, then no password prompt will occur and --batch may
+be used provided all other required values (case number, upload user) are provided.
+
 .TP
 .B \--upload-directory DIR
 Specify a directory to upload to, if one is not specified by a vendor default location

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1419,7 +1419,7 @@ class LinuxPolicy(Policy):
         """Should be overridden by policies to determine if a user needs to
         be provided or not
         """
-        if not self.upload_user and not self._upload_user:
+        if not self.get_upload_user():
             msg = "Please provide upload user for %s: " % self.get_upload_url()
             self.upload_user = input(_(msg))
 
@@ -1427,12 +1427,9 @@ class LinuxPolicy(Policy):
         """Should be overridden by policies to determine if a password needs to
         be provided for upload or not
         """
-        if ((not self.upload_password and not self._upload_password) and
-                self.upload_user):
-            msg = (
-                "Please provide the upload password for %s: "
-                % self.upload_user
-            )
+        if not self.get_upload_password() and self.get_upload_user():
+            msg = ("Please provide the upload password for %s: "
+                   % self.get_upload_user())
             self.upload_password = getpass(msg)
 
     def upload_archive(self, archive):
@@ -1550,16 +1547,23 @@ class LinuxPolicy(Policy):
         :returns: The username to use for upload
         :rtype: ``str``
         """
-        return self.upload_user or self._upload_user
+        return (os.getenv('SOSUPLOADUSER', None) or
+                self.upload_user or
+                self._upload_user)
 
     def get_upload_password(self):
         """Helper function to determine if we should use the policy default
         upload password or one provided by the user
 
+        A user provided password, either via option or the 'SOSUPLOADPASSWORD'
+        environment variable will have precendent over any policy value
+
         :returns: The password to use for upload
         :rtype: ``str``
         """
-        return self.upload_password or self._upload_password
+        return (os.getenv('SOSUPLOADPASSWORD', None) or
+                self.upload_password or
+                self._upload_password)
 
     def upload_sftp(self):
         """Attempts to upload the archive to an SFTP location.

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -315,7 +315,7 @@ support representative.
         if self.commons['cmdlineopts'].upload_url:
             super(RHELPolicy, self).prompt_for_upload_user()
             return
-        if self.case_id:
+        if self.case_id and not self.get_upload_user():
             self.upload_user = input(_(
                 "Enter your Red Hat Customer Portal username (empty to use "
                 "public dropbox): ")
@@ -324,8 +324,8 @@ support representative.
     def get_upload_url(self):
         if self.commons['cmdlineopts'].upload_url:
             return self.commons['cmdlineopts'].upload_url
-        if (not self.case_id or not self.upload_user or not
-                self.upload_password):
+        if (not self.case_id or not self.get_upload_user() or not
+                self.get_upload_password()):
             # Cannot use the RHCP. Use anonymous dropbox
             self.upload_user = self._upload_user
             self.upload_directory = self._upload_directory
@@ -348,7 +348,7 @@ support representative.
     def get_upload_user(self):
         # if this is anything other than dropbox, annonymous won't work
         if self.upload_url != RH_FTP_HOST:
-            return self.upload_user
+            return os.getenv('SOSUPLOADUSER', None) or self.upload_user
         return self._upload_user
 
     def dist_version(self):


### PR DESCRIPTION
The username and password used by `Policy` when `--upload` is used may
now be read via environment variables to avoid sensitive information
from being included in `ps` output if they were provided via
command-line options instead of the interactive prompts.

Upload username may now be provided via the SOSUPLOADUSER variable.

Upload password may now be provided via the SOSUPLOADPASSWORD variable.

Resolves: #2216

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
