### PR TITLE
[plugins] Use `IndependentPlugin` tag in more plugins

### DIFF
--- a/sos/report/plugins/anacron.py
+++ b/sos/report/plugins/anacron.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Anacron(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Anacron(Plugin, IndependentPlugin):
 
     short_desc = 'Anacron job scheduling service'
 

--- a/sos/report/plugins/arcconf.py
+++ b/sos/report/plugins/arcconf.py
@@ -10,10 +10,10 @@
 # This sosreport plugin is meant for sas adapters.
 # This plugin logs inforamtion on each adapter it finds.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class arcconf(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class arcconf(Plugin, IndependentPlugin):
 
     short_desc = 'arcconf Integrated RAID adapter information'
 

--- a/sos/report/plugins/ata.py
+++ b/sos/report/plugins/ata.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import os
 
 
-class Ata(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Ata(Plugin, IndependentPlugin):
 
     short_desc = 'ATA and IDE information'
 

--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Auditd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Auditd(Plugin, IndependentPlugin):
 
     short_desc = 'Audit daemon information'
 

--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 from glob import glob
 
 
-class Boot(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Boot(Plugin, IndependentPlugin):
 
     short_desc = 'Bootloader information'
 

--- a/sos/report/plugins/btrfs.py
+++ b/sos/report/plugins/btrfs.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Btrfs(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Btrfs(Plugin, IndependentPlugin):
 
     short_desc = 'Btrfs filesystem'
 

--- a/sos/report/plugins/cifs.py
+++ b/sos/report/plugins/cifs.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Cifs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Cifs(Plugin, IndependentPlugin):
 
     short_desc = 'SMB file system information'
     plugin_name = 'cifs'

--- a/sos/report/plugins/clear_containers.py
+++ b/sos/report/plugins/clear_containers.py
@@ -8,12 +8,10 @@
 
 import re
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, SuSEPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class ClearContainers(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin,
-                      SuSEPlugin):
+class ClearContainers(Plugin, IndependentPlugin):
 
     short_desc = 'Intel(R) Clear Containers configuration'
 

--- a/sos/report/plugins/cloud_init.py
+++ b/sos/report/plugins/cloud_init.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class CloudInit(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class CloudInit(Plugin, IndependentPlugin):
 
     short_desc = 'cloud-init instance configurations'
 

--- a/sos/report/plugins/cockpit.py
+++ b/sos/report/plugins/cockpit.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Cockpit(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Cockpit(Plugin, IndependentPlugin):
 
     short_desc = 'Cockpit Web Service'
 

--- a/sos/report/plugins/collectd.py
+++ b/sos/report/plugins/collectd.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 import re
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Collectd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Collectd(Plugin, IndependentPlugin):
 
     short_desc = 'Collectd config collector'
     plugin_name = "collectd"

--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -1,7 +1,14 @@
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Composer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Composer(Plugin, IndependentPlugin):
 
     short_desc = 'Lorax Composer'
 

--- a/sos/report/plugins/conntrack.py
+++ b/sos/report/plugins/conntrack.py
@@ -7,11 +7,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, SuSEPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Conntrack(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
+class Conntrack(Plugin, IndependentPlugin):
 
     short_desc = 'conntrack - netfilter connection tracking'
 

--- a/sos/report/plugins/container_log.py
+++ b/sos/report/plugins/container_log.py
@@ -8,11 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import os
 
 
-class ContainerLog(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class ContainerLog(Plugin, IndependentPlugin):
 
     short_desc = 'All logs under /var/log/containers'
     plugin_name = 'container_log'

--- a/sos/report/plugins/cron.py
+++ b/sos/report/plugins/cron.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Cron(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Cron(Plugin, IndependentPlugin):
 
     short_desc = 'Cron job scheduler'
 

--- a/sos/report/plugins/crypto.py
+++ b/sos/report/plugins/crypto.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Crypto(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Crypto(Plugin, IndependentPlugin):
 
     short_desc = 'System crypto services information'
 

--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Cups(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Cups(Plugin, IndependentPlugin):
 
     short_desc = 'CUPS IPP print service'
 

--- a/sos/report/plugins/dbus.py
+++ b/sos/report/plugins/dbus.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Dbus(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Dbus(Plugin, IndependentPlugin):
 
     short_desc = 'D-Bus message bus'
 

--- a/sos/report/plugins/devicemapper.py
+++ b/sos/report/plugins/devicemapper.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class DeviceMapper(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class DeviceMapper(Plugin, IndependentPlugin):
 
     short_desc = 'device-mapper framework'
 

--- a/sos/report/plugins/devices.py
+++ b/sos/report/plugins/devices.py
@@ -6,11 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Devices(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+class Devices(Plugin, IndependentPlugin):
 
     short_desc = 'devices specific commands'
 

--- a/sos/report/plugins/dlm.py
+++ b/sos/report/plugins/dlm.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import re
 
 
-class Dlm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Dlm(Plugin, IndependentPlugin):
 
     short_desc = 'DLM (Distributed lock manager)'
 

--- a/sos/report/plugins/dmraid.py
+++ b/sos/report/plugins/dmraid.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Dmraid(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Dmraid(Plugin, IndependentPlugin):
 
     short_desc = 'dmraid software RAID'
 

--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import json
 
 
-class Ebpf(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Ebpf(Plugin, IndependentPlugin):
 
     short_desc = 'eBPF tool'
     plugin_name = 'ebpf'

--- a/sos/report/plugins/elastic.py
+++ b/sos/report/plugins/elastic.py
@@ -8,11 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import re
 
 
-class Elastic(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Elastic(Plugin, IndependentPlugin):
 
     short_desc = 'ElasticSearch service'
     plugin_name = 'elastic'

--- a/sos/report/plugins/fwupd.py
+++ b/sos/report/plugins/fwupd.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Fwupd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Fwupd(Plugin, IndependentPlugin):
 
     short_desc = 'fwupd information'
 

--- a/sos/report/plugins/gdm.py
+++ b/sos/report/plugins/gdm.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Gdm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Gdm(Plugin, IndependentPlugin):
 
     short_desc = 'GNOME display manager'
 

--- a/sos/report/plugins/gfs2.py
+++ b/sos/report/plugins/gfs2.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Gfs2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Gfs2(Plugin, IndependentPlugin):
 
     short_desc = 'GFS2 (Global Filesystem 2)'
 

--- a/sos/report/plugins/grafana.py
+++ b/sos/report/plugins/grafana.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Grafana(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Grafana(Plugin, IndependentPlugin):
 
     short_desc = 'Fetch Grafana configuration, logs and CLI output'
     plugin_name = "grafana"

--- a/sos/report/plugins/grub.py
+++ b/sos/report/plugins/grub.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Grub(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Grub(Plugin, IndependentPlugin):
 
     short_desc = 'GRUB bootloader'
 

--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -6,11 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, SoSPredicate)
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
-class Grub2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Grub2(Plugin, IndependentPlugin):
 
     short_desc = 'GRUB2 bootloader'
 

--- a/sos/report/plugins/gssproxy.py
+++ b/sos/report/plugins/gssproxy.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class GSSProxy(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class GSSProxy(Plugin, IndependentPlugin):
 
     short_desc = 'GSSAPI Proxy'
 

--- a/sos/report/plugins/hpasm.py
+++ b/sos/report/plugins/hpasm.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Hpasm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Hpasm(Plugin, IndependentPlugin):
 
     short_desc = 'HP Advanced Server Management'
 

--- a/sos/report/plugins/hyperv.py
+++ b/sos/report/plugins/hyperv.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Hyperv(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Hyperv(Plugin, IndependentPlugin):
     """Hyper-V client information"""
 
     plugin_name = "hyperv"

--- a/sos/report/plugins/i18n.py
+++ b/sos/report/plugins/i18n.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class I18n(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class I18n(Plugin, IndependentPlugin):
 
     short_desc = 'Internationalization'
 

--- a/sos/report/plugins/infiniband.py
+++ b/sos/report/plugins/infiniband.py
@@ -9,10 +9,10 @@
 # See the LICENSE file in the source distribution for further information.
 
 import os
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Infiniband(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Infiniband(Plugin, IndependentPlugin):
 
     short_desc = 'Infiniband information'
 

--- a/sos/report/plugins/iprconfig.py
+++ b/sos/report/plugins/iprconfig.py
@@ -9,10 +9,10 @@
 # This plugin enables collection of logs for Power systems
 
 import re
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class IprConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class IprConfig(Plugin, IndependentPlugin):
 
     short_desc = 'IBM Power RAID storage adapter configuration information'
 

--- a/sos/report/plugins/java.py
+++ b/sos/report/plugins/java.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Java(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Java(Plugin, IndependentPlugin):
 
     short_desc = 'Java runtime'
 

--- a/sos/report/plugins/kata_containers.py
+++ b/sos/report/plugins/kata_containers.py
@@ -6,12 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, SuSEPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class KataContainers(Plugin, RedHatPlugin, DebianPlugin,
-                     UbuntuPlugin, SuSEPlugin):
+class KataContainers(Plugin, IndependentPlugin):
 
     short_desc = 'Kata Containers configuration'
 

--- a/sos/report/plugins/kimchi.py
+++ b/sos/report/plugins/kimchi.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Kimchi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Kimchi(Plugin, IndependentPlugin):
 
     short_desc = 'kimchi-related information'
 

--- a/sos/report/plugins/kvm.py
+++ b/sos/report/plugins/kvm.py
@@ -9,10 +9,10 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Kvm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Kvm(Plugin, IndependentPlugin):
 
     short_desc = 'Kernel virtual machine'
 

--- a/sos/report/plugins/libreswan.py
+++ b/sos/report/plugins/libreswan.py
@@ -9,10 +9,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Libreswan(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Libreswan(Plugin, IndependentPlugin):
 
     short_desc = 'Libreswan IPsec'
 

--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -6,12 +6,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import glob
 import os
 
 
-class Libvirt(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Libvirt(Plugin, IndependentPlugin):
 
     short_desc = 'libvirt virtualization API'
 

--- a/sos/report/plugins/lightdm.py
+++ b/sos/report/plugins/lightdm.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class LightDm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class LightDm(Plugin, IndependentPlugin):
 
     short_desc = 'Light Display Manager'
     packages = ('lightdm', )

--- a/sos/report/plugins/login.py
+++ b/sos/report/plugins/login.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Login(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Login(Plugin, IndependentPlugin):
 
     short_desc = 'login information'
 

--- a/sos/report/plugins/logrotate.py
+++ b/sos/report/plugins/logrotate.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class LogRotate(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class LogRotate(Plugin, IndependentPlugin):
 
     short_desc = 'LogRotate service'
 

--- a/sos/report/plugins/lstopo.py
+++ b/sos/report/plugins/lstopo.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 from sos.utilities import is_executable
 
 
-class Lstopo(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Lstopo(Plugin, IndependentPlugin):
 
     short_desc = 'Machine topology information'
 

--- a/sos/report/plugins/lvm2.py
+++ b/sos/report/plugins/lvm2.py
@@ -6,11 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, SoSPredicate)
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
-class Lvm2(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Lvm2(Plugin, IndependentPlugin):
 
     short_desc = 'Logical Volume Manager 2'
 

--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Md(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Md(Plugin, IndependentPlugin):
 
     short_desc = 'MD RAID subsystem'
 

--- a/sos/report/plugins/mpt.py
+++ b/sos/report/plugins/mpt.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Mpt(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Mpt(Plugin, IndependentPlugin):
 
     short_desc = 'LSI Message Passing Technology'
     files = ('/proc/mpt',)

--- a/sos/report/plugins/multipath.py
+++ b/sos/report/plugins/multipath.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Multipath(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Multipath(Plugin, IndependentPlugin):
 
     short_desc = 'Device-mapper multipath tools'
 

--- a/sos/report/plugins/mvcli.py
+++ b/sos/report/plugins/mvcli.py
@@ -10,10 +10,10 @@
 # This sosreport plugin is meant for sas adapters.
 # This plugin logs inforamtion on each adapter it finds.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class mvCLI(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class mvCLI(Plugin, IndependentPlugin):
 
     short_desc = 'mvCLI Integrated RAID adapter information'
 

--- a/sos/report/plugins/nfs.py
+++ b/sos/report/plugins/nfs.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Nfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Nfs(Plugin, IndependentPlugin):
 
     short_desc = 'Network file system information'
     plugin_name = 'nfs'

--- a/sos/report/plugins/nfsganesha.py
+++ b/sos/report/plugins/nfsganesha.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class NfsGanesha(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class NfsGanesha(Plugin, IndependentPlugin):
 
     short_desc = 'NFS-Ganesha file server information'
     plugin_name = 'nfsganesha'

--- a/sos/report/plugins/nginx.py
+++ b/sos/report/plugins/nginx.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Nginx(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Nginx(Plugin, IndependentPlugin):
 
     short_desc = 'nginx http daemon'
     plugin_name = "nginx"

--- a/sos/report/plugins/nis.py
+++ b/sos/report/plugins/nis.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Nis(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Nis(Plugin, IndependentPlugin):
 
     short_desc = 'Network Information Service'
     plugin_name = 'nis'

--- a/sos/report/plugins/npm.py
+++ b/sos/report/plugins/npm.py
@@ -10,11 +10,10 @@
 import os
 import json
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, SuSEPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Npm(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, SuSEPlugin):
+class Npm(Plugin, IndependentPlugin):
 
     short_desc = 'Information from available npm modules'
     plugin_name = 'npm'

--- a/sos/report/plugins/nscd.py
+++ b/sos/report/plugins/nscd.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Nscd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Nscd(Plugin, IndependentPlugin):
 
     short_desc = 'Name service caching daemon'
     plugin_name = 'nscd'

--- a/sos/report/plugins/nss.py
+++ b/sos/report/plugins/nss.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class NSS(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class NSS(Plugin, IndependentPlugin):
 
     short_desc = 'Network Security Services configuration'
 

--- a/sos/report/plugins/numa.py
+++ b/sos/report/plugins/numa.py
@@ -8,11 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import os.path
 
 
-class Numa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Numa(Plugin, IndependentPlugin):
 
     short_desc = 'NUMA state and configuration'
 

--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Nvme(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Nvme(Plugin, IndependentPlugin):
 
     short_desc = 'Collect config and system information about NVMe devices'
 

--- a/sos/report/plugins/nvmetcli.py
+++ b/sos/report/plugins/nvmetcli.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class NvmetCli(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class NvmetCli(Plugin, IndependentPlugin):
 
     short_desc = 'Collect config and system information for nvmetcli'
 

--- a/sos/report/plugins/omsa.py
+++ b/sos/report/plugins/omsa.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class omsa(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class omsa(Plugin, IndependentPlugin):
 
     short_desc = 'Dell OpenManage Server Administrator (OMSA)'
 

--- a/sos/report/plugins/openstack_ansible.py
+++ b/sos/report/plugins/openstack_ansible.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class OpenStackAnsible(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class OpenStackAnsible(Plugin, IndependentPlugin):
 
     short_desc = 'OpenStack-Ansible'
 

--- a/sos/report/plugins/openstack_tripleo.py
+++ b/sos/report/plugins/openstack_tripleo.py
@@ -8,11 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import re
 
 
-class OpenStackTripleO(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class OpenStackTripleO(Plugin, IndependentPlugin):
 
     short_desc = 'Installation information from OpenStack Installer'
 

--- a/sos/report/plugins/os_net_config.py
+++ b/sos/report/plugins/os_net_config.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class OsNetConfig(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class OsNetConfig(Plugin, IndependentPlugin):
 
     short_desc = 'OpenStack Net Config'
 

--- a/sos/report/plugins/perl.py
+++ b/sos/report/plugins/perl.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Perl(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Perl(Plugin, IndependentPlugin):
 
     short_desc = 'Perl runtime'
 

--- a/sos/report/plugins/pmem.py
+++ b/sos/report/plugins/pmem.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class pmem(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class pmem(Plugin, IndependentPlugin):
     """This plugin collects data from Persistent Memory devices,
     commonly referred to as NVDIMM's or Storage Class Memory (SCM)
     """

--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -10,10 +10,10 @@
 # specific logs for Pseries, PowerNV platforms.
 
 import os
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class PowerPC(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class PowerPC(Plugin, IndependentPlugin):
 
     short_desc = 'IBM Power systems'
 

--- a/sos/report/plugins/ppp.py
+++ b/sos/report/plugins/ppp.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Ppp(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Ppp(Plugin, IndependentPlugin):
 
     short_desc = 'Point-to-point protocol'
 

--- a/sos/report/plugins/ptp.py
+++ b/sos/report/plugins/ptp.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Ptp(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Ptp(Plugin, IndependentPlugin):
 
     short_desc = 'Precision time protocol'
 

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -6,11 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 from glob import glob
 
 
-class Puppet(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Puppet(Plugin, IndependentPlugin):
 
     short_desc = 'Puppet service'
 

--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class RabbitMQ(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class RabbitMQ(Plugin, IndependentPlugin):
 
     short_desc = 'RabbitMQ messaging service'
     plugin_name = 'rabbitmq'

--- a/sos/report/plugins/ruby.py
+++ b/sos/report/plugins/ruby.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Ruby(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Ruby(Plugin, IndependentPlugin):
 
     short_desc = 'Ruby runtime'
 

--- a/sos/report/plugins/s390.py
+++ b/sos/report/plugins/s390.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class S390(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class S390(Plugin, IndependentPlugin):
 
     short_desc = 'IBM S/390'
 

--- a/sos/report/plugins/sas3ircu.py
+++ b/sos/report/plugins/sas3ircu.py
@@ -10,10 +10,10 @@
 # This sosreport plugin is meant for sas adapters.
 # This plugin logs inforamtion on each adapter it finds.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class SAS3ircu(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class SAS3ircu(Plugin, IndependentPlugin):
 
     short_desc = 'SAS-3 Integrated RAID adapter information'
 

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -7,10 +7,10 @@
 # See the LICENSE file in the source distribution for further information.
 
 from glob import glob
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Scsi(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Scsi(Plugin, IndependentPlugin):
 
     short_desc = 'SCSI devices'
 

--- a/sos/report/plugins/snap.py
+++ b/sos/report/plugins/snap.py
@@ -7,10 +7,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Snap(Plugin, UbuntuPlugin, DebianPlugin, RedHatPlugin):
+class Snap(Plugin, IndependentPlugin):
 
     short_desc = 'Snap packages'
 

--- a/sos/report/plugins/sos_extras.py
+++ b/sos/report/plugins/sos_extras.py
@@ -6,12 +6,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 import os
 import stat
 
 
-class SosExtras(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class SosExtras(Plugin, IndependentPlugin):
 
     short_desc = 'Collect extra data defined in /etc/sos/extras.d'
 

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Ssh(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Ssh(Plugin, IndependentPlugin):
 
     short_desc = 'Secure shell service'
 

--- a/sos/report/plugins/sudo.py
+++ b/sos/report/plugins/sudo.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Sudo(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Sudo(Plugin, IndependentPlugin):
 
     short_desc = 'Sudo command execution'
     plugin_name = 'sudo'

--- a/sos/report/plugins/sunrpc.py
+++ b/sos/report/plugins/sunrpc.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class SunRPC(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class SunRPC(Plugin, IndependentPlugin):
 
     short_desc = 'Sun RPC service'
 

--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -8,11 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin, SoSPredicate)
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
-class Systemd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+class Systemd(Plugin, IndependentPlugin):
 
     short_desc = 'System management daemon'
 

--- a/sos/report/plugins/systemtap.py
+++ b/sos/report/plugins/systemtap.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class SystemTap(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class SystemTap(Plugin, IndependentPlugin):
 
     short_desc = 'SystemTap dynamic instrumentation'
 

--- a/sos/report/plugins/sysvipc.py
+++ b/sos/report/plugins/sysvipc.py
@@ -7,10 +7,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class SysVIPC(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class SysVIPC(Plugin, IndependentPlugin):
 
     short_desc = 'SysV IPC'
 

--- a/sos/report/plugins/targetcli.py
+++ b/sos/report/plugins/targetcli.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class TargetCli(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class TargetCli(Plugin, IndependentPlugin):
 
     short_desc = 'TargetCLI TCM/LIO configuration'
     packages = ('targetcli', 'python-rtslib')

--- a/sos/report/plugins/teamd.py
+++ b/sos/report/plugins/teamd.py
@@ -7,10 +7,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Teamd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Teamd(Plugin, IndependentPlugin):
 
     short_desc = 'Network Interface Teaming'
     plugin_name = 'teamd'

--- a/sos/report/plugins/tftpserver.py
+++ b/sos/report/plugins/tftpserver.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class TftpServer(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class TftpServer(Plugin, IndependentPlugin):
 
     short_desc = 'TFTP Server information'
     plugin_name = 'tftpserver'

--- a/sos/report/plugins/udev.py
+++ b/sos/report/plugins/udev.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Udev(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Udev(Plugin, IndependentPlugin):
 
     short_desc = 'udev dynamic device management'
 

--- a/sos/report/plugins/upstart.py
+++ b/sos/report/plugins/upstart.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Upstart(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Upstart(Plugin, IndependentPlugin):
 
     short_desc = 'Upstart init system'
 

--- a/sos/report/plugins/usb.py
+++ b/sos/report/plugins/usb.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Usb(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Usb(Plugin, IndependentPlugin):
 
     short_desc = 'USB devices'
 

--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class LibvirtClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class LibvirtClient(Plugin, IndependentPlugin):
 
     short_desc = 'client for libvirt virtualization API'
 

--- a/sos/report/plugins/xdp.py
+++ b/sos/report/plugins/xdp.py
@@ -6,11 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, \
-    UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Xdp(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Xdp(Plugin, IndependentPlugin):
 
     short_desc = 'XDP program information'
     plugin_name = 'xdp'

--- a/sos/report/plugins/xfs.py
+++ b/sos/report/plugins/xfs.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Xfs(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Xfs(Plugin, IndependentPlugin):
 
     short_desc = 'XFS filesystem'
 

--- a/sos/report/plugins/xinetd.py
+++ b/sos/report/plugins/xinetd.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Xinetd(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
+class Xinetd(Plugin, IndependentPlugin):
 
     short_desc = 'xinetd information'
 

--- a/sos/report/plugins/zfs.py
+++ b/sos/report/plugins/zfs.py
@@ -7,10 +7,10 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Zfs(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
+class Zfs(Plugin, IndependentPlugin):
 
     short_desc = 'ZFS filesystem'
 


### PR DESCRIPTION
This commit updates 94 plugins to use `IndependentPlugin` as the tagging
class, instead of the distro-specific tags.

This tag is applied to plugins where _all_ of `RedHatPlugin`,
`DebianPlugin`, and `UbuntuPlugin` are imported and there is only a
single class definition for the plugin which uses all of those tagging
classes. `SuSEPlugin` is also accepted where it is explicitly imported,
as the SuSE policy already uses the `RedHatPlugin` tagging class as
well.

Resolves: #2256

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
