### PR TITLE
**[insights]** Removing insights-client command as it's superfluous

### DIFF
--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -32,11 +32,6 @@ class RedHatInsights(Plugin, RedHatPlugin):
         else:
             self.add_copy_spec("/var/log/insights-client/insights-client.log")
 
-        # Collect insights-client report data into given dump dir
-        path = self.get_cmd_output_path(name="insights-client-dump")
-        self.add_cmd_output("insights-client --offline --output-dir %s" % path,
-                            suggest_filename="insights-client-dump.log")
-
     def postproc(self):
         for conf in self.config:
             self.do_file_sub(


### PR DESCRIPTION
The `insights-client` command should not be run within sosreport,
as it collects data sosreport already collects and is not cautious
about how it does so.  Running it is therefore superfluous.

Closes: #2508
Resolves: #2508 

Signed-off-by: Paul Wayper <paulway@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
