### PR TITLE
[ipa] dogtag debug logfile name format change

### DIFF
--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -50,13 +50,13 @@ class Ipa(Plugin, RedHatPlugin):
     def retrieve_pki_logs(self, ipa_version):
         if ipa_version == "v4":
             self.add_copy_spec([
-               "/var/log/pki/pki-tomcat/ca/debug",
+               "/var/log/pki/pki-tomcat/ca/debug*",
                "/var/log/pki/pki-tomcat/ca/system",
                "/var/log/pki/pki-tomcat/ca/transactions",
                "/var/log/pki/pki-tomcat/ca/selftests.log",
                "/var/log/pki/pki-tomcat/catalina.*",
                "/var/log/pki/pki-ca-spawn.*",
-               "/var/log/pki/pki-tomcat/kra/debug",
+               "/var/log/pki/pki-tomcat/kra/debug*",
                "/var/log/pki/pki-tomcat/kra/system",
                "/var/log/pki/pki-tomcat/kra/transactions",
                "/var/log/pki/pki-kra-spawn.*"


### PR DESCRIPTION
Starting with Dogtag 10.6 a new logging framework is used. As a result,
debug logfiles now have the format 'debug-<date>' rather than just 'debug'.

Signed-off-by: Thorsten Scherf <tscherf@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
