### PR TITLE
[ebpf|networking] Ignore stderr from ip netns for list of namespaces

### DIFF
--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -67,15 +67,12 @@ class Ebpf(Plugin, IndependentPlugin):
         ])
 
         # Capture list of bpf program attachments from namespaces
-        ip_netns = self.exec_cmd("ip netns")
+        ip_netns = self.exec_cmd("ip netns", stderr=False)
         cmd_prefix = "ip netns exec "
         if ip_netns['status'] == 0:
             out_ns = []
             for line in ip_netns['output'].splitlines():
-                # If there's no namespaces, no need to continue
-                if line.startswith("Object \"netns\" is unknown") \
-                        or line.isspace() \
-                        or line[:1].isspace():
+                if line.isspace() or line[:1].isspace():
                     continue
                 out_ns.append(line.partition(' ')[0])
             for namespace in out_ns:

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -229,8 +229,9 @@ class Networking(Plugin):
             self.add_cmd_output("/bin/traceroute -n %s" % self.trace_host)
 
         # Capture additional data from namespaces; each command is run
-        # per-namespace.
-        ip_netns = self.collect_cmd_output("ip netns")
+        # per-namespace. Collect error lines only into the archive.
+        self.add_cmd_output("ip netns", stderr=True)
+        ip_netns = self.exec_cmd("ip netns", stderr=False)
         cmd_prefix = "ip netns exec "
         if ip_netns['status'] == 0:
             out_ns = []
@@ -240,10 +241,7 @@ class Networking(Plugin):
                         self.get_option("namespace_pattern").split()
                         ).replace('*', '.*')
             for line in ip_netns['output'].splitlines():
-                # If there's no namespaces, no need to continue
-                if line.startswith("Object \"netns\" is unknown") \
-                        or line.isspace() \
-                        or line[:1].isspace():
+                if line.isspace() or line[:1].isspace():
                     continue
                 # if namespace_pattern defined, append only namespaces
                 # matching with pattern


### PR DESCRIPTION
The sosreport of a system with this issue:
```
    # ip netns
    Error: Peer netns reference is invalid.
    Error: Peer netns reference is invalid.
    test-ns
```

Shows that the networking plugin runs commands for the `Error:` lines:
(the ebpf plugin does not; due to differences addressed in PR #2306.)
```
    # ./bin/sos report -o ebpf,networking --batch

    # tar tf /tmp/sosreport-*.tar.xz | grep ip_netns_exec
    .../sos_commands/ebpf/ip_netns_exec_test-ns_bpftool_net_list
    .../sos_commands/networking/ip_netns_exec_Error_ip6tables-save
    .../sos_commands/networking/ip_netns_exec_Error_ip6tables-save.1
    ...
    .../sos_commands/networking/ip_netns_exec_test-ns_ip6tables-save
    ...
```

This happens because the networking plugin calls `collect_cmd_output()`
with default `stderr=True` and does not handle such line type.

For the purposes of getting the list of network namespaces, it is OK to
ignore `stderr` since it does not provide that information. However, we
do want it in the archive, so it is fully documented for analysis/debug.

And if we get rid of `stderr` there, we can drop the existing check for
`Object unknown` in `ip`, as `iproute2` has always had it in `stderr`.
(This applies to the ebpf plugin as well; it's copied from networking.)

```
@ iproute2.git:

    commit aba5acdfdb347d2c21fc67d613d83d4430ca3937
    Author: Stephen Hemminger <stephen@networkplumber.org>
    Date:   Thu Apr 15 20:56:59 2004 +0000

        (Logical change 1.3)
    ...
    diff --git a/ip/ip.c b/ip/ip.c
    ...
    +               fprintf(stderr, "Object \"%s\" is unknown, try
                    \"ip help\".\n", argv[1]);
    +               exit(-1);
    ...
```

Note that both plugins _currently_ do not need `exec_cmd(stderr=False)`
(see output above) as described in PR #2306, but it will once/if that is
applied.  So, add that proactively; and it doesn't hurt/has any effects
without that PR anyway.

Before:
```
  # tar tf /tmp/sosreport-*.tar.xz | grep ip_netns_exec
  .../sos_commands/ebpf/ip_netns_exec_test-ns_bpftool_net_list
  .../sos_commands/networking/ip_netns_exec_Error_ip6tables-save
  .../sos_commands/networking/ip_netns_exec_Error_ip6tables-save.1
  ...
  .../sos_commands/networking/ip_netns_exec_test-ns_ip6tables-save
  ...
```

After:
```
  # tar tf /tmp/sosreport-*.tar.xz | grep ip_netns_exec
  .../sos_commands/ebpf/ip_netns_exec_test-ns_bpftool_net_list
  .../sos_commands/networking/ip_netns_exec_test-ns_ip6tables-save
  .../sos_commands/networking/ip_netns_exec_test-ns_ip_-s_-s_neigh_show
  ...
```

And the `ip netns` contents with `stderr` still remain in the archive:
```
    # tar xf /tmp/sosreport-*.tar.xz --to-stdout \
      --wildcards '*/sos_commands/networking/ip_netns'
    Error: Peer netns reference is invalid.
    Error: Peer netns reference is invalid.
    test-ns
```

Test suite:

```
    # ./tests/simple.sh
    ...
    Everything worked!
```

Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
