### PR TITLE
[mysql] Update collection paths for Debian/Ubuntu

### DIFF
--- a/sos/report/plugins/mysql.py
+++ b/sos/report/plugins/mysql.py
@@ -35,7 +35,8 @@ class Mysql(Plugin):
             "/var/log/mysqld.log",
             "/var/log/mysql/mysqld.log",
             "/var/log/mariadb/mariadb.log",
-            "/var/lib/mysql/grastate.dat"
+            "/var/lib/mysql/grastate.dat",
+            "/var/lib/mysql/gvwstate.dat"
         ])
 
         if self.get_option("all_logs"):
@@ -98,14 +99,25 @@ class RedHatMysql(Mysql, RedHatPlugin):
 class DebianMysql(Mysql, DebianPlugin, UbuntuPlugin):
 
     packages = (
-        'mysql-server',
+        'mysql-server.*',
         'mysql-common',
-        'mariadb-server',
-        'mariadb-common'
+        'mariadb-server.*',
+        'mariadb-common',
+        'percona-xtradb-cluster-server-.*',
     )
 
     def setup(self):
         super(DebianMysql, self).setup()
-        self.add_copy_spec("/etc/mysql/conf.d/mysql*")
+        self.add_copy_spec([
+            "/etc/mysql/",
+            "/var/log/mysql/error.log",
+            "/var/lib/mysql/*.err",
+            "/var/lib/percona-xtradb-cluster/*.err",
+            "/var/lib/percona-xtradb-cluster/grastate.dat",
+            "/var/lib/percona-xtradb-cluster/gvwstate.dat",
+            "/var/lib/percona-xtradb-cluster/innobackup.*.log",
+        ])
+        self.add_cmd_output("du -s /var/lib/percona-xtradb-cluster/*")
+
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
- All configuration files from /etc/mysql/
- Default error log path: /var/log/mysql/error.log
- Alternative data directory location /var/lib/percona-xtradb-cluster
- gvwstate.dat for galera debugging
- Update the various server package names (though all seem to depend on
  mysql-common anyway)

Signed-off-by: Trent Lloyd <trent.lloyd@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
