### PR TITLE
[networking/ufw/firewall_tables] Split out firewall from networking

### DIFF
--- a/sos/report/plugins/firewall_tables.py
+++ b/sos/report/plugins/firewall_tables.py
@@ -1,0 +1,87 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate)
+
+
+class firewall_tables(Plugin, IndependentPlugin):
+
+    short_desc = 'firewall tables'
+
+    plugin_name = "firewall_tables"
+    profiles = ('network', 'system')
+
+    def collect_iptable(self, tablename):
+        """ Collecting iptables rules for a table loads either kernel module
+        of the table name (for kernel <= 3), or nf_tables (for kernel >= 4).
+        If neither module is present, the rules must be empty."""
+
+        modname = "iptable_" + tablename
+        cmd = "iptables -t " + tablename + " -nvL"
+        self.add_cmd_output(
+            cmd,
+            pred=SoSPredicate(self, kmods=[modname, 'nf_tables']))
+
+    def collect_ip6table(self, tablename):
+        """ Same as function above, but for ipv6 """
+
+        modname = "ip6table_" + tablename
+        cmd = "ip6tables -t " + tablename + " -nvL"
+        self.add_cmd_output(
+            cmd,
+            pred=SoSPredicate(self, kmods=[modname, 'nf_tables']))
+
+    def collect_nftables(self):
+        """ Collects nftables rulesets with 'nft' commands if the modules
+        are present """
+
+        self.add_cmd_output(
+            "nft list ruleset",
+            pred=SoSPredicate(self, kmods=['nf_tables'])
+        )
+
+    def setup(self):
+        # collect iptables -t for any existing table, if we can't read the
+        # tables, collect 2 default ones (mangle, filter)
+        try:
+            ip_tables_names = open("/proc/net/ip_tables_names").read()
+        except IOError:
+            ip_tables_names = "mangle\nfilter\n"
+        for table in ip_tables_names.splitlines():
+            self.collect_iptable(table)
+        # collect the same for ip6tables
+        try:
+            ip_tables_names = open("/proc/net/ip6_tables_names").read()
+        except IOError:
+            ip_tables_names = "mangle\nfilter\n"
+        for table in ip_tables_names.splitlines():
+            self.collect_ip6table(table)
+
+        self.collect_nftables()
+
+        # When iptables is called it will load the modules
+        # iptables_filter (for kernel <= 3) or
+        # nf_tables (for kernel >= 4) if they are not loaded.
+        # The same goes for ipv6.
+        self.add_cmd_output(
+            "iptables -vnxL",
+            pred=SoSPredicate(self, kmods=['iptable_filter', 'nf_tables'])
+        )
+
+        self.add_cmd_output(
+            "ip6tables -vnxL",
+            pred=SoSPredicate(self, kmods=['ip6table_filter', 'nf_tables'])
+        )
+
+        self.add_copy_spec([
+            "/etc/nftables",
+            "/etc/sysconfig/nftables.conf",
+            "/etc/nftables.conf",
+        ])
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -33,35 +33,6 @@ class Networking(Plugin):
     # switch to enable netstat "wide" (non-truncated) output mode
     ns_wide = "-W"
 
-    def collect_iptable(self, tablename):
-        """ Collecting iptables rules for a table loads either kernel module
-        of the table name (for kernel <= 3), or nf_tables (for kernel >= 4).
-        If neither module is present, the rules must be empty."""
-
-        modname = "iptable_" + tablename
-        cmd = "iptables -t " + tablename + " -nvL"
-        self.add_cmd_output(
-            cmd,
-            pred=SoSPredicate(self, kmods=[modname, 'nf_tables']))
-
-    def collect_ip6table(self, tablename):
-        """ Same as function above, but for ipv6 """
-
-        modname = "ip6table_" + tablename
-        cmd = "ip6tables -t " + tablename + " -nvL"
-        self.add_cmd_output(
-            cmd,
-            pred=SoSPredicate(self, kmods=[modname, 'nf_tables']))
-
-    def collect_nftables(self):
-        """ Collects nftables rulesets with 'nft' commands if the modules
-        are present """
-
-        self.add_cmd_output(
-            "nft list ruleset",
-            pred=SoSPredicate(self, kmods=['nf_tables'])
-        )
-
     def setup(self):
         super(Networking, self).setup()
 
