### PR TITLE
[cirrus] Add testing on CentOS Stream 8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,20 +7,22 @@ env:
     FEDORA_PRIOR_VER: "32"
     FEDORA_NAME: "fedora-${FEDORA_VER}"
     FEDORA_PRIOR_NAME: "fedora-${FEDORA_PRIOR_VER}"
-    #RHEL_NAME: "rhel-8.3"
 
     UBUNTU_NAME: "ubuntu-20.04"
     UBUNTU_PRIOR_NAME: "ubuntu-18.04"
 
-    RH_PROJECT: "sos-devel-jobs"
+    CENTOS_NAME: "centos-stream-8"
+
+    CENTOS_PROJECT: "centos-cloud"
+    SOS_PROJECT: "sos-devel-jobs"
     UBUNTU_PROJECT: "ubuntu-os-cloud"
 
     # These are generated images pushed to GCP from Red Hat
     FEDORA_IMAGE_NAME: "f${FEDORA_VER}-server-sos-testing"
     FEDORA_PRIOR_IMAGE_NAME: "f${FEDORA_PRIOR_VER}-server-sos-testing"
-    #RHEL_IMAGE_NAME: "${RHEL_NAME}-server-sos-testing"
 
     # Images exist on GCP already
+    CENTOS_IMAGE_NAME: "centos-stream-8-v20210316"
     UBUNTU_IMAGE_NAME: "ubuntu-2004-focal-v20201111"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-1804-bionic-v20201111"
 
@@ -70,21 +72,22 @@ report_stageone_task:
         image_project: "${PROJECT}"
         image_name: "${VM_IMAGE_NAME}"
         cpu: 2
-        memory: "2Gb"
+        memory: "4Gb"
         # minimum disk size is 20
         disk: 20
     matrix:
         - env:
-            PROJECT: ${RH_PROJECT}
+            PROJECT: ${CENTOS_PROJECT}
+            BUILD_NAME: ${CENTOS_NAME}
+            VM_IMAGE_NAME: ${CENTOS_IMAGE_NAME}
+        - env:
+            PROJECT: ${SOS_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env:
-            PROJECT: ${RH_PROJECT}
+            PROJECT: ${SOS_PROJECT}
             BUILD_NAME: ${FEDORA_PRIOR_NAME}
             VM_IMAGE_NAME: ${FEDORA_PRIOR_IMAGE_NAME}
-       # - env:
-       #     BUILD_NAME: ${RHEL_NAME}
-       #     VM_IMAGE_NAME: ${RHEL_IMAGE_NAME}
         - env:
             PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: ${UBUNTU_NAME}
@@ -113,7 +116,11 @@ report_stagetwo_task:
     gce_instance: *standardvm
     matrix:
         - env:
-            PROJECT: ${RH_PROJECT}
+            PROJECT: ${CENTOS_PROJECT}
+            BUILD_NAME: ${CENTOS_NAME}
+            VM_IMAGE_NAME: ${CENTOS_IMAGE_NAME}
+        - env:
+            PROJECT: ${SOS_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env:

--- a/sos/report/plugins/devicemapper.py
+++ b/sos/report/plugins/devicemapper.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
 class DeviceMapper(Plugin, IndependentPlugin):
@@ -16,6 +17,7 @@ class DeviceMapper(Plugin, IndependentPlugin):
     plugin_name = 'devicemapper'
     profiles = ('storage',)
     packages = ('device-mapper',)
+    kernel_mods = ('dm_mod', )
     files = ('/dev/mapper',)
 
     def setup(self):
@@ -27,6 +29,6 @@ class DeviceMapper(Plugin, IndependentPlugin):
             "dmsetup udevcookies",
             "dmstats list",
             "dmstats print --allregions"
-        ])
+        ], pred=SoSPredicate(self, kmods=['dm_mod']))
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -39,7 +39,8 @@ class Grub2(Plugin, IndependentPlugin):
         co = {'cmd': '%s --help' % grub_cmd, 'output': '--no-grubenv-update'}
         if self.test_predicate(self, pred=SoSPredicate(self, cmd_outputs=co)):
             grub_cmd += ' --no-grubenv-update'
-        self.add_cmd_output(grub_cmd, env={'GRUB_DISABLE_OS_PROBER': 'true'})
+        self.add_cmd_output(grub_cmd, env={'GRUB_DISABLE_OS_PROBER': 'true'},
+                            pred=SoSPredicate(self, kmods=['dm_mod']))
 
     def postproc(self):
         # the trailing space is required; python treats '_' as whitespace

