### PR TITLE
[policy] Fix the passing of 'query_command' argument for SUSE.

### DIFF
--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -20,6 +20,7 @@ class SuSEPolicy(LinuxPolicy):
     vendor = "SuSE"
     vendor_url = "https://www.suse.com/"
     _tmp_dir = "/var/tmp"
+    _rpmq_cmd = 'rpm -qa --queryformat "%{NAME}|%{VERSION}\\n"'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
@@ -27,7 +28,7 @@ class SuSEPolicy(LinuxPolicy):
                                          probe_runtime=probe_runtime)
         self.ticket_number = ""
         self.package_manager = PackageManager(
-            'rpm -qa --queryformat "%{NAME}|%{VERSION}\\n"',
+            query_command=self._rpmq_cmd,
             remote_exec=remote_exec)
         self.valid_subclasses += [SuSEPlugin, RedHatPlugin]
 


### PR DESCRIPTION
RPM query string was passing to chroot argument insted of query_command.

Resolves: #2279

Signed-off-by: Daria Bukharina <d.bukharina@yadro.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
