### PR TITLE
[archive|logging] Fix archive debug logging, change meaning of different logging levels

### DIFF
--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -116,6 +116,14 @@ Specify the number of threads sosreport will use for concurrency. Defaults to 4.
 .B \-v, \--verbose
 Increase logging verbosity. May be specified multiple times to enable
 additional debugging messages.
+
+The following table summarizes the effects of different verbosity levels:
+
+    1 (-v)   :  Enable debug messages for sos.log. Show individual plugins starting.
+    2 (-vv)  :  Also print debug messages to console.
+    3 (-vvv) :  Enable debug messages for archive file operations. Note this will dramatically
+                increase the amount of logging.
+
 .TP
 .B \-q, \--quiet
 Only log fatal errors to stderr.

--- a/sos/archive.py
+++ b/sos/archive.py
@@ -476,7 +476,6 @@ class FileCacheArchive(Archive):
             else:
                 self.log_debug("No link follow up: source=%s link_name=%s" %
                                (source, link_name))
-        self.log_debug("leaving add_link()")
 
     def add_dir(self, path):
         """Create a directory in the archive.

--- a/sos/component.py
+++ b/sos/component.py
@@ -256,7 +256,7 @@ class SoSComponent():
                                           enc_opts, self.sysroot,
                                           self.manifest)
 
-        self.archive.set_debug(True if self.opts.debug else False)
+        self.archive.set_debug(True if self.opts.verbosity > 2 else False)
 
     def _setup_logging(self):
         """Creates the log handler that shall be used by all components and any
@@ -283,7 +283,7 @@ class SoSComponent():
                 if flog:
                     flog.setLevel(logging.DEBUG)
             elif self.opts.verbosity and self.opts.verbosity > 0:
-                console.setLevel(logging.INFO)
+                console.setLevel(logging.WARNING)
                 if flog:
                     flog.setLevel(logging.DEBUG)
             else:

--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -15,10 +15,14 @@ class NormalSoSReport(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '-vvv --label thisismylabel'
+    sos_cmd = '-v --label thisismylabel'
 
     def test_debug_in_logs_verbose(self):
         self.assertSosLogContains('DEBUG')
+
+    def test_debug_not_printed_to_console(self):
+        self.assertOutputNotContains('added cmd output')
+        self.assertOutputNotContains('\[archive:.*\]')
 
     def test_postproc_called(self):
         self.assertSosLogContains('substituting scrpath')
@@ -28,6 +32,21 @@ class NormalSoSReport(StageOneReportTest):
 
     def test_free_symlink_created(self):
         self.assertFileCollected('free')
+
+
+class LogLevelTest(StageOneReportTest):
+    """
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-vvv'
+
+    def test_archive_logging_enabled(self):
+        self.assertSosLogContains('DEBUG: \[archive:.*\]')
+        self.assertSosLogContains('Making leading paths for')
+
+    def test_debug_printed_to_console(self):
+        self.assertOutputContains('\[plugin:.*\]')
 
 
 class RestrictedSoSReport(StageOneReportTest):

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -400,7 +400,8 @@ class BaseSoSReportTest(BaseSoSTest):
         :param content:  The string that should not be in stdout
         :type content:  ``str``
         """
-        assert content in self.cmd_output.stdout, "Content string '%s' not in output" % content
+        found = re.search(r"(.*)?%s(.*)?" % content, self.cmd_output.stdout)
+        assert found, "Content string '%s' not in output" % content
 
     def assertOutputNotContains(self, content):
         """Ensure that stdout did NOT contain the given content string
@@ -408,7 +409,8 @@ class BaseSoSReportTest(BaseSoSTest):
         :param content:  The string that should not be in stdout
         :type content:  ``str``
         """
-        assert not re.match(".*%s.*" % content, self.cmd_output.stdout), "String '%s' present in stdout" % content
+        found = re.search(r"(.*)?%s(.*)?" % content, self.cmd_output.stdout)
+        assert not found, "String '%s' present in stdout" % content
 
     def assertPluginIncluded(self, plugin):
         """Ensure that the specified plugin did run for the sos execution


### PR DESCRIPTION
This is a 2-patch set that accomplishes 2 changes:

* Fixes archive debug logging to not be tied to `--debug`, but some level of `--verbose`
* Gives more (and documented) meaning to the different verbosity levels

One of the more pertinent changes is that a single `-v` will now write debug logs to `sos.log`, but will *no longer* print info level messages to console. Using `-vv` is now required for printing logs to console. Using `-vvv` is what enables the archive debug logs being recorded, as these messages generate a whole lot more noise than any other part of logging currently.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
