### PR TITLE
[options] Fix --log-size=0 being ignored and unreported otherwise

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -192,7 +192,7 @@ class SoSComponent():
         for opt, val in codict.items():
             if opt not in cmdopts.arg_defaults.keys():
                 continue
-            if val and val != opts.arg_defaults[opt]:
+            if val is not None and val != opts.arg_defaults[opt]:
                 setattr(opts, opt, val)
 
         return opts

--- a/sos/options.py
+++ b/sos/options.py
@@ -282,6 +282,9 @@ class SoSOptions():
             """
             if name in ("add_preset", "del_preset", "desc", "note"):
                 return False
+            # Exception list for options that still need to be reported when 0
+            if name in ['log_size', 'plugin_timeout'] and value == 0:
+                return True
             return has_value(name, value)
 
         def argify(name, value):


### PR DESCRIPTION
The `--log-size` option was being silently ignored, due to a too-loose
conditional in `Component.apply_options_from_cmdline()` which was
inadvertently filtering out the option when a user set it to 0. Note
that this did not affect `sos.conf` settings for this same value.

Similarly, reporting the effective options after preset and cmdline
merging was skipping log-size when it was set to 0, since we normally
want to filter out null-value options (which imply they were not
invoked). Adding an explicit check for `log-size` here is the easiest
route forward to allow the reporting we expect.

Closes: #2334
Resolves: #2335

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
