### PR TITLE
[iscsi] Mask passwords in iscsid.conf file

### DIFF
--- a/sos/report/plugins/iscsi.py
+++ b/sos/report/plugins/iscsi.py
@@ -33,6 +33,20 @@ class Iscsi(Plugin):
             "iscsiadm -m node --op=show"
         ])
 
+    def postproc(self):
+        # Example for scrubbing node.session.auth.password
+        #
+        # node.session.auth.password = jfaiu1nNQJcsa,sti4lho'jZia=ia
+        #
+        # to
+        #
+        # node.session.auth.password = ********
+        nodesessionpwd = r"(node\.session\.auth\.password\s+=\s+)(\S+)"
+        discoverypwd = r"(discovery\.sendtargets\.auth\.password\s+=\s+)(\S+)"
+        repl = r"\1********\n"
+        self.do_path_regex_sub('/etc/iscsi/iscsid.conf', nodesessionpwd, repl)
+        self.do_path_regex_sub('/etc/iscsi/iscsid.conf', discoverypwd, repl)
+
 
 class RedHatIscsi(Iscsi, RedHatPlugin):
 


### PR DESCRIPTION
The following passwords are collected unencrypted:

node.session.auth.password
discovery.sendtargets.auth.password

This patch ofbuscates these two entries in
/etc/iscsi/iscsid.conf

An example of this obfuscation:

```
3c3,4
< node.session.auth.password = jfaiuunNQJcaasa,stillhooo'jmiajia
---
> node.session.auth.password = ********
6c7,8
< discovery.sendtargets.auth.password = jfaiuunNQJcaasa,stillhooo'jmiajia
---
> discovery.sendtargets.auth.password = ********
```
Resolves: #2461 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
