### PR TITLE
[grub2] Stylistic cleanup for grub2-mkconfig calls

### DIFF
--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -35,13 +35,11 @@ class Grub2(Plugin, IndependentPlugin):
         # further, check if the command supports --no-grubenv-update option
         # to prevent removing of extra args in $kernel_opts, and (only) if so,
         # call the command with this argument
-        env = {}
-        env['GRUB_DISABLE_OS_PROBER'] = 'true'
         grub_cmd = 'grub2-mkconfig'
-        co = {'cmd': 'grub2-mkconfig --help', 'output': '--no-grubenv-update'}
+        co = {'cmd': '%s --help' % grub_cmd, 'output': '--no-grubenv-update'}
         if self.test_predicate(self, pred=SoSPredicate(self, cmd_outputs=co)):
             grub_cmd += ' --no-grubenv-update'
-        self.add_cmd_output(grub_cmd, env=env)
+        self.add_cmd_output(grub_cmd, env={'GRUB_DISABLE_OS_PROBER': 'true'})
 
     def postproc(self):
         # the trailing space is required; python treats '_' as whitespace


### PR DESCRIPTION
Small stylistic cleanups for the `grub2-mkconfig` environment variable
settings and command formatting.

Closes: #1070
Resolves: #2317

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
