### PR TITLE
[Policy] Handle addition FTP authentication issues

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -470,9 +470,13 @@ class LinuxPolicy(Policy):
             errno = str(err).split()[0]
             if errno == '503':
                 raise Exception("could not login as '%s'" % user)
+            if errno == '530':
+                raise Exception("invalid password for user '%s'" % user)
             if errno == '550':
                 raise Exception("could not set upload directory to %s"
                                 % directory)
+            raise Exception("error trying to establish session: %s"
+                            % str(err))
 
         try:
             with open(self.upload_archive, 'rb') as _arcfile:


### PR DESCRIPTION
It was found that some implementations will return a 530 rather than a
503 as the more specific error for incorrect passwords. Handle this
error code explicitly, and then also add a catch-all for any other
ftplib errors that may get raised.

Resolves: #2368

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
