### PR TITLE
[kdump] Collect the list of files compressed by squashfs

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -8,6 +8,8 @@
 
 import os
 import platform
+import tempfile
+import subprocess
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
@@ -67,6 +69,11 @@ class RedHatKDump(KDump, RedHatPlugin):
                         + "kdump.img"
         if os.path.exists(initramfs_img):
             self.add_cmd_output("lsinitrd %s" % initramfs_img)
+            with tempfile.NamedTemporaryFile(delete=False) as tempfp:
+                p = subprocess.Popen(['lsinitrd', '-f', 'squash/root.img', initramfs_img], stdout=tempfp)
+                out, err = p.communicate()
+                if not err:
+                    self.add_cmd_output("unsquashfs -lls %s" % tempfp.name, suggest_filename="unsquashfs_-lls_squash_root.img")
 
         self.add_copy_spec([
             "/etc/kdump.conf",


### PR DESCRIPTION
Initramfs for kdump has "squash/root.img" compressed by squashfs.
It includes files needed by kdump kernel to boot. The list of them
is collected.

Signed-off-by: MORISHIMA shigeki <s.morishima@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
