### PR TITLE
[rpm] Capture the output of 'rpm --showrc'

### DIFF
--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -65,4 +65,6 @@ class Rpm(Plugin, RedHatPlugin):
                                 suggest_filename='lsof_D_var_lib_rpm')
             self.add_copy_spec("/var/lib/rpm")
 
+        self.add_cmd_output("rpm --showrc")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This request adds the output of --showrc  to sos
so we can verify the default values of options set
via rpmrc and macros config files.

Resolves: RHBZ#1921496
Resolves: #2388 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
