### PR TITLE
[profiles] Add nvme and devices plugins to storage profile

### DIFF
--- a/sos/report/plugins/devices.py
+++ b/sos/report/plugins/devices.py
@@ -14,7 +14,7 @@ class Devices(Plugin, IndependentPlugin):
     short_desc = 'devices specific commands'
 
     plugin_name = 'devices'
-    profiles = ('system', 'hardware', 'boot')
+    profiles = ('system', 'hardware', 'boot', 'storage')
     packages = ('udev', 'systemd-udev')
     files = ('/dev',)
 

--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -14,6 +14,7 @@ class Nvme(Plugin, IndependentPlugin):
     short_desc = 'Collect config and system information about NVMe devices'
 
     plugin_name = "nvme"
+    profiles = ('storage',)
     packages = ('nvme-cli',)
 
     def setup(self):


### PR DESCRIPTION
This patch adds nvme and devices to the list of plugins
in the storage profile.

Resolves: #2435 
Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
