### PR TITLE
[scsi] add scsi tapes cmd function

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -339,7 +339,8 @@ class SoSReport(SoSComponent):
     def _get_hardware_devices(self):
         self.devices = {
             'block': self.get_block_devs(),
-            'fibre': self.get_fibre_devs()
+            'fibre': self.get_fibre_devs(),
+	    'tape' : self.get_tape_devs()
         }
         # TODO: enumerate network devices, preferably with devtype info
 
@@ -376,6 +377,27 @@ class SoSReport(SoSComponent):
         except Exception as err:
             self.soslog.error("Could not get block device list: %s" % err)
             return []
+
+    def get_tape_devs(self):
+        """Enumerate a list of tape devices on this system so that plugins
+        can iterate over them
+
+        These devices are used by add_tape_cmd() in the Plugin class.
+        """
+        try:
+            devs = []
+            devdirs = [
+                'scsi_tape',
+                'lin_tape'
+            ]
+            for devdir in devdirs:
+                if os.path.isdir("/sys/class/%s" % devdir):
+                    devs.extend(glob.glob("/sys/class/%s/*" % devdir))
+            return devs
+        except Exception as err:
+            self.soslog.error("Could not get tape device list: %s" % err)
+            return []
+
 
     def _get_namespaces(self):
         self.namespaces = {

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -340,7 +340,7 @@ class SoSReport(SoSComponent):
         self.devices = {
             'block': self.get_block_devs(),
             'fibre': self.get_fibre_devs(),
-	    'tape' : self.get_tape_devs()
+            'tape': self.get_tape_devs()
         }
         # TODO: enumerate network devices, preferably with devtype info
 
@@ -397,7 +397,6 @@ class SoSReport(SoSComponent):
         except Exception as err:
             self.soslog.error("Could not get tape device list: %s" % err)
             return []
-
 
     def _get_namespaces(self):
         self.namespaces = {

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -370,7 +370,7 @@ class SoSReport(SoSComponent):
         """Enumerate a list of block devices on this system so that plugins
         can iterate over them
 
-        These devices are used by add_blockdev_cmd() in the Plugin class.
+        These devices are used by add_device_cmd() in the Plugin class.
         """
         try:
             return os.listdir('/sys/block/')

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1570,9 +1570,9 @@ class Plugin(object):
                              tags=_dev_tags)
 
     def add_tape_cmd(self, cmds, devices='tape', timeout=300,
-                         sizelimit=None, chroot=True, runat=None, env=None,
-                         binary=False, prepend_path=None, whitelist=[],
-                         blacklist=[], tags=[]):
+                     sizelimit=None, chroot=True, runat=None, env=None,
+                     binary=False, prepend_path=None, whitelist=[],
+                     blacklist=[], tags=[]):
         _dev_tags = []
         prepend_path = prepend_path or '/dev/'
         devices = self.devices['tape']

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1569,6 +1569,21 @@ class Plugin(object):
                              whitelist=whitelist, blacklist=blacklist,
                              tags=_dev_tags)
 
+    def add_tape_cmd(self, cmds, devices='tape', timeout=300,
+                         sizelimit=None, chroot=True, runat=None, env=None,
+                         binary=False, prepend_path=None, whitelist=[],
+                         blacklist=[], tags=[]):
+        _dev_tags = []
+        prepend_path = prepend_path or '/dev/'
+        devices = self.devices['tape']
+        _dev_tags.append('block')
+        _dev_tags.extend(tags)
+        self._add_device_cmd(cmds, devices, timeout=timeout,
+                             sizelimit=sizelimit, chroot=chroot, runat=runat,
+                             env=env, binary=binary, prepend_path=prepend_path,
+                             whitelist=whitelist, blacklist=blacklist,
+                             tags=_dev_tags)
+
     def _add_device_cmd(self, cmds, devices, timeout=300, sizelimit=None,
                         chroot=True, runat=None, env=None, binary=False,
                         prepend_path=None, whitelist=[], blacklist=[],

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1505,10 +1505,10 @@ class Plugin(object):
                     'tags': _spec_tags
                 })
 
