### PR TITLE
[rabbitmq] Add 10 second timeout to call to `maybe_stuck()`.

### DIFF
--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -41,12 +41,13 @@ class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
                     self.fmt_container_cmd(
                         container, "rabbitmqctl eval "
                         "'rabbit_diagnostics:maybe_stuck().'"),
-                    foreground=True
+                    foreground=True, timeout=10
                 )
         else:
             self.add_cmd_output("rabbitmqctl report")
             self.add_cmd_output(
-                "rabbitmqctl eval 'rabbit_diagnostics:maybe_stuck().'")
+                "rabbitmqctl eval 'rabbit_diagnostics:maybe_stuck().'",
+                timeout=10)
 
         self.add_copy_spec([
             "/etc/rabbitmq/*",


### PR DESCRIPTION
The `maybe_stuck()` function might run for a long time if it is
tracking down a lot of potentially stuck processes. In order to
prevent long run times of `sos report` the `cmd` timeout should be set
explicitly. As a compromise between acceptable execution times and
information gathered from the plugin, this change introduces a timeout
of 10 seconds for the `maybe_stuck()` call.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
