### PR TITLE
[clean] Improve collect cleaning consistency

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -508,7 +508,7 @@ third party.
                     for line in content.splitlines():
                         if isinstance(_parser, SoSHostnameParser):
                             _parser.load_hostname_into_map(line)
-                        self.obfuscate_line(line, _parser.prep_map_file)
+                        self.obfuscate_line(line)
                 except Exception as err:
                     self.log_debug("Could not prep %s: %s" % (_arc_path, err))
 
@@ -606,7 +606,7 @@ third party.
                 if not line.strip():
                     continue
                 try:
-                    line, count = self.obfuscate_line(line, short_name)
+                    line, count = self.obfuscate_line(line)
                     subs += count
                     tfile.write(line)
                 except Exception as err:
@@ -631,7 +631,7 @@ third party.
                 pass
         return string_data
 
-    def obfuscate_line(self, line, filename):
+    def obfuscate_line(self, line):
         """Run a line through each of the obfuscation parsers, keeping a
         cumulative total of substitutions done on that particular line.
 
@@ -639,16 +639,11 @@ third party.
 
             :param line str:        The raw line as read from the file being
                                     processed
-            :param filename str:    Filename the line was read from
 
         Returns the fully obfuscated line and the number of substitutions made
         """
         count = 0
         for parser in self.parsers:
-            if filename and any([
-                re.match(_s, filename) for _s in parser.skip_files
-            ]):
-                continue
             try:
                 line, _count = parser.parse_line(line)
                 count += _count

--- a/sos/cleaner/obfuscation_archive.py
+++ b/sos/cleaner/obfuscation_archive.py
@@ -219,8 +219,6 @@ class SoSObfuscationArchive():
             :param filename str:        Filename relative to the extracted
                                         archive root
         """
-        if filename in self.file_sub_list:
-            return True
 
         if not os.path.isfile(self.get_file_path(filename)):
             return True

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -39,16 +39,15 @@ class SoSUsernameParser(SoSCleanerParser):
         super(SoSUsernameParser, self).__init__(conf_file)
         self.mapping.load_names_from_options(opt_names)
 
-    def load_usernames_into_map(self, fname):
+    def load_usernames_into_map(self, content):
         """Since we don't get the list of usernames from a straight regex for
         this parser, we need to override the initial parser prepping here.
         """
-        with open(fname, 'r') as lastfile:
-            for line in lastfile.read().splitlines()[1:]:
-                user = line.split()[0]
-                if user in self.skip_list:
-                    continue
-                self.mapping.get(user)
+        for line in content.splitlines()[1:]:
+            user = line.split()[0]
+            if user in self.skip_list:
+                continue
+            self.mapping.get(user)
 
     def parse_line(self, line):
         count = 0


### PR DESCRIPTION
This 2-patch set resolves issues surrounding the consistency of `--clean` when used with `collect`.

All subsequent archives from a multi-node `collect` should now be properly cleaned every time, just the same
as the first archive. Additionally, we now more accurately prep our mappings for consistent obfuscation across archives
regardless of which order they are obfuscated in.

Closes: #2490
Related: RHBZ#1930181
Resolves: #2492

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
