### PR TITLE
[ds] Mask password and encryption keys in ldif files

### DIFF
--- a/sos/report/plugins/ds.py
+++ b/sos/report/plugins/ds.py
@@ -74,4 +74,11 @@ class DirectoryServer(Plugin, RedHatPlugin):
 
         self.add_cmd_output("ls -l /var/lib/dirsrv/slapd-*/db/*")
 
+    def postproc(self):
+        regexppass = r"(nsslapd-rootpw(\s)*:(\s)*)(\S+)([\r\n]\s.*)*\n"
+        regexpkey = r"(nsSymmetricKey(\s)*::(\s)*)(\S+)([\r\n]\s.*)*\n"
+        repl = r"\1********\n"
+        self.do_path_regex_sub('/etc/dirsrv/*', regexppass, repl)
+        self.do_path_regex_sub('/etc/dirsrv/*', regexpkey, repl)
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Both /etc/dirsrv/slapd*/dse.ldif{,.startOK} files contain
sensitive information :
- all the nsSymmetricKey entries : symmetric encryption key
- nsslapd-rootpw : the admin password's hash

This patch masks these entries in the files we collect.

Resolves: #2442 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
