### PR TITLE
[ovirt] Include oVirt imageio configuration

### DIFF
--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -121,6 +121,8 @@ class Ovirt(Plugin, RedHatPlugin):
             "/etc/ovirt-engine-metrics",
             "/etc/ovirt-engine-setup",
             "/etc/ovirt-vmconsole",
+            "/etc/ovirt-imageio",
+            "/etc/ovirt-imageio-proxy",
             "/var/log/ovirt-engine",
             "/var/log/ovirt-engine-dwh",
             "/var/log/ovirt-engine-reports",


### PR DESCRIPTION
Include the ovirt imageio proxy configuration.
In ovirt >= 4.4 the configuration is located in /etc/ovirt-imageio
for older versions it is in /etc/ovirt-imageio-proxy

Closes: #2260

Signed-off-by: Juan Orti <jortialc@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
