### PR TITLE
[sosnode] Fix scoping issues within finalize_sos_cmd()

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -116,6 +116,7 @@ class SosNode():
         self.manifest.add_field('hostname', self._hostname)
         self.manifest.add_field('policy', self.host.distro)
         self.manifest.add_field('sos_version', self.sos_info['version'])
+        self.manifest.add_field('final_sos_command', '')
 
     def check_in_container(self):
         """
@@ -425,6 +426,7 @@ class SosNode():
         """Run a sosreport on the node, then collect it"""
         self.sos_cmd = self.finalize_sos_cmd()
         self.log_info('Final sos command set to %s' % self.sos_cmd)
+        self.manifest.add_field('final_sos_command', self.sos_cmd)
         try:
             path = self.execute_sos_command()
             if path:
@@ -618,7 +620,7 @@ class SosNode():
         sos_cmd = self.sos_info['sos_cmd']
         label = self.determine_sos_label()
         if label:
-            self.sos_cmd = '%s %s ' % (sos_cmd, quote(label))
+            sos_cmd = '%s %s ' % (sos_cmd, quote(label))
 
         if self.opts.sos_opt_line:
             return '%s %s' % (sos_cmd, self.opts.sos_opt_line)
@@ -719,7 +721,6 @@ class SosNode():
                                'not exist on node' % self.opts.preset)
 
         _sos_cmd = "%s %s" % (sos_cmd, ' '.join(sos_opts))
-        self.manifest.add_field('final_sos_command', _sos_cmd)
         return _sos_cmd
 
     def determine_sos_label(self):


### PR DESCRIPTION
First fixes an issue with an improperly scoped setting of the sos
command label. Second, addresses an issue where the final sos command
determined wasn't being written to the node's metadata.

Resolves: #2363

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
