### PR TITLE
[sos] Fix argparse error output formatting

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -110,7 +110,8 @@ class SoS():
         for comp in self._components:
             _com_subparser = self.subparsers.add_parser(
                 comp,
-                aliases=self._components[comp][1]
+                aliases=self._components[comp][1],
+                prog="sos %s" % comp
             )
             _com_subparser.usage = "sos %s [options]" % comp
             _com_subparser.register('action', 'extend', SosListOption)


### PR DESCRIPTION
Error message propagation from the subparsers was causing the error
message to be mangled with the usage string from the "main" parser when
an invalid argument value was passed.

After discussion with python upstream, while this is an issue with the
subparser formatting (as %(prog) is being set to the main parser's
usage), there are simple paths around this behavior so a code change
there will not be forthcoming.

Instead, override the subparser's prog to be a single line string
instead of the main parser's usage string.

Closes: #2285
Resolves: #2301

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
