### PR TITLE
[redhat] Add podman to valid container env vars

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -140,7 +140,7 @@ class RedHatPolicy(LinuxPolicy):
         specific initialisation based on ENV_HOST_SYSROOT.
         """
         if ENV_CONTAINER in os.environ:
-            if os.environ[ENV_CONTAINER] in ['docker', 'oci']:
+            if os.environ[ENV_CONTAINER] in ['docker', 'oci', 'podman']:
                 self._in_container = True
         if ENV_HOST_SYSROOT in os.environ:
             self._host_sysroot = os.environ[ENV_HOST_SYSROOT]


### PR DESCRIPTION
In newer versions of podman, the `container` env var set inside the
container will be set to `podman` instead of `oci`. Add this value to
the list of valid values to use to determine if sos is running inside a
container or not, for when we want to capture from the host system.

Resolves: #2320

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
