### PR TITLE
[policy] Use FTP server when user isnt set in batch mode

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -324,13 +324,21 @@ support representative.
                 self.upload_url = RH_FTP_HOST
                 self.upload_user = self._upload_user
 
+    def _upload_user_set(self):
+        user = self.get_upload_user()
+        return user and (user != 'anonymous')
+
     def get_upload_url(self):
         if self.upload_url:
             return self.upload_url
         if self.commons['cmdlineopts'].upload_url:
             return self.commons['cmdlineopts'].upload_url
-        if not self.case_id:
-            # Cannot use the RHCP. Use anonymous dropbox
+        # anonymous FTP server should be used as fallback when either:
+        # - case id is not set, or
+        # - upload user isn't set AND batch mode prevents to prompt for it
+        if (not self.case_id) or \
+           ((not self._upload_user_set()) and
+               self.commons['cmdlineopts'].batch):
             self.upload_user = self._upload_user
             if self.upload_directory is None:
                 self.upload_directory = self._upload_directory


### PR DESCRIPTION
Caling "sos report --upload --case-id=123 --batch" should fallback
to uploading to FTP server as the upload user is unknown and can't
be prompted in batch mode.

Resolves: #2276

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