--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -12,7 +12,7 @@ import os
 
 from sos_tests import StageOneReportTest, StageTwoReportTest
 from string import ascii_uppercase, digits
-
+from time import sleep
 
 class LogsPluginTest(StageOneReportTest):
     """Ensure common collections from the `logs` plugin are properly collected
@@ -51,22 +51,26 @@ class LogsSizeLimitTest(StageTwoReportTest):
         # write over 100MB to ensure we will actually size limit inside sos,
         # allowing for any compression or de-dupe systemd does
         from systemd import journal
-        rsize = 20 * 1048576
-        for i in range(3):
-            # generate 20MB, write it, then write it in reverse.
+        sosfd = journal.stream('sos-testing')
+        rsize = 10 * 1048576
+        for i in range(6):
+            # generate 10MB, write it, then write it in reverse.
             # Spend less time generating new strings
             rand = ''.join(random.choice(ascii_uppercase + digits) for _ in range(rsize))
-            journal.send(rand)
-            journal.send(rand[::-1])
+            sosfd.write(rand + '\n')
+            # sleep to avoid burst rate-limiting
+            sleep(15)
+            sosfd.write(rand[::-1] + '\n')
 
     def test_journal_size_limit(self):
-        journ = 'sos_commands/logs/journalctl_--no-pager_--catalog_--boot'
+        journ = 'sos_commands/logs/journalctl_--no-pager'
         self.assertFileCollected(journ)
         jsize = os.stat(self.get_name_in_archive(journ)).st_size
         assert jsize <= 105906176, "Collected journal is larger than 100MB (size: %s)" % jsize
         assert jsize > 27262976, "Collected journal limited by --log-size (size: %s)" % jsize
 
     def test_journal_tailed_and_linked(self):
-        self.assertFileCollected('sos_strings/logs/journalctl_--no-pager_--catalog_--boot.tailed')
-        journ = self.get_name_in_archive('sos_commands/logs/journalctl_--no-pager_--catalog_--boot')
+        tailed = self.get_name_in_archive('sos_strings/logs/journalctl_--no-pager.tailed')
+        self.assertFileExists(tailed)
+        journ = self.get_name_in_archive('sos_commands/logs/journalctl_--no-pager')
         assert os.path.islink(journ), "Journal in sos_commands/logs is not a symlink"

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -262,11 +262,11 @@ class BaseSoSReportTest(BaseSoSTest):
             # setup our class-shared tmpdir
             self._setup_tmpdir()
 
-            # do any pre-execution setup
-            self.pre_sos_setup()
-
             # do mocking called for in stage 2+ tests
             self.setup_mocking()
+
+            # do any pre-execution setup
+            self.pre_sos_setup()
 
             # gather some pre-execution information
             self.set_pre_sysinfo()

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -315,7 +315,8 @@ class BaseSoSReportTest(BaseSoSTest):
         """
         if os.path.exists(fname):
             self.assertFileExists(self.get_name_in_archive(fname))
-        assert True
+        else:
+            assert True
 
     def assertFileNotCollected(self, fname):
         """Ensure that a given fname is NOT in the extracted archive
@@ -327,13 +328,16 @@ class BaseSoSReportTest(BaseSoSTest):
 
     def assertFileGlobInArchive(self, fname):
         """Ensure that at least one file in the archive matches a given fname
-        glob
+        glob, iff it exists on the host system
 
         :param fname:  The glob to match filenames of
         :type fname:  ``str``
         """
-        files = glob.glob(os.path.join(self.archive_path, fname.lstrip('/')))
-        assert files, "No files matching %s found" % fname
+        if not glob.glob(fname):
+            assert True
+        else:
+            files = glob.glob(os.path.join(self.archive_path, fname.lstrip('/')))
+            assert files, "No files matching %s found" % fname
 
     def assertFileGlobNotInArchive(self, fname):
         """Ensure that there are NO files in the archive matching a given fname


### PR DESCRIPTION
As CentOS Stream now runs ahead of RHEL, instead of behind, using it as
a testing distribution on GCE allows us to have more confidence on those
distributions than testing on Fedora alone.

As CentOS Stream does not have version locks, there is only one version
to test on, rather than two as is the case with Fedora and Ubuntu. The
image we build from will need to be updated more regularly however as
new versions are released following RHEL minor version releases.

Resolves: #2499

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
