### PR TITLE
[networking] check for the presence of devlink

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -9,6 +9,7 @@
 from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
                                 DebianPlugin, SoSPredicate)
 from os import listdir
+from os import path
 
 
 class Networking(Plugin):
@@ -103,15 +104,20 @@ class Networking(Plugin):
             "ip neigh show nud noarp",
             "biosdevname -d",
             "tc -s qdisc show",
-            "devlink dev param show",
-            "devlink dev info",
         ])
 
-        devlinks = self.collect_cmd_output("devlink dev")
-        if devlinks['status'] == 0:
-            devlinks_list = devlinks['output'].splitlines()
-            for devlink in devlinks_list:
-                self.add_cmd_output("devlink dev eswitch show %s" % devlink)
+        if path.isdir('/sys/class/devlink'):
+            self.add_cmd_output([
+                "devlink dev param show",
+                "devlink dev info",
+            ])
+
+            devlinks = self.collect_cmd_output("devlink dev")
+            if devlinks['status'] == 0:
+                devlinks_list = devlinks['output'].splitlines()
+                for devlink in devlinks_list:
+                    self.add_cmd_output("devlink dev eswitch show %s" %
+                                        devlink)
 
         # below commands require some kernel module(s) to be loaded
         # run them only if the modules are loaded, or if explicitly requested


### PR DESCRIPTION
On certain kernel configuration, devlink cmds may trigger
the module to load.

Closes: #2468

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
