### PR TITLE
[report] remove redundant test of compression methods

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -820,15 +820,6 @@ class SoSReport(SoSComponent):
         self.policy.pre_work()
         try:
             self.ui_log.info(_(" Setting up archive ..."))
-            compression_methods = ('auto', 'bzip2', 'gzip', 'xz')
-            method = self.opts.compression_type
-            if method not in compression_methods:
-                compression_list = ', '.join(compression_methods)
-                self.ui_log.error("")
-                self.ui_log.error("Invalid compression specified: " + method)
-                self.ui_log.error("Valid types are: " + compression_list)
-                self.ui_log.error("")
-                self._exit(1)
             self.setup_archive()
             self._make_archive_paths()
             return


### PR DESCRIPTION
Argparse processing of compression method already contains
this inclusion test, let delete it from here.

Resolves: #2286

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
