### PR TITLE
Increasing Usage+Readability of ThreadPoolExecutor

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -910,11 +910,13 @@ class SoSReport(SoSComponent):
             plugruncount += 1
             self.pluglist.append((plugruncount, i[0]))
         try:
-            self.plugpool = ThreadPoolExecutor(self.opts.threads)
-            # Pass the plugpool its own private copy of self.pluglist
-            results = self.plugpool.map(self._collect_plugin,
-                                        list(self.pluglist))
-            self.plugpool.shutdown(wait=True)
+            results = []
+            with ThreadPoolExecutor(
+                max_workers=self.opts.threads) as executor:
+                results = executor.map(
+                    self._collect_plugin,
+                    *list(self.pluglist)
+                )
             for res in results:
                 if not res:
                     self.soslog.debug("Unexpected plugin task result: %s" %


### PR DESCRIPTION
While checking out another issue (#2289) I stumbled over the ThreadPoolExecutor that is used in the Report to execute plugins asynchronously. I knew about Futures from other languages and I know that there was an asyncio trend a few years ago, but I didn't know that Python decided to implement something like this into the core. Loving the idea, so I [checked out the 3.6 docs](https://docs.python.org/3.6/library/concurrent.futures.html).

There I found some differences to how the framework is used in the sos codebase.

 * I added the ContextManager wrapping through a `with` statement. The advantage of that version is that the cleanup code will be executed even if an exception occurs during execution.
 * I removed it as attribute of the Report object. I only saw it being used in these few lines, so it's not necessary to have this variable to exist outside the context where it was used.
 * I give it the pluglist as expanded list.


The last point shouldn't be underestimated and might result in code breaking for users. In the old version the whole `pluglist` was treated as one item that was given to one thread of `_collect_plugin`. In the new version *each item* of `pluglist` is handed separately to its own thread of `_collect_plugin`. I think this was the intention of using ThreadPoolExecutor in the first place. But if the items are not split up by expanding the list, actually only one thread would run and not "up to max_workers" in parallel.

Example:

```
>>> def asdf(a, *b):
...   print(str(a))
...   print(str(b))
... 
>>> asdf(1,[2,3,4,5])
1
([2, 3, 4, 5],)    # <----- the whole list is given as one item in the tuple
>>> asdf(1, *[2,3,4,5])
1
(2, 3, 4, 5)      # <-----  each item is treated separately in the tuple so map() can apply "1" to each item individually
```

I really expect that there might be some non-obvious bugs coming out of this change since asynchronous processing is super hard to get right. But the test suite runs through successfully:

``` 
(venv) 11:13:54:sosreport🍔  nosetests
.................................................................................................................
----------------------------------------------------------------------
Ran 113 tests in 4.676s

OK
```

What do you think?

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?