### PR TITLE
[boot] Add ls /sys/firmware command output

### DIFF
--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -33,7 +33,8 @@ class Boot(Plugin, IndependentPlugin):
         ])
         self.add_cmd_output([
             "ls -lanR /boot",
-            "lsinitrd"
+            "lsinitrd",
+            "ls -lanR /sys/firmware",
         ])
 
         self.add_cmd_output([


### PR DESCRIPTION
"ls /sys/firmware" command is useful to check if system boots with
UEFI or BIOS.

Signed-off-by: Akshay Gaikwad <akgaikwad001@gmail.com>

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
