### PR TITLE
Improvements to `ip netns` code

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2662,6 +2662,9 @@ class Plugin(object):
                 continue
         return pids
 
+    def get_network_namespaces(self):
+        return self.commons['namespaces']['network']
+
 
 class RedHatPlugin(object):
     """Tagging class for Red Hat's Linux distributions"""

--- a/sos/report/plugins/conntrack.py
+++ b/sos/report/plugins/conntrack.py
@@ -41,20 +41,10 @@ class Conntrack(Plugin, IndependentPlugin):
 
         # Capture additional data from namespaces; each command is run
         # per-namespace
-        ip_netns = self.exec_cmd("ip netns")
         cmd_prefix = "ip netns exec "
-        if ip_netns['status'] == 0:
-            out_ns = []
-            for line in ip_netns['output'].splitlines():
-                # If there's no namespaces, no need to continue
-                if line.startswith("Object \"netns\" is unknown") \
-                        or line.isspace() \
-                        or line[:1].isspace():
-                    continue
-                out_ns.append(line.partition(' ')[0])
-            for namespace in out_ns:
-                ns_cmd_prefix = cmd_prefix + namespace + " "
-                self.add_cmd_output(ns_cmd_prefix + "conntrack -L -o extended")
-                self.add_cmd_output(ns_cmd_prefix + "conntrack -S")
+        for namespace in self.get_network_namespaces():
+            ns_cmd_prefix = cmd_prefix + namespace + " "
+            self.add_cmd_output(ns_cmd_prefix + "conntrack -L -o extended")
+            self.add_cmd_output(ns_cmd_prefix + "conntrack -S")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -67,19 +67,9 @@ class Ebpf(Plugin, IndependentPlugin):
         ])
 
         # Capture list of bpf program attachments from namespaces
-        ip_netns = self.exec_cmd("ip netns")
         cmd_prefix = "ip netns exec "
-        if ip_netns['status'] == 0:
-            out_ns = []
-            for line in ip_netns['output'].splitlines():
-                # If there's no namespaces, no need to continue
-                if line.startswith("Object \"netns\" is unknown") \
-                        or line.isspace() \
-                        or line[:1].isspace():
-                    continue
-                out_ns.append(line.partition(' ')[0])
-            for namespace in out_ns:
-                ns_cmd_prefix = cmd_prefix + namespace + " "
-                self.add_cmd_output(ns_cmd_prefix + "bpftool net list")
+        for namespace in self.get_network_namespaces():
+            ns_cmd_prefix = cmd_prefix + namespace + " "
+            self.add_cmd_output(ns_cmd_prefix + "bpftool net list")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -231,53 +231,52 @@ class Networking(Plugin):
         # per-namespace.
         self.add_cmd_output("ip netns")
         cmd_prefix = "ip netns exec "
-        if self.get_network_namespaces():
-            out_ns = self.get_network_namespaces(
-                        self.get_option("namespace_pattern"),
-                        self.get_option("namespaces"))
+        for namespace in self.get_network_namespaces(
+                            self.get_option("namespace_pattern"),
+                            self.get_option("namespaces")):
+            ns_cmd_prefix = cmd_prefix + namespace + " "
+            self.add_cmd_output([
+                ns_cmd_prefix + "ip address show",
+                ns_cmd_prefix + "ip route show table all",
+                ns_cmd_prefix + "ip -s -s neigh show",
+                ns_cmd_prefix + "ip rule list",
+                ns_cmd_prefix + "iptables-save",
+                ns_cmd_prefix + "ip6tables-save",
+                ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
+                ns_cmd_prefix + "netstat -s",
+                ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,
+            ])
 
