### PR TITLE
[foreman] scrub rhsm proxy_password in installer logs

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -266,7 +266,8 @@ class Foreman(Plugin):
 
     def postproc(self):
         satreg = r"((foreman.*)?(\"::(foreman(.*?)|katello).*)?((::(.*)::.*" \
-              r"(passw|cred|token|secret|key).*(\")?:)|(storepass )))(.*)"
+              r"(passw|cred|token|secret|key).*(\")?:)|(storepass )" \
+              r"|(password =)))(.*)"
         self.do_path_regex_sub(
             "/var/log/foreman-installer/sat*",
             satreg,


### PR DESCRIPTION
Scrub potential RHSM proxy_password = <secret> in installer logs.

Related: #2144
Resolves: #2354

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
