### PR TITLE
[process] Drop -b and consolidate duplicate calls

### DIFF
--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -40,8 +40,9 @@ class Process(Plugin, IndependentPlugin):
         if self.get_option("smaps"):
             self.add_copy_spec("/proc/[0-9]*/smaps")
 
-        self.add_cmd_output("ps auxwww", root_symlink="ps",
-                            tags=['ps_aux', 'ps_auxww', 'ps_auxwww'])
+        self.add_cmd_output("ps auxwwwm", root_symlink="ps",
+                            tags=['ps_aux', 'ps_auxww', 'ps_auxwww',
+                                  'ps_auxwwwm'])
         self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
             self.add_cmd_output("lsof +M -n -l -c ''", root_symlink="lsof",
@@ -51,7 +52,6 @@ class Process(Plugin, IndependentPlugin):
             self.add_cmd_output("lsof +M -n -l", timeout=15)
 
         self.add_cmd_output([
-            "ps auxwwwm",
             "ps alxwww",
             "ps -elfL",
             "%s %s" % (ps_axo, ps_group_opts),

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -44,10 +44,11 @@ class Process(Plugin, IndependentPlugin):
                             tags=['ps_aux', 'ps_auxww', 'ps_auxwww'])
         self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
-            self.add_cmd_output("lsof -b +M -n -l -c ''", root_symlink="lsof")
+            self.add_cmd_output("lsof +M -n -l -c ''", root_symlink="lsof",
+                                timeout=15)
 
         if self.get_option("lsof-threads"):
-            self.add_cmd_output("lsof -b +M -n -l")
+            self.add_cmd_output("lsof +M -n -l", timeout=15)
 
         self.add_cmd_output([
             "ps auxwwwm",


### PR DESCRIPTION
2-commit patchset that:

1. Drops `-b` per #2352 and adds a timeout to those `lsof` commands as a safeguard
2. Consolidates 2 duplicate `ps` calls to get some headway on #1979 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