-            for namespace in out_ns:
+            ss_cmd = ns_cmd_prefix + "ss -peaonmi"
+            # --allow-system-changes is handled directly in predicate
+            # evaluation, so plugin code does not need to separately
+            # check for it
+            self.add_cmd_output(ss_cmd, pred=ss_pred)
+
+        # Collect ethtool commands only when ethtool_namespaces
+        # is set to true.
+        if self.get_option("ethtool_namespaces"):
+            # Devices that exist in a namespace use less ethtool
+            # parameters. Run this per namespace.
+            for namespace in self.get_network_namespaces(
+                                self.get_option("namespace_pattern"),
+                                self.get_option("namespaces")):
                 ns_cmd_prefix = cmd_prefix + namespace + " "
-                self.add_cmd_output([
-                    ns_cmd_prefix + "ip address show",
-                    ns_cmd_prefix + "ip route show table all",
-                    ns_cmd_prefix + "ip -s -s neigh show",
-                    ns_cmd_prefix + "ip rule list",
-                    ns_cmd_prefix + "iptables-save",
-                    ns_cmd_prefix + "ip6tables-save",
-                    ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
-                    ns_cmd_prefix + "netstat -s",
-                    ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,
-                ])
-
-                ss_cmd = ns_cmd_prefix + "ss -peaonmi"
-                # --allow-system-changes is handled directly in predicate
-                # evaluation, so plugin code does not need to separately
-                # check for it
-                self.add_cmd_output(ss_cmd, pred=ss_pred)
-
-            # Collect ethtool commands only when ethtool_namespaces
-            # is set to true.
-            if self.get_option("ethtool_namespaces"):
-                # Devices that exist in a namespace use less ethtool
-                # parameters. Run this per namespace.
-                for namespace in out_ns:
-                    ns_cmd_prefix = cmd_prefix + namespace + " "
-                    netns_netdev_list = self.exec_cmd(
-                        ns_cmd_prefix + "ls -1 /sys/class/net/"
-                    )
-                    for eth in netns_netdev_list['output'].splitlines():
-                        # skip 'bonding_masters' file created when loading the
-                        # bonding module but the file does not correspond to
-                        # a device
-                        if eth == "bonding_masters":
-                            continue
-                        self.add_cmd_output([
-                            ns_cmd_prefix + "ethtool " + eth,
-                            ns_cmd_prefix + "ethtool -i " + eth,
-                            ns_cmd_prefix + "ethtool -k " + eth,
-                            ns_cmd_prefix + "ethtool -S " + eth
-                        ])
+                netns_netdev_list = self.exec_cmd(
+                    ns_cmd_prefix + "ls -1 /sys/class/net/"
+                )
+                for eth in netns_netdev_list['output'].splitlines():
+                    # skip 'bonding_masters' file created when loading the
+                    # bonding module but the file does not correspond to
+                    # a device
+                    if eth == "bonding_masters":
+                        continue
+                    self.add_cmd_output([
+                        ns_cmd_prefix + "ethtool " + eth,
+                        ns_cmd_prefix + "ethtool -i " + eth,
+                        ns_cmd_prefix + "ethtool -k " + eth,
+                        ns_cmd_prefix + "ethtool -S " + eth
+                    ])
 
         return
 

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -230,7 +230,8 @@ class Networking(Plugin):
 
         # Capture additional data from namespaces; each command is run
         # per-namespace.
-        ip_netns = self.collect_cmd_output("ip netns")
+        self.add_cmd_output("ip netns")
+        ip_netns = self.exec_cmd("ip netns")
         cmd_prefix = "ip netns exec "
         if ip_netns['status'] == 0:
             out_ns = []

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -9,7 +9,6 @@
 from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
                                 DebianPlugin, SoSPredicate)
 from os import listdir
-from re import match
 
 
 class Networking(Plugin):
@@ -233,30 +232,9 @@ class Networking(Plugin):
         self.add_cmd_output("ip netns")
         cmd_prefix = "ip netns exec "
         if self.get_network_namespaces():
