### PR TITLE
[systemd] Add tmpfiles.d conf files

### DIFF
--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -71,7 +71,10 @@ class Systemd(Plugin, IndependentPlugin):
             "/run/systemd/system",
             "/run/systemd/users",
             "/etc/modules-load.d/*.conf",
-            "/etc/yum/protected.d/systemd.conf"
+            "/etc/yum/protected.d/systemd.conf",
+            "/etc/tmpfiles.d/*.conf",
+            "/run/tmpfiles.d/*.conf",
+            "/usr/lib/tmpfiles.d/*.conf",
         ])
         self.add_forbidden_path('/dev/null')
 


### PR DESCRIPTION
systemd-tmpfiles uses these configuration files to create volatile
files and directories. These configurations needs to gathered by
sosreport for analyzing what tmpfiles rule are included.

Signed-off-by: Akshay Gaikwad <akgaikwad001@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
