### PR TITLE
[openstack_designate] Add current pool configuration

### DIFF
--- a/sos/report/plugins/openstack_designate.py
+++ b/sos/report/plugins/openstack_designate.py
@@ -19,6 +19,16 @@ class OpenStackDesignate(Plugin):
     var_puppet_gen = "/var/lib/config-data/puppet-generated/designate"
 
     def setup(self):
+        # collect current pool config
+        pools_cmd = self.fmt_container_cmd(
+            self.get_container_by_name(".*designate_central"),
+            "designate-manage pool generate_file --file /dev/stdout")
+
+        self.add_cmd_output(
+            pools_cmd,
+            suggest_filename="openstack_designate_current_pools.yaml"
+        )
+
         # configs
         self.add_copy_spec([
             "/etc/designate/*",


### PR DESCRIPTION
Use designate-manage to grab the current pools from designate, in
case they differ from the pools stored in pools.yaml

Signed-off-by: Michael Chapman <woppin@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
