### PR TITLE
[sapnw] call sapconf only when a limits.d file exists

### DIFF
--- a/sos/report/plugins/sapnw.py
+++ b/sos/report/plugins/sapnw.py
@@ -129,6 +129,12 @@ class sapnw(Plugin, RedHatPlugin):
         self.collect_list_dbs()
 
         # run sapconf in check mode
-        self.add_cmd_output("sapconf -n", suggest_filename="sapconf_checkmode")
+        #
+        # since the command creates a limits.d file on its own,
+        # we must predicate it by presence of the file
+        if os.path.exists('/etc/security/limits.d/99-sap-limits.conf') \
+                or self.get_option('allow_system_changes'):
+            self.add_cmd_output("sapconf -n",
+                                suggest_filename="sapconf_checkmode")
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
sapconf command creates /etc/security/limits.d/99-sap-limits.conf
on its own when missing, so calling the command must be gated
by a predicate testing the file presence.

Resolves: #2361

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
