### PR TITLE
[chrony] configuration can now be fragmented

### DIFF
--- a/sos/report/plugins/chrony.py
+++ b/sos/report/plugins/chrony.py
@@ -45,6 +45,8 @@ class DebianChrony(Chrony, DebianPlugin, UbuntuPlugin):
         super(DebianChrony, self).setup()
         self.add_copy_spec([
             "/etc/chrony/chrony.conf",
+            "/etc/chrony/conf.d",
+            "/etc/chrony/sources.d",
             "/var/lib/chrony/chrony.drift",
             "/etc/default/chrony"
         ])


### PR DESCRIPTION
Chrony 4.0 added better support for fragmented
configuration.

Chrony's configuration and NTP sources can now
be under:

NTP sources:
/etc/chrony/sources.d/

Chrony's configuration:
/etc/chrony/conf.d/

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
