### PR TITLE
[man] Document size limits more clearly

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -20,6 +20,7 @@ sos collect \- Collect sosreports from multiple (cluster) nodes
     [\-\-nopasswd-sudo]
     [\-k PLUGIN_OPTION]
     [\-\-label LABEL]
+    [\-\-log-size SIZE]
     [\-n SKIP_PLUGINS]
     [\-\-nodes NODES]
     [\-\-no\-pkg\-check]
@@ -197,6 +198,18 @@ both the sos collect archive and the sosreport archives.
 
 If a cluster sets a default label, the user-provided label will be appended to
 that cluster default.
+.TP
+\fB \--log-size\fR SIZE
+Places a limit on the size of collected logs and output in MiB. Note that this
+causes sos to capture the last X amount of the file or command output collected.
+
+By default, this is set to 25 MiB and applies to all files and command output collected
+with the exception of journal collections, which are limited to 100 MiB.
+
+Setting this value to 0 removes all size limitations, and any files or commands
+collected will be collected in their entirety, which may drastically increase the
+size of the final sos report tarball and the memory usage of sos during collection
+of commands, such as very large journals that may be several GiB in size.
 .TP
 \fB\-n\fR SKIP_PLUGINS, \fB\-\-skip\-plugins\fR SKIP_PLUGINS
 Sosreport option. Disable (skip) a particular plugin that would otherwise run.

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -168,9 +168,17 @@ testing or other plugin defined behaviour. Use of \--verify may cause
 the time taken to generate a report to be considerably longer.
 .TP
 .B \--log-size
-Places a global limit on the size (in MiB) of any collected set of logs. The
-limit is applied separately for each set of logs collected by any
-plugin.
+Places a limit on the size of collected logs and output in MiB. Note that this
+causes sos to capture the last X amount of the file or command output collected.
+
+By default, this is set to 25 MiB and applies to all files and command output collected
+with the exception of journal collections, which are limited to 100 MiB.
+
+Setting this value to 0 removes all size limitations, and any files or commands
+collected will be collected in their entirety, which may drastically increase the
+size of the final sos report tarball and the memory usage of sos during collection
+of commands, such as very large journals that may be several GiB in size.
+
 .TP
 .B \--all-logs
 Tell plugins to collect all possible log data ignoring any size limits


### PR DESCRIPTION
Adds more explicit documentation around the function and defaults of `--log-size`.

Adds the section to the manpage for `collect` as well as it was missing there.

Closes: #1900 
Resolves: #2513

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
