### PR TITLE
[conntrackd] add conntrack info

### DIFF
--- a/sos/report/plugins/conntrack.py
+++ b/sos/report/plugins/conntrack.py
@@ -11,16 +11,17 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
                                 UbuntuPlugin, SuSEPlugin)
 
 
-class Conntrackd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
+class Conntrack(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
 
-    short_desc = 'conntrackd - netfilter connection tracking user-space daemon'
+    short_desc = 'conntrack - netfilter connection tracking'
 
-    plugin_name = 'conntrackd'
+    plugin_name = 'conntrack'
     profiles = ('network', 'cluster')
 
-    packages = ('conntrack-tools', 'conntrackd')
+    packages = ('conntrack-tools', 'conntrack', 'conntrackd')
 
     def setup(self):
+        # Collect info from conntrackd
         self.add_copy_spec("/etc/conntrackd/conntrackd.conf")
         self.add_cmd_output([
             "conntrackd -s network",
@@ -31,6 +32,12 @@ class Conntrackd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
             "conntrackd -s queue",
             "conntrackd -s ct",
             "conntrackd -s expect",
+        ])
+
+        # Collect info from conntrack
+        self.add_cmd_output([
+            "conntrack -L -o extended",
+            "conntrack -S",
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The plugin conntrackd is renamed to conntrack. Added the following
conntrack commands to the plugin.
conntrack -L -o extended
conntrack -S

Closes: #2049

Signed-off-by: Hemanth Nakkina hemanth.nakkina@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
