### PR TITLE
[kdump] Gather the file kexec-dmesg.log

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -72,6 +72,7 @@ class RedHatKDump(KDump, RedHatPlugin):
             "/etc/kdump.conf",
             "/etc/udev/rules.d/*kexec.rules",
             "/var/crash/*/vmcore-dmesg.txt",
+            "/var/crash/*/kexec-dmesg.log",
             "/var/log/kdump.log"
         ])
         try:
@@ -81,7 +82,7 @@ class RedHatKDump(KDump, RedHatPlugin):
             path = "/var/crash"
 
         self.add_copy_spec("{}/*/vmcore-dmesg.txt".format(path))
-        self.add_copy_spec("{}/*/kexec-kdump.log".format(path))
+        self.add_copy_spec("{}/*/kexec-dmesg.log".format(path))
 
 
 class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Moved the file name from kexec-kdump.log to
the right one, kexec-dmesg.log

Resolves: RHBZ#1817042
Resolves: #2386 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
