### PR TITLE
[Policy] Allow any number of vendor urls in banner messages

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -775,8 +775,9 @@ class Policy(object):
     :cvar vendor: The name of the vendor producing the distribution
     :vartype vendor: ``str``
 
-    :cvar vendor_url: URL for the vendor's website, or support portal
-    :vartype vendor_url: ``str``
+    :cvar vendor_urls: List of URLs for the vendor's website, or support portal
+    :vartype vendor_urls: ``list`` of ``tuples`` formatted
+        ``(``description``, ``url``)``
 
     :cvar vendor_text: Additional text to add to the banner message
     :vartype vendor_text: ``str``
@@ -794,7 +795,7 @@ from this %(distro)s system.
 
 For more information on %(vendor)s visit:
 
-  %(vendor_url)s
+  %(vendor_urls)s
 
 The generated archive may contain data considered sensitive and its content \
 should be reviewed by the originating organization before being passed to \
@@ -807,7 +808,7 @@ any third party.
 
     distro = "Unknown"
     vendor = "Unknown"
-    vendor_url = "http://www.example.com/"
+    vendor_urls = [('Example URL', "http://www.example.com/")]
     vendor_text = ""
     PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     default_scl_prefix = ""
@@ -1131,7 +1132,7 @@ any third party.
             changes_text = "No changes will be made to system configuration."
         width = 72
         _msg = self.msg % {'distro': self.distro, 'vendor': self.vendor,
-                           'vendor_url': self.vendor_url,
+                           'vendor_urls': self._fmt_vendor_urls(),
                            'vendor_text': self.vendor_text,
                            'tmpdir': self.commons['tmpdir'],
                            'changes_text': changes_text}
@@ -1139,6 +1140,19 @@ any third party.
         for line in _msg.splitlines():
             _fmt = _fmt + fill(line, width, replace_whitespace=False) + '\n'
         return _fmt
+
+    def _fmt_vendor_urls(self):
+        """Formats all items in the ``vendor_urls`` class attr into a usable
+        string for the banner message.
+
+        :returns:   Formatted string of URLS
+        :rtype:     ``str``
+        """
+        width = max([len(v[0]) for v in self.vendor_urls])
+        return "\n".join("\t{desc:<{width}} : {url}".format(
+                         desc=u[0], width=width, url=u[1])
+                         for u in self.vendor_urls
+                         )
 
     def register_presets(self, presets, replace=False):
         """Add new presets to this policy object.

--- a/sos/policies/amazon.py
+++ b/sos/policies/amazon.py
@@ -16,7 +16,7 @@ class AmazonPolicy(RedHatPolicy):
 
     distro = "Amazon Linux"
     vendor = "Amazon"
-    vendor_url = "https://aws.amazon.com"
+    vendor_urls = [('Distribution Website', 'https://aws.amazon.com')]
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):

--- a/sos/policies/cos.py
+++ b/sos/policies/cos.py
@@ -29,7 +29,10 @@ def _blank_or_comment(line):
 class CosPolicy(LinuxPolicy):
     distro = "Container-Optimized OS"
     vendor = "Google Cloud Platform"
-    vendor_url = "https://cloud.google.com/container-optimized-os/"
+    vendor_urls = [
+        ('Distribution Website',
+         'https://cloud.google.com/container-optimized-os/')
+    ]
     valid_subclasses = [CosPlugin, IndependentPlugin]
     PATH = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -7,7 +7,7 @@ import os
 class DebianPolicy(LinuxPolicy):
     distro = "Debian"
     vendor = "the Debian project"
-    vendor_url = "https://www.debian.org/"
+    vendor_urls = [('Community Website', 'https://www.debian.org/')]
     ticket_number = ""
     _debq_cmd = "dpkg-query -W -f='${Package}|${Version}\\n'"
     _debv_cmd = "dpkg --verify"

--- a/sos/policies/ibmkvm.py
+++ b/sos/policies/ibmkvm.py
@@ -19,7 +19,10 @@ import os
 class PowerKVMPolicy(RedHatPolicy):
     distro = "PowerKVM"
     vendor = "IBM"
-    vendor_url = "http://www-03.ibm.com/systems/power/software/linux/powerkvm"
+    vendor_urls = [
+        ('Commercial Support',
+         'http://www-03.ibm.com/systems/power/software/linux/powerkvm')
+    ]
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
@@ -50,7 +53,10 @@ class PowerKVMPolicy(RedHatPolicy):
 class ZKVMPolicy(RedHatPolicy):
     distro = "IBM Hypervisor"
     vendor = "IBM Hypervisor"
-    vendor_url = "http://www.ibm.com/systems/z/linux/IBMHypervisor/support/"
+    vendor_urls = [
+        ('Commercial Support',
+         'http://www.ibm.com/systems/z/linux/IBMHypervisor/support/')
+    ]
 
     def __init__(self, sysroot=None):
         super(ZKVMPolicy, self).__init__(sysroot=sysroot)

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -23,7 +23,10 @@ OS_RELEASE = "/etc/os-release"
 class RedHatPolicy(LinuxPolicy):
     distro = "Red Hat"
     vendor = "Red Hat"
-    vendor_url = "https://www.redhat.com/"
+    vendor_urls = [
+        ('Distribution Website', 'https://www.redhat.com/'),
+        ('Commercial Support', 'https://www.access.redhat.com/')
+    ]
     _redhat_release = '/etc/redhat-release'
     _tmp_dir = "/var/tmp"
     _rpmq_cmd = 'rpm -qa --queryformat "%{NAME}|%{VERSION}|%{RELEASE}\\n"'
@@ -243,7 +246,7 @@ rhel_presets = {
 disclaimer_text = """
 Any information provided to %(vendor)s will be treated in \
 accordance with the published support policies at:\n
