### PR TITLE
[suse] Update policy enablement check

### DIFF
--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -98,9 +98,11 @@ No changes will be made to system configuration.
 %(vendor_text)s
 """)
 
-    def __init__(self, sysroot=None, init=None, probe_runtime=True):
+    def __init__(self, sysroot=None, init=None, probe_runtime=True,
+                 remote_exec=None):
         super(OpenSuSEPolicy, self).__init__(sysroot=sysroot, init=init,
-                                             probe_runtime=probe_runtime)
+                                             probe_runtime=probe_runtime,
+                                             remote_exec=remote_exec)
 
     @classmethod
     def check(cls, remote):
@@ -110,4 +112,4 @@ No changes will be made to system configuration.
         if remote:
             return cls.distro in remote
 
-        return (os.path.isfile('/etc/SuSE-release'))
+        return os.path.isfile('/etc/SUSE-brand')


### PR DESCRIPTION
Updates the policy's enablement check for the presence of
/etc/SUSE-brand instead of /etc/SuSE-release.

Closes: #2217
Resolves: #2219

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
