### PR TITLE
[cleaner] Skip Ubuntu user to prevent false positive

### DIFF
--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -30,7 +30,8 @@ class SoSUsernameParser(SoSCleanerParser):
     skip_list = [
         'nobody',
         'nfsnobody',
-        'root'
+        'root',
+        'ubuntu'
     ]
 
     def __init__(self, conf_file=None, opt_names=None):


### PR DESCRIPTION
Default ubuntu user uses UID 1000 by default.

Closes: #2454

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
