### PR TITLE
[clean] Allow specifying keywords in a text file

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -4,6 +4,8 @@ sos clean - Obfuscate sensitive data from one or more sosreports
 .SH SYNOPSIS
 .B sos clean TARGET [options]
     [\-\-domains]
+    [\-\-keywords]
+    [\-\-keyword-file]
     [\-\-map-file]
     [\-\-jobs]
     [\-\-no-update]
@@ -53,6 +55,10 @@ Provide a comma-delimited list of keywords to scrub in addition to the default p
 Keywords provided by this option will be obfuscated as "obfuscatedwordX" where X is an
 integer based on the keyword's index in the parser. Note that keywords will be replaced as
 both standalone words and in substring matches.
+.TP
+.B \-\-keyword-file FILE
+Provide a file that contains a list of keywords that should be obfuscated. Each word must
+be specified on a newline within the file.
 .TP
 .B \-\-map-file FILE
 Provide a location to a valid mapping file to use as a reference for existing obfuscation pairs.

--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -44,6 +44,7 @@ class SoSCleaner(SoSComponent):
         'domains': [],
         'jobs': 4,
         'keywords': [],
+        'keyword_file': None,
         'map_file': '/etc/sos/cleaner/default_mapping',
         'no_update': False,
         'target': '',
@@ -85,7 +86,8 @@ class SoSCleaner(SoSComponent):
             SoSHostnameParser(self.opts.map_file, self.opts.domains),
             SoSIPParser(self.opts.map_file),
             SoSMacParser(self.opts.map_file),
-            SoSKeywordParser(self.opts.map_file, self.opts.keywords),
+            SoSKeywordParser(self.opts.map_file, self.opts.keywords,
+                             self.opts.keyword_file),
             SoSUsernameParser(self.opts.map_file, self.opts.usernames)
         ]
 
@@ -170,6 +172,9 @@ third party.
         clean_grp.add_argument('--keywords', action='extend', default=[],
                                dest='keywords',
                                help='List of keywords to obfuscate')
+        clean_grp.add_argument('--keyword-file', default=None,
+                               dest='keyword_file',
+                               help='Provide a file a keywords to obfuscate')
         clean_grp.add_argument('--map-file', dest='map_file',
                                default='/etc/sos/cleaner/default_mapping',
                                help=('Provide a previously generated mapping '

--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -8,6 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
+
 from sos.cleaner.parsers import SoSCleanerParser
 from sos.cleaner.mappings.keyword_map import SoSKeywordMap
 
@@ -20,7 +22,7 @@ class SoSKeywordParser(SoSCleanerParser):
     map_file_key = 'keyword_map'
     prep_map_file = ''
 
-    def __init__(self, conf_file=None, keywords=None):
+    def __init__(self, conf_file=None, keywords=None, keyword_file=None):
         self.mapping = SoSKeywordMap()
         self.user_keywords = []
         super(SoSKeywordParser, self).__init__(conf_file)
@@ -28,6 +30,9 @@ class SoSKeywordParser(SoSCleanerParser):
             self.user_keywords.append(_keyword)
         if keywords:
             self.user_keywords.extend(keywords)
+        if keyword_file and os.path.exists(keyword_file):
+            with open(keyword_file, 'r') as kwf:
+                self.user_keywords.extend(kwf.read().splitlines())
 
     def parse_line(self, line):
         count = 0

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -65,6 +65,7 @@ class SoSCollector(SoSComponent):
         'image': '',
         'jobs': 4,
         'keywords': [],
+        'keyword_file': None,
         'label': '',
         'list_options': False,
         'log_size': 0,
@@ -375,6 +376,9 @@ class SoSCollector(SoSComponent):
         cleaner_grp.add_argument('--keywords', action='extend', default=[],
                                  dest='keywords',
                                  help='List of keywords to obfuscate')
+        cleaner_grp.add_argument('--keyword-file', default=None,
+                                 dest='keyword_file',
+                                 help='Provide a file a keywords to obfuscate')
         cleaner_grp.add_argument('--no-update', action='store_true',
                                  default=False, dest='no_update',
                                  help='Do not update the default cleaner map')

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -88,6 +88,7 @@ class SoSReport(SoSComponent):
         'experimental': False,
         'enable_plugins': [],
         'keywords': [],
+        'keyword_file': None,
         'plugopts': [],
         'label': '',
         'list_plugins': False,
@@ -317,6 +318,9 @@ class SoSReport(SoSComponent):
         cleaner_grp.add_argument('--keywords', action='extend', default=[],
                                  dest='keywords',
                                  help='List of keywords to obfuscate')
+        cleaner_grp.add_argument('--keyword-file', default=None,
+                                 dest='keyword_file',
+                                 help='Provide a file a keywords to obfuscate')
         cleaner_grp.add_argument('--no-update', action='store_true',
                                  default=False, dest='no_update',
                                  help='Do not update the default cleaner map')


### PR DESCRIPTION
This commit adds the ability for users to provide a text file with a
list of newline-delimited keywords that should be obfuscated, rather
than requiring all keywords be specified either by the `--keywords`
option or configuration file settings.

Files may be provided via the new `--keyword-file` option which is
available to `clean`, `collect`, and `report`.

Closes #2401 
Resolves: #2408

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
