### PR TITLE
[collect] Detect sos-4.0 and use new binary

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -62,6 +62,7 @@ class SosNode():
             'presets': [],
             'sos_cmd': commons['sos_cmd']
         }
+        self.sos_bin = 'sosreport'
         filt = ['localhost', '127.0.0.1']
         self.soslog = logging.getLogger('sos')
         self.ui_log = logging.getLogger('sos_ui')
@@ -390,9 +391,6 @@ class SosNode():
                 self.log_debug("Error while trying to create new SSH control "
                                "socket: %s" % err)
                 raise
-        if cmd.startswith('sosreport'):
-            cmd = cmd.replace('sosreport', self.host.sos_bin_path)
-            need_root = True
         if use_container and self.host.containerized:
             cmd = self.host.format_container_command(cmd)
         if need_root:
@@ -648,6 +646,15 @@ class SosNode():
 
             if self.opts.since:
                 sos_opts.append('--since=%s' % quote(self.opts.since))
+
+        # sos-4.0 changes the binary
+        if self.check_sos_version('4.0'):
+            self.sos_bin = 'sos report'
+
+        sos_cmd = sos_cmd.replace(
+            'sosreport',
+            os.path.join(self.host.sos_bin_path, self.sos_bin)
+        )
 
         if self.opts.only_plugins:
             plugs = [o for o in self.opts.only_plugins

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1289,7 +1289,7 @@ class LinuxPolicy(Policy):
     container_image = None
     sos_path_strip = None
     sos_pkg_name = None
-    sos_bin_path = None
+    sos_bin_path = '/usr/bin'
     sos_container_name = 'sos-collector-tmp'
     container_version_command = None
 

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -17,7 +17,6 @@ class DebianPolicy(LinuxPolicy):
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin"
     sos_pkg_name = 'sosreport'
-    sos_bin_path = '/usr/bin/sosreport'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -39,7 +39,7 @@ class RedHatPolicy(LinuxPolicy):
     upload_directory = '/incoming'
     default_container_runtime = 'podman'
     sos_pkg_name = 'sos'
-    sos_bin_path = '/usr/sbin/sosreport'
+    sos_bin_path = '/usr/sbin'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):


### PR DESCRIPTION
Updates the `collect` module to detect sos-4.0 installation, and if
present update the binary called to `sos report`.

As part of this change, move the update of the binary path to the
policy's full filesystem path into `finalize_sos_cmd()`

Closes: #2214
Resolves: #2221

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
