### PR TITLE
[ovirt] collect /etc/pki/ovirt-engine/.truststore

### DIFF
--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -137,12 +137,15 @@ class Ovirt(Plugin, RedHatPlugin):
             "/var/lib/ovirt-engine-reports/jboss_runtime/config"
         ])
 
-        # Copying host certs.
+        # Copying host certs; extra copy the hidden .truststore file
         self.add_forbidden_path([
             "/etc/pki/ovirt-engine/keys",
             "/etc/pki/ovirt-engine/private"
         ])
-        self.add_copy_spec("/etc/pki/ovirt-engine/")
+        self.add_copy_spec([
+            "/etc/pki/ovirt-engine/",
+            "/etc/pki/ovirt-engine/.truststore",
+        ])
 
     def postproc(self):
         """


### PR DESCRIPTION
.truststore contains useful public CAs but a_c_s skips collecting
that hidden file.

Resolves: #2296

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
