### PR TITLE
[archive] Don't shell out for compressing the archive

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -261,24 +261,6 @@ any third party.
     def _get_pkg_name_for_binary(self, binary):
         return binary
 
-    def get_cmd_for_compress_method(self, method, threads):
-        """Determine the command to use for compressing the archive
-
-        :param method: The compression method/binary to use
-        :type method: ``str``
-
-        :param threads: Number of threads compression should use
-        :type threads: ``int``
-
-        :returns: Full command to use to compress the archive
-        :rtype: ``str``
-        """
-        cmd = method
-        if cmd.startswith("xz"):
-            # XZ set compression to -2 and use threads
-            cmd = "%s -2 -T%d" % (cmd, threads)
-        return cmd
-
     def get_tmp_dir(self, opt_tmp_dir):
         if not opt_tmp_dir:
             return tempfile.gettempdir()

--- a/tests/report_tests/compression_tests.py
+++ b/tests/report_tests/compression_tests.py
@@ -1,0 +1,35 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos_tests import StageOneReportTest
+
+
+class AutoCompressionTest(StageOneReportTest):
+    """Tests to ensure that 'auto' defaults to lzma, as it is in the standard
+    library
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o kernel -z auto'
+
+    def test_lzma_compressed(self):
+        self.assertTrue(self.archive.endswith('.tar.xz'))
+
+
+class GzipCompressionTest(StageOneReportTest):
+    """Tests to ensure that users can manually specify the use of gzip
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o kernel -z gzip'
+
+    def test_gzip_compressed(self):
+        self.assertTrue(self.archive.endswith('.tar.gz'))

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -503,6 +503,15 @@ class StageOneReportTest(BaseSoSReportTest):
         self.assertFileExists(self.archive)
         self.assertTrue(os.stat(self.archive).st_uid == 0)
 
+    def test_checksum_is_valid(self):
+        """Ensure that a checksum was generated, reported, and is correct
+        """
+        _chk = re.findall('sha256\t.*\n', self.cmd_output.stdout)
+        _chk = _chk[0].split('sha256\t')[1].strip()
+        assert _chk, "No checksum reported"
+        _found = process.run("sha256sum %s" % self.archive).stdout.decode().split()[0]
+        self.assertEqual(_chk, _found)
+
     def test_no_new_kmods_loaded(self):
         """Ensure that no additional kernel modules have been loaded during an
         execution of a test

--- a/tests/unittests/archive_tests.py
+++ b/tests/unittests/archive_tests.py
@@ -27,14 +27,14 @@ class TarFileArchiveTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def check_for_file(self, filename):
-        rtf = tarfile.open(os.path.join(self.tmpdir, 'test.tar'))
+        rtf = tarfile.open(os.path.join(self.tmpdir, 'test.tar.xz'))
         rtf.getmember(filename)
         rtf.close()
 
     def test_create(self):
         self.tf.finalize('auto')
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir,
-                                                    'test.tar')))
+                                                    'test.tar.xz')))
 
     def test_add_file(self):
         self.tf.add_file('tests/unittests/ziptest')


### PR DESCRIPTION
As sos is now python3-only, we can avoid shelling-out to compression
utilities like `xz` or `gzip`, and instead use the method provided by
the built-in `tarfile` module.

Resolves: #2523

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
