### PR TITLE
[reporting] Sort order of report contents by name

### DIFF
--- a/sos/report/reporting.py
+++ b/sos/report/reporting.py
@@ -191,7 +191,10 @@ class PlainTextReport(object):
     def process_subsection(self, section, key, header, format_, footer):
         if key in section:
             self.line_buf.append(header)
-            for item in section.get(key):
+            for item in sorted(
+                    section.get(key),
+                    key=lambda x: x["name"] if isinstance(x, dict) else ''
+            ):
                 self.line_buf.append(format_ % item)
             if (len(footer) > 0):
                 self.line_buf.append(footer)


### PR DESCRIPTION
When using `reporting.py`, e.g. for `sos.txt`, sort the content on a
per-section basis so that comparison between multiple sos reports is
easier.

Closes: #1998
Resolves: #2515

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
