### PR TITLE
[plugin] Clarify default timeout for all plugins

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -243,7 +243,8 @@ Specify the number of threads sosreport will use for concurrency. Defaults to 4.
 .TP
 .B \--plugin-timeout TIMEOUT
 Specify a timeout in seconds to allow each plugin to run for. A value of 0
-means no timeout will be set.
+means no timeout will be set. A value of -1 is used to indicate the default
+timeout of 300 seconds.
 
 Note that this options sets the timeout for all plugins. If you want to set
 a timeout for a specific plugin, use the 'timeout' plugin option available to

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -470,7 +470,8 @@ class Plugin(object):
     predicate = None
     cmd_predicate = None
     _default_plug_opts = [
-        ('timeout', 'Timeout in seconds for plugin', 'fast', -1),
+        ('timeout', 'Timeout in seconds for plugin. The default value (-1) ' +
+            'defers to the general plugin timeout, 300 seconds', 'fast', -1),
         ('postproc', 'Enable post-processing collected plugin data', 'fast',
          True)
     ]


### PR DESCRIPTION
The default timeout for all plugins is 300, but
the global timeout is set as -1 in the option list. This is
because this timeout is unset by default. This patch
attempts to clarify the -1 exposed to the user when using
commands like 'sos report -l', via the option description
as well as a note clarifying it in the man page.

Closes: #2003
Resolves: #2415

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
