### PR TITLE
[cleaner|hostname] Fix duplication issue, allow for matching all uppercase domains

### DIFF
--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -51,10 +51,21 @@ class SoSHostnameMap(SoSMap):
             else:
                 # strip the host name and trailing top-level domain so that
                 # we in inject the domain properly for later string matching
-                _domain = '.'.join(domain.split('.')[1:-1]).strip()
-                if not _domain:
+
+                # note: this is artificially complex due to our stance on
+                # preserving TLDs. If in the future the project decides to
+                # obfuscate TLDs as well somehow, then this will all become
+                # much simpler
+                _domain_to_inject = '.'.join(domain.split('.')[1:-1])
+                if not _domain_to_inject:
                     continue
-                self._domains[_domain] = self.dataset[domain]
+                for existing_domain in self.dataset.keys():
+                    _existing = '.'.join(existing_domain.split('.')[:-1])
+                    if _existing == _domain_to_inject:
+                        _ob_domain = '.'.join(
+                            self.dataset[existing_domain].split('.')[:-1]
+                        )
+                        self._domains[_domain_to_inject] = _ob_domain
         self.set_initial_counts()
 
     def load_domains_from_options(self, domains):

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -111,12 +111,16 @@ class SoSHostnameMap(SoSMap):
         if item.startswith(('.', '_')):
             item = item.lstrip('._')
         item = item.strip()
-        if not self.domain_name_in_loaded_domains(item):
+        if not self.domain_name_in_loaded_domains(item.lower()):
             return item
         return super(SoSHostnameMap, self).get(item)
 
     def sanitize_item(self, item):
         host = item.split('.')
+        if all([h.isupper() for h in host]):
+            # by convention we have just a domain
+            _host = [h.lower() for h in host]
+            return self.sanitize_domain(_host).upper()
         if len(host) == 1:
             # we have a shortname for a host
             return self.sanitize_short_name(host[0])


### PR DESCRIPTION
This 2-commit patchset addresses two issues with the hostname parser:

1. Refines the fix for #2406 to avoid duplicating TLDs over subsequent no-host-plugin executions
2. Handles #2254 by detecting an all-uppercase convention for kerberos realms and obfuscating appropriately.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
