### PR TITLE
[ata] Convert to using add_blockdev_cmd()

### DIFF
--- a/sos/report/plugins/ata.py
+++ b/sos/report/plugins/ata.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, IndependentPlugin
-import os
 
 
 class Ata(Plugin, IndependentPlugin):
@@ -20,18 +19,13 @@ class Ata(Plugin, IndependentPlugin):
     packages = ('hdparm', 'smartmontools')
 
     def setup(self):
-        dev_path = '/dev'
-        sys_block = '/sys/block'
         self.add_copy_spec('/proc/ide')
-        if os.path.isdir(sys_block):
-            for disk in os.listdir(sys_block):
-                if disk.startswith("sd") or disk.startswith("hd"):
-                    disk_path = os.path.join(dev_path, disk)
-                    self.add_cmd_output([
-                        "hdparm %s" % disk_path,
-                        "smartctl -a %s" % disk_path,
-                        "smartctl -l scterc %s" % disk_path,
-                    ])
+        cmd_list = [
+            "hdparm %(dev)s",
+            "smartctl -a %(dev)s",
+            "smartctl -l scterc %(dev)s"
+        ]
+        self.add_blockdev_cmd(cmd_list, whitelist=['sd.*', 'hd.*'])
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Converts the `ata` plugin to using the `add_block_dev()` method instead
of generating it's own list of device paths.

Closes: #2430
Resolves: #2481

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
