### PR TITLE
[s390|zvm] Integrate s390's dbginfo.sh collections into plugins

### DIFF
--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -27,6 +27,7 @@ class Processor(Plugin, IndependentPlugin):
 
         self.add_cmd_output([
             "lscpu",
+            "lscpu -ae",
             "cpupower info",
             "cpupower idle-info",
             "cpupower frequency-info",

--- a/sos/report/plugins/s390.py
+++ b/sos/report/plugins/s390.py
@@ -42,7 +42,11 @@ class S390(Plugin, IndependentPlugin):
             "/etc/sysconfig/dumpconf",
             "/etc/src_vipa.conf",
             "/etc/ccwgroup.conf",
-            "/etc/chandev.conf"
+            "/etc/chandev.conf",
+            "/var/log/IBMtape.trace",
+            "/var/log/IBMtape.errorlog",
+            "/var/log/lin_tape.trace",
+            "/var/log/lin_tape.errorlog",
         ])
 
         # skip flush as it is useless for sos collection
@@ -51,13 +55,17 @@ class S390(Plugin, IndependentPlugin):
         self.add_cmd_output([
             "lscss",
             "lsdasd",
+            "lsshut",
             "lstape",
             "qethconf list_all",
             "lsqeth",
             "lszfcp",
-            "lszcrypt",
+            "lszfcp -D",
+            "lszfcp -V",
+            "lszcrypt -VV",
             "icainfo",
-            "icastats"
+            "icastats",
+            "smc_dbg"
         ])
 
         r = self.exec_cmd("ls /dev/dasd?")

--- a/sos/report/plugins/zvm.py
+++ b/sos/report/plugins/zvm.py
@@ -1,0 +1,109 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
+from sos.utilities import is_executable
+
+
+class ZVM(Plugin, IndependentPlugin):
+
+    plugin_name = 'zvm'
+    short_desc = 'IBM z/VM information'
+    commands = ('vmcp', 'hcp')
+
+    def setup(self):
+
+        zvm_pred = SoSPredicate(self, kmods=['vmcp', 'cpint'])
+        self.set_cmd_predicate(zvm_pred)
+
+        self.vm_cmd = None
+        for cmd in self.commands:
+            if is_executable(cmd):
+                self.vm_cmd = cmd
+                break
+
+        # vm commands from dbginfo.sh
+        vm_cmds = [
+            "q userid",
+            "q users",
+            "q privclass",
+            "q cplevel",
+            "q cpservice",
+            "q cpprot user",
+            "q specex",
+            "q ssi",
+            "q cpus",
+            "q srm",
+            "q vtod",
+            "q time full",
+            "q timezone",
+            "q loaddev",
+            "q v osa",
+            "q v dasd",
+            "q v crypto",
+            "q v fcp",
+            "q v pav",
+            "q v sw",
+            "q v st",
+            "q v nic",
+            "q st",
+            "q xstore",
+            "q xstore user system",
+            "q sxspages",
+            "q vmlan",
+            "q vswitch",
+            "q vswitch details",
+            "q vswitch access",
+            "q vswitch active",
+            "q vswitch accesslist",
+            "q vswitch promiscuous",
+            "q vswitch controller",
+            "q port group all active details",
+            "q set",
+            "q comm",
+            "q controller all",
+            "q fcp",
+            "q frames",
+            "q lan",
+            "q lan all details",
+            "q lan all access",
+            "q memassist",
+            "q nic",
+            "q pav",
+            "q proc",
+            "q proc topology",
+            "q mt",
+            "q qioass",
+            "q spaces",
+            "q swch all",
+            "q trace",
+            "q mdcache",
+            "q alloc page",
+            "q alloc spool",
+            "q dump",
+            "q dumpdev",
+            "q pcifunction",
+            "q vmrelocate",
+            "ind load",
+            "ind sp",
+            "ind user"
+        ]
+
+        vm_id_out = self.collect_cmd_output("%s q userid" % self.vm_cmd)
+        if vm_id_out['status'] == 0:
+            vm_id = vm_id_out['output'].split()[0]
+            vm_cmds.extend([
+                "q reorder %s" % vm_id,
+                "q quickdsp %s" % vm_id
+            ])
+
+        self.add_cmd_output([
+            "%s %s" % (self.vm_cmd, vcmd) for vcmd in vm_cmds
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patchset serves to integrate the extra collections perform by s390's `dbginfo.sh` script into sos plugins.

The additions to the `s390` plugin have been tests, however the new `zvm` plugin has not been tested against an actual system running Z/VM. The testing thus far has been `sanityonly` in validating command construction.

 Closes: #2228

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
