### PR TITLE
[postfix] forbid collecting SSL keys files declared in main.cf

### DIFF
--- a/sos/report/plugins/postfix.py
+++ b/sos/report/plugins/postfix.py
@@ -17,6 +17,41 @@ class Postfix(Plugin):
 
     packages = ('postfix',)
 
+    def forbidden_ssl_keys_files(self):
+        # list of attributes defining a location of a SSL key file
+        # we must forbid from collection
+        forbid_attributes = [
+            "lmtp_tls_dkey_file",
+            "lmtp_tls_eckey_file",
+            "lmtp_tls_key_file",
+            "smtp_tls_dkey_file",
+            "smtp_tls_eckey_file",
+            "smtp_tls_key_file",
+            "smtpd_tls_dkey_file",
+            "smtpd_tls_eckey_file",
+            "smtpd_tls_key_file",
+            "tls_legacy_public_key_fingerprints",
+            "tlsproxy_tls_dkey_file",
+            "tlsproxy_tls_eckey_file",
+            "tlsproxy_tls_key_file",
+            "smtpd_tls_dh1024_param_file",
+            "smtpd_tls_dh512_param_file",
+            "tlsproxy_tls_dh1024_param_file",
+            "tlsproxy_tls_dh512_param_file",
+        ]
+        fp = []
+        try:
+            with open('/etc/postfix/main.cf', 'r') as cffile:
+                for line in cffile.readlines():
+                    # ignore comments and take the first word after '='
+                    if line.startswith('#'):
+                        continue
+                    words = line.split('=')
+                    if words[0].strip() in forbid_attributes:
+                        fp.append(words[1].split()[0])
+        finally:
+            return fp
+
     def setup(self):
         self.add_copy_spec([
             "/etc/postfix/",
@@ -31,6 +66,7 @@ class Postfix(Plugin):
             "/etc/postfix/*.crt",
             "/etc/postfix/ssl/",
         ])
+        self.add_forbidden_path(self.forbidden_ssl_keys_files())
 
 
 class RedHatPostfix(Postfix, RedHatPlugin):


### PR DESCRIPTION
Collecting whole /etc/postfix, we might collect some SSL keys placed
to this directory. Traverse main.cf to identify all such potential
files we must add to forbidden paths.

Resolves: #2362

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
