### PR TITLE
[Openvswitch] Add ovs-configuration journal

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -130,6 +130,7 @@ class OpenVSwitch(Plugin):
         self.add_journal(units="openvswitch-nonetwork")
         self.add_journal(units="ovs-vswitchd")
         self.add_journal(units="ovsdb-server")
+        self.add_journal(units="ovs-configuration")
 
         if check_6wind:
             self.add_copy_spec(files_6wind)


### PR DESCRIPTION
OpenShift 4.6 Introduces a new  service called ovs-configuration,
usually this information is also acquired in the must-gather but
if precisely this service is at fault we may not be able to run
must-gather.

Signed-off-by: Juan Luis de Sousa-Valadas <jdesousa@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X ] Is the subject and message clear and concise?
- [ X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
