### PR TITLE
[cirrus] Update Fedora testing matrix for F34

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,9 @@
 # Main environment vars to set for all tasks
 env:
 
-    FEDORA_VER: "33"
-    FEDORA_PRIOR_VER: "32"
-    FEDORA_NAME: "fedora-${FEDORA_VER}"
-    FEDORA_PRIOR_NAME: "fedora-${FEDORA_PRIOR_VER}"
+
+    FEDORA_NAME: "fedora-34"
+    FEDORA_PRIOR_NAME: "fedora-33"
 
     UBUNTU_NAME: "ubuntu-20.04"
     UBUNTU_PRIOR_NAME: "ubuntu-18.04"
@@ -14,15 +13,14 @@ env:
     CENTOS_NAME: "centos-stream-8"
 
     CENTOS_PROJECT: "centos-cloud"
+    FEDORA_PROJECT: "fedora-cloud"
     SOS_PROJECT: "sos-devel-jobs"
     UBUNTU_PROJECT: "ubuntu-os-cloud"
 
-    # These are generated images pushed to GCP from Red Hat
-    FEDORA_IMAGE_NAME: "f${FEDORA_VER}-server-sos-testing"
-    FEDORA_PRIOR_IMAGE_NAME: "f${FEDORA_PRIOR_VER}-server-sos-testing"
-
     # Images exist on GCP already
     CENTOS_IMAGE_NAME: "centos-stream-8-v20210316"
+    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-34-1-2-x86-64"
+    FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-33-1-2-x86-64"
     UBUNTU_IMAGE_NAME: "ubuntu-2004-focal-v20201111"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-1804-bionic-v20201111"
 
@@ -81,11 +79,11 @@ report_stageone_task:
             BUILD_NAME: ${CENTOS_NAME}
             VM_IMAGE_NAME: ${CENTOS_IMAGE_NAME}
         - env:
-            PROJECT: ${SOS_PROJECT}
+            PROJECT: ${FEDORA_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env:
-            PROJECT: ${SOS_PROJECT}
+            PROJECT: ${FEDORA_PROJECT}
             BUILD_NAME: ${FEDORA_PRIOR_NAME}
             VM_IMAGE_NAME: ${FEDORA_PRIOR_IMAGE_NAME}
         - env:
@@ -120,7 +118,7 @@ report_stagetwo_task:
             BUILD_NAME: ${CENTOS_NAME}
             VM_IMAGE_NAME: ${CENTOS_IMAGE_NAME}
         - env:
-            PROJECT: ${SOS_PROJECT}
+            PROJECT: ${FEDORA_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env:


### PR DESCRIPTION
Fedora 34 has released and the project now publishes images directly to
GCE. Update the Cirrus CI configuration to use the official Fedora
images, now using F34 and F33.

Resolves: #2529

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
