### PR TITLE
[virtwho] improve regexp processing performance on huge lines

### DIFF
--- a/sos/report/plugins/virtwho.py
+++ b/sos/report/plugins/virtwho.py
@@ -24,7 +24,7 @@ class VirtWho(Plugin, RedHatPlugin):
     def postproc(self):
         # the regexp path catches both /etc/virt-who.d/ and /etc/virt-who.conf
         self.do_path_regex_sub(r"\/etc\/virt-who\.",
-                               r"(.*password=)(\S*)",
+                               r"(password=)(\S*)",
                                r"\1********")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
We can ignore .* at the start of a RE.

Resolves: #2527

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
