### PR TITLE
Add snapped dockerd service

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -217,7 +217,8 @@ class DockerContainerRuntime(ContainerRuntime):
     def check_is_active(self):
         # the daemon must be running
         if (is_executable('docker') and
-                self.policy.init_system.is_running('docker')):
+                (self.policy.init_system.is_running('docker') or
+                 self.policy.init_system.is_running('snap.docker.dockerd'))):
             self.active = True
             return True
         return False
@@ -740,7 +741,7 @@ NO_PRESET_NOTE = 'Use to disable automatically loaded presets'
 GENERIC_PRESETS = {
     NO_PRESET: PresetDefaults(name=NO_PRESET, desc=NO_PRESET_DESC,
                               note=NO_PRESET_NOTE, opts=SoSOptions())
-    }
+}
 
 
 class Policy(object):
@@ -1096,7 +1097,7 @@ any third party.
             self._print(" " + self.get_preferred_hash_name() + "\t" + checksum)
             self._print()
             self._print(_("Please send this file to your support "
-                        "representative."))
+                          "representative."))
         self._print()
 
     def _print(self, msg=None, always=False):


### PR DESCRIPTION
When the docker service is installed via snap then the systemd service
is called `snap.docker.dockerd.service` and the test whether the
service is running fails. This change adds the snap service name so
that the `DockerContainerRuntime` can detect it.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
