### PR TITLE
[report] Do not fail on skipping non-existing plugins

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -643,7 +643,7 @@ class SoSReport(SoSComponent):
                     del opts[plugname]
             for plugname in opts.keys():
                 self.soslog.error('WARNING: unable to set option for disabled '
-                                  'or non-existing plugin (%s)' % (plugname))
+                                  'or non-existing plugin (%s).' % (plugname))
             # in case we printed warnings above, visually intend them from
             # subsequent header text
             if opts.keys():
@@ -652,13 +652,17 @@ class SoSReport(SoSComponent):
     def _check_for_unknown_plugins(self):
         import itertools
         for plugin in itertools.chain(self.opts.only_plugins,
-                                      self.opts.skip_plugins,
                                       self.opts.enable_plugins):
             plugin_name = plugin.split(".")[0]
             if plugin_name not in self.plugin_names:
                 self.soslog.fatal('a non-existing plugin (%s) was specified '
-                                  'in the command line' % (plugin_name))
+                                  'in the command line.' % (plugin_name))
                 self._exit(1)
+        for plugin in self.opts.skip_plugins:
+            if plugin not in self.plugin_names:
+                self.soslog.warning(
+                    "Requested to skip non-existing plugin '%s'." % plugin
+                )
 
     def _set_plugin_options(self):
         for plugin_name, plugin in self.loaded_plugins:

--- a/tests/report_tests/exception_tests.py
+++ b/tests/report_tests/exception_tests.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos_tests import StageOneReportExceptionTest
+from sos_tests import StageOneReportExceptionTest, StageOneReportTest
 
 
 class InvalidPluginEnabledTest(StageOneReportExceptionTest):
@@ -41,3 +41,14 @@ class InvalidReportOptionTest(StageOneReportExceptionTest):
     def test_caught_invalid_option(self):
         self.assertOutputContains('unrecognized arguments\: --magic')
 
+
+class InvalidPluginDisableTest(StageOneReportTest):
+    """Ensure passing an invalid plugin name for skipping does not stop the
+    execution, see PR#2517
+
+    :avocado: tags=stageone
+    """
+    sos_cmd = '-n logs,foobar,networking'
+
+    def test_caught_invalid_plugin_name(self):
+        self.assertOutputContains("Requested to skip non-existing plugin 'foobar'")


### PR DESCRIPTION
Specifying a non-existing plugin to skip is no longer considered a fatal
error. This was previously in place, in part, for third party utilities
calling sos to ensure adherence to known plugins. However, since
`collect` has been integrated into sos natively, this is far less of a
concern.

Specfying non-existing plugins will now only generate a warning message
for plugins wanting to be skipped (`-n`). If non-existing plugins are
specified for enablement via `-e` or `-o`, that will still generate a
fatal error.

Closes: #537
Closes: #1723
Resolves: #2517

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
