### PR TITLE
[sosnode] Avoid checksum cleanup if archive was not generated

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -914,10 +914,10 @@ class SosNode():
     def cleanup(self):
         """Remove the sos archive from the node once we have it locally"""
         self.remove_sos_archive()
-        if os.path.isfile(self.sos_path + '.sha256'):
-            self.remove_file(self.sos_path + '.sha256')
-        elif os.path.isfile(self.sos_path + '.md5'):
-            self.remove_file(self.sos_path + '.md5')
+        if self.sos_path:
+            for ext in ['.sha256', '.md5']:
+                if os.path.isfile(self.sos_path + ext):
+                    self.remove_file(self.sos_path + ext)
         cleanup = self.host.set_cleanup_cmd()
         if cleanup:
             self.run_command(cleanup)


### PR DESCRIPTION
Fixes an exception propagation from `cleanup()` where an attempt to look
for and remove a checksum file was made when an archive was not
generated (and thus no checksum would be present either).

Related: #2488
Resolves: #2494

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
