### PR TITLE
[ubuntu] Prefer ua over ubuntu-advantages cmd

### DIFF
--- a/sos/report/plugins/ubuntu.py
+++ b/sos/report/plugins/ubuntu.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, UbuntuPlugin
+from sos.utilities import is_executable
 
 
 class Ubuntu(Plugin, UbuntuPlugin):
@@ -23,7 +24,12 @@ class Ubuntu(Plugin, UbuntuPlugin):
         ])
 
         if self.is_installed('ubuntu-advantage-tools'):
-            self.add_cmd_output("ubuntu-advantage status")
+            if is_executable('ua'):
+                ua_tools_status = 'ua status'
+            else:
+                ua_tools_status = 'ubuntu-advantage status'
+            self.add_cmd_output(ua_tools_status)
+
             if not self.get_option("all_logs"):
                 self.add_copy_spec([
                     "/var/log/ubuntu-advantage.log",


### PR DESCRIPTION
'ubuntu-advantage' cli has been shorten to 'ua'
in version 19 and then symlink at package level
to make them both available for users as a
smooth transition.

While most stable Ubuntu releases are at version 19 and
onwards, others aren't yet. The idea is to prefer 'ua'
but fall back to the deprecated 'ubuntu-advantage' cli
as needed.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
