### PR TITLE
[plugins] Dont stop collecting by empty specfile when sizelimit=0

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1483,7 +1483,7 @@ class Plugin(object):
                     self._add_copy_paths([_file])
                     # in the corner case we just reached the sizelimit, we
                     # should collect the whole file and stop
-                    limit_reached = (current_size == sizelimit)
+                    limit_reached = (sizelimit and current_size == sizelimit)
             if self.manifest:
                 self.manifest.files.append({
                     'specification': copyspec,


### PR DESCRIPTION
When sizelimit=0, collecting an empty file would set limit_reached
wrongly and stop collecting further files. Let fix this corner case.

Resolves: #2330

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
