### PR TITLE
[kernel] Collect kernel log for page allocation failure

### DIFF
--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -41,6 +41,7 @@ class Block(Plugin, IndependentPlugin):
             "/sys/block/*/queue/",
             "/sys/block/sd*/device/timeout",
             "/sys/block/hd*/device/timeout",
+            "/sys/block/sd*/device/state",
         ])
 
         cmds = [

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -107,6 +107,8 @@ class Kernel(Plugin, IndependentPlugin):
             "/var/log/dmesg",
             "/sys/fs/pstore",
             "/sys/kernel/debug/dynamic_debug/control",
+            "/sys/kernel/debug/extfrag/unusable_index",
+            "/sys/kernel/debug/extfrag/extfrag_index",
             clocksource_path + "available_clocksource",
             clocksource_path + "current_clocksource"
         ])

--- a/sos/report/plugins/snapper.py
+++ b/sos/report/plugins/snapper.py
@@ -1,0 +1,27 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Snapper(Plugin, IndependentPlugin):
+
+    short_desc = 'System snapper'
+
+    plugin_name = 'snapper'
+    commands = ("snapper",)
+
+    def setup(self):
+
+        self.add_cmd_output([
+            "ls -la /usr/lib/snapper/",
+            "snapper --version",
+            "snapper list"
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch is to update kernel plugin to collect
page allocation failure info

Signed-off-by: Mamatha Inamdar mamatha4@linux.vnet.ibm.com

Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ x] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
