### PR TITLE
[ipmitool] Add elist and lan command output

### DIFF
--- a/sos/report/plugins/ipmitool.py
+++ b/sos/report/plugins/ipmitool.py
@@ -21,19 +21,18 @@ class IpmiTool(Plugin, RedHatPlugin, DebianPlugin):
     packages = ('ipmitool',)
 
     def setup(self):
+        cmd = "ipmitool"
         result = self.collect_cmd_output("ipmitool -I usb mc info")
-        have_usbintf = result['status']
-
-        if not have_usbintf:
-            cmd = "ipmitool -I usb"
-        else:
-            cmd = "ipmitool"
+        if result['status'] == 0:
+            cmd += " -I usb"
 
         self.add_cmd_output([
             "%s sel info" % cmd,
-            "%s sel list" % cmd,
+            "%s sel elist" % cmd,
+            "%s sel list -v" % cmd,
             "%s sensor list" % cmd,
             "%s chassis status" % cmd,
+            "%s lan print" % cmd,
             "%s fru print" % cmd,
             "%s mc info" % cmd,
             "%s sdr info" % cmd


### PR DESCRIPTION
This commit adds collection of `ipmitool isel elist` and adds verbosity to
the regular `ipmitool sel list` collection.

Additionally, simplify the base command construction logic, and pull in
`ipmitool lan print` from #998. Note that network obfuscation is
relegated to the use of `sos clean` here, rather than doing plugin-based
scrubbing.

Closes: #998
Closes: #2015
Resolves: #2486

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
