### PR TITLE
[Plugin] Make command output size limiting obvious

### DIFF
--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -67,3 +67,7 @@ class LogsSizeLimitTest(StageTwoReportTest):
         assert jsize <= 105906176, "Collected journal is larger than 100MB"
         assert jsize > 27262976, "Collected journal limited by --log-size"
 
+    def test_journal_tailed_and_linked(self):
+        self.assertFileCollected('sos_strings/logs/journalctl_--no-pager_--catalog_--boot.tailed')
+        journ = self.get_name_in_archive('sos_commands/logs/journalctl_--no-pager_--catalog_--boot')
+        assert os.path.islink(journ), "Journal in sos_commands/logs is not a symlink"


### PR DESCRIPTION
When command output is size limited it should be made obvious that it is
not the whole output of the command, beyond the collected output (most
likely) starting in the middle of a string.

To do this, we add a 'truncated' key to the results dict returned by
`sos_get_command_output()`, which is set based on if the `AsyncReader`
was filled during command execution.

From that, first log if a command was truncated. Second, instead of
dropping the collected output in the normal plugin directory, instead
drop it into `sos_strings` with a `.tailed` extention to mimic how we
handled tailed file collections. Finally, add a symlink from the plugin
dir with the original filename that points to the `sos_strings` path.

Closes: #1332
Resolves: #2506

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
