### PR TITLE
[Plugin] Add method to get all containers matching a regex

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2130,6 +2130,24 @@ class Plugin(object):
             return con is not None
         return False
 
+    def get_all_containers_by_regex(self, regex, get_all=False):
+        """Get a list of all container names and ID matching a regex
+
+        :param regex:   The regular expression to match
+        :type regex:    ``str``
+
+        :param get_all: Return all containers found, even terminated ones
+        :type get_all:  ``bool``
+
+        :returns:   All container IDs and names matching ``regex``
+        :rtype:     ``list`` of ``tuples`` as (id, name)
+        """
+        _runtime = self._get_container_runtime()
+        if _runtime is not None:
+            _containers = _runtime.get_containers(get_all=get_all)
+            return [c for c in _containers if re.match(regex, c[1])]
+        return []
+
     def get_container_by_name(self, name):
         """Get the container ID for a specific container
 


### PR DESCRIPTION
Adds a new method, `Plugin.get_all_containers_by_regex()`, that will
return all known containers on the system with a name matching a
provided regex string. Optionally, this method may also return
terminated containers in addition to those that are active and running.

Closes: #2176
Resolves: #2319

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
