### PR TITLE
[archive] Fix exception handling and LGTM alerts

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -341,13 +341,11 @@ class FileCacheArchive(Archive):
                 try:
                     shutil.copy(src, dest)
                 except OSError as e:
-                    self.log_info("File not collected: '%s'" % e)
-                except IOError as e:
                     # Filter out IO errors on virtual file systems.
                     if src.startswith("/sys/") or src.startswith("/proc/"):
                         pass
                     else:
-                        self.log_info("caught '%s' copying '%s'" % (e, src))
+                        self.log_info("File %s not collected: '%s'" % (src, e))
 
                 # copy file attributes, skip SELinux xattrs for /sys and /proc
                 try:
@@ -638,7 +636,9 @@ class TarFileArchive(FileCacheArchive):
         super(TarFileArchive, self).__init__(name, tmpdir, policy, threads,
                                              enc_opts, sysroot, manifest)
         self._suffix = "tar"
-        self._archive_name = os.path.join(tmpdir, self.name())
+        self._archive_name = os.path.join(
+            tmpdir, self.name()  # lgtm [py/init-calls-subclass]
+        )
 
     def set_tarinfo_from_stat(self, tar_info, fstat, mode=None):
         tar_info.mtime = fstat.st_mtime


### PR DESCRIPTION
First, consolidate a catch for IOError and OSError into a single OSError
catch, as since python-3.3 IOError has been merged into OSError. This in
turn resolves a LGTM alert for an unreachable exception catch.

Second, disable the init-calls-subclass warning as it is being triggered
by part of the test suite which for our purposes is a false-positive.

Resolves: #2225

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
