### PR TITLE
[cloud_init] Collect command output and update file collections

### DIFF
--- a/sos/report/plugins/cloud_init.py
+++ b/sos/report/plugins/cloud_init.py
@@ -20,10 +20,16 @@ class CloudInit(Plugin, IndependentPlugin):
     services = ('cloud-init',)
 
     def setup(self):
+
+        self.add_cmd_output([
+            'cloud-init --version',
+            'cloud-init features',
+            'cloud-init status'
+        ])
+
         self.add_copy_spec([
-            '/var/lib/cloud/',
             '/etc/cloud/',
-            '/run/cloud-init/cloud-init-generator.log',
+            '/run/cloud-init/',
             '/var/log/cloud-init*'
         ])
 


### PR DESCRIPTION
Adds collection of several `cloud-init` command outputs, and
additionally updates the file collections performed based on the
behavior of `cloud-init collect-logs`.

Most notably, removes the collection of `/var/lib/cloud-init` to avoid
possible user sensitive data being collected.

Closes: #2080
Resolves: #2485

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
