### PR TITLE
[policy] Fix several failure conditions with upload

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1680,15 +1680,20 @@ class LinuxPolicy(Policy):
             directory = self.upload_directory or self._upload_directory
 
         try:
-            session = ftplib.FTP(url, user, password)
+            session = ftplib.FTP(url, user, password, timeout=15)
+            if not session:
+                raise Exception("connection failed, did you set a user and "
+                                "password?")
             session.cwd(directory)
+        except socket.timeout:
+            raise Exception("timeout hit while connecting to %s" % url)
         except socket.gaierror:
             raise Exception("unable to connect to %s" % url)
         except ftplib.error_perm as err:
             errno = str(err).split()[0]
-            if errno == 503:
+            if errno == '503':
                 raise Exception("could not login as '%s'" % user)
-            if errno == 550:
+            if errno == '550':
                 raise Exception("could not set upload directory to %s"
                                 % directory)
 

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1677,7 +1677,7 @@ class LinuxPolicy(Policy):
             password = self.get_upload_password()
 
         if not directory:
-            directory = self._upload_directory
+            directory = self.upload_directory or self._upload_directory
 
         try:
             session = ftplib.FTP(url, user, password)

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1420,7 +1420,8 @@ class LinuxPolicy(Policy):
         """Should be overridden by policies to determine if a password needs to
         be provided for upload or not
         """
-        if not self.get_upload_password() and self.get_upload_user():
+        if not self.get_upload_password() and (self.get_upload_user() !=
+                                               self._upload_user):
             msg = ("Please provide the upload password for %s: "
                    % self.get_upload_user())
             self.upload_password = getpass(msg)
@@ -1472,7 +1473,8 @@ class LinuxPolicy(Policy):
             Print a more human-friendly string than vendor URLs
         """
         self.upload_archive = archive
-        self.upload_url = self.get_upload_url()
+        if not self.upload_url:
+            self.upload_url = self.get_upload_url()
         if not self.upload_url:
             raise Exception("No upload destination provided by policy or by "
                             "--upload-url")

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -320,12 +320,16 @@ support representative.
                 "Enter your Red Hat Customer Portal username (empty to use "
                 "public dropbox): ")
             )
+            if not self.upload_user:
+                self.upload_url = RH_FTP_HOST
+                self.upload_user = self._upload_user
 
     def get_upload_url(self):
+        if self.upload_url:
+            return self.upload_url
         if self.commons['cmdlineopts'].upload_url:
             return self.commons['cmdlineopts'].upload_url
-        if (not self.case_id or not self.get_upload_user() or not
-                self.get_upload_password()):
+        if not self.case_id:
             # Cannot use the RHCP. Use anonymous dropbox
             self.upload_user = self._upload_user
             self.upload_directory = self._upload_directory

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -332,7 +332,8 @@ support representative.
         if not self.case_id:
             # Cannot use the RHCP. Use anonymous dropbox
             self.upload_user = self._upload_user
-            self.upload_directory = self._upload_directory
+            if self.upload_directory is None:
+                self.upload_directory = self._upload_directory
             self.upload_password = None
             return RH_FTP_HOST
         else:


### PR DESCRIPTION
This patchset fixes several error conditions with `--upload`. First, a too-strict logic check for `RHELPolicy` specifically, then followed by several global fixes for FTP uploads.

The FTP upload fixes include honoring the user-provided upload directory, and then correcting existing error handling while also adding more handlers for specific error conditions.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
