### PR TITLE
[networking] Add ip6tables-save output for namespaces

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -269,6 +269,7 @@ class Networking(Plugin):
                     ns_cmd_prefix + "ip address show",
                     ns_cmd_prefix + "ip route show table all",
                     ns_cmd_prefix + "iptables-save",
+                    ns_cmd_prefix + "ip6tables-save",
                     ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
                     ns_cmd_prefix + "netstat -s",
                     ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,


### PR DESCRIPTION
The loop that collects iptables-save output should be
doing the same for IPv6.

Signed-off-by: Brian Haley <bhaley@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
