### PR TITLE
[rhcos] update relevant packages and services

### DIFF
--- a/sos/report/plugins/rhcos.py
+++ b/sos/report/plugins/rhcos.py
@@ -16,15 +16,23 @@ class RHCoreOS(Plugin, RedHatPlugin):
     short_desc = 'Red Hat CoreOS'
 
     plugin_name = 'rhcos'
-    packages = ('redhat-release-coreos', 'coreos-metadata')
+    packages = ('afterburn', 'redhat-release-coreos')
 
     def setup(self):
-        units = ['coreos-growpart', 'coreos-firstboot-complete']
+        units = ['coreos-boot-edit', 'coreos-copy-firstboot-network',
+                 'coreos-generate-iscsi-initiatorname',
+                 'coreos-gpt-setup', 'coreos-teardown-initramfs',
+                 'gcp-routes', 'ignition-disks', 'ignition-fetch',
+                 'ignition-fetch-offline', 'ignition-files',
+                 'ignition-firstboot-complete', 'ignition-mount',
+                 'ignition-ostree-growfs', 'ignition-ostree-populate-var',
+                 'ignition-remount-system', 'ignition-setup-user']
+
         for unit in units:
             self.add_journal(unit)
 
         self.add_cmd_output(
-            'coreos-metadata --cmdline --attributes /dev/stdout',
+            'afterburn --cmdline --attributes /dev/stdout',
             timeout=60
         )
 


### PR DESCRIPTION
This replaces the `coreos-metadata` package with `afterburn`, which
has been in use for multiple releases now.

Additionally, this expands the list of services queried to include a
number of relevant Ignition services that are run early during boot.
Ignition related failures are responsible for a good portion of RHCOS
related problems, so grabbing those logs is prudent.

Signed-off-by: Micah Abbott <miabbott@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
