### PR TITLE
[apache] Forbid collecting keystone logs

### DIFF
--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -29,11 +29,21 @@ class Apache(Plugin):
             "apachectl -t"
         ])
 
-        # The foreman and pulp plugins collect these files;
+        # Other plugins collect these files;
         # do not collect them here to avoid collisions in the archive paths.
+        subdirs = [
+            'aodh',
+            'ceilometer',
+            'cinder',
+            'foreman',
+            'horizon',
+            'keystone',
+            'nova',
+            'placement',
+            'pulp'
+        ]
         self.add_forbidden_path([
-            "/var/log/{}*/foreman*".format(self.apachepkg),
-            "/var/log/{}*/pulp*".format(self.apachepkg)
+            "/var/log/%s*/%s*" % (self.apachepkg, sub) for sub in subdirs
         ])
 
 


### PR DESCRIPTION
Like we do for foreman and pulp, avoid collecting keystone logs in the
apache plugin and instead allow the `openstack_keystone` plugin to
collect them instead.

Closes: #1950
Resolves: #2516

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
