### PR TITLE
[auditd] Collect all fanotify message by default

### DIFF
--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -26,7 +26,7 @@ class Auditd(Plugin, IndependentPlugin):
             "/etc/audisp/",
         ])
         self.add_cmd_output([
-            "ausearch --input-logs -m avc,user_avc -ts today",
+            "ausearch --input-logs -m avc,user_avc,fanotify -ts today",
             "auditctl -s",
             "auditctl -l"
         ])


### PR DESCRIPTION
The auditd plugin should collect all fanotify messages by default.

Resolves: https://github.com/sosreport/sos/issues/2313

Signed-off-by: Thorsten Scherf <tscherf@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
