### PR TITLE
Capture 'dmsetup udevcookies'

### DIFF
--- a/sos/report/plugins/devicemapper.py
+++ b/sos/report/plugins/devicemapper.py
@@ -24,6 +24,7 @@ class DeviceMapper(Plugin, IndependentPlugin):
             "dmsetup table",
             "dmsetup status",
             "dmsetup ls --tree",
+            "dmsetup udevcookies",
             "dmstats list",
             "dmstats print --allregions"
         ])


### PR DESCRIPTION
This patch enables the devicemapper plugin to capture
udevcookies, which is a cookie used for all LVM and
device-mapper commands to synchronize with udev processing.
This output, in combination with the output of ipcs,
helps debug various synchronization issues.

Resolves: #2450 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
