### PR TITLE
[man]:Remove ticket-number option in man page

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -14,7 +14,7 @@ sosreport \- Collect and package diagnostic and support data
           [--preset preset] [--add-preset add_preset]\fR
           [--del-preset del_preset] [--desc description]\fR
           [--batch] [--build] [--debug] [--dry-run]\fR
-          [--label label] [--case-id id] [--ticket-number nr]\fR
+          [--label label] [--case-id id]\fR
           [--threads threads]\fR
           [--plugin-timeout TIMEOUT]\fR
           [-s|--sysroot SYSROOT]\fR
@@ -239,12 +239,6 @@ the logs plugin and 60 seconds for all other enabled plugins.
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.
 Identifiers may include alphanumeric characters, commas and periods ('.').
-Synonymous with \--ticket-number.
-.TP
-.B \--ticket-number NUMBER
-Specify a ticket number or other identifier to associate with the archive.
-Identifiers may include alphanumeric characters, commas and periods ('.').
-Synonymous with \--case-id.
 .TP
 .B \--build
 Do not archive copied data. Causes sosreport to leave an uncompressed

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -8,7 +8,6 @@ class DebianPolicy(LinuxPolicy):
     distro = "Debian"
     vendor = "the Debian project"
     vendor_url = "https://www.debian.org/"
-    ticket_number = ""
     _debq_cmd = "dpkg-query -W -f='${Package}|${Version}\\n'"
     _debv_cmd = "dpkg --verify"
     _debv_filter = ""
@@ -23,7 +22,6 @@ class DebianPolicy(LinuxPolicy):
                  remote_exec=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot, init=init,
                                            probe_runtime=probe_runtime)
-        self.ticket_number = ""
         self.package_manager = PackageManager(query_command=self._debq_cmd,
                                               verify_command=self._debv_cmd,
                                               verify_filter=self._debv_filter,

--- a/sos/policies/redhat.py
+++ b/sos/policies/redhat.py
@@ -45,7 +45,6 @@ class RedHatPolicy(LinuxPolicy):
                  remote_exec=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot, init=init,
                                            probe_runtime=probe_runtime)
-        self.ticket_number = ""
         self.usrmove = False
         # need to set _host_sysroot before PackageManager()
         if sysroot:

--- a/sos/policies/suse.py
+++ b/sos/policies/suse.py
@@ -25,7 +25,6 @@ class SuSEPolicy(LinuxPolicy):
                  remote_exec=None):
         super(SuSEPolicy, self).__init__(sysroot=sysroot, init=init,
                                          probe_runtime=probe_runtime)
-        self.ticket_number = ""
         self.package_manager = PackageManager(
             'rpm -qa --queryformat "%{NAME}|%{VERSION}\\n"',
             remote_exec=remote_exec)


### PR DESCRIPTION
    
This patch is to delete ticket-number option
in man page for sosreport

ticket-number option is not supporting in sosreport
so remove it from man page
Note: ticket-number option is not there in help message

Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
