### PR TITLE
[sssd] Collect memory cache individual files

### DIFF
--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -23,18 +23,21 @@ class Sssd(Plugin):
 
     def setup(self):
         self.add_copy_spec([
-            # Main config file
+            # main config file
             "/etc/sssd/sssd.conf",
             # SSSD 1.14
             "/etc/sssd/conf.d/*.conf",
-            # Memory cache
-            "/var/lib/sss/mc/*",
-            # Dynamic Kerberos configuration
+            # dynamic Kerberos configuration
             "/var/lib/sss/pubconf/krb5.include.d/*"
         ])
 
         # add individual log files
         self.add_copy_spec(glob("/var/log/sssd/*log*"))
+
+        # add memory cache
+        self.add_copy_spec(["/var/lib/sss/mc/passwd",
+                            "/var/lib/sss/mc/group",
+                            "/var/lib/sss/mc/initgroups"])
 
         # call sssctl commands only when sssd service is running,
         # otherwise the command timeouts


### PR DESCRIPTION
By default SSSD collects all memory cache files:
* /var/lib/sss/mc/passwd
* /var/lib/sss/mc/group
* /var/lib/sss/mc/initgroups

They all are included in 25MB size limit for sosreport.
This commits add memory cache files one - by - one,
this way 25MB size limit will be aplied per file.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
