### PR TITLE
[ceph] include time-sync-status for ceph mon

### DIFF
--- a/sos/report/plugins/ceph.py
+++ b/sos/report/plugins/ceph.py
@@ -106,6 +106,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "fs dump",
             "pg dump",
             "pg stat",
+            "time-sync-status",
         ]
 
         self.add_cmd_output([


### PR DESCRIPTION
Ceph mons might get into time sync problems if ntp/chrony
isn't installed or configured correctly. Since Luminous
release, upstream support 'time-sync-status' to detect this
more easily.

Closes: #2356

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
