### PR TITLE
[build] Update distutils config and specfile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ setup(
                             'man/en/sos-mask.1']),
         ('share/man/man5', ['man/en/sos.conf.5']),
         ('share/licenses/sos', ['LICENSE']),
-        ('share/doc/sos', ['AUTHORS', 'README.md'])
+        ('share/doc/sos', ['AUTHORS', 'README.md']),
+        ('config', ['sos.conf'])
     ],
     packages=[
         'sos', 'sos.policies', 'sos.report', 'sos.report.plugins',

--- a/sos.spec
+++ b/sos.spec
@@ -12,8 +12,8 @@ BuildArch: noarch
 Url: https://github.com/sosreport/sos/
 BuildRequires: python3-devel
 BuildRequires: gettext
-Requires: libxml2-python
-Requires: rpm-python
+Requires: python3-libxml2
+Requires: python3-rpm
 Requires: tar
 Requires: xz
 Requires: python3-pexpect
@@ -41,7 +41,7 @@ install -d -m 755 ${RPM_BUILD_ROOT}/etc/sos/groups.d
 install -d -m 755 ${RPM_BUILD_ROOT}/etc/sos/extras.d
 install -m 644 %{name}.conf ${RPM_BUILD_ROOT}/etc/sos/%{name}.conf
 
-rm ${RPM_BUILD_ROOT}/sos.conf
+rm -rf ${RPM_BUILD_ROOT}/usr/config/
 
 %find_lang %{name} || echo 0
 


### PR DESCRIPTION
This patchset adds `sos.conf` to the distutils configuration for manual installs and source dist tarball generation. It also fixes issues in the specfile to correct RPM builds.

Resolves: #2222
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
