### PR TITLE
[fibrechannel] Add optional arguments for plugin

### DIFF
--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -18,8 +18,18 @@ class Fibrechannel(Plugin, RedHatPlugin):
     plugin_name = 'fibrechannel'
     profiles = ('hardware', 'storage', 'system')
     files = ('/sys/class/fc_host', '/sys/class/fc_remote_ports')
+    option_list = [
+        ("debug", "enable debug logs", "fast", True)
+    ]
+
+    # vendor specific debug paths
+    debug_paths = [
+        '/sys/kernel/debug/qla2*/'
+    ]
 
     def setup(self):
         self.add_blockdev_cmd("udevadm info -a %(dev)s", devices='fibre')
+        if self.get_option('debug'):
+            self.add_copy_spec(self.debug_paths)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add a possibility to enable collecting debug logs from vendor specific
paths. And add a posibility to extend collecting debug logs with
optional argument.
Second argument has to get additional paths. The input format of
argument is <path_1>:...:<path_n>. The default value is 'None'.
It is useful when you need to collect additional debug information.

Resolves: #2324

Signed-off-by: Daria Bukharina d.bukharina@yadro.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
