### PR TITLE
[component] Use sysroot from Policy when opts doesn't specify it

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -246,13 +246,13 @@ class SoSComponent():
             auto_archive = self.policy.get_preferred_archive()
             self.archive = auto_archive(archive_name, self.tmpdir,
                                         self.policy, self.opts.threads,
-                                        enc_opts, self.opts.sysroot,
+                                        enc_opts, self.sysroot,
                                         self.manifest)
 
         else:
             self.archive = TarFileArchive(archive_name, self.tmpdir,
                                           self.policy, self.opts.threads,
-                                          enc_opts, self.opts.sysroot,
+                                          enc_opts, self.sysroot,
                                           self.manifest)
 
         self.archive.set_debug(True if self.opts.debug else False)


### PR DESCRIPTION
Until --sysroot option is specified, Archive (sub)classes should
be called with sysroot determined from Policy.

Resolves: #2346

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
