### PR TITLE
[redhat] Automatically failover to dropbox when RHCP upload fails

### DIFF
--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -364,6 +364,21 @@ support representative.
             return os.getenv('SOSUPLOADUSER', None) or self.upload_user
         return self._upload_user
 
+    def upload_archive(self, archive):
+        """Override the base upload_archive to provide for automatic failover
+        from RHCP failures to the public RH dropbox
+        """
+        try:
+            uploaded = super(RHELPolicy, self).upload_archive(archive)
+        except Exception:
+            uploaded = False
+        if not uploaded and self.upload_url.startswith(RH_API_HOST):
+            print("Upload to Red Hat Customer Portal failed. Trying %s"
+                  % RH_FTP_HOST)
+            self.upload_url = RH_FTP_HOST
+            uploaded = super(RHELPolicy, self).upload_archive(archive)
+        return uploaded
+
     def dist_version(self):
         try:
             rr = self.package_manager.all_pkgs_by_name_regex("redhat-release*")


### PR DESCRIPTION
When an upload to the RHCP fails for some reason, now automatically
failover to attempt an upload to the FTP dropbox.

This failover has been intended for some time, as we already failover
to the FTP location if we detect we're missing, for example, login
credentials for the Customer Portal. This change just extends that
intention to when we run into errors with the actual upload process.

Resolves: #2350

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
