### PR TITLE
[WIP] [cups] Add gathering job logs into separate files

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2332,7 +2332,7 @@ class Plugin(object):
     def add_journal(self, units=None, boot=None, since=None, until=None,
                     lines=None, allfields=False, output=None,
                     timeout=cmd_timeout, identifier=None, catalog=None,
-                    sizelimit=None, pred=None, tags=[]):
+                    sizelimit=None, otherargs=None, pred=None, tags=[]):
         """Collect journald logs from one of more units.
 
         :param units:   Which journald units to collect
@@ -2420,6 +2420,10 @@ class Plugin(object):
 
         if output:
             journal_cmd += output_opt % output
+
+        if otherargs:
+            for arg in otherargs:
+                journal_cmd += ' {}'.format(arg)
 
         self._log_debug("collecting journal: %s" % journal_cmd)
         self._add_cmd_output(cmd=journal_cmd, timeout=timeout,

--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -6,6 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
+from re import compile
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
@@ -17,6 +19,37 @@ class Cups(Plugin, IndependentPlugin):
     profiles = ('hardware',)
 
     packages = ('cups',)
+
+    def get_jids(self, dir="/var/spool/cups", n_jids=10,
+                 exists_f=os.path.exists, listdir_f=os.listdir):
+        jids = []
+
+        if not exists_f(dir):
+            return
+
+        spool_files = listdir_f(dir)
+
+        jid_pattern = compile(r'c0*')
+
+        for file in spool_files:
+            matched = jid_pattern.search(file)
+            if not matched:
+                continue
+            jids.append(file[matched.span()[1]:])
+
+        return jids[-n_jids:]
+
+    def get_jid_strings(self):
+        jid_strings = []
+
+        jids = self.get_jids()
+
+        if not jids:
+            return
+
+        jid_strings = ["JID={}".format(jid) for jid in jids]
+
+        return jid_strings
 
     def setup(self):
         if not self.get_option("all_logs"):
@@ -40,5 +73,13 @@ class Cups(Plugin, IndependentPlugin):
         ])
 
         self.add_journal(units="cups")
+
+        jid_arguments = self.get_jid_strings()
+
+        if not jid_arguments:
+            return
+
+        for jid_arg in jid_arguments:
+            self.add_journal(units="cups", otherargs=[jid_arg])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
All CUPS logs are sent to journal in Fedora/RHEL, so job related logs
are hidden within other logs. The job specific logs can be obtained by
`journalctl -u cups JID=N`, where N is a job id.
This feature introduces gathering 10 latest job logs (to prevent big
sosreports on print servers) one by one via `journalctl` command. I
enhanced `add_journal()` arguments with `otherargs`, which is a list of
commands which can be added to `journalctl` command. It contains a list
of JID strings for CUPS ['JID=1', 'JID=2', 'JID=3'].

Closes: RHBZ#1940310
Signed-off-by: Zdenek Dohnal <zdohnal@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
