### PR TITLE
[collect] Add a prompt to continue after node discovery

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -805,6 +805,13 @@ class SoSCollector(SoSComponent):
             self.ui_log.info("\t%-*s" % (self.commons['hostlen'], node))
 
         self.ui_log.info('')
+        if not self.opts.batch:
+            try:
+                input("\nPress ENTER to continue with these nodes, or press "
+                      "CTRL-C to quit\n")
+                self.ui_log.info("")
+            except KeyboardInterrupt:
+                self.exit("Exiting on user cancel", 130)
 
     def configure_sos_cmd(self):
         """Configures the sosreport command that is run on the nodes"""


### PR DESCRIPTION
When not using `--batch`, sos will now prompt the user to accept the
list of discovered nodes before connecting to those nodes.

Resolves: #2234

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
