### PR TITLE
[SCLPlugin] Fix SCLPlugin enablement triggers

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2568,7 +2568,8 @@ class Plugin(object):
                                                    commands,
                                                    services):
                         type(self)._scls_matched.append(scl)
-                return len(type(self)._scls_matched) > 0
+                    if type(self)._scls_matched:
+                        return True
 
             return self._check_plugin_triggers(self.files,
                                                self.packages,
@@ -2793,6 +2794,8 @@ class SCLPlugin(RedHatPlugin):
         """Same as add_cmd_output, except that it wraps command in
         "scl enable" call and sets proper PATH.
         """
+        if scl not in self.scls_matched:
+            return
         if isinstance(cmds, str):
             cmds = [cmds]
         scl_cmds = []
@@ -2817,21 +2820,14 @@ class SCLPlugin(RedHatPlugin):
         """Same as add_copy_spec, except that it prepends path to SCL root
         to "copyspecs".
         """
+        if scl not in self.scls_matched:
+            return
         if isinstance(copyspecs, str):
             copyspecs = [copyspecs]
         scl_copyspecs = []
         for copyspec in copyspecs:
             scl_copyspecs.append(self.convert_copyspec_scl(scl, copyspec))
         self.add_copy_spec(scl_copyspecs)
-
-    def add_copy_spec_limit_scl(self, scl, copyspec, **kwargs):
-        """Same as add_copy_spec_limit, except that it prepends path to SCL
-        root to "copyspec".
-        """
-        self.add_copy_spec_limit(
-            self.convert_copyspec_scl(scl, copyspec),
-            **kwargs
-        )
 
 
 class PowerKVMPlugin(RedHatPlugin):


### PR DESCRIPTION
It was found that if a system has `scl` available to it, and has a
non-scl package installed for a plugin that subclasses `SCLPlugin`, but
the scl packages are not installed, then the plugin will not be enabled
even for the non-scl collections.

This was due to a too-restrictive check if the plugin subclasses
`SCLPlugins` that prevented the normal plugin triggers from being
checked.

The future of Software Collections is uncertain to the sos project at
this time, but our current use of it is only 3 plugins; foreman,
postgresql, and redis.

As such, rather than splitting out `SCLPlugin` further into a distinct
separate subclass of a plugin and then having to deal with how to
determine which plugin class should be instantiated if both the scl and
non-scl plugin would otherwise be enabled, make the `SCLPlugin`
enablement conditions not prevent normal plugin enablement, and add
gates to the `_scl` methods provided by `SCLPlugin` to abort any
collection attempt if the specified scl is not detected.

If, at a later date, the project sees further (new) use of the
`SCLPlugin` then we can/will review this approach at that time.

Closes: #2407
Resolves: #2412

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
