### PR TITLE
[sos] Use parse_args() instead of parse_known_args()

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -118,7 +118,7 @@ class SoS():
             self._add_common_options(_com_subparser)
             self._components[comp][0].add_parser_options(parser=_com_subparser)
             _com_subparser.set_defaults(component=comp)
-        self.args, _unknown = self.parser.parse_known_args(self.cmdline)
+        self.args = self.parser.parse_args(self.cmdline)
         self._init_component()
 
     def _add_common_options(self, parser):


### PR DESCRIPTION
When sos-4.0 work first went in, the way we extracted cmdline args for
the parser was to call `parse_known_args()` in an effort to avoid
passing unknown args to subcmds that don't support those specific args.

As the parsers were built out however, this became unnecessary. The
default behavior of `parse_args()` is smart enough to filter out args
that are not supported by the specific component being run.

With this being the case, we no longer need to manually check for
unknown args being passed, and with that clear a LGTM warning.

Resolves: #2299

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
