### PR TITLE
[global] Drop plugin version

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -933,9 +933,6 @@ class SoSReport(SoSComponent):
         versions = []
         versions.append("sosreport: %s" % __version__)
 
-        for plugname, plug in self.loaded_plugins:
-            versions.append("%s: %s" % (plugname, plug.version))
-
         self.archive.add_string(content="\n".join(versions),
                                 dest='version.txt')
 

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -417,9 +417,6 @@ class Plugin(object):
     :cvar plugin_name:  The name of the plugin, will be returned by `name()`
     :vartype plugin_name: ``str``
 
-    :cvar version:      The version of the plugin, defaults to 'unversioned'
-    :vartype version:   ``str``
-
     :cvar packages:     Package name(s) that, if installed, enable this plugin
     :vartype packages:  ``tuple``
 
@@ -450,7 +447,6 @@ class Plugin(object):
     """
 
     plugin_name = None
-    version = 'unversioned'
     packages = ()
     files = ()
     commands = ()

--- a/sos/report/plugins/jars.py
+++ b/sos/report/plugins/jars.py
@@ -22,7 +22,6 @@ class Jars(Plugin, RedHatPlugin):
     short_desc = 'Collect information about available Java archives'
 
     plugin_name = "jars"
-    version = "1.0.0"
     profiles = ("java",)
     option_list = [
         ("append_locations", "colon-separated list of additional JAR paths",

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -17,7 +17,6 @@ class Pacemaker(Plugin):
     short_desc = 'Pacemaker high-availability cluster resource manager'
 
     plugin_name = "pacemaker"
-    version = "1.0"
     profiles = ("cluster", )
     packages = (
         "pacemaker",


### PR DESCRIPTION
Plugin version never really took off. A very few plugins
had it configured (e.g. jars, pacemaker)

Closes: #2495

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
