### PR TITLE
[tests] Fix typo

### DIFF
--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -171,7 +171,7 @@ test_mask () {
         ip_addr=$(ip route show default | awk '/default/ {print $3}')
         if [ "$(grep -rI $ip_addr /var/tmp/sosreport_test/*)" ]; then
             add_failure "IP address not obfuscated in all places"
-            echo "$(grep -rI $ip_addr /var/tmp/sosreport/_test/*)"
+            echo "$(grep -rI $ip_addr /var/tmp/sosreport_test/*)"
         fi
         update_failures
     fi


### PR DESCRIPTION
/var/tmp/sosreport_test/ instead of
/var/tmp/sosreport/_test/

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
