### PR TITLE
[sssd] Enable collecting SSSD memory cache

### DIFF
--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -22,11 +22,16 @@ class Sssd(Plugin):
 
     def setup(self):
         self.add_copy_spec([
+            # Main config file
             "/etc/sssd/sssd.conf",
-            "/var/log/sssd/*",
-            "/var/lib/sss/pubconf/krb5.include.d/*",
             # SSSD 1.14
-            "/etc/sssd/conf.d/*.conf"
+            "/etc/sssd/conf.d/*.conf",
+            # Main logs directory
+            "/var/log/sssd/*",
+            # Memory cache
+            "/var/lib/sss/mc/*",
+            # Dynamic Kerberos configuration
+            "/var/lib/sss/pubconf/krb5.include.d/*"
         ])
 
         # call sssctl commands only when sssd service is running,


### PR DESCRIPTION
SSSD plugin by default collects only logs and configuration.
This patch enables collecting memory cache maintained
by SSSD daemon. Cache does not contain any client sensible
data so can be safely included in the sos-report.

Signed-off-by: Paweł Poławski <ppolawsk@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
