### PR TITLE
[sosnode] Update regex parsing for newer plugin option output

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -283,11 +283,12 @@ class SosNode():
     def _load_sos_plugins(self, sosinfo):
         ENABLED = 'The following plugins are currently enabled:'
         DISABLED = 'The following plugins are currently disabled:'
+        ALL_OPTIONS = 'The following options are available for ALL plugins:'
         OPTIONS = 'The following plugin options are available:'
         PROFILES = 'Profiles:'
 
         enablereg = ENABLED + '(.*?)' + DISABLED
-        disreg = DISABLED + '(.*?)' + OPTIONS
+        disreg = DISABLED + '(.*?)' + ALL_OPTIONS
         optreg = OPTIONS + '(.*?)' + PROFILES
         proreg = PROFILES + '(.*?)' + '\n\n'
 


### PR DESCRIPTION
In order to determine the available plugins on each node, `collect`
parses the `--list` output. This relies on several multiline regexes
that are built from the headers from each section printed in that
output.

Since there are now options available to every plugin, the order of
output sections has changed, and `collect` needs to break parsing
earlier to avoid scraping non-plugin-name strings into the available
plugin list for each node.

Resolves: #2477

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
