### PR TITLE
[ovirt_imageio] Include oVirt imageio v2 files

### DIFF
--- a/sos/report/plugins/ovirt_imageio.py
+++ b/sos/report/plugins/ovirt_imageio.py
@@ -29,15 +29,19 @@ class OvirtImageIO(Plugin, RedHatPlugin):
         # Add configuration files
         self.add_copy_spec([
             '/etc/ovirt-imageio-daemon/logger.conf',
+            '/etc/ovirt-imageio-daemon/daemon.conf',
             '/etc/ovirt-imageio-proxy/ovirt-imageio-proxy.conf',
+            '/etc/ovirt-imageio/conf.d/*.conf',
         ])
 
         if all_logs:
             logs = ['/var/log/ovirt-imageio-proxy/image-proxy.log*',
-                    '/var/log/ovirt-imageio-daemon/daemon.log*']
+                    '/var/log/ovirt-imageio-daemon/daemon.log*',
+                    '/var/log/ovirt-imageio/daemon.log*']
         else:
             logs = ['/var/log/ovirt-imageio-proxy/image-proxy.log',
-                    '/var/log/ovirt-imageio-daemon/daemon.log']
+                    '/var/log/ovirt-imageio-daemon/daemon.log',
+                    '/var/log/ovirt-imageio/daemon.log']
 
         # Add log files
         self.add_copy_spec(logs)


### PR DESCRIPTION
Include logs and configuration of ovirt-imageio v2 (ovirt >= 4.4)
The configuration is now located in /etc/ovirt-imageio, and the logs
in /var/log/ovirt-imageio.
Include also /etc/ovirt-imageio-daemon/daemon.conf which was missing
for older versions.

Closes: #2260

Signed-off-by: Juan Orti <jortialc@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
