### PR TITLE
[gluster] collect public keys from the right dir

### DIFF
--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -76,9 +76,8 @@ class Gluster(Plugin, RedHatPlugin):
             "/var/lib/glusterd/",
             # collect nfs-ganesha related configuration
             "/run/gluster/shared_storage/nfs-ganesha/",
-            # collect status files and public ssh keys
-            "/var/lib/glusterd/.keys/",
-            "/var/lib/glusterd/glusterfind/"
+            # collect public ssh keys (a_s_c skips implicit hidden files)
+            "/var/lib/glusterd/glusterfind/.keys/",
         ] + glob.glob('/run/gluster/*tier-dht/*'))
 
         if not self.get_option("all_logs"):


### PR DESCRIPTION
Collection of glusterfind dir is achieved by /var/lib/gluster
so it doesn't be collected explicitly.

/var/lib/glusterd/glusterfind/.keys/ subdir is required to be
explicitly collected, as add_copy_spec uses glob.glob() that skips
hidden files.

Resolves: #2451

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
