### PR TITLE
[kdump] Collect new kdump logfiles

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -71,7 +71,8 @@ class RedHatKDump(KDump, RedHatPlugin):
         self.add_copy_spec([
             "/etc/kdump.conf",
             "/etc/udev/rules.d/*kexec.rules",
-            "/var/crash/*/vmcore-dmesg.txt"
+            "/var/crash/*/vmcore-dmesg.txt",
+            "/var/log/kdump.log"
         ])
         try:
             path = self.read_kdump_conffile()
@@ -80,6 +81,7 @@ class RedHatKDump(KDump, RedHatPlugin):
             path = "/var/crash"
 
         self.add_copy_spec("{}/*/vmcore-dmesg.txt".format(path))
+        self.add_copy_spec("{}/*/kexec-kdump.log".format(path))
 
 
 class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Two new logfiles are available in kdump:

/var/log/kdump.log
/var/crash/*/kexec-kdump.log

The path for the second logfile mentioned above is the
default one, but this patch deals with a change in
default directory the same way that we do with the
file vmcore-dmesg.txt.

Resolves RHBZ#1817042 and RHBZ#1887390.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
