### PR TITLE
[cleaner] Fix two conditions where files can be incorrectly skipped

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -483,7 +483,7 @@ third party.
 
             file_list = archive.get_file_list()
             for fname in file_list:
-                short_name = fname.split(archive.archive_name)[1].lstrip('/')
+                short_name = fname.split(archive.archive_name + '/')[1]
                 if archive.should_skip_file(short_name):
                     continue
                 try:

--- a/sos/cleaner/obfuscation_archive.py
+++ b/sos/cleaner/obfuscation_archive.py
@@ -73,7 +73,9 @@ class SoSObfuscationArchive():
             'sys/kernel/debug',
             'sys/module',
             'var/log/.*dnf.*',
-            '.*.tar.*',  # TODO: support archive unpacking
+            '.*\.tar$',  # TODO: support archive unpacking
+            # Be explicit with these tar matches to avoid matching commands
+            '.*\.tar\.xz',
             '.*.gz'
         ]
 


### PR DESCRIPTION
Fixes two separate issues leading to incorrect file skipping.

First, fixes a condition where a file would be skipped if the name of the archive being cleaned appears more than once in the filename.

Second, fixes a regex issue that was too broad for matching against tarballs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
