### PR TITLE
powerpc: Collect opal-prd log files

### DIFF
--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -84,7 +84,8 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/proc/ppc64/topology_updates",
                 "/sys/firmware/opal/msglog",
                 "/var/log/opal-elog/",
-                "/var/log/opal-prd"
+                "/var/log/opal-prd",
+                "/var/log/opal-prd.log*"
             ])
             if os.path.isdir("/var/log/dump"):
                 self.add_cmd_output("ls -l /var/log/dump")


### PR DESCRIPTION
Recent distros redirecting opal-prd logs to /var/log/opal-prd.log file.

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
