### PR TITLE
[openvswitch] catch cases when 'ovs-vsctl list bridge' has no output

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -219,6 +219,7 @@ class OpenVSwitch(Plugin):
                 ovs_list_bridge_cmd = "ovs-vsctl -t 5 list bridge %s" % br
                 br_info = self.collect_cmd_output(ovs_list_bridge_cmd)
 
+                br_protos = []
                 for line in br_info['output'].splitlines():
                     if "protocols" in line:
                         br_protos_ln = line[line.find("[")+1:line.find("]")]


### PR DESCRIPTION
If ovs_list_bridge_cmd does not return a valuable output, br_protos
variable won't be assigned before we reference it.

Fix that by assigning an empty list to br_protos .

Resolves: #2249

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
