### PR TITLE
Make quoting of container cmd optional

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -181,7 +181,7 @@ class ContainerRuntime(object):
                     vols.append(ent[-1])
         return vols
 
-    def fmt_container_cmd(self, container, cmd):
+    def fmt_container_cmd(self, container, cmd, quotecmd):
         """Format a command to run inside a container using the runtime
 
         :param container: The name or ID of the container in which to run
@@ -190,10 +190,17 @@ class ContainerRuntime(object):
         :param cmd: The command to run inside `container`
         :type cmd: ``str``
 
+        :param quotecmd: Whether the cmd should be quoted.
+        :type quotecmd: ``bool``
+
         :returns: Formatted string to run `cmd` inside `container`
         :rtype: ``str``
         """
-        return "%s %s %s" % (self.run_cmd, container, quote(cmd))
+        if quotecmd:
+            quoted_cmd = quote(cmd)
+        else:
+            quoted_cmd = cmd
+        return "%s %s %s" % (self.run_cmd, container, quoted_cmd)
 
     def get_logs_command(self, container):
         """Get the command string used to dump container logs from the

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2005,7 +2005,7 @@ class Plugin(object):
 
     def exec_cmd(self, cmd, timeout=cmd_timeout, stderr=True, chroot=True,
                  runat=None, env=None, binary=False, pred=None,
-                 foreground=False, container=False):
+                 foreground=False, container=False, quotecmd=False):
         """Execute a command right now and return the output and status, but
         do not save the output within the archive.
 
@@ -2044,6 +2044,9 @@ class Plugin(object):
                                     this name
         :type container: ``str``
 
+        :param quotecmd:            Whether the cmd should be quoted.
+        :type quotecmd: ``bool``
+
         :returns:                   Command exit status and output
         :rtype: ``dict``
         """
@@ -2062,7 +2065,7 @@ class Plugin(object):
                                "runtime detected on host." % (cmd, container))
                 return _default
             if self.container_exists(container):
-                cmd = self.fmt_container_cmd(container, cmd)
+                cmd = self.fmt_container_cmd(container, cmd, quotecmd)
             else:
                 self._log_info("Cannot run cmd '%s' in container %s: no such "
                                "container is running." % (cmd, container))
@@ -2192,7 +2195,7 @@ class Plugin(object):
         if _runtime is not None:
             self.add_cmd_output(_runtime.get_logs_command(container), **kwargs)
 
-    def fmt_container_cmd(self, container, cmd):
+    def fmt_container_cmd(self, container, cmd, quotecmd=False):
         """Format a command to be executed by the loaded ``ContainerRuntime``
         in a specified container
 
@@ -2202,13 +2205,16 @@ class Plugin(object):
         :param cmd:         The command to run within the container
         :type cmd: ``str``
 
+        :param quotecmd:    Whether the cmd should be quoted.
+        :type quotecmd: ``bool``
+
         :returns: The command to execute so that the specified `cmd` will run
                   within the `container` and not on the host
         :rtype: ``str``
         """
         if self.container_exists(container):
             _runtime = self._get_container_runtime()
-            return _runtime.fmt_container_cmd(container, cmd)
+            return _runtime.fmt_container_cmd(container, cmd, quotecmd)
         return cmd
 
     def is_module_loaded(self, module_name):


### PR DESCRIPTION
In case of the `docker` runtime (and potentially also in case of
`podman`) quoting a command that consists of multiple words separated
by whitespace leads to an incorrectly quoted command that fails to
execute. Whitespaces are explicitly not supported by upstream `docker`
for the `docker exec` command [1].

[1] https://docs.docker.com/engine/reference/commandline/exec/#extended-description

Fixes: #2231

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
