### PR TITLE
[md] Add "mdadm -E" command output

### DIFF
--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -18,6 +18,8 @@ class Md(Plugin, IndependentPlugin):
 
     def setup(self):
         self.add_cmd_output("mdadm -D /dev/md*")
+        self.add_blockdev_cmd("mdadm -E %(dev)s",
+                              blacklist=['ram.*', 'zram.*'])
         self.add_copy_spec([
             "/proc/mdstat",
             "/etc/mdadm.conf",


### PR DESCRIPTION
The "mdadm -E" print contents of the metadata stored in devices. -E
applies to devices which are components of an array, where -D applies
to whole array.

Signed-off-by: Akshay Gaikwad <akgaikwad001@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
