### PR TITLE
[sssd] legacy-3.9 merge of PR #2445 #2444 #2462

### DIFF
--- a/sos/plugins/sssd.py
+++ b/sos/plugins/sssd.py
@@ -10,6 +10,7 @@
 
 from sos.plugins import (Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin,
                          SoSPredicate)
+from glob import glob
 
 
 class Sssd(Plugin):
@@ -23,11 +24,13 @@ class Sssd(Plugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/sssd/sssd.conf",
-            "/var/log/sssd/*",
             "/var/lib/sss/pubconf/krb5.include.d/*",
             # SSSD 1.14
             "/etc/sssd/conf.d/*.conf"
         ])
+
+        # add individual log files
+        self.add_copy_spec(glob("/var/log/sssd/*log*"))
 
         # call sssctl commands only when sssd service is running,
         # otherwise the command timeouts


### PR DESCRIPTION
The issue is that SSSD creates individual log files for its
components. To be able to track the issue we need all of them.

With one wildcard copy set we usually get just one truncated
log file and this is not very useful for solving issues. We
need to track the request accross logs to understand the
problem. Also log file names are specific for paricular
configuration.

With this patch we list log files under /var/log/sssd and
we add them one by one.

SSSD plugin by default collects only logs and configuration.
This patch enables collecting memory cache maintained
by SSSD daemon. Cache does not contain any client sensible
data so can be safely included in the sos-report.

By default SSSD collects all memory cache files:

/var/lib/sss/mc/passwd
/var/lib/sss/mc/group
/var/lib/sss/mc/initgroups
They all are included in 25MB size limit for sosreport.
This commits add memory cache files one - by - one,
this way 25MB size limit will be aplied per file

Related: #2445
Related: #2444
Related: #2462
Resolves: #2475

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
