### PR TITLE
[collector] declare sysroot for each component

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -108,6 +108,7 @@ class SoSComponent():
             try:
                 import sos.policies
                 self.policy = sos.policies.load(sysroot=self.opts.sysroot)
+                self.sysroot = self.policy.host_sysroot()
             except KeyboardInterrupt:
                 self._exit(0)
             self._is_root = self.policy.is_root()


### PR DESCRIPTION
Commit 7f72a36 requires self.sysroot to exist for each component,
but it is not set for sos-collector. Let pre-fill self.sysroot
every time.

Resolves: #2358

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