@@ -89,9 +60,6 @@ class Networking(Plugin):
             "/etc/host*",
             "/etc/resolv.conf",
             "/etc/network*",
-            "/etc/nftables",
-            "/etc/sysconfig/nftables.conf",
-            "/etc/nftables.conf",
             "/etc/dnsmasq*",
             "/sys/class/net/*/device/numa_node",
             "/sys/class/net/*/flags",
@@ -113,23 +81,6 @@ class Networking(Plugin):
         self.add_cmd_output("ip -o addr", root_symlink="ip_addr")
         self.add_cmd_output("route -n", root_symlink="route")
         self.add_cmd_output("plotnetcfg")
-        # collect iptables -t for any existing table, if we can't read the
-        # tables, collect 3 default ones (nat, mangle, filter)
-        try:
-            ip_tables_names = open("/proc/net/ip_tables_names").read()
-        except IOError:
-            ip_tables_names = "nat\nmangle\nfilter\n"
-        for table in ip_tables_names.splitlines():
-            self.collect_iptable(table)
-        # collect the same for ip6tables
-        try:
-            ip_tables_names = open("/proc/net/ip6_tables_names").read()
-        except IOError:
-            ip_tables_names = "nat\nmangle\nfilter\n"
-        for table in ip_tables_names.splitlines():
-            self.collect_ip6table(table)
-
-        self.collect_nftables()
 
         self.add_cmd_output("netstat %s -neopa" % self.ns_wide,
                             root_symlink="netstat")
@@ -165,20 +116,6 @@ class Networking(Plugin):
             'af_packet_diag'
         ], required={'kmods': 'all'})
         self.add_cmd_output(ss_cmd, pred=ss_pred, changes=True)
-
-        # When iptables is called it will load the modules
-        # iptables_filter (for kernel <= 3) or
-        # nf_tables (for kernel >= 4) if they are not loaded.
-        # The same goes for ipv6.
-        self.add_cmd_output(
-            "iptables -vnxL",
-            pred=SoSPredicate(self, kmods=['iptable_filter', 'nf_tables'])
-        )
-
-        self.add_cmd_output(
-            "ip6tables -vnxL",
-            pred=SoSPredicate(self, kmods=['ip6table_filter', 'nf_tables'])
-        )
 
         # Get ethtool output for every device that does not exist in a
         # namespace.
@@ -308,21 +245,12 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/etc/resolvconf",
             "/etc/network/interfaces",
             "/etc/network/interfaces.d",
-            "/etc/ufw",
-            "/var/log/ufw.Log",
             "/etc/resolv.conf",
             "/run/netplan/*.yaml",
             "/etc/netplan/*.yaml",
             "/lib/netplan/*.yaml",
             "/run/systemd/network"
         ])
-
-        ufw_pred = SoSPredicate(self, kmods=['bpfilter', 'iptable_filter'],
-                                required={'kmods': 'all'})
-        self.add_cmd_output([
-            "ufw status numbered",
-            "ufw app list"
-        ], pred=ufw_pred)
 
         if self.get_option("traceroute"):
             self.add_cmd_output("/usr/sbin/traceroute -n %s" % self.trace_host)

--- a/sos/report/plugins/ufw.py
+++ b/sos/report/plugins/ufw.py
@@ -1,0 +1,34 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate)
+
+
+class ufw(Plugin, IndependentPlugin):
+
+    short_desc = 'Uncomplicated FireWall'
+
+    plugin_name = 'ufw'
+    profiles = ('system', 'network')
+    packages = ('ufw',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/ufw",
+            "/var/log/ufw.Log"
+        ])
+
+        ufw_pred = SoSPredicate(self, kmods=['bpfilter', 'iptable_filter'],
+                                required={'kmods': 'all'})
+
+        self.add_cmd_output([
+            "ufw status numbered",
+            "ufw app list"
+        ], pred=ufw_pred)
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Drop fallback to nat as that can bring in more kernel modules
Left ip/6-table save in networking for now as it can be filtered by
networking options and I don't want to break that.

Signed-off-by: Bryan Quigley <code@bryanquigley.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
