### PR TITLE
[systemd] list all active inhibition locks

### DIFF
--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -42,6 +42,7 @@ class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "systemd-analyze",
             "systemd-analyze blame",
             "systemd-analyze dump",
+            "systemd-inhibit --list",
             "journalctl --list-boots",
             "ls -lR /lib/systemd",
             "timedatectl"


### PR DESCRIPTION
Inhibitor locks may be used to block or delay
system sleep and shutdown requests from the user,
as well as automatic idle handling of the OS.

Documentation:
https://www.freedesktop.org/software/systemd/man/systemd-inhibit.html

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
