### PR TITLE
[tests] ignore devlink for certains kernel config

### DIFF
--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -102,7 +102,7 @@ add_failure () {
 test_normal_report () {
     cmd="-vvv"
     # get a list of initial kmods loaded
-    kmods=( $(lsmod | cut -f1 -d ' ' | sort) )
+    kmods=( $(lsmod | grep -v devlink | cut -f1 -d ' ' | sort) )
     run_expecting_success "$cmd" extract
     if [ $? -eq 0 ]; then
         if [ ! -f /var/tmp/sosreport_test/sos_reports/sos.html ]; then
@@ -118,7 +118,7 @@ test_normal_report () {
             add_failure "did not find debug logging when using -vvv"
         fi
         # new list, see if we added any
-        new_kmods=( $(lsmod | cut -f1 -d ' ' | sort) )
+        new_kmods=( $(lsmod | grep -v devlink | cut -f1 -d ' ' | sort) )
         if [ "$(printf '%s\n' "${kmods[@]}" "${new_kmods[@]}" | sort | uniq -u)" ]; then
             add_failure "new kernel modules loaded during execution"
             echo "$(printf '%s\n' "${kmods[@]}" "${new_kmods[@]}" | sort | uniq -u)"


### PR DESCRIPTION
Ignore devlink module for kernel configuration where
devlink is set as loadable module (=m). The module
may automatically load after devlink cmd is performed
by the networking plugin.

sosreport reproducer:
 $ lsmod | grep -i devlink
 $ sos report -o networking

sosreport (version 4.1)

.....

Your sosreport has been generated and saved in:
 /tmp/sosreport-srv-2021-03-31-tvjgeyv.tar.xz

 Size 29.75KiB
 Owner root
 sha256 72d49c26463f8fe42f11696dbc69aaa6eaf4e621551d88822b72a6f27ed7a136

Please send this file to your support representative.

 $ lsmod | grep -i devlink
devlink 45056 0

More precisely caused after this specific code line:
https://github.com/sosreport/sos/blob/master/sos/report/plugins/networking.py#L109

Manual reproducer:
 $ lsmod | grep -i devlink
 $ devlink dev
 $ lsmod | grep -i devlink
 devlink 45056 0

Closes: #2468

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
