### PR TITLE
[cleaner] Add username parser

### DIFF
--- a/sos/cleaner/mappings/username_map.py
+++ b/sos/cleaner/mappings/username_map.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Red Hat, Inc. Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.cleaner.mappings import SoSMap
+
+
+class SoSUsernameMap(SoSMap):
+    """Mapping to store usernames matched from ``lastlog`` output.
+
+    Usernames are obfuscated as ``obfuscateduserX`` where ``X`` is a counter
+    that gets incremented for every new username found.
+
+    Note that this specifically obfuscates user_names_ and not UIDs.
+    """
+
+    name_count = 0
+
+    def load_names_from_options(self, opt_names):
+        for name in opt_names:
+            if name not in self.dataset.keys():
+                self.add(name)
+
+    def sanitize_item(self, username):
+        """Obfuscate a new username not currently found in the map
+        """
+        ob_name = "obfuscateduser%s" % self.name_count
+        self.name_count += 1
+        if ob_name in self.dataset.values():
+            return self.sanitize_item(username)
+        return ob_name

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -1,0 +1,58 @@
+# Copyright 2020 Red Hat, Inc. Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos.cleaner.parsers import SoSCleanerParser
+from sos.cleaner.mappings.username_map import SoSUsernameMap
+
+
+class SoSUsernameParser(SoSCleanerParser):
+    """Parser for obfuscating usernames within an sosreport archive.
+
+    Note that this parser does not rely on regex matching directly, like most
+    other parsers do. Instead, usernames are discovered via scraping the
+    collected output of lastlog. As such, we do not discover new usernames
+    later on, and only usernames present in lastlog output will be obfuscated,
+    and those passed via the --usernames option if one is provided.
+    """
+
+    name = 'Username Parser'
+    map_file_key = 'username_map'
+    prep_map_file = 'sos_commands/login/lastlog_-u_1000-60000'
+    regex_patterns = []
+    skip_list = [
+        'nobody',
+        'nfsnobody',
+        'root'
+    ]
+
+    def __init__(self, conf_file=None, opt_names=None):
+        self.mapping = SoSUsernameMap()
+        super(SoSUsernameParser, self).__init__(conf_file)
+        self.mapping.load_names_from_options(opt_names)
+
+    def load_usernames_into_map(self, fname):
+        """Since we don't get the list of usernames from a straight regex for
+        this parser, we need to override the initial parser prepping here.
+        """
+        with open(fname, 'r') as lastfile:
+            for line in lastfile.read().splitlines()[1:]:
+                user = line.split()[0]
+                if user in self.skip_list:
+                    continue
+                self.mapping.get(user)
+
+    def parse_line(self, line):
+        count = 0
+        for username in self.mapping.dataset.keys():
+            if username in line:
+                count = line.count(username)
+                line = line.replace(username, self.mapping.get(username))
+        return line, count

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -91,6 +91,7 @@ class SoSCollector(SoSComponent):
         'ssh_user': 'root',
         'timeout': 600,
         'verify': False,
+        'usernames': [],
         'upload': False,
         'upload_url': None,
         'upload_directory': None,
@@ -373,6 +374,9 @@ class SoSCollector(SoSComponent):
                                  default='/etc/sos/cleaner/default_mapping',
                                  help=('Provide a previously generated mapping'
                                        ' file for obfuscation'))
+        cleaner_grp.add_argument('--usernames', dest='usernames', default=[],
+                                 action='extend',
+                                 help='List of usernames to obfuscate')
 
     def _check_for_control_persist(self):
         """Checks to see if the local system supported SSH ControlPersist.

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -107,6 +107,7 @@ class SoSReport(SoSComponent):
         'since': None,
         'verify': False,
         'allow_system_changes': False,
+        'usernames': [],
         'upload': False,
         'upload_url': None,
         'upload_directory': None,
@@ -305,6 +306,9 @@ class SoSReport(SoSComponent):
                                  default='/etc/sos/cleaner/default_mapping',
                                  help=('Provide a previously generated mapping'
                                        ' file for obfuscation'))
+        cleaner_grp.add_argument('--usernames', dest='usernames', default=[],
+                                 action='extend',
+                                 help='List of usernames to obfuscate')
 
     def print_header(self):
         print("\n%s\n" % _("sosreport (version %s)" % (__version__,)))


### PR DESCRIPTION
Adds a username parser for native obfuscation of usernames that appear
in `lastlog` output as collected by the `login` plugin.

Users may also supply additional usernames not appearing in `lastlog`
output via the `--usernames` option for either report, clean, or
collect.

Resolves: #2253

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
