### PR TITLE
[s390] Collect dasd.conf file

### DIFF
--- a/sos/report/plugins/s390.py
+++ b/sos/report/plugins/s390.py
@@ -25,6 +25,7 @@ class S390(Plugin, IndependentPlugin):
             "/proc/crypto",
             "/proc/dasd/devices",
             "/proc/dasd/statistics",
+            "/etc/dasd.conf",
             "/proc/qeth",
             "/proc/qeth_perf",
             "/proc/qeth_ipa_takeover",


### PR DESCRIPTION
From RHBZ:
The /etc/dasd.conf is the common configuration file for the dasd portion of s390,
similar to how /etc/multipath.conf is to multipath.  It has settings like
failover timings, readonly settings, diag settings, etc.  It's very useful to see
what the customer has set in this file when doing an initial analysis of s390 and
more specifically dasd (s390 storage) issues.  It's also useful to have when
suggesting dasd tuning changes to the customer.

Resolves: RHBZ#1919277
Resolves: #2381

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
