### PR TITLE
[tests] Add test for newly loaded kernel modules

### DIFF
--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin
+from sos.report.plugins import Plugin, UbuntuPlugin, SoSPredicate
 
 
 class LXD(Plugin, UbuntuPlugin):
@@ -20,9 +20,30 @@ class LXD(Plugin, UbuntuPlugin):
     commands = ('lxd',)
 
     def setup(self):
+
+        lxd_kmods = [
+            'bpfilter',
+            'ebtable_filter',
+            'ebtables',
+            'ip6table_filter',
+            'ip6table_mangle',
+            'ip6table_nat',
+            'ip6table_raw',
+            'ip6_tables',
+            'iptable_filter',
+            'iptable_mangle',
+            'iptable_nat',
+            'iptable_raw',
+            'nf_nat',
+            'nf_tables',
+        ]
+
+        lxd_pred = SoSPredicate(self, kmods=lxd_kmods,
+                                required={'kmods': 'all'})
+
         snap_list = self.exec_cmd('snap list lxd')
         if snap_list["status"] == 0:
-            self.add_cmd_output("lxd.buginfo")
+            self.add_cmd_output("lxd.buginfo", pred=lxd_pred)
         else:
             self.add_copy_spec([
                 "/etc/default/lxd-bridge",
@@ -35,7 +56,7 @@ class LXD(Plugin, UbuntuPlugin):
                 "lxc network list",
                 "lxc profile list",
                 "lxc storage list"
-            ])
+            ], pred=lxd_pred)
 
             self.add_cmd_output([
                 "find /var/lib/lxd -maxdepth 2 -type d -ls",

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -316,10 +316,14 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/lib/netplan/*.yaml",
             "/run/systemd/network"
         ])
+
+        ufw_pred = SoSPredicate(self, kmods=['bpfilter', 'iptable_filter'],
+                                required={'kmods': 'all'})
         self.add_cmd_output([
             "ufw status numbered",
             "ufw app list"
-        ])
+        ], pred=ufw_pred)
+
         if self.get_option("traceroute"):
             self.add_cmd_output("/usr/sbin/traceroute -n %s" % self.trace_host)
 

--- a/sos/report/plugins/wireless.py
+++ b/sos/report/plugins/wireless.py
@@ -6,31 +6,24 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
-class Wireless(Plugin, DebianPlugin, UbuntuPlugin):
+class Wireless(Plugin, IndependentPlugin):
 
-    short_desc = 'Wireless'
+    short_desc = 'Wireless Device Information'
 
     plugin_name = 'wireless'
     profiles = ('hardware', 'desktop', 'network')
-    files = ('/sbin/iw', '/usr/sbin/iw')
+    commands = ('iw', )
 
     def setup(self):
+        wireless_pred = SoSPredicate(self, kmods=['cfg80211'])
         self.add_cmd_output([
             "iw list",
             "iw dev",
             "iwconfig",
             "iwlist scanning"
-        ])
-
-
-class RedHatWireless(Wireless, RedHatPlugin):
-
-    short_desc = 'Wireless'
-
-    files = ('/usr/sbin/iw', '/usr/sbin/iwlist')
-    packages = ('iw', 'wireless-tools')
+        ], pred=wireless_pred)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a test to `simple.sh` to check if we loaded any new kernel modules
during a normal exeuction. This test will be somewhat limited in the
fact that this currently only tests the plugins that are loaded by
default on each tested distribution.

Also included is a minor typo fix for reporting where IP addresses were
not obfuscated, if any. This typo did not affect the actual test
however.

Resolves: #2326

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
