### PR TITLE
[collector] allow overriding plain --cluster-type

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -764,6 +764,7 @@ class SoSCollector(SoSComponent):
                 self.cluster = self.clusters['jbon']
             else:
                 self.cluster = self.clusters[self.opts.cluster_type]
+                self.cluster_type = self.opts.cluster_type
             self.cluster.master = self.master
 
         else:


### PR DESCRIPTION
In few user scenarios, it is useful to force sos collect to override
cluster type, but let it generate list of nodes by itself. For that,
it is sufficient to set the self.cluster_type accordingly.

Resolves: #2332

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
