### PR TITLE
[cleaner] Add 'cleaner' alias functionality

### DIFF
--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -50,7 +50,7 @@ May also be invoked via the alias \fBsos collector\fR or the deprecated command
 \fBsos-collector\fR.
 
 .TP
-.B clean|mask
+.B clean|cleaner|mask
 This subcommand takes input of either 1) an sosreport tarball, 2) a collection
 of sosreport tarballs such as from \fBcollect\fR, or 3) the unpackaged
 directory of an sosreport and obfuscates potentially sensitive system information
@@ -63,7 +63,8 @@ between matched data items.
 
 See \fB sos clean --help\fR and \fBman sos-clean\fR for more information.
 
-May be invoked via either \fBsos clean\fR, \fBsos mask\fR, or via the \fB--clean\fR or \fB --mask\fR options
+May be invoked via either \fBsos clean\fR, \fBsos cleaner\fR, \fBsos mask\fR,
+or via the \fB--clean\fR, \fB--cleaner\fR or \fB --mask\fR options
 for \fBreport\fR and \fBcollect\fR.
 
 .SH GLOBAL OPTIONS

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -366,7 +366,8 @@ class SoSCollector(SoSComponent):
             'Cleaner/Masking Options',
             'These options control how data obfuscation is performed'
         )
-        cleaner_grp.add_argument('--clean', '--mask', dest='clean',
+        cleaner_grp.add_argument('--clean', '--cleaner', '--mask',
+                                 dest='clean',
                                  default=False, action='store_true',
                                  help='Obfuscate sensistive information')
         cleaner_grp.add_argument('--domains', dest='domains', default=[],

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -308,7 +308,8 @@ class SoSReport(SoSComponent):
             'Cleaner/Masking Options',
             'These options control how data obfuscation is performed'
         )
-        cleaner_grp.add_argument('--clean', '--mask', dest='clean',
+        cleaner_grp.add_argument('--clean', '--cleaner', '--mask',
+                                 dest='clean',
                                  default=False, action='store_true',
                                  help='Obfuscate sensistive information')
         cleaner_grp.add_argument('--domains', dest='domains', default=[],


### PR DESCRIPTION
The option 'cleaner' was not implemented
as an alias. This patch enables it for both
'sos report' and 'sos collect'.

Resolves: #2405

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
