### PR TITLE
[clean] Fix hostnames not being obfuscated when host plugin wasn't run

### DIFF
--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -22,9 +22,25 @@ class SoSHostnameParser(SoSCleanerParser):
     ]
 
     def __init__(self, conf_file=None, opt_domains=None):
-        self.mapping = SoSHostnameMap(opt_domains)
-        self.short_names = []
+        self.mapping = SoSHostnameMap()
         super(SoSHostnameParser, self).__init__(conf_file)
+        self.mapping.load_domains_from_map()
+        self.mapping.load_domains_from_options(opt_domains)
+        self.short_names = []
+        self.load_short_names_from_mapping()
+        self.mapping.set_initial_counts()
+
+    def load_short_names_from_mapping(self):
+        """When we load the mapping file into the hostname map, we have to do
+        some dancing to get those loaded properly into the "intermediate" dicts
+        that the map uses to hold hosts and domains. Similarly, we need to also
+        extract shortnames known to the map here.
+        """
+        for hname in self.mapping.dataset.keys():
+            if len(hname.split('.')) == 1:
+                # we have a short name only with no domain
+                if hname not in self.short_names:
+                    self.short_names.append(hname)
 
     def load_hostname_into_map(self, hostname_string):
         """Force add the domainname found in /sos_commands/host/hostname into

--- a/tests/cleaner_tests.py
+++ b/tests/cleaner_tests.py
@@ -24,7 +24,8 @@ class CleanerMapTests(unittest.TestCase):
     def setUp(self):
         self.mac_map = SoSMacMap()
         self.ip_map = SoSIPMap()
-        self.host_map = SoSHostnameMap(['redhat.com'])
+        self.host_map = SoSHostnameMap()
+        self.host_map.load_domains_from_options(['redhat.com'])
         self.kw_map = SoSKeywordMap()
 
     def test_mac_map_obfuscate_valid_v4(self):


### PR DESCRIPTION
It was discovered that if a report was generated without the host plugin
being run, then the hostname parser would not obfuscate the localhost
hostname or domain at all. This was due to the fact that while the
default_mapping values were being read into the parser's map's dataset
correctly, they weren't being loaded into the 'intermediary' dicts that
the parser uses to separate short names from domain names.

Fix this by reading the contents of the map's dataset dict (which is
populated by the map file) into those intermediary dicts that the parser
uses.

Resolves: #2406

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
