### PR TITLE
[saphana] remove redundant unused argument of get_inst_info

### DIFF
--- a/sos/report/plugins/saphana.py
+++ b/sos/report/plugins/saphana.py
@@ -51,7 +51,7 @@ class saphana(Plugin, RedHatPlugin):
                             inst = inst.strip()[-2:]
                             self.get_inst_info(sid, sidadm, inst)
 
-    def get_inst_info(self, prefix, sid, sidadm, inst):
+    def get_inst_info(self, sid, sidadm, inst):
         proc_cmd = 'su - %s -c "sapcontrol -nr %s -function GetProcessList"'
         status_fname = "%s_%s_status" % (sid, inst)
         self.add_cmd_output(


### PR DESCRIPTION
get_inst_info does not use and isnt called with 'prefix' argument

Resolves: #2535

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
