### PR TITLE
[report] clean up references to ticket-number

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -14,7 +14,7 @@ sosreport \- Collect and package diagnostic and support data
           [--preset preset] [--add-preset add_preset]\fR
           [--del-preset del_preset] [--desc description]\fR
           [--batch] [--build] [--debug] [--dry-run]\fR
-          [--label label] [--case-id id] [--ticket-number nr]\fR
+          [--label label] [--case-id id]\fR
           [--threads threads]\fR
           [--plugin-timeout TIMEOUT]\fR
           [-s|--sysroot SYSROOT]\fR
@@ -256,12 +256,6 @@ the logs plugin and 60 seconds for all other enabled plugins.
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.
 Identifiers may include alphanumeric characters, commas and periods ('.').
-Synonymous with \--ticket-number.
-.TP
-.B \--ticket-number NUMBER
-Specify a ticket number or other identifier to associate with the archive.
-Identifiers may include alphanumeric characters, commas and periods ('.').
-Synonymous with \--case-id.
 .TP
 .B \--build
 Do not archive copied data. Causes sosreport to leave an uncompressed

--- a/sos/policies/distros/debian.py
+++ b/sos/policies/distros/debian.py
@@ -17,7 +17,6 @@ class DebianPolicy(LinuxPolicy):
     distro = "Debian"
     vendor = "the Debian project"
     vendor_urls = [('Community Website', 'https://www.debian.org/')]
-    ticket_number = ""
     name_pattern = 'friendly'
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
@@ -28,7 +27,6 @@ class DebianPolicy(LinuxPolicy):
                  remote_exec=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot, init=init,
                                            probe_runtime=probe_runtime)
-        self.ticket_number = ""
         self.package_manager = DpkgPackageManager(chroot=sysroot,
                                                   remote_exec=remote_exec)
         self.valid_subclasses += [DebianPlugin]

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -50,7 +50,6 @@ class RedHatPolicy(LinuxPolicy):
                  remote_exec=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot, init=init,
                                            probe_runtime=probe_runtime)
-        self.ticket_number = ""
         self.usrmove = False
         # need to set _host_sysroot before PackageManager()
         if sysroot:

--- a/sos/policies/distros/suse.py
+++ b/sos/policies/distros/suse.py
@@ -25,7 +25,6 @@ class SuSEPolicy(LinuxPolicy):
                  remote_exec=None):
         super(SuSEPolicy, self).__init__(sysroot=sysroot, init=init,
                                          probe_runtime=probe_runtime)
-        self.ticket_number = ""
         self.valid_subclasses += [SuSEPlugin, RedHatPlugin]
 
         pkgs = self.package_manager.all_pkgs()


### PR DESCRIPTION
Cleaning up references of --ticket-number, as it was fully replaced
by --case-id.

The credit goes to @mamatha4 .

Resolves: #2375
Relates to: #2374

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
