### PR TITLE
[azure] Include AEM (Azure Enhanced Monitoring for Linux) data (if available)

### DIFF
--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -27,7 +27,8 @@ class Azure(Plugin, UbuntuPlugin):
             "/etc/default/kv-kvp-daemon-init",
             "/etc/waagent.conf",
             "/sys/module/hv_netvsc/parameters/ring_size",
-            "/sys/module/hv_storvsc/parameters/storvsc_ringbuffer_size"
+            "/sys/module/hv_storvsc/parameters/storvsc_ringbuffer_size",
+            "/var/lib/AzureEnhancedMonitor"
         ])
 
         # Adds all files under /var/log/azure to the sosreport


### PR DESCRIPTION
If available, use AEM to fetch PerfCounters.

Signed-off-by: Oliver Falk <oliver@linux-kernel.at>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [ x Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
