### PR TITLE
[policy] Add /sbin to PATH for SuSE policy.

### DIFF
--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -39,7 +39,7 @@ class SuSEPolicy(LinuxPolicy):
             print("Could not obtain installed package list", file=sys.stderr)
             sys.exit(1)
 
-        self.PATH = "/usr/sbin:/usr/bin:/root/bin"
+        self.PATH = "/usr/sbin:/usr/bin:/root/bin:/sbin"
         self.PATH += os.pathsep + "/usr/local/bin"
         self.PATH += os.pathsep + "/usr/local/sbin"
         self.set_exec_path()


### PR DESCRIPTION
These changes fix iscsi plugin for SuSE distributions because `iscsiadm`
util is placed in /sbin.

Resolves: #2344
Closes: #2340

Signed-off-by: Daria Bukharina d.bukharina@yadro.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
