### PR TITLE
[build] Add the new presets module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ setup(
         ('config', ['sos.conf'])
     ],
     packages=[
-        'sos', 'sos.policies', 'sos.policies.distros', 'sos.policies.runtimes',
+        'sos', 'sos.presets', 'sos.presets.redhat', 'sos.policies',
+        'sos.policies.distros', 'sos.policies.runtimes',
         'sos.policies.package_managers', 'sos.policies.init_systems',
         'sos.report', 'sos.report.plugins', 'sos.collector',
         'sos.collector.clusters', 'sos.cleaner', 'sos.cleaner.mappings',


### PR DESCRIPTION
When presets were split out from policies, they were not added to
`setup.py` in the list of packages. As such they would not be included
in any builds that relied upon using `setup.py` to generate a source
tarball.

Add those packages to the list so that they may be included.

Closes: #2390
Resolves: #2402

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
