### PR TITLE
[powerpc] Collect logs for power specific components (HNV and SCSI)

### DIFF
--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -106,7 +106,6 @@ class Kernel(Plugin, IndependentPlugin):
             "/proc/misc",
             "/var/log/dmesg",
             "/sys/fs/pstore",
-            "/var/log/hcnmgr",
             clocksource_path + "available_clocksource",
             clocksource_path + "current_clocksource"
         ])

--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -63,7 +63,10 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/proc/ppc64/systemcfg",
                 "/var/log/platform",
                 "/var/log/drmgr",
-                "/var/log/drmgr.0"
+                "/var/log/drmgr.0",
+                "/var/log/hcnmgr",
+                "/var/ct/IBM.DRM.stderr",
+                "/var/ct/IW/log/mc/IBM.DRM/trace*"
             ])
             ctsnap_path = self.get_cmd_output_path(name="ctsnap", make=True)
             self.add_cmd_output([
@@ -74,8 +77,10 @@ class PowerPC(Plugin, IndependentPlugin):
                 "serv_config -l",
                 "bootlist -m both -r",
                 "lparstat -i",
-                "ctsnap -xrunrpttr -d %s" % (ctsnap_path)
+                "ctsnap -xrunrpttr -d %s" % (ctsnap_path),
+                "lsdevinfo"
             ])
+            self.add_service_status("hcn-init")
 
         if isPowerNV:
             self.add_copy_spec([

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -29,10 +29,18 @@ class Scsi(Plugin, IndependentPlugin):
         ])
 
         self.add_cmd_output("lsscsi -i", suggest_filename="lsscsi")
-        self.add_cmd_output("sg_map -x")
-        self.add_cmd_output("lspath")
-        self.add_cmd_output("lsmap -all")
-        self.add_cmd_output("lsnports")
+
+        self.add_cmd_output([
+            "sg_map -x",
+            "lspath",
+            "lsmap -all",
+            "lsnports",
+            "lsscsi -H",
+            "lsscsi -g",
+            "lsscsi -d",
+            "lsscsi -s",
+            "lsscsi -L"
+        ])
 
         scsi_hosts = glob("/sys/class/scsi_host/*")
         self.add_blockdev_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,


### PR DESCRIPTION
This patch set enables sosreport to capture
logs for power specific components (HNV and SCSI)

signed-off-by: Mamatha Inamdar mamatha4@linux.vnet.ibm.com

Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [x ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
