### PR TITLE
[ubuntu|Policy] Fix exception when attempting upload

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -149,6 +149,7 @@ class LinuxPolicy(Policy):
         self.upload_user = cmdline_opts.upload_user
         self.upload_directory = cmdline_opts.upload_directory
         self.upload_password = cmdline_opts.upload_pass
+        self.upload_archive_name = ''
 
         if not cmdline_opts.batch and not \
                 cmdline_opts.quiet:
@@ -237,7 +238,7 @@ class LinuxPolicy(Policy):
         `get_upload_url_string()`
             Print a more human-friendly string than vendor URLs
         """
-        self.upload_archive = archive
+        self.upload_archive_name = archive
         if not self.upload_url:
             self.upload_url = self.get_upload_url()
         if not self.upload_url:
@@ -384,7 +385,7 @@ class LinuxPolicy(Policy):
             raise Exception("Unable to upload due to missing python requests "
                             "library")
 
-        with open(self.upload_archive, 'rb') as arc:
+        with open(self.upload_archive_name, 'rb') as arc:
             if not self._use_https_streaming:
                 r = self._upload_https_no_stream(arc)
             else:
@@ -467,9 +468,9 @@ class LinuxPolicy(Policy):
                             % str(err))
 
         try:
-            with open(self.upload_archive, 'rb') as _arcfile:
+            with open(self.upload_archive_name, 'rb') as _arcfile:
                 session.storbinary(
-                    "STOR %s" % self.upload_archive.split('/')[-1],
+                    "STOR %s" % self.upload_archive_name.split('/')[-1],
                     _arcfile
                 )
             session.quit()

--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -74,7 +74,9 @@ class UbuntuPolicy(DebianPolicy):
 
     def get_upload_url(self):
         if not self.upload_url or self.upload_url.startswith(self._upload_url):
-            fname = os.path.basename(self.upload_archive)
+            if not self.upload_archive_name:
+                return self._upload_url
+            fname = os.path.basename(self.upload_archive_name)
             return self._upload_url + fname
         super(UbuntuPolicy, self).get_upload_url()
 


### PR DESCRIPTION
Fixes an issue where an upload attempt on Ubuntu systems would fail with
a traceback due to the upload archive's name not being available when we
first check to make sure we have an upload location, since the Ubuntu
default location requires an archive/file name.

Related to this, stop clobbering `upload_archive` and assign the archive
name to an `upload_archive_name` variable instead.

Closes: #2472
Resolves: #2479

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
