### PR TITLE
[collect] Add unavailable warning to `sos collect --help`

### DIFF
--- a/sos/missing.py
+++ b/sos/missing.py
@@ -14,6 +14,10 @@ class MissingCollect(SoSComponent):
     load_policy = False
     configure_logging = False
     desc = '(unavailable) Collect an sos report from multiple nodes'
+    missing_msg = (
+        'It appears likely that your distribution separately ships a package '
+        'called sos-collector. Please install it to enable this function'
+    )
 
     def execute(self):
         sys.stderr.write(
@@ -30,11 +34,28 @@ class MissingCollect(SoSComponent):
         """
         return []
 
+    @classmethod
+    def add_parser_options(cls, parser):
+        """Set the --help output for collect to a message that shows that
+        the functionality is unavailable
+        """
+        msg = "%s %s" % (
+            'WARNING: `collect` is not available with this installation!',
+            cls.missing_msg
+        )
+        parser.epilog = msg
+        return parser
+
 
 class MissingPexpect(MissingCollect):
     """This is used as a placeholder for when the collect component is locally
     installed, but cannot be used due to a missing pexpect dependency.
     """
+
+    missing_msg = (
+        'Please install the python3-pexpect package for your distribution in '
+        'order to enable this function'
+    )
 
     def execute(self):
         sys.stderr.write(
@@ -42,3 +63,5 @@ class MissingPexpect(MissingCollect):
             "on python3-pexpect.\n\nPlease install python3-pexpect to enable "
             "this functionality.\n"
         )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a warning message to the end of `sos collect --help` output when
the `collect` component is not available due to a missing dependency or
missing sub package.

Closes: #2336
Resolves: #2341

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
