### PR TITLE
insights.py: Adding .registered file to Insights client config collection

### DIFF
--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -17,6 +17,7 @@ class RedHatInsights(Plugin, RedHatPlugin):
     profiles = ('system', 'sysmgmt')
     config = (
         '/etc/insights-client/insights-client.conf',
+        '/etc/insights-client/.registered',
         '/etc/redhat-access-insights/redhat-access-insights.conf'
     )
 


### PR DESCRIPTION
This makes it easier for users to tell if the Insights client is
registered on the target system.

Signed-off-by: Paul Wayper <paulway@redhat.com>
Closes: #2372
Resolves: #2372 
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
