### PR TITLE
[subscription_manager] scrub passwords on one line only

### DIFF
--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -45,8 +45,8 @@ class SubscriptionManager(Plugin, RedHatPlugin):
         self.add_cmd_output(["rct cat-cert %s" % cert for cert in certs])
 
     def postproc(self):
-        passwdreg = r"(proxy_password(\s)*=(\s)*)(.*)"
-        repl = r"\1 ********"
+        passwdreg = r"(proxy_password(\s)*=(\s)*)(\S+)\n"
+        repl = r"\1********\n"
         self.do_path_regex_sub("/etc/rhsm/rhsm.conf", passwdreg, repl)
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Fix regexp to scrub proxy_password on one line and don't
obfuscate subsequent line when the password is empty.

Closes: #2328
Resolves: #2343

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
