### PR TITLE
[containers_common] Gather container digests

### DIFF
--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -41,6 +41,7 @@ class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
             'podman unshare cat /proc/self/uid_map',
             'podman unshare cat /proc/self/gid_map',
             'podman images',
+            'podman images --digests',
             'podman pod ps',
             'podman port --all',
             'podman ps',

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -37,6 +37,7 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
         subcmds = [
             'info',
             'images',
+            'images --digests',
             'pod ps',
             'port --all',
             'ps',


### PR DESCRIPTION
It can be useful to have the digest for each container image for
verifying exact binary compatibility, etc.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
