### PR TITLE
filesys: never collect content of /proc/fs/panfs

### DIFF
--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -43,6 +43,8 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "lslocks"
         ])
 
+        self.add_forbidden_path('/proc/fs/panfs')
+
         if self.get_option('lsof'):
             self.add_cmd_output("lsof -b +M -n -l -P", root_symlink="lsof")
 


### PR DESCRIPTION
panfs (from Panasas company) provides statistics under /proc/fs/panfs which makes sosreports become several hundreds of GBs. This path must hence be blacklisted.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
