### PR TITLE
[cleaner] Do not break iteration of parse_string_for_keys on first match

### DIFF
--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -104,7 +104,7 @@ class SoSCleanerParser():
         """
         for key, val in self.mapping.dataset.items():
             if key in string_data:
-                return string_data.replace(key, val)
+                string_data = string_data.replace(key, val)
         return string_data
 
     def get_map_contents(self):


### PR DESCRIPTION
Previously, `parse_string_for_keys()`, called by `obfuscate_string()`
for non-regex based obfuscations, would return on the first match in the
string found for each parser.

Instead, continue iterating over all items in each parser's dataset
before returning the (now fully) obfuscated string.

Resolves: #2480

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
