### PR TITLE
[openvswitch] fix dpdk-devbind.py command

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -87,7 +87,7 @@ class OpenVSwitch(Plugin):
             "ls -laZ /var/lib/vhost_sockets",
             # List devices and their drivers
             "dpdk_nic_bind --status",
-            "dpdk_devbind.py --status",
+            "dpdk-devbind.py --status",
             "driverctl list-devices",
             "driverctl list-overrides",
             # Capture a list of all bond devices


### PR DESCRIPTION
dpdk_nic_bind.py came from DPDK project and was renamed
to dpdk-devbind.py in DPDK 16.07.

The renamed script uses a hyphen as a seperator and
not an underscore.

Checked upstream DPDK project and packaged versions
on Fedora32/RHEL8/Ubuntu20.04 and all using hyphen.

Replace underscore with hyphen in the sos command.

Signed-off-by: Kevin Traynor <ktraynor@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
