### PR TITLE
[openctack_octavia] Gather rsyslog settings for amphora log offloading

### DIFF
--- a/sos/report/plugins/openstack_octavia.py
+++ b/sos/report/plugins/openstack_octavia.py
@@ -42,6 +42,7 @@ class OpenStackOctavia(Plugin):
             "/var/lib/octavia",
             self.var_config_data + "/octavia/etc/octavia",
             self.var_puppet_gen + "/etc/octavia",
+            self.var_puppet_gen + "/etc/rsyslog.d",
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf",
         ])
 


### PR DESCRIPTION
Recently TripleO added support for Octavia amphora log offloading.
When this feature is enabled an additional rsyslog container is started
to receive logs from amphora instances.
This change ensures that settings for the rsyslog container is also
captured in sosreport.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X ] Is the subject and message clear and concise?
- [ X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ X ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
