### PR TITLE
[yum] Mask the proxy passwords in /etc/yum.repos.d/

### DIFF
--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -109,4 +109,9 @@ class Yum(Plugin, RedHatPlugin):
             except IndexError:
                 pass
 
+    def postproc(self):
+        regexp = r"(proxy_password(\s)*=(\s)*)(\S+)\n"
+        repl = r"\1********\n"
+        self.do_path_regex_sub("/etc/yum.repos.d/*", regexp, repl)
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch makes sure that all passwords specified
in the opcion proxy_password in any file inside
/etc/yum.repos.d/ ends up masked in the sosreport.

Closes: #2394
Resolves: #2396 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
