### PR TITLE
[cups] Add cups-browsed from journal logs

### DIFF
--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -40,5 +40,6 @@ class Cups(Plugin, IndependentPlugin):
         ])
 
         self.add_journal(units="cups")
+        self.add_journal(units="cups-browsed")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Gather logs from the service cups-browsed sent
to the journal.

Resolves: RHBZ#1939963
Closes: #2452 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
