### PR TITLE
[tests] Add test class for when exceptions are expected in an execution

### DIFF
--- a/tests/report_tests/exception_tests.py
+++ b/tests/report_tests/exception_tests.py
@@ -1,0 +1,43 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageOneReportExceptionTest
+
+
+class InvalidPluginEnabledTest(StageOneReportExceptionTest):
+    """
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o foobar'
+
+    def test_caught_invalid_plugin(self):
+        self.assertOutputContains('a non-existing plugin \(foobar\)')
+
+
+class InvalidPluginOptionTest(StageOneReportExceptionTest):
+    """
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o kernel -k kernel.colonel=on'
+
+    def test_caught_invalid_plugin_option(self):
+        self.assertOutputContains('no such option "colonel" for plugin \(kernel\)')
+
+
+class InvalidReportOptionTest(StageOneReportExceptionTest):
+    """
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '--magic'
+
+    def test_caught_invalid_option(self):
+        self.assertOutputContains('unrecognized arguments\: --magic')
+


### PR DESCRIPTION
Adds a new `StageOneReportExceptionTest` class that is to be used for
tests that should ensure an exception IS hit, for example when testing
plugin enablement or invalid options.

Included with this commit is a small set of plugin enablement tests.
Future tests for component and plugin specific exception handling should
be built using this class and design approach.

Resolves: #2518

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
