### PR TITLE
[rhui] Add newly redesigned plugin

### DIFF
--- a/sos/report/plugins/pulp.py
+++ b/sos/report/plugins/pulp.py
@@ -63,10 +63,13 @@ class Pulp(Plugin, RedHatPlugin):
             pass
 
         self.add_copy_spec([
+            "/etc/pulp/admin",
             "/etc/pulp/*.conf",
             "/etc/pulp/settings.py",
             "/etc/pulp/server/plugins.conf.d/",
             "/etc/default/pulp*",
+            "/etc/httpd/conf.d/pulp*",
+            "/etc/pki/pulp",
             "/var/log/httpd/pulp-http.log*",
             "/var/log/httpd/pulp-https.log*",
             "/var/log/httpd/pulp-http_access_ssl.log*",

--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -1,0 +1,45 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class Rhui(Plugin, RedHatPlugin):
+
+    short_desc = "RHUI Information"
+    plugin_name = 'rhui'
+    profiles = ('sysmgmt',)
+    packages = ('rh-rhui-tools',)
+
+    def setup(self):
+        self.add_copy_spec([
+            '/etc/rhui-installer/',
+            '/etc/rhui/rhui-tools.conf',
+            '/etc/pki/rhua',
+            '/etc/pki/rhui',
+            '/etc/pki/katello-certs-tools',
+            '/root/ssl-build',
+            '/root/.rhui',
+            '/var/log/kafo',
+            '/var/log/rhui-sub-sync.log'
+        ])
+
+        self.add_cmd_output([
+            'rhui-manager status',
+            'rhui-manager cert info',
+            'ls /var/lib/rhui/remote_share'
+        ])
+
+    def postproc(self):
+        self.do_file_sub(
+            '/etc/rhui-installer/answers.yml',
+            r'(.*_(password|key):)(.*)',
+            r'\1 *******'
+        )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
First commit adds a `rhui` plugin back, this time redesigned and meant to offset `rhui-debug`.

Second commit extends the `pulp` collections for rhui-related data.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
