### PR TITLE
[ata] Add "smartcl -l scterc dev-name- command

### DIFF
--- a/sos/report/plugins/ata.py
+++ b/sos/report/plugins/ata.py
@@ -29,7 +29,8 @@ class Ata(Plugin, IndependentPlugin):
                     disk_path = os.path.join(dev_path, disk)
                     self.add_cmd_output([
                         "hdparm %s" % disk_path,
-                        "smartctl -a %s" % disk_path
+                        "smartctl -a %s" % disk_path,
+                        "smartctl -l scterc %s" % disk_path,
                     ])
 
 


### PR DESCRIPTION
"-l scterc" prints values and description of the SCT Error Recovery
Control settings.

Signed-off-by: Akshay Gaikwad <akgaikwad001@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
