### PR TITLE
[process] Collect per-process files from /proc

### DIFF
--- a/tests/report_tests/plugin_tests/process.py
+++ b/tests/report_tests/plugin_tests/process.py
@@ -1,0 +1,29 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import glob
+import os
+
+from sos_tests import StageOneReportTest
+
+
+class ProcessPluginTest(StageOneReportTest):
+    """
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o process -k process.numprocs=100'
+
+    def test_proc_files_collected(self):
+        self.assertFileGlobInArchive('/proc/*/status')
+        self.assertFileGlobInArchive('/proc/*/stack')
+        self.assertFileGlobInArchive('/proc/*/oom_*')
+
+    def test_option_limited_proc_collection(self):
+        count = glob.glob(os.path.join(self.archive_path, 'proc/*/status'))
+        self.assertTrue(len(count) < 101)


### PR DESCRIPTION
Adds collection of per-process files from /proc/$pid, limited to a
number of pids controlled by the new `process.numprocs` option. This
option will default to the first 2048 processes. Using a value of `0`
for this option will result in all pids being collected.

In testing, the initial limit of 2048 process did not significantly
raise collection time or archive size. Note however, that collection of
20k or more processes does show a significant increase in plugin
execution time and archive size. This is however tempered, by the
whole-plugin timeout that sos imposes.

Related: #436
Closes: #542
Resolves: #1783
Resolves: #2498

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
