### PR TITLE
[cleaner] Automatically create directory for sos-cleaner default_mapping

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -405,7 +405,13 @@ third party.
         able to provide the same consistent mapping
         """
         if self.opts.map_file and not self.opts.no_update:
+            cleaner_dir = "/etc/sos/cleaner/"
+            """ Check first if the /etc/sos/cleaner directory exists
+            and if not, create it
+            """
             try:
+                if not os.path.exists(cleaner_dir):
+                    os.makedirs(cleaner_dir, exist_ok=True)
                 self.write_map_to_file(_map, self.opts.map_file)
                 self.log_debug("Wrote mapping to %s" % self.opts.map_file)
             except Exception as err:

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -65,4 +65,6 @@ class Rpm(Plugin, RedHatPlugin):
                                 suggest_filename='lsof_D_var_lib_rpm')
             self.add_copy_spec("/var/lib/rpm")
 
+        self.add_cmd_output("rpm --showrc")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
When /etc/sos/cleaner directory is missing, cleaner fails to store 
new default_mapping file due to:
  
[cleaner] Could not update mapping config file:
    [Errno 2] No such file or directory: '/etc/sos/cleaner/default_mapping'
    
This patch adds the code to check the existence of the directory 
and create it if necessary.
   
Resolves: RHBZ#1923937
Closes: #2393
Resolves: #2395 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
