### PR TITLE
[foreman] fix unmatched group error in scrubbing installer logs

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -293,7 +293,7 @@ class Foreman(Plugin):
             satreg,
             r"\1 ********")
         # need to do two passes here, debug output has different formatting
-        sat_debug_reg = (r"(\s)* (Found key: (\"(foreman(.*?)|katello)"
+        sat_debug_reg = (r"(\s)+(Found key: (\"(foreman(.*?)|katello)"
                          r"::(.*(token|secret|key|passw).*)\") value:) "
                          r"(.*)")
         self.do_path_regex_sub(


### PR DESCRIPTION
Having just one whitespace before "Found key:" failed to match
the first group.

Resolves: #2521

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
