### PR TITLE
[sos] Align plugin options with destination names

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -4,7 +4,7 @@ sos clean - Obfuscate sensitive data from one or more sosreports
 .SH SYNOPSIS
 .B sos clean TARGET [options]
     [\-\-domains]
-    [\-\-map]
+    [\-\-map-file]
     [\-\-jobs]
     [\-\-no-update]
 
@@ -54,7 +54,7 @@ Keywords provided by this option will be obfuscated as "obfuscatedwordX" where X
 integer based on the keyword's index in the parser. Note that keywords will be replaced as
 both standalone words and in substring matches.
 .TP
-.B \-\-map FILE
+.B \-\-map-file FILE
 Provide a location to a valid mapping file to use as a reference for existing obfuscation pairs.
 If one is found, the contents are loaded before parsing is started. This allows consistency between
 runs of this command for obfuscated pairs. By default, sos will write the generated private map file

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -151,7 +151,7 @@ compressed report.
 .B \--list-profiles
 Display a list of available profiles and the plugins that they enable.
 .TP
-.B \-p, \--profile NAME
+.B \-p, \--profile, \--profiles NAME
 Only run plugins that correspond to the given profile. Multiple profiles
 may be specified as a comma-separated list; the set of plugins executed
 is the union of each of the profile's plugin sets. Currently defined

--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -170,7 +170,7 @@ third party.
         clean_grp.add_argument('--keywords', action='extend', default=[],
                                dest='keywords',
                                help='List of keywords to obfuscate')
-        clean_grp.add_argument('--map', dest='map_file',
+        clean_grp.add_argument('--map-file', dest='map_file',
                                default='/etc/sos/cleaner/default_mapping',
                                help=('Provide a previously generated mapping '
                                      'file for obfuscation'))

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -84,7 +84,7 @@ class SoSCollector(SoSComponent):
         'preset': '',
         'save_group': '',
         'since': '',
-        'skip_cmds': [],
+        'skip_commands': [],
         'skip_files': [],
         'skip_plugins': [],
         'sos_opt_line': '',
@@ -280,7 +280,7 @@ class SoSCollector(SoSComponent):
                                    'This will also affect --all-logs. '
                                    'Format: YYYYMMDD[HHMMSS]'))
         sos_grp.add_argument('--skip-commands', default=[], action='extend',
-                             dest='skip_cmds',
+                             dest='skip_commands',
                              help="do not execute these commands")
         sos_grp.add_argument('--skip-files', default=[], action='extend',
                              dest='skip_files',

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -655,9 +655,9 @@ class SosNode():
             self.sos_bin = 'sos report'
 
         if self.check_sos_version('4.1'):
-            if self.opts.skip_cmds:
+            if self.opts.skip_commands:
                 sos_opts.append(
-                    '--skip-commands=%s' % (quote(self.opts.skip_cmds))
+                    '--skip-commands=%s' % (quote(self.opts.skip_commands))
                 )
             if self.opts.skip_files:
                 sos_opts.append(

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -95,10 +95,10 @@ class SoSReport(SoSComponent):
         'list_profiles': False,
         'log_size': 25,
         'map_file': '/etc/sos/cleaner/default_mapping',
-        'skip_cmds': [],
+        'skip_commands': [],
         'skip_files': [],
         'skip_plugins': [],
-        'noreport': False,
+        'no_report': False,
         'no_env_vars': False,
         'no_postproc': False,
         'no_update': False,
@@ -222,7 +222,8 @@ class SoSReport(SoSComponent):
         report_grp.add_argument("-e", "--enable-plugins", action="extend",
                                 dest="enable_plugins", type=str,
                                 help="enable these plugins", default=[])
-        report_grp.add_argument("-k", "--plugin-option", action="extend",
+        report_grp.add_argument("-k", "--plugin-option", "--plugopts",
+                                action="extend",
                                 dest="plugopts", type=str,
                                 help="plugin options in plugname.option=value "
                                      "format (see -l)", default=[])
@@ -247,7 +248,7 @@ class SoSReport(SoSComponent):
                                 dest="skip_plugins", type=str,
                                 help="disable these plugins", default=[])
         report_grp.add_argument("--no-report", action="store_true",
-                                dest="noreport", default=False,
+                                dest="no_report", default=False,
                                 help="disable plaintext/HTML reporting")
         report_grp.add_argument("--no-env-vars", action="store_true",
                                 dest="no_env_vars", default=False,
@@ -264,12 +265,13 @@ class SoSReport(SoSComponent):
                                 help="A preset identifier", default="auto")
         report_grp.add_argument("--plugin-timeout", default=None,
                                 help="set a timeout for all plugins")
-        report_grp.add_argument("-p", "--profile", action="extend",
-                                dest="profiles", type=str, default=[],
+        report_grp.add_argument("-p", "--profile", "--profiles",
+                                action="extend", dest="profiles", type=str,
+                                default=[],
                                 help="enable plugins used by the given "
                                      "profiles")
         report_grp.add_argument('--skip-commands', default=[], action='extend',
-                                dest='skip_cmds',
+                                dest='skip_commands',
                                 help="do not execute these commands")
         report_grp.add_argument('--skip-files', default=[], action='extend',
                                 dest='skip_files',
@@ -1367,7 +1369,7 @@ class SoSReport(SoSComponent):
             self.collect()
             if not self.opts.no_env_vars:
                 self.collect_env_vars()
-            if not self.opts.noreport:
+            if not self.opts.no_report:
                 self.generate_reports()
             if not self.opts.no_postproc:
                 self.postproc()

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -496,7 +496,7 @@ class Plugin(object):
         self.devices = commons['devices']
         self.manifest = None
         self.skip_files = commons['cmdlineopts'].skip_files
-        self.skip_cmds = commons['cmdlineopts'].skip_cmds
+        self.skip_commands = commons['cmdlineopts'].skip_commands
 
         self.soslog = self.commons['soslog'] if 'soslog' in self.commons \
             else logging.getLogger('sos')
@@ -1609,7 +1609,7 @@ class Plugin(object):
         pred = kwargs.pop('pred') if 'pred' in kwargs else None
         soscmd = SoSCommand(**kwargs)
         self._log_debug("packed command: " + soscmd.__str__())
-        for _skip_cmd in self.skip_cmds:
+        for _skip_cmd in self.skip_commands:
             # This probably seems weird to be doing filename matching on the
             # commands, however we want to remain consistent with our regex
             # matching with file paths, which sysadmins are almost guaranteed

--- a/tests/option_tests.py
+++ b/tests/option_tests.py
@@ -17,7 +17,7 @@ class MockOptions(object):
     dry_run = False
     log_size = 25
     allow_system_changes = False
-    skip_cmds = []
+    skip_commands = []
     skip_files = []
 
 

--- a/tests/plugin_tests.py
+++ b/tests/plugin_tests.py
@@ -116,7 +116,7 @@ class MockOptions(object):
     allow_system_changes = False
     no_postproc = False
     skip_files = []
-    skip_cmds = []
+    skip_commands = []
 
 
 class PluginToolTests(unittest.TestCase):


### PR DESCRIPTION
This commit alters several option long-form names or destination names
to align those values in a sensible way. This serves to not only remove
some abiguity in option naming in code, but also to make it so that the
"effective options" line logged in every sos execution can be direction
copy-pasted as a working command.

Closes: #2288
Resolves: #2398

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
