### PR TITLE
[openstack_tripleo] Add new path for log collection

### DIFF
--- a/sos/report/plugins/openstack_tripleo.py
+++ b/sos/report/plugins/openstack_tripleo.py
@@ -23,12 +23,14 @@ class OpenStackTripleO(Plugin, IndependentPlugin):
     def setup(self):
         # Notes: recursion is max 2 for container-puppet and tripleo-config
         # Those directories are present on all OpenStack nodes
-        self.add_copy_spec([
+        self.tripleo_log_paths = [
             '/var/log/paunch.log',
             '/var/lib/container-puppet/',
             '/var/lib/tripleo-config/',
+            '/var/lib/tripleo/',
             '/etc/puppet/hieradata/'
-        ])
+        ]
+        self.add_copy_spec(self.tripleo_log_paths)
 
     def postproc(self):
         # Ensures we do not leak passwords from the tripleo-config and
@@ -38,10 +40,7 @@ class OpenStackTripleO(Plugin, IndependentPlugin):
                   r'([":\s]+)(.*[^"])([",]+)'
         rgxp = re.compile(secrets, re.IGNORECASE)
 
-        self.do_path_regex_sub('/var/lib/tripleo-config/',
-                               rgxp, r'\1\3*********\5')
-        self.do_path_regex_sub('/etc/puppet/hieradata/',
-                               rgxp, r'\1\3*********\5')
-
+        for path in self.tripleo_log_paths:
+            self.do_path_regex_sub(path, rgxp, r'\1\3*********\5')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This change essentially adds /var/lib/tripleo to the collection path.

All of the collection targets have been moved into a class object
which is easily shared across methods. This will allow us to easily
collect more in the future and ensure all of our collected objects
are sanitized.

Signed-off-by: Kevin Carter <kecarter@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