-    def add_blockdev_cmd(self, cmds, devices='block', timeout=300,
-                         sizelimit=None, chroot=True, runat=None, env=None,
-                         binary=False, prepend_path=None, whitelist=[],
-                         blacklist=[], tags=[]):
+    def add_device_cmd(self, cmds, devices='block', timeout=300,
+                       sizelimit=None, chroot=True, runat=None, env=None,
+                       binary=False, prepend_path=None, whitelist=[],
+                       blacklist=[], tags=[]):
         """Run a command or list of commands against storage-related devices.
 
         Any commands specified by cmd will be iterated over the list of the
@@ -1562,21 +1562,9 @@ class Plugin(object):
         if devices == 'fibre':
             devices = self.devices['fibre']
             _dev_tags.append('fibre')
-        _dev_tags.extend(tags)
-        self._add_device_cmd(cmds, devices, timeout=timeout,
-                             sizelimit=sizelimit, chroot=chroot, runat=runat,
-                             env=env, binary=binary, prepend_path=prepend_path,
-                             whitelist=whitelist, blacklist=blacklist,
-                             tags=_dev_tags)
-
-    def add_tape_cmd(self, cmds, devices='tape', timeout=300,
-                     sizelimit=None, chroot=True, runat=None, env=None,
-                     binary=False, prepend_path=None, whitelist=[],
-                     blacklist=[], tags=[]):
-        _dev_tags = []
-        prepend_path = prepend_path or '/dev/'
-        devices = self.devices['tape']
-        _dev_tags.append('block')
+        if devices == 'tape':
+            devices = self.devices['tape']
+            _dev_tags.append('tape')
         _dev_tags.extend(tags)
         self._add_device_cmd(cmds, devices, timeout=timeout,
                              sizelimit=sizelimit, chroot=chroot, runat=runat,

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -49,7 +49,7 @@ class Block(Plugin, IndependentPlugin):
             "udevadm info %(dev)s",
             "udevadm info -a %(dev)s"
         ]
-        self.add_blockdev_cmd(cmds, blacklist='ram.*')
+        self.add_device_cmd(cmds, blacklist='ram.*')
 
         lsblk = self.collect_cmd_output("lsblk -f -a -l")
         # for LUKS devices, collect cryptsetup luksDump

--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -28,7 +28,7 @@ class Fibrechannel(Plugin, RedHatPlugin):
     ]
 
     def setup(self):
-        self.add_blockdev_cmd("udevadm info -a %(dev)s", devices='fibre')
+        self.add_device_cmd("udevadm info -a %(dev)s", devices='fibre')
         if self.get_option('debug'):
             self.add_copy_spec(self.debug_paths)
 

--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -18,8 +18,8 @@ class Md(Plugin, IndependentPlugin):
 
     def setup(self):
         self.add_cmd_output("mdadm -D /dev/md*")
-        self.add_blockdev_cmd("mdadm -E %(dev)s",
-                              blacklist=['ram.*', 'zram.*'])
+        self.add_device_cmd("mdadm -E %(dev)s",
+                            blacklist=['ram.*', 'zram.*'])
         self.add_copy_spec([
             "/proc/mdstat",
             "/etc/mdadm.conf",

--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -34,6 +34,6 @@ class Nvme(Plugin, IndependentPlugin):
             "nvme error-log %(dev)s",
             "nvme show-regs %(dev)s"
         ]
-        self.add_blockdev_cmd(cmds, whitelist='nvme.*')
+        self.add_device_cmd(cmds, whitelist='nvme.*')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -46,4 +46,11 @@ class Scsi(Plugin, IndependentPlugin):
         self.add_blockdev_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,
                               prepend_path='/sys/class/scsi_host')
 
+        cmds = [
+            "udevadm info %(dev)s",
+            "udevadm info -a %(dev)s"
+        ]
+        self.add_tape_cmd(cmds, devices='tape',
+                          prepend_path='/dev/')
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -43,14 +43,14 @@ class Scsi(Plugin, IndependentPlugin):
         ])
 
         scsi_hosts = glob("/sys/class/scsi_host/*")
-        self.add_blockdev_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,
-                              prepend_path='/sys/class/scsi_host')
+        self.add_device_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,
+                            prepend_path='/sys/class/scsi_host')
 
         cmds = [
             "udevadm info %(dev)s",
             "udevadm info -a %(dev)s"
         ]
-        self.add_tape_cmd(cmds, devices='tape',
-                          prepend_path='/dev/')
+        self.add_device_cmd(cmds, devices='tape',
+                            prepend_path='/dev/')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This commit enables the capture of SCSI tape 
information via two commands:

udevadm info -a <tape device>
udevadm info <tape device>

It relies on two commits. The first one adds the required
commands in the scsi plugin, the second one adds the 
function get_tape_devs() and add_blockdev_cmd() so 
plugins can iterate over them. It's based on get_block_devs().

Resolves: #2463

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