-            out_ns = []
-            # Regex initialization outside of for loop
-            if self.get_option("namespace_pattern"):
-                pattern = '(?:%s$)' % '$|'.join(
-                        self.get_option("namespace_pattern").split()
-                        ).replace('*', '.*')
-            for ns in self.get_network_namespaces():
-                # if namespace_pattern defined, append only namespaces
-                # matching with pattern
-                if self.get_option("namespace_pattern"):
-                    if bool(match(pattern, ns)):
-                        out_ns.append(ns)
-
-                # if namespaces is defined and namespace_pattern is not defined
-                # remove from out_ns namespaces with higher index than defined
-                elif self.get_option("namespaces") != 0:
-                    out_ns.append(ns)
-                    if len(out_ns) == self.get_option("namespaces"):
-                        self._log_warn("Limiting namespace iteration " +
-                                       "to first %s namespaces found"
-                                       % self.get_option("namespaces"))
-                        break
-                else:
-                    out_ns.append(ns)
+            out_ns = self.get_network_namespaces(
+                        self.get_option("namespace_pattern"),
+                        self.get_option("namespaces"))
 
             for namespace in out_ns:
                 ns_cmd_prefix = cmd_prefix + namespace + " "


### PR DESCRIPTION
This PR:
 - Fixes one issue where the networking plugin runs commands on `Error` namespaces;
 - Gathers per-namespace data in the conntrack plugin too.
 - Deduplicates code to get/filter the list of namespaces in the conntrack/ebpf/networking plugins.

Each commit message contains testing details, and a final `# ./tests/simple.sh` ends in `Everything worked!`.

Comparing the contents of `sos_commands` before/after patches, the only changes are the new per-namespace commands in the `conntrack` plugin:

Before and After:
```
$ sudo ./bin/sos report -o conntrack,ebpf,networking --batch
```
Compare:
```
$ find sosreport-<OLD>/sos_commands/ | cut -d/ -f2- | sort \
    > find-sosreport.old

$ find sosreport-<NEW>/sos_commands/ | cut -d/ -f2- | sort \
    > find-sosreport.new

$ diff find-sosreport.{old,new}
4a5,10
> sos_commands/conntrack/ip_netns_exec_ns1_conntrack_-L_-o_extended
> sos_commands/conntrack/ip_netns_exec_ns1_conntrack_-S
> sos_commands/conntrack/ip_netns_exec_ns2_conntrack_-L_-o_extended
> sos_commands/conntrack/ip_netns_exec_ns2_conntrack_-S
> sos_commands/conntrack/ip_netns_exec_ns3_conntrack_-L_-o_extended
> sos_commands/conntrack/ip_netns_exec_ns3_conntrack_-S
```
And the contents of the `ip_netns_exec` files is identical before/after:

```
$ md5sum sosreport-<OLD>/sos_commands/*/* | grep ip_netns_exec | sed 's, [^/]\+/, ,' > md5sum-sosreport.old
$ md5sum sosreport-<NEW>/sos_commands/*/* | grep ip_netns_exec | sed 's, [^/]\+/, ,' > md5sum-sosreport.new

$ diff md5sum-sosreport.{old,new}
0a1,6
> 70e61b0a6cfc43f1fbaa7884f5296495 sos_commands/conntrack/ip_netns_exec_ns1_conntrack_-L_-o_extended
> 84e5f5c039b6d1f35f836f0a2a7c4cdc sos_commands/conntrack/ip_netns_exec_ns1_conntrack_-S
> 70e61b0a6cfc43f1fbaa7884f5296495 sos_commands/conntrack/ip_netns_exec_ns2_conntrack_-L_-o_extended
> 84e5f5c039b6d1f35f836f0a2a7c4cdc sos_commands/conntrack/ip_netns_exec_ns2_conntrack_-S
> 70e61b0a6cfc43f1fbaa7884f5296495 sos_commands/conntrack/ip_netns_exec_ns3_conntrack_-L_-o_extended
> 84e5f5c039b6d1f35f836f0a2a7c4cdc sos_commands/conntrack/ip_netns_exec_ns3_conntrack_-S
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
