### PR TITLE
[subscription_manager] call curl to the RHSM server

### DIFF
--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -8,6 +8,7 @@
 
 from sos.report.plugins import Plugin, RedHatPlugin
 import glob
+from configparser import NoOptionError, NoSectionError
 
 
 class SubscriptionManager(Plugin, RedHatPlugin):
@@ -19,6 +20,35 @@ class SubscriptionManager(Plugin, RedHatPlugin):
 
     files = ('/etc/rhsm/rhsm.conf',)
     packages = ('subscription-manager',)
+
+    def get_proxy_string(self, config):
+        # return curl options --proxy[-user] per RHSM config
+        proxy = ""
+        proxy_hostname = config.get('server', 'proxy_hostname')
+        if proxy_hostname:
+            proxy_scheme = config.get('server', 'proxy_scheme')
+            proxy_port = config.get('server', 'proxy_port')
+            if proxy_port:
+                proxy_port = ":" + proxy_port
+            proxy = "--proxy %s://%s%s" % (proxy_scheme, proxy_hostname,
+                                           proxy_port)
+        proxy_user = config.get('server', 'proxy_user')
+        if proxy and proxy_user:
+            proxy += " --proxy-user %s" % proxy_user
+            proxy_password = config.get('server', 'proxy_password')
+            if proxy_password:
+                proxy += ":%s" % proxy_password
+        return proxy
+
+    def get_server_url(self, config):
+        # return URL per RHSM config for curl command
+        secure = "s" if config.get('server', 'insecure') != '1' else ""
+        port = config.get('server', 'port')
+        # if port is set, prepend it by ':' separating it from hostname
+        if len(port) > 0:
+            port = ":" + port
+        return "http%s://%s%s%s" % (secure, config.get('server', 'hostname'),
+                                    port, config.get('server', 'prefix'))
 
     def setup(self):
         # rhsm config and logs
@@ -43,6 +73,28 @@ class SubscriptionManager(Plugin, RedHatPlugin):
 
         certs = glob.glob('/etc/pki/product-default/*.pem')
         self.add_cmd_output(["rct cat-cert %s" % cert for cert in certs])
+
+        # try curl to the RHSM server for potential certificate/proxy issue
+        curlcmd = "curl -vv --cacert /etc/rhsm/ca/redhat-uep.pem " \
+                  "https://subscription.rhsm.redhat.com:443/subscription"
+        env = None  # for no_proxy
+        try:
+            from rhsm.config import get_config_parser
+            config = get_config_parser()
+            proxy = self.get_proxy_string(config)
+            server_url = self.get_server_url(config)
+            curlcmd = "curl -vv %s --cacert %s %s" % \
+                      (server_url,
+                       config.get('rhsm', 'repo_ca_cert'),
+                       proxy)
+            # honour os.environ no_proxy, if set
+            no_proxy = config.get('server', 'no_proxy')
+            if no_proxy:
+                env = {'NO_PROXY': no_proxy}
+        except (ModuleNotFoundError, ImportError, NoOptionError,
+                NoSectionError):
+            pass
+        self.add_cmd_output(curlcmd, env=env, timeout=30)
 
     def postproc(self):
         passwdreg = r"(proxy_password(\s)*=(\s)*)(\S+)\n"


### PR DESCRIPTION
Collect a verbose curl command output, run against RHSM server like
subscription-manager does. This helps troubleshooting with RHSM proxy
issues.

Resolves: #2503

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
