### PR TITLE
[candlepin] move tomcat logs from foreman plugin

### DIFF
--- a/sos/report/plugins/candlepin.py
+++ b/sos/report/plugins/candlepin.py
@@ -62,7 +62,14 @@ class Candlepin(Plugin, RedHatPlugin):
             "/var/log/candlepin/candlepin.log[.-]*",
             "/var/log/candlepin/cpdb*.log*",
             "/var/log/candlepin/cpinit*.log*",
-            "/var/log/candlepin/error.log[.-]*"
+            "/var/log/candlepin/error.log[.-]*",
+            # Specific to candlepin, ALL catalina logs are relevant. Adding it
+            # here rather than the tomcat plugin to ease maintenance and not
+            # pollute non-candlepin sosreports that enable the tomcat plugin
+            "/var/log/tomcat*/catalina*log*",
+            "/var/log/tomcat*/host-manager*log*",
+            "/var/log/tomcat*/localhost*log*",
+            "/var/log/tomcat*/manager*log*",
         ])
 
         self.add_cmd_output("du -sh /var/lib/candlepin/*/*")

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -104,13 +104,6 @@ class Foreman(Plugin):
             "/var/log/foreman-installer/",
             "/var/log/foreman-maintain/",
             "/var/log/syslog*",
-            # Specific to TFM, _all_ catalina logs are relevant. Adding this
-            # here rather than the tomcat plugin to ease maintenance and not
-            # pollute non-Sat sosreports that enable the tomcat plugin
-            "/var/log/tomcat*/catalina*log*",
-            "/var/log/tomcat*/host-manager*log*",
-            "/var/log/tomcat*/localhost*log*",
-            "/var/log/tomcat*/manager*log*",
             "/usr/share/foreman/Gemfile*",
             "/var/lib/puppet/ssl/certs/ca.pem",
             "/etc/puppetlabs/puppet/ssl/certs/ca.pem",


### PR DESCRIPTION
Candlepin as a tomcat application needs to collect the logs, not
foreman.

Ideally, the tomcat plugin should be responsible for colecting the
logs, but doing so would pollute non-candlepin usage (cf. apache
logs in foreman plugin as well).

Resolves: #2530

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
