### PR TITLE
[networkmanager] Stop collecting "password" field.

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -109,7 +109,6 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
             for net_conf in files:
                 self.do_file_sub(
                     "/etc/NetworkManager/system-connections/"+net_conf,
-                    r"psk=(.*)", r"psk=***")
-
+                    r"(psk|password)=(.*)", r"\1=***")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
"password" fields in /etc/NetworkManager/system-connections/ is being
collected.
This commit stops that from happening.
See issue #2220 for more details.

Closes: #2220
Resolves: #2226

Signed-off-by: Adam R Bell <adam.bell@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
