### PR TITLE
[opensvc] Add OpenSVC plugin

### DIFF
--- a/sos/report/plugins/opensvc.py
+++ b/sos/report/plugins/opensvc.py
@@ -1,0 +1,69 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Opensvc(Plugin, IndependentPlugin):
+
+    short_desc = 'OpenSVC cluster and services (config and state collection)'
+    plugin_name = 'opensvc'
+    profiles = ('cluster', 'services', 'system')
+    packages = ('opensvc',)
+
+    def get_status(self, kind):
+        getobjs = self.collect_cmd_output("om %s ls --color=no" % kind)
+        dirname = kind + '_status'
+        if getobjs['status'] == 0:
+            for line in getobjs['output'].splitlines():
+                self.add_cmd_output(
+                    "om %s print status --color=no" % line,
+                    subdir=dirname
+                )
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/opensvc/*",
+            "/var/log/opensvc/*",
+            "/etc/conf.d/opensvc",
+            "/etc/default/opensvc",
+            "/etc/sysconfig/opensvc",
+            "/var/lib/opensvc/*.json",
+            "/var/lib/opensvc/list.*",
+            "/var/lib/opensvc/ccfg",
+            "/var/lib/opensvc/cfg",
+            "/var/lib/opensvc/certs/ca_certificates",
+            "/var/lib/opensvc/certs/certificate_chain",
+            "/var/lib/opensvc/compliance/*",
+            "/var/lib/opensvc/namespaces/*",
+            "/var/lib/opensvc/node/*",
+            "/var/lib/opensvc/sec/*",
+            "/var/lib/opensvc/svc/*",
+            "/var/lib/opensvc/usr/*",
+            "/var/lib/opensvc/vol/*",
+        ])
+        self.add_cmd_output([
+            "ls -laRt /var/lib/opensvc",
+            "om pool status --verbose --color=no",
+            "om net status --verbose --color=no",
+            "om mon --color=no",
+            "om daemon dns dump --color=no",
+            "om daemon status --format flat_json --color=no"
+        ])
+        self.get_status('vol')
+        self.get_status('svc')
+
+    def postproc(self):
+        regexp = r"(\s*secret =\s*)\S+"
+        self.do_file_sub(
+            "/etc/opensvc/cluster.conf",
+            regexp,
+            r"\1****************************"
+        )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
* configuration collected from /etc/opensvc
* logs collected from /var/log/opensvc
* states collected from /var/lib/opensvc and cli commands
* as secrets are encrypted with cluster secret, obfuscation is needed
* all strings matching "secret =" are obfuscated, as per example

    Example
    -------

    root@xps13# cat ${SOSREPORT}/etc/opensvc/cluster.conf
    [DEFAULT]
    id = d3387ce0-e766-496b-8438-b0dd23e083fd

    [cluster]
    nodes = xps13
    id = 5c736690-60ed-11e9-81d7-8b360f06a5a4
    name = xps13
    secret = ****************************
    ; secret = ****************************
    vip@titi = titi

    [array#freenas.opensvc.com]
    type = freenas
    api = https://freenas.opensvc.com/api/v1.0
    username = root
    password = system/sec/freenas.opensvc.com

    [hb#2]
    secret = ****************************
    type = relay
    timeout = 30
    relay = relay.opensvc.com

Signed-off-by: Arnaud Veron <arnaud.veron@opensvc.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