-  %(vendor_url)s
+  %(vendor_urls)s
 
 The generated archive may contain data considered sensitive \
 and its content should be reviewed by the originating \
@@ -259,7 +262,6 @@ RH_FTP_HOST = "ftp://dropbox.redhat.com"
 class RHELPolicy(RedHatPolicy):
     distro = RHEL_RELEASE_STR
     vendor = "Red Hat"
-    vendor_url = "https://access.redhat.com/support/"
     msg = _("""\
 This command will collect diagnostic and configuration \
 information from this %(distro)s system and installed \
@@ -405,7 +407,7 @@ support representative.
 class CentOsPolicy(RHELPolicy):
     distro = "CentOS"
     vendor = "CentOS"
-    vendor_url = "https://www.centos.org/"
+    vendor_urls = [('Community Website', 'https://www.centos.org/')]
 
 
 ATOMIC = "atomic"
@@ -543,14 +545,17 @@ support representative.
 class CentOsAtomicPolicy(RedHatAtomicPolicy):
     distro = "CentOS Atomic Host"
     vendor = "CentOS"
-    vendor_url = "https://www.centos.org/"
+    vendor_urls = [('Community Website', 'https://www.centos.org/')]
 
 
 class FedoraPolicy(RedHatPolicy):
 
     distro = "Fedora"
     vendor = "the Fedora Project"
-    vendor_url = "https://fedoraproject.org/"
+    vendor_urls = [
+        ('Community Website', 'https://fedoraproject.org/'),
+        ('Community Forums', 'https://discussion.fedoraproject.org/')
+    ]
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):

--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -18,7 +18,7 @@ from sos import _sos as _
 class SuSEPolicy(LinuxPolicy):
     distro = "SuSE"
     vendor = "SuSE"
-    vendor_url = "https://www.suse.com/"
+    vendor_urls = [('Distribution Website', 'https://www.suse.com/')]
     _tmp_dir = "/var/tmp"
     _rpmq_cmd = 'rpm -qa --queryformat "%{NAME}|%{VERSION}\\n"'
 
@@ -85,7 +85,7 @@ class SuSEPolicy(LinuxPolicy):
 class OpenSuSEPolicy(SuSEPolicy):
     distro = "OpenSuSE"
     vendor = "SuSE"
-    vendor_url = "https://www.opensuse.org/"
+    vendor_urls = [('Community Website', 'https://www.opensuse.org/')]
     msg = _("""\
 This command will collect diagnostic and configuration \
 information from this %(distro)s system and installed \

--- a/sos/policies/ubuntu.py
+++ b/sos/policies/ubuntu.py
@@ -7,7 +7,10 @@ import os
 class UbuntuPolicy(DebianPolicy):
     distro = "Ubuntu"
     vendor = "Canonical"
-    vendor_url = "https://www.ubuntu.com/"
+    vendor_urls = [
+        ('Community Website', 'https://www.ubuntu.com/'),
+        ('Commercial Support', 'https://www.canonical.com')
+    ]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
            + ":/usr/local/sbin:/usr/local/bin:/snap/bin"
     _upload_url = "https://files.support.canonical.com/uploads/"


### PR DESCRIPTION
Enhances policy banner message generation by allowing an arbitrary
number of vendor urls to be displayed. The `vendor_url` class attr has
been changed to `vendor_urls` which should be a list of 2-tuples
formatted as `(description, url)`.

Further updates the existing policies to use this new form, and expands
on the Red Hat family distributions to include support website locations
where applicable. Also updates the Ubuntu policy to point to both the
community and commercial support resources.

Closes: #1869
Resolves: #2325

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
