### PR TITLE
[cleaner] Only skip packaging-based files for the IP parser

### DIFF
--- a/sos/cleaner/obfuscation_archive.py
+++ b/sos/cleaner/obfuscation_archive.py
@@ -59,20 +59,10 @@ class SoSObfuscationArchive():
         Returns: list of files and file regexes
         """
         return [
-            'installed-debs',
-            'installed-rpms',
-            'sos_commands/dpkg',
-            'sos_commands/python/pip_list',
-            'sos_commands/rpm',
-            'sos_commands/yum/.*list.*',
-            'sos_commands/snappy/snap_list_--all',
-            'sos_commands/snappy/snap_--version',
-            'sos_commands/vulkan/vulkaninfo',
             'sys/firmware',
             'sys/fs',
             'sys/kernel/debug',
             'sys/module',
-            'var/log/.*dnf.*',
             r'.*\.tar$',  # TODO: support archive unpacking
             # Be explicit with these tar matches to avoid matching commands
             r'.*\.tar\.xz',

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -24,6 +24,22 @@ class SoSIPParser(SoSCleanerParser):
         # don't match package versions recorded in journals
         r'.*dnf\[.*\]:'
     ]
+
+    skip_files = [
+        # skip these as version numbers will frequently look like IP addresses
+        # when using regex matching
+        'installed-debs',
+        'installed-rpms',
+        'sos_commands/dpkg',
+        'sos_commands/python/pip_list',
+        'sos_commands/rpm',
+        'sos_commands/yum/.*list.*',
+        'sos_commands/snappy/snap_list_--all',
+        'sos_commands/snappy/snap_--version',
+        'sos_commands/vulkan/vulkaninfo',
+        'var/log/.*dnf.*'
+    ]
+
     map_file_key = 'ip_map'
     prep_map_file = 'sos_commands/networking/ip_-o_addr'
 


### PR DESCRIPTION
Files primarily containing package information, e.g. `installed-rpms` or
`installed-debs`, were previously being skipped by all parsers. In
reality, we only need to skip these for the IP parser due to the fact
that version numbers often generate a match for IP address regexes.

This will also fix a problem where if a system was the build host for
certain packages, the hostname would remain in these files as the
hostname parser was previously not checking these files.

Closes: #2400
Resolves: #2464

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
