### PR TITLE
[policies] Make IndependentPlugin work and switch 17 to use it

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -819,25 +819,10 @@ any third party.
         self.case_id = None
         self.probe_runtime = probe_runtime
         self.package_manager = PackageManager()
-        self._valid_subclasses = []
+        self.valid_subclasses = [IndependentPlugin]
         self.set_exec_path()
         self._host_sysroot = sysroot
         self.register_presets(GENERIC_PRESETS)
-
-    def get_valid_subclasses(self):
-        return [IndependentPlugin] + self._valid_subclasses
-
-    def set_valid_subclasses(self, subclasses):
-        self._valid_subclasses = subclasses
-
-    def del_valid_subclasses(self):
-        del self._valid_subclasses
-
-    valid_subclasses = property(get_valid_subclasses,
-                                set_valid_subclasses,
-                                del_valid_subclasses,
-                                "list of subclasses that this policy can "
-                                "process")
 
     def check(self, remote=''):
         """

--- a/sos/policies/cos.py
+++ b/sos/policies/cos.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import CosPlugin
+from sos.report.plugins import CosPlugin, IndependentPlugin
 from sos.policies import LinuxPolicy
 
 
@@ -30,7 +30,7 @@ class CosPolicy(LinuxPolicy):
     distro = "Container-Optimized OS"
     vendor = "Google Cloud Platform"
     vendor_url = "https://cloud.google.com/container-optimized-os/"
-    valid_subclasses = [CosPlugin]
+    valid_subclasses = [CosPlugin, IndependentPlugin]
     PATH = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 
     @classmethod

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -29,8 +29,7 @@ class DebianPolicy(LinuxPolicy):
                                               verify_filter=self._debv_filter,
                                               chroot=sysroot,
                                               remote_exec=remote_exec)
-
-        self.valid_subclasses = [DebianPlugin]
+        self.valid_subclasses += [DebianPlugin]
 
     def _get_pkg_name_for_binary(self, binary):
         # for binary not specified inside {..}, return binary itself

--- a/sos/policies/ibmkvm.py
+++ b/sos/policies/ibmkvm.py
@@ -10,7 +10,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import PowerKVMPlugin, ZKVMPlugin, RedHatPlugin
+from sos.report.plugins import PowerKVMPlugin, ZKVMPlugin
 from sos.policies.redhat import RedHatPolicy
 
 import os
@@ -26,7 +26,7 @@ class PowerKVMPolicy(RedHatPolicy):
         super(PowerKVMPolicy, self).__init__(sysroot=sysroot, init=init,
                                              probe_runtime=probe_runtime,
                                              remote_exec=remote_exec)
-        self.valid_subclasses = [PowerKVMPlugin, RedHatPlugin]
+        self.valid_subclasses += [PowerKVMPlugin]
 
     @classmethod
     def check(cls, remote=''):
@@ -54,7 +54,7 @@ class ZKVMPolicy(RedHatPolicy):
 
     def __init__(self, sysroot=None):
         super(ZKVMPolicy, self).__init__(sysroot=sysroot)
-        self.valid_subclasses = [ZKVMPlugin, RedHatPlugin]
+        self.valid_subclasses += [ZKVMPlugin]
 
     @classmethod
     def check(cls, remote=''):

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -61,7 +61,7 @@ class RedHatPolicy(LinuxPolicy):
                                               chroot=sysroot,
                                               remote_exec=remote_exec)
 
-        self.valid_subclasses = [RedHatPlugin]
+        self.valid_subclasses += [RedHatPlugin]
 
         self.pkgs = self.package_manager.all_pkgs()
 

--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -29,7 +29,7 @@ class SuSEPolicy(LinuxPolicy):
         self.package_manager = PackageManager(
             'rpm -qa --queryformat "%{NAME}|%{VERSION}\\n"',
             remote_exec=remote_exec)
-        self.valid_subclasses = [SuSEPlugin, RedHatPlugin]
+        self.valid_subclasses += [SuSEPlugin, RedHatPlugin]
 
         pkgs = self.package_manager.all_pkgs()
 

--- a/sos/policies/ubuntu.py
+++ b/sos/policies/ubuntu.py
@@ -1,4 +1,4 @@
-from sos.report.plugins import UbuntuPlugin, DebianPlugin
+from sos.report.plugins import UbuntuPlugin
 from sos.policies.debian import DebianPolicy
 
 import os
@@ -20,7 +20,7 @@ class UbuntuPolicy(DebianPolicy):
         super(UbuntuPolicy, self).__init__(sysroot=sysroot, init=init,
                                            probe_runtime=probe_runtime,
                                            remote_exec=remote_exec)
-        self.valid_subclasses = [UbuntuPlugin, DebianPlugin]
+        self.valid_subclasses += [UbuntuPlugin]
 
     @classmethod
     def check(cls, remote=''):

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Block(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Block(Plugin, IndependentPlugin):
 
     short_desc = 'Block device information'
 

--- a/sos/report/plugins/date.py
+++ b/sos/report/plugins/date.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Date(Plugin, RedHatPlugin, DebianPlugin):
+class Date(Plugin, IndependentPlugin):
 
     short_desc = 'Basic system time information'
 

--- a/sos/report/plugins/hardware.py
+++ b/sos/report/plugins/hardware.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Hardware(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Hardware(Plugin, IndependentPlugin):
 
     short_desc = 'General hardware information'
 

--- a/sos/report/plugins/host.py
+++ b/sos/report/plugins/host.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Host(Plugin, RedHatPlugin, DebianPlugin):
+class Host(Plugin, IndependentPlugin):
 
     short_desc = 'Host information'
 

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -6,13 +6,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 import os
 import glob
 
 
-class Kernel(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+class Kernel(Plugin, IndependentPlugin):
 
     short_desc = 'Linux kernel'
 

--- a/sos/report/plugins/libraries.py
+++ b/sos/report/plugins/libraries.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Libraries(Plugin, RedHatPlugin, UbuntuPlugin):
+class Libraries(Plugin, IndependentPlugin):
 
     short_desc = 'Dynamic shared libraries'
 

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -8,11 +8,10 @@
 
 import os
 import glob
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Logs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+class Logs(Plugin, IndependentPlugin):
 
     short_desc = 'System logs'
 

--- a/sos/report/plugins/memory.py
+++ b/sos/report/plugins/memory.py
@@ -6,11 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Memory(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+class Memory(Plugin, IndependentPlugin):
 
     short_desc = 'Memory configuration and use'
 

--- a/sos/report/plugins/nvidia.py
+++ b/sos/report/plugins/nvidia.py
@@ -9,10 +9,10 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Nvidia(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Nvidia(Plugin, IndependentPlugin):
 
     short_desc = 'Nvidia GPU information'
 

--- a/sos/report/plugins/opencl.py
+++ b/sos/report/plugins/opencl.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class OpenCL(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class OpenCL(Plugin, IndependentPlugin):
 
     short_desc = 'OpenCL'
 

--- a/sos/report/plugins/opengl.py
+++ b/sos/report/plugins/opengl.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class OpenGL(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class OpenGL(Plugin, IndependentPlugin):
 
     short_desc = 'OpenGL'
 

--- a/sos/report/plugins/pci.py
+++ b/sos/report/plugins/pci.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import os
 
 
-class Pci(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Pci(Plugin, IndependentPlugin):
 
     short_desc = 'PCI devices'
 

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -6,11 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Process(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+class Process(Plugin, IndependentPlugin):
 
     short_desc = 'process information'
 

--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Processor(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Processor(Plugin, IndependentPlugin):
 
     short_desc = 'CPU information'
 

--- a/sos/report/plugins/system.py
+++ b/sos/report/plugins/system.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class System(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class System(Plugin, IndependentPlugin):
 
     short_desc = 'core system information'
 

--- a/sos/report/plugins/vulkan.py
+++ b/sos/report/plugins/vulkan.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Vulkan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Vulkan(Plugin, IndependentPlugin):
 
     short_desc = 'Vulkan'
 

--- a/sos/report/plugins/x11.py
+++ b/sos/report/plugins/x11.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class X11(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class X11(Plugin, IndependentPlugin):
 
     short_desc = 'X windowing system'
 


### PR DESCRIPTION
Switch valid_subclasses to be something we can just add to and default
it to include IndependentPlugin.

17 plugins switched are those that generally are going to activate via
files =, commands or the like.  Not packages. This will allow them to run
without sos being able to determine the OS release.

Closes: #2018

Signed-off-by: Bryan Quigley <code@bryanquigley.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
