### PR TITLE
[block] Add block device timeout spec

### DIFF
--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -38,7 +38,9 @@ class Block(Plugin, IndependentPlugin):
             "/run/blkid/blkid.tab",
             "/proc/partitions",
             "/proc/diskstats",
-            "/sys/block/*/queue/"
+            "/sys/block/*/queue/",
+            "/sys/block/sd*/device/timeout",
+            "/sys/block/hd*/device/timeout",
         ])
 
         cmds = [


### PR DESCRIPTION
The "/sys/block/sd*/device/timeout" and
"/sys/block/hd*/device/timeout" holds block device timeouts value in
seconds.

Signed-off-by: Akshay Gaikwad <akgaikwad001@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
