### PR TITLE
openstack-nova: Add nova-status upgrade check output

### DIFF
--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -51,6 +51,10 @@ class OpenStackNova(Plugin):
                 "nova-manage " + nova_config + " floating list",
                 suggest_filename="nova-manage_floating_list"
             )
+            self.add_cmd_output(
+                "nova-status " + nova_config + " upgrade check",
+                suggest_filename="nova-status_upgrade_check"
+            )
 
             vars_all = [p in os.environ for p in [
                         'OS_USERNAME', 'OS_PASSWORD']]


### PR DESCRIPTION
nova-status upgrade check [1] is a tool that preforms release specific
checks ahead of an upgrade.

[1] https://docs.openstack.org/nova/latest/cli/nova-status.html

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
