### PR TITLE
[openstack_ceilometer] Add backend_url to protected keys

### DIFF
--- a/sos/report/plugins/openstack_ceilometer.py
+++ b/sos/report/plugins/openstack_ceilometer.py
@@ -51,10 +51,9 @@ class OpenStackCeilometer(Plugin):
             "admin_password", "connection_password", "host_password",
             "memcache_secret_key", "os_password", "password", "qpid_password",
             "rabbit_password", "readonly_user_password", "secret_key",
-            "ssl_key_password", "telemetry_secret", "metering_secret",
-            "transport_url"
+            "ssl_key_password", "telemetry_secret", "metering_secret"
         ]
-        connection_keys = ["connection"]
+        connection_keys = ["connection", "backend_url", "transport_url"]
 
         self.apply_regex_sub(
             r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),


### PR DESCRIPTION
This patch adds the password and url in backend_url to the
list of protected keys, so it gets properly masked.

Related: RHBZ#1892692
Resolves: #2298 

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
