### PR TITLE
[component] honour plugopts from config file

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -192,7 +192,7 @@ class SoSComponent():
         for opt, val in codict.items():
             if opt not in cmdopts.arg_defaults.keys():
                 continue
-            if val is not None and val != opts.arg_defaults[opt]:
+            if val not in [None, [], ''] and val != opts.arg_defaults[opt]:
                 setattr(opts, opt, val)
 
         return opts


### PR DESCRIPTION
Currently, config file plugopts are ignored as we overwrite it
in apply_options_from_cmdline by empty list default value from
cmdline.

Resolves: #2359

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
