### PR TITLE
[report] Allow users to specify commands and files to skip

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -30,6 +30,8 @@ sos collect \- Collect sosreports from multiple (cluster) nodes
     [\-\-password]
     [\-\-password\-per\-node]
     [\-\-preset PRESET]
+    [\-\-skip-commands COMMANDS]
+    [\-\-skip-files FILES]
     [\-s|\-\-sysroot SYSROOT]
     [\-\-ssh\-user SSH_USER]
     [\-\-sos-cmd SOS_CMD]
@@ -260,6 +262,18 @@ defined, or has a version of sos prior to 3.6, this option is ignored for that n
 .TP
 \fB\-p\fR SSH_PORT, \fB\-\-ssh\-port\fR SSH_PORT
 Specify SSH port for all nodes. Use this if SSH runs on any port other than 22.
+.TP
+\fB\-\-skip-commands\fR COMMANDS
+A comma delimited list of commands to skip execution of, but still allowing the
+rest of the plugin that calls the command to run. This will generally need to
+be some form of UNIX shell-style wildcard matching. For example, using a value
+of \fBhostname\fR will skip only that single command, while using \fBhostname*\fR
+will skip all commands with names that begin with the string "hostname".
+.TP
+\fB\-\-skip-files\fR FILES
+A comma delimited list of files or filepath wildcard matches to skip collection
+of. Values may either be exact filepaths or paths using UNIX shell-style wildcards,
+for example \fB/etc/sos/*\fR.
 .TP
 \fB\-\-ssh\-user\fR SSH_USER
 Specify an SSH user for sos collect to connect to nodes with. Default is root.

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -26,6 +26,8 @@ sosreport \- Collect and package diagnostic and support data
           [--log-size]\fR
           [--all-logs]\fR
           [--since YYYYMMDD[HHMMSS]]\fR
+          [--skip-commands commands]\fR
+          [--skip-files files]\fR
           [--allow-system-changes]\fR
           [-z|--compression-type method]\fR
           [--encrypt-key KEY]\fR
@@ -179,6 +181,18 @@ archive is any file not found in /etc, that has either a numeric or a
 compression-type file extension for example ".zip". ".1", ".gz" etc.).
 This also affects \--all-logs. The date string will be padded with zeros
 if HHMMSS is not specified.
+.TP
+.B \--skip-commands COMMANDS
+A comma delimited list of commands to skip execution of, but still allowing the
+rest of the plugin that calls the command to run. This will generally need to
+be some form of UNIX shell-style wildcard matching. For example, using a value
+of \fBhostname\fR will skip only that single command, while using \fBhostname*\fR
+will skip all commands with names that begin with the string "hostname".
+.TP
+.B \--skip-files FILES
+A comma delimited list of files or filepath wildcard matches to skip collection
+of. Values may either be exact filepaths or paths using UNIX shell-style wildcards,
+for example \fB/etc/sos/*\fR.
 .TP
 .B \--allow-system-changes
 Run commands even if they can change the system (e.g. load kernel modules).

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -84,6 +84,8 @@ class SoSCollector(SoSComponent):
         'preset': '',
         'save_group': '',
         'since': '',
+        'skip_cmds': [],
+        'skip_files': [],
         'skip_plugins': [],
         'sos_opt_line': '',
         'ssh_key': '',
@@ -277,6 +279,12 @@ class SoSCollector(SoSComponent):
                              help=('Escapes archived files older than date. '
                                    'This will also affect --all-logs. '
                                    'Format: YYYYMMDD[HHMMSS]'))
+        sos_grp.add_argument('--skip-commands', default=[], action='extend',
+                             dest='skip_cmds',
+                             help="do not execute these commands")
+        sos_grp.add_argument('--skip-files', default=[], action='extend',
+                             dest='skip_files',
+                             help="do not collect these files")
         sos_grp.add_argument('--verify', action="store_true",
                              help='perform pkg verification during collection')
 

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -651,6 +651,16 @@ class SosNode():
         if self.check_sos_version('4.0'):
             self.sos_bin = 'sos report'
 
+        if self.check_sos_version('4.1'):
+            if self.opts.skip_cmds:
+                sos_opts.append(
+                    '--skip-commands=%s' % (quote(self.opts.skip_cmds))
+                )
+            if self.opts.skip_files:
+                sos_opts.append(
+                    '--skip-files=%s' % (quote(self.opts.skip_files))
+                )
+
         sos_cmd = sos_cmd.replace(
             'sosreport',
             os.path.join(self.host.sos_bin_path, self.sos_bin)

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -94,6 +94,8 @@ class SoSReport(SoSComponent):
         'list_profiles': False,
         'log_size': 25,
         'map_file': '/etc/sos/cleaner/default_mapping',
+        'skip_cmds': [],
+        'skip_files': [],
         'skip_plugins': [],
         'noreport': False,
         'no_env_vars': False,
@@ -258,6 +260,12 @@ class SoSReport(SoSComponent):
                                 dest="profiles", type=str, default=[],
                                 help="enable plugins used by the given "
                                      "profiles")
+        report_grp.add_argument('--skip-commands', default=[], action='extend',
+                                dest='skip_cmds',
+                                help="do not execute these commands")
+        report_grp.add_argument('--skip-files', default=[], action='extend',
+                                dest='skip_files',
+                                help="do not collect these files")
         report_grp.add_argument("--verify", action="store_true",
                                 dest="verify", default=False,
                                 help="perform data verification during "

--- a/tests/option_tests.py
+++ b/tests/option_tests.py
@@ -16,6 +16,8 @@ class MockOptions(object):
     dry_run = False
     log_size = 25
     allow_system_changes = False
+    skip_cmds = []
+    skip_files = []
 
 
 class GlobalOptionTest(unittest.TestCase):

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -114,6 +114,8 @@ class MockOptions(object):
     log_size = 25
     allow_system_changes = False
     no_postproc = False
+    skip_files = []
+    skip_cmds = []
 
 
 class PluginToolTests(unittest.TestCase):


### PR DESCRIPTION
Adds two new options, `--skip-commands` and `--skip-files`, that allow
users to selectively skip specific command or file collection instead of
having to disable whole plugins to skip those collections.

These options are also exposed via `sos collect`, being gated by a
version of 4.1 since that is the next scheduled release where we can
guarantee this functionality will be present.

Closes: #2203
Resolves: #2271

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
