### PR TITLE
[component] Add log verbosity from presets

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -153,6 +153,12 @@ class SoSReport(SoSComponent):
         self.opts.merge(self.preset.opts)
         # re-apply any cmdline overrides to the preset
         self.opts = self.apply_options_from_cmdline(self.opts)
+        if hasattr(self.preset.opts, 'verbosity') and \
+            self.preset.opts.verbosity > 0:
+            print('\nWARNING: It is not recommended to set verbosity via the '
+                  'preset as it might have\nunforseen consequences for your '
+                  'report logs.\n')
+            self._setup_logging()
 
         self._set_directories()
 


### PR DESCRIPTION
A simple fix suggestion for #2289 . See commit message for more details.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?