### PR TITLE
[apt] Move unattended-upgrades log collection

### DIFF
--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -20,7 +20,9 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
 
     def setup(self):
         self.add_copy_spec([
-            "/etc/apt", "/var/log/apt"
+            "/etc/apt", 
+            "/var/log/apt",
+            "/var/log/unattended-upgrades"
         ])
 
         self.add_forbidden_path("/etc/apt/auth.conf")

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -48,7 +48,6 @@ class Logs(Plugin, IndependentPlugin):
             "/etc/rsyslog.d",
             "/var/log/boot.log",
             "/var/log/installer",
-            "/var/log/unattended-upgrades",
             "/var/log/messages*",
             "/var/log/secure*",
             "/var/log/udev",


### PR DESCRIPTION
Having u-u logs collection inside the apt
plugin make more sense as it is using apt
functionnalities and python modules such as
apt, apt_inst, apt_pkg.

u-u is a mechanism to automatically install
security upgrades on Debian/Ubuntu. It is
enabled by default at installation.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
