### PR TITLE
[gluster] Add glusterd public keys and status files

### DIFF
--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -55,6 +55,9 @@ class Gluster(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_forbidden_path("/var/lib/glusterd/geo-replication/secret.pem")
+        self.add_forbidden_path(
+            "/var/lib/glusterd/glusterfind/glusterfind_*_secret.pem"
+        )
 
         self.add_cmd_output([
             "gluster peer status",
@@ -72,7 +75,10 @@ class Gluster(Plugin, RedHatPlugin):
             "/etc/glusterfs",
             "/var/lib/glusterd/",
             # collect nfs-ganesha related configuration
-            "/run/gluster/shared_storage/nfs-ganesha/"
+            "/run/gluster/shared_storage/nfs-ganesha/",
+            # collect status files and public ssh keys
+            "/var/lib/glusterd/.keys/",
+            "/var/lib/glusterd/glusterfind/"
         ] + glob.glob('/run/gluster/*tier-dht/*'))
 
         if not self.get_option("all_logs"):


### PR DESCRIPTION
This patch helps capture some missing files in the
gluster plugin, i.e.:

Files inside /var/lib/glusterd/glusterfind, like
*.status files, that store the required timestamps,
*.pem.pub files, that store ssh public keys.
We also need to omit the glusterfind_*_secret.pem,
which contains the openssh private key.

Files inside /var/lib/glusterd/.keys, that contains
*.pem.pub,  the ssh public key.

Closes: RHBZ#1925035, RHBZ#1925419
Resolves: #2411 
Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
