### PR TITLE
[networking] Collect 'ethtool -e <device>' conditionally only

### DIFF
--- a/sos/plugins/networking.py
+++ b/sos/plugins/networking.py
@@ -27,7 +27,8 @@ class Networking(Plugin):
         ("namespaces", "Number of namespaces to collect, 0 for unlimited. " +
          "Incompatible with the namespace_pattern plugin option", "slow", 0),
         ("ethtool_namespaces", "Define if ethtool commands should be " +
-         "collected for namespaces", "slow", True)
+         "collected for namespaces", "slow", True),
+        ("eepromdump", "collect 'ethtool -e' for all devices", "slow", False)
     ]
 
     # switch to enable netstat "wide" (non-truncated) output mode
@@ -186,16 +187,15 @@ class Networking(Plugin):
                 "ethtool --show-eee " + eth
             ])
 
-            # skip EEPROM collection for 'bnx2x' NICs as this command
-            # can pause the NIC and is not production safe.
-            bnx_output = {
-                "cmd": "ethtool -i %s" % eth,
-                "output": "bnx2x"
-            }
-            bnx_pred = SoSPredicate(self,
-                                    cmd_outputs=bnx_output,
-                                    required={'cmd_outputs': 'none'})
-            self.add_cmd_output("ethtool -e %s" % eth, pred=bnx_pred)
+            # skip EEPROM collection by default, as it might hang or
+            # negatively impact the system on some device types
+            if self.get_option("eepromdump"):
+                cmd = "ethtool -e %s" % eth
+                self._log_warn("WARNING (about to collect '%s'): collecting "
+                               "an eeprom dump is known to cause certain NIC "
+                               "drivers (e.g. bnx2x/tg3) to interrupt device "
+                               "operation" % cmd)
+                self.add_cmd_output(cmd)
 
         # Collect information about bridges (some data already collected via
         # "ip .." commands)


### PR DESCRIPTION
EEPROM dump collection might hang on specific types of devices, or
negatively impact the system otherwise. As a safe option, sos report
should collect the command when explicitly asked via a plugopt only.

Related: #2376
Resolved: #2380

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
