### PR TITLE
[apache] skip collecting pulp* logs

### DIFF
--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -29,9 +29,12 @@ class Apache(Plugin):
             "apachectl -t"
         ])
 
-        # The foreman plugin collects these files with a greater size limit:
+        # The foreman and pulp plugins collect these files;
         # do not collect them here to avoid collisions in the archive paths.
-        self.add_forbidden_path("/var/log/{}*/foreman*".format(self.apachepkg))
+        self.add_forbidden_path([
+            "/var/log/{}*/foreman*".format(self.apachepkg),
+            "/var/log/{}*/pulp*".format(self.apachepkg)
+        ])
 
 
 class RedHatApache(Apache, RedHatPlugin):


### PR DESCRIPTION
Since these are collected in the pulp plugin directly.

Resolves: #2413

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
