### PR TITLE
[process] Collect the output of the "pidstat" command

### DIFF
--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -60,4 +60,9 @@ class Process(Plugin, IndependentPlugin):
         if self.get_option("samples"):
             self.add_cmd_output("iotop -b -o -d 0.5 -t -n %s"
                                 % self.get_option("samples"))
+
+        self.add_cmd_output([
+            "pidstat -p ALL -rudvwsRU --human -h",
+            "pidstat -tl"
+        ])
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The "pidstat" command prints CPU time breakdowns per CPU
and, it can also print useful information from other
subsystems {I/O, MM} in a single line.

The two commands this patches capture are:

Related: RHBZ#1898155
Resolves: #2310

Signed-off-by: Jose Castillo <jose.mfcastillo@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
