### PR TITLE
[Plugin|tags] Add tagging to numerous plugins for Insights

### DIFF
--- a/sos/report/plugins/abrt.py
+++ b/sos/report/plugins/abrt.py
@@ -25,7 +25,8 @@ class Abrt(Plugin, RedHatPlugin):
     ]
 
     def setup(self):
-        self.add_cmd_output("abrt-cli status")
+        self.add_cmd_output("abrt-cli status",
+                            tags=["abrt_status", "insights_abrt_status_bare"])
         abrt_list = self.collect_cmd_output("abrt-cli list")
         if self.get_option("detailed") and abrt_list['status'] == 0:
             for line in abrt_list["output"].splitlines():

--- a/sos/report/plugins/alternatives.py
+++ b/sos/report/plugins/alternatives.py
@@ -19,6 +19,11 @@ class Alternatives(Plugin, RedHatPlugin):
     commands = ('alternatives',)
 
     def setup(self):
+
+        self.add_cmd_tags({
+            "alternatives --display java.*": 'insights_display_java'
+        })
+
         self.add_cmd_output('alternatives --version')
 
         alts = []

--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -27,7 +27,7 @@ class Apache(Plugin):
             "apachectl -M",
             "apachectl -S",
             "apachectl -t"
-        ])
+        ], cmd_as_tag=True)
 
         # Other plugins collect these files;
         # do not collect them here to avoid collisions in the archive paths.
@@ -56,6 +56,14 @@ class RedHatApache(Apache, RedHatPlugin):
     apachepkg = 'httpd'
 
     def setup(self):
+
+        self.add_file_tags({
+            ".*/access_log": 'httpd_access_log',
+            ".*/error_log": 'httpd_error_log',
+            ".*/ssl_access_log": 'httpd_ssl_access_log',
+            ".*/ssl_error_log": 'httpd_ssl_error_log'
+        })
+
         super(RedHatApache, self).setup()
 
         # httpd versions, including those used for JBoss Web Server
@@ -86,7 +94,7 @@ class RedHatApache(Apache, RedHatPlugin):
 
         for edir in etcdirs:
             for conf in confs:
-                self.add_copy_spec("%s/%s" % (edir, conf))
+                self.add_copy_spec("%s/%s" % (edir, conf), tags="httpd_conf")
 
         if self.get_option("log") or self.get_option("all_logs"):
             self.add_copy_spec(logdirs)
@@ -95,7 +103,7 @@ class RedHatApache(Apache, RedHatPlugin):
                 for log in logs:
                     self.add_copy_spec("%s/%s" % (ldir, log))
 
-        self.add_service_status('httpd')
+        self.add_service_status('httpd', tags='systemctl_httpd')
 
 
 class DebianApache(Apache, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -21,6 +21,10 @@ class Block(Plugin, IndependentPlugin):
     def setup(self):
         self.add_forbidden_path("/sys/block/*/queue/iosched")
 
+        self.add_file_tags({
+            '/sys/block/.*/queue/scheduler': 'scheduler'
+        })
+
         self.add_cmd_output([
             "lsblk",
             "lsblk -t",

--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -31,8 +31,10 @@ class Boot(Plugin, IndependentPlugin):
             "/etc/yaboot.conf",
             "/boot/yaboot.conf"
         ])
+
+        self.add_cmd_output("ls -lanR /boot", tags="insights_ls_boot")
+
         self.add_cmd_output([
-            "ls -lanR /boot",
             "lsinitrd",
             "ls -lanR /sys/firmware",
         ])

--- a/sos/report/plugins/candlepin.py
+++ b/sos/report/plugins/candlepin.py
@@ -44,6 +44,13 @@ class Candlepin(Plugin, RedHatPlugin):
         except (IOError, IndexError):
             # fallback when the cfg file is not accessible or parseable
             pass
+
+        self.add_file_tags({
+            '/var/log/candlepin/candlepin.log.*': 'candlepin_log',
+            '/var/log/candlepin/err.log.*': 'candlepin_error_log',
+            '/etc/candlepin/candlepin.conf': 'candlepin_conf'
+        })
+
         # set the password to os.environ when calling psql commands to prevent
         # printing it in sos logs
         # we can't set os.environ directly now: other plugins can overwrite it

--- a/sos/report/plugins/ceph.py
+++ b/sos/report/plugins/ceph.py
@@ -40,6 +40,12 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
     def setup(self):
         all_logs = self.get_option("all_logs")
 
+        self.add_file_tags({
+            '.*/ceph.conf': 'ceph_conf',
+            '/var/log/ceph/ceph.log.*': 'ceph_log',
+            '/var/log/ceph/ceph-osd.*.log': 'ceph_osd_log'
+        })
+
         if not all_logs:
             self.add_copy_spec([
                 "/var/log/ceph/*.log",
@@ -117,7 +123,7 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.add_cmd_output([
             "ceph %s --format json-pretty" % s for s in ceph_cmds
-        ], subdir="json_output")
+        ], subdir="json_output", tags="insights_ceph_health_detail")
 
         for service in self.services:
             self.add_journal(units=service)

--- a/sos/report/plugins/cgroups.py
+++ b/sos/report/plugins/cgroups.py
@@ -19,6 +19,11 @@ class Cgroups(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
     files = ('/proc/cgroups',)
 
     def setup(self):
+
+        self.add_file_tags({
+            '/proc/1/cgroups': 'insights_init_process_cgroup'
+        })
+
         self.add_copy_spec([
             "/proc/cgroups",
             "/sys/fs/cgroup"

--- a/sos/report/plugins/cron.py
+++ b/sos/report/plugins/cron.py
@@ -30,6 +30,7 @@ class Cron(Plugin, IndependentPlugin):
             self.add_copy_spec("/var/log/cron*")
 
         self.add_cmd_output("crontab -l -u root",
-                            suggest_filename="root_crontab")
+                            suggest_filename="root_crontab",
+                            tags="root_crontab")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/crypto.py
+++ b/sos/report/plugins/crypto.py
@@ -19,6 +19,16 @@ class Crypto(Plugin, IndependentPlugin):
     profiles = ('system', 'hardware')
 
     def setup(self):
+
+        cpth = '/etc/crypto-policies/back-ends'
+
+        self.add_file_tags({
+            "%s/bind.config" % cpth: 'crypto_policies_bind',
+            "%s/opensshserver.config" % cpth: 'crypto_policies_opensshserver',
+            '/etc/crypto-policies/.*/current': 'crypto_policies_state_current',
+            '/etc/crypto-policies/config': 'crypto_policies_config'
+        })
+
         self.add_copy_spec([
             "/proc/crypto",
             "/proc/sys/crypto/fips_enabled",

--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -34,9 +34,15 @@ class DNFPlugin(Plugin, RedHatPlugin):
             if "[i]" in line:
                 module = line.split()[0]
                 if module != "Hint:":
-                    self.add_cmd_output("dnf --assumeno module info " + module)
+                    self.add_cmd_output("dnf --assumeno module info " + module,
+                                        tags='dnf_module_info')
 
     def setup(self):
+
+        self.add_file_tags({
+            '/etc/dnf/modules.d/.*.modules': 'dnf_modules'
+        })
+
         self.add_copy_spec("/etc/dnf/")
 
         if self.get_option("all_logs"):
@@ -46,11 +52,13 @@ class DNFPlugin(Plugin, RedHatPlugin):
             self.add_copy_spec("/var/log/dnf.librepo.log*")
             self.add_copy_spec("/var/log/dnf.rpm.log*")
 
+        self.add_cmd_output("dnf --assumeno module list",
+                            tags='dnf_module_list')
+
         self.add_cmd_output([
             "dnf --version",
             "dnf --assumeno list installed *dnf*",
             "dnf --assumeno list extras",
-            "dnf --assumeno module list",
             "package-cleanup --dupes",
             "package-cleanup --problems"
         ])

--- a/sos/report/plugins/etcd.py
+++ b/sos/report/plugins/etcd.py
@@ -28,6 +28,10 @@ class etcd(Plugin, RedHatPlugin):
         else:
             etcd_cmd = 'etcdctl'
 
+        self.add_file_tags({
+            '/etc/etcd/etcd.conf': 'etcd_conf'
+        })
+
         etcd_url = self.get_etcd_url()
 
         self.add_forbidden_path([

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -36,7 +36,8 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "/etc/fstab"
         ])
         self.add_cmd_output("mount -l", root_symlink="mount")
-        self.add_cmd_output("df -al -x autofs", root_symlink="df")
+        self.add_cmd_output("df -al -x autofs", root_symlink="df",
+                            tags='insights_df__al')
         self.add_cmd_output([
             "df -ali -x autofs",
             "findmnt",

--- a/sos/report/plugins/firewalld.py
+++ b/sos/report/plugins/firewalld.py
@@ -22,8 +22,11 @@ class FirewallD(Plugin, RedHatPlugin):
     packages = ('firewalld',)
 
     def setup(self):
+
+        self.add_copy_spec("/etc/firewalld/firewalld.conf",
+                           tags='firewalld_conf')
+
         self.add_copy_spec([
-            "/etc/firewalld/firewalld.conf",
             "/etc/firewalld/*.xml",
             "/etc/firewalld/icmptypes/*.xml",
             "/etc/firewalld/services/*.xml",
@@ -51,6 +54,6 @@ class FirewallD(Plugin, RedHatPlugin):
             "firewall-cmd --permanent --direct --get-all-passthroughs",
             "firewall-cmd --state",
             "firewall-cmd --get-log-denied"
-        ], timeout=10)
+        ], timeout=10, cmd_as_tag=True)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -63,6 +63,14 @@ class Foreman(Plugin):
         # we can't set os.environ directly now: other plugins can overwrite it
         self.env = {"PGPASSWORD": self.dbpasswd}
 
+        self.add_file_tags({
+            '/var/log/foreman/production.log.*': 'foreman_production_log',
+            '/var/log/foreman-proxy/proxy.log.*': 'foreman_proxy_log',
+            '/etc/foreman-proxy/settings.yml': 'foreman_proxy_conf',
+            '/etc/sysconfig/foreman-tasks': 'foreman_tasks_config',
+            '/etc/sysconfig/dynflowd': 'foreman_tasks_config'
+        })
+
         self.add_forbidden_path([
             "/etc/foreman*/*key.pem",
             "/etc/foreman*/encryption_key.rb"
@@ -326,6 +334,13 @@ class RedHatForeman(Foreman, SCLPlugin, RedHatPlugin):
     apachepkg = 'httpd'
 
     def setup(self):
+
+        self.add_file_tags({
+            '/var/log/foreman-installer/satellite.log.*':
+                ['insights_satellite_log' 'satellite_installer_log'],
+            '/usr/share/foreman/.ssh/ssh_config': 'ssh_foreman_config',
+        })
+
         super(RedHatForeman, self).setup()
         self.add_cmd_output_scl('tfm', 'gem list',
                                 suggest_filename='scl enable tfm gem list')

--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -18,6 +18,12 @@ class Grub2(Plugin, IndependentPlugin):
     packages = ('grub2', 'grub2-efi', 'grub2-common')
 
     def setup(self):
+
+        self.add_file_tags({
+            '/boot/grub2/grub.cfg': 'grub2_cfg',
+            '/boot/efi/.*/grub.cfg': 'grub2_efi_cfg'
+        })
+
         self.add_copy_spec([
             "/boot/efi/EFI/*/grub.cfg",
             "/boot/grub2/grub.cfg",
@@ -29,7 +35,7 @@ class Grub2(Plugin, IndependentPlugin):
             "/etc/grub.d"
         ])
 
-        self.add_cmd_output("ls -lanR /boot")
+        self.add_cmd_output("ls -lanR /boot", tags="ls_boot")
         # call grub2-mkconfig with GRUB_DISABLE_OS_PROBER=true to prevent
         # possible unwanted loading of some kernel modules
         # further, check if the command supports --no-grubenv-update option

--- a/sos/report/plugins/hardware.py
+++ b/sos/report/plugins/hardware.py
@@ -17,8 +17,10 @@ class Hardware(Plugin, IndependentPlugin):
     profiles = ('system', 'hardware')
 
     def setup(self):
+
+        self.add_copy_spec("/proc/interrupts", tags='interrupts')
+
         self.add_copy_spec([
-            "/proc/interrupts",
             "/proc/irq",
             "/proc/dma",
             "/proc/devices",

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -35,7 +35,8 @@ class Kernel(Plugin, IndependentPlugin):
         try:
             modules = os.listdir(self.sys_module)
             self.add_cmd_output("modinfo " + " ".join(modules),
-                                suggest_filename="modinfo_ALL_MODULES")
+                                suggest_filename="modinfo_ALL_MODULES",
+                                tags='modinfo_all')
         except OSError:
             self._log_warn("could not list %s" % self.sys_module)
 
@@ -56,7 +57,7 @@ class Kernel(Plugin, IndependentPlugin):
             "dmesg",
             "sysctl -a",
             "dkms status"
-        ])
+        ], cmd_as_tag=True)
 
         clocksource_path = "/sys/devices/system/clocksource/clocksource0/"
 

--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -21,12 +21,12 @@ class Md(Plugin, IndependentPlugin):
         self.add_blockdev_cmd("mdadm -E %(dev)s",
                               blacklist=['ram.*', 'zram.*'])
         self.add_copy_spec([
-            "/proc/mdstat",
             "/etc/mdadm.conf",
             "/dev/md/md-device-map",
             "/proc/sys/dev/raid/*",
             "/sys/block/md*/md*"
         ])
 
+        self.add_copy_spec("/proc/mdstat", tags='mdstat')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/multipath.py
+++ b/sos/report/plugins/multipath.py
@@ -17,10 +17,14 @@ class Multipath(Plugin, IndependentPlugin):
     profiles = ('system', 'storage', 'hardware')
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/multipath/",
-            "/etc/multipath.conf"
-        ])
+
+        self.add_cmd_tags({
+            'multipath -v4 -ll': 'insights_multipath__v4__ll'
+        })
+
+        self.add_copy_spec("/etc/multipath.conf", tags='multipath_conf')
+        self.add_copy_spec("/etc/multipath/")
+
         self.add_cmd_output([
             "multipath -ll",
             "multipath -v4 -ll",

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -45,11 +45,13 @@ class Networking(Plugin):
             'ethtool -S .*': 'ethtool_S',
             'ethtool -g .*': 'ethtool_g',
             'ethtool -T .*': 'ethtool_T',
-            'ethtool -c .*': 'ethtool_c'
+            'ethtool -c .*': 'ethtool_c',
+            'ethtool -d .*': 'ethtool_d'
         })
 
         self.add_file_tags({
-            '/proc/net/bonding/bond.*': 'bond'
+            '/proc/net/bonding/bond.*': 'bond',
+            '/etc/hosts': 'hosts'
         })
 
         self.add_copy_spec([
@@ -80,8 +82,9 @@ class Networking(Plugin):
             "/proc/net/eicon"
         ])
 
-        self.add_cmd_output("ip -o addr", root_symlink="ip_addr")
-        self.add_cmd_output("route -n", root_symlink="route")
+        self.add_cmd_output("ip -o addr", root_symlink="ip_addr",
+                            tags='ip_addr')
+        self.add_cmd_output("route -n", root_symlink="route", tags='route')
         self.add_cmd_output("plotnetcfg")
 
         self.add_cmd_output("netstat %s -neopa" % self.ns_wide,

--- a/sos/report/plugins/ntp.py
+++ b/sos/report/plugins/ntp.py
@@ -18,15 +18,17 @@ class Ntp(Plugin):
     packages = ('ntp',)
 
     def setup(self):
+
+        self.add_copy_spec("/etc/ntp.conf", tags="ntp_conf")
+
         self.add_copy_spec([
-            "/etc/ntp.conf",
             "/etc/ntp/step-tickers",
             "/etc/ntp/ntpservers"
         ])
         self.add_cmd_output([
             "ntptime",
             "ntpq -pn"
-        ])
+        ], cmd_as_tag=True)
 
         ids = self.collect_cmd_output('ntpq -c as')
         if ids['status'] == 0:

--- a/sos/report/plugins/numa.py
+++ b/sos/report/plugins/numa.py
@@ -22,6 +22,12 @@ class Numa(Plugin, IndependentPlugin):
     packages = ('numad', 'numactl')
 
     def setup(self):
+        numa_path = "/sys/devices/system/node"
+
+        self.add_file_tags({
+            "%s/node.*/cpulist": 'numa_cpus'
+        })
+
         self.add_copy_spec([
             "/etc/numad.conf",
             "/etc/logrotate.d/numad"
@@ -35,7 +41,6 @@ class Numa(Plugin, IndependentPlugin):
             "numactl --hardware",
         ])
 
-        numa_path = "/sys/devices/system/node"
         self.add_copy_spec([
             os.path.join(numa_path, "node*/meminfo"),
             os.path.join(numa_path, "node*/cpulist"),

--- a/sos/report/plugins/pam.py
+++ b/sos/report/plugins/pam.py
@@ -19,6 +19,12 @@ class Pam(Plugin):
     security_libs = ""
 
     def setup(self):
+
+        self.add_file_tags({
+            '/etc/pam.d/password-auth': 'password_auth',
+            '/etc/security/limits.*.conf': 'limits_conf'
+        })
+
         self.add_copy_spec([
             "/etc/pam.d",
             "/etc/security"

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -59,7 +59,9 @@ class Process(Plugin, IndependentPlugin):
 
         self.add_cmd_output("ps auxwwwm", root_symlink="ps",
                             tags=['ps_aux', 'ps_auxww', 'ps_auxwww',
-                                  'ps_auxwwwm'], priority=1)
+                                  'ps_auxwwwm', 'insights_ps_auxcww'],
+                            priority=1)
+
         self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
             self.add_cmd_output("lsof +M -n -l -c ''", root_symlink="lsof",
@@ -70,7 +72,10 @@ class Process(Plugin, IndependentPlugin):
 
         self.add_cmd_output([
             "ps alxwww",
-            "ps -elfL",
+            "ps -elfL"
+        ], cmd_as_tag=True)
+
+        self.add_cmd_output([
             "%s %s" % (ps_axo, ps_group_opts),
             "%s %s" % (ps_axo, ps_sched_opts)
         ])

--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -19,6 +19,18 @@ class Processor(Plugin, IndependentPlugin):
     packages = ('cpufreq-utils', 'cpuid')
 
     def setup(self):
+
+        cpupath = '/sys/devices/system/cpu'
+
+        self.add_file_tags({
+            "%s/smt/control" % cpupath: 'cpu_smt_control',
+            "%s/smt/active" % cpupath: 'cpu_smt_active',
+            "%s/vulnerabilities/.*" % cpupath: 'cpu_vulns',
+            "%s/vulnerabilities/spectre_v2" % cpupath: 'cpu_vulns_spectre_v2',
+            "%s/vulnerabilities/meltdown" % cpupath: 'cpu_vulns_meltdown',
+            "%s/cpu.*/online" % cpupath: 'cpu_cores'
+        })
+
         self.add_copy_spec([
             "/proc/cpuinfo",
             "/sys/class/cpuid",
@@ -35,7 +47,7 @@ class Processor(Plugin, IndependentPlugin):
             "cpuid",
             "cpuid -r",
             "turbostat --debug sleep 10"
-        ])
+        ], cmd_as_tag=True)
 
         if '86' in self.policy.get_arch():
             self.add_cmd_output("x86info -a")

--- a/sos/report/plugins/pulp.py
+++ b/sos/report/plugins/pulp.py
@@ -62,6 +62,10 @@ class Pulp(Plugin, RedHatPlugin):
             # fallback when the cfg file is not accessible
             pass
 
+        self.add_file_tags({
+            '/etc/default/pulp_workers': 'pulp_worker_defaults'
+        })
+
         self.add_copy_spec([
             "/etc/pulp/*.conf",
             "/etc/pulp/settings.py",

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -49,7 +49,9 @@ class Rpm(Plugin, RedHatPlugin):
         if self.get_option("rpmva"):
             self.plugin_timeout = 1000
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",
-                                timeout=900, priority=100)
+                                timeout=900, priority=100,
+                                tags=['rpm_va', 'rpm_V', 'rpm_v',
+                                      'insights_rpm_V_packages'])
 
         if self.get_option("rpmdb"):
             self.add_cmd_output("lsof +D /var/lib/rpm",

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -19,6 +19,12 @@ class Ssh(Plugin, IndependentPlugin):
     profiles = ('services', 'security', 'system', 'identity')
 
     def setup(self):
+
+        self.add_file_tags({
+            '/etc/ssh/sshd_config': 'sshd_config',
+            '/etc/ssh/ssh_config': 'ssh_config'
+        })
+
         sshcfgs = [
             "/etc/ssh/ssh_config",
             "/etc/ssh/sshd_config"
@@ -30,6 +36,7 @@ class Ssh(Plugin, IndependentPlugin):
         # Read configs for any includes and copy those
         try:
             for sshcfg in sshcfgs:
+                tag = sshcfg.split('/')[-1]
                 with open(sshcfg, 'r') as cfgfile:
                     for line in cfgfile:
                         # skip empty lines and comments
@@ -38,7 +45,7 @@ class Ssh(Plugin, IndependentPlugin):
                         # ssh_config keywords are allowed as case-insensitive
                         if line.lower().startswith('include'):
                             confarg = line.split()
-                            self.add_copy_spec(confarg[1])
+                            self.add_copy_spec(confarg[1], tags=tag)
         except Exception:
             pass
 

--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -32,7 +32,7 @@ class Sssd(Plugin):
         ])
 
         # add individual log files
-        self.add_copy_spec(glob("/var/log/sssd/*log*"))
+        self.add_copy_spec(glob("/var/log/sssd/*log*"), tags='sssd_logs')
 
         # add memory cache
         self.add_copy_spec([

--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -66,13 +66,14 @@ class SubscriptionManager(Plugin, RedHatPlugin):
             "subscription-manager release --show",
             "subscription-manager release --list",
             "syspurpose show"
-        ])
+        ], cmd_as_tag=True)
         self.add_cmd_output("rhsm-debug system --sos --no-archive "
                             "--no-subscriptions --destination %s"
                             % self.get_cmd_output_path())
 
         certs = glob.glob('/etc/pki/product-default/*.pem')
-        self.add_cmd_output(["rct cat-cert %s" % cert for cert in certs])
+        self.add_cmd_output(["rct cat-cert %s" % cert for cert in certs],
+                            tags='subscription_manager_installed_product_ids')
 
         # try curl to the RHSM server for potential certificate/proxy issue
         curlcmd = "curl -vv --cacert /etc/rhsm/ca/redhat-uep.pem " \

--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -22,6 +22,14 @@ class Systemd(Plugin, IndependentPlugin):
     files = ('/run/systemd/system',)
 
     def setup(self):
+
+        self.add_file_tags({
+            '/etc/systemd/journald.conf.*': 'insights_etc_journald_conf',
+            '/usr/lib/systemd/journald.conf.*': 'insights_usr_journald_conf_d',
+            '/etc/systemd/system.conf': 'insights_systemd_system_conf',
+            '/etc/systemd/logind.conf': 'insights_systemd_logind_conf'
+        })
+
         self.add_cmd_output([
             "systemctl status --all",
             "systemctl show --all",

--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -30,6 +30,13 @@ class Yum(Plugin, RedHatPlugin):
     ]
 
     def setup(self):
+
+        self.add_file_tags({
+            '/etc/yum.repos.d/.*': 'yum_repos_d',
+            '/var/log/yum.log': 'yum_log',
+            '/etc/yum.conf': 'yum_conf'
+        })
+
         # Pull all yum related information
         self.add_copy_spec([
             "/etc/yum",
@@ -79,7 +86,7 @@ class Yum(Plugin, RedHatPlugin):
             "yum list installed",
             "package-cleanup --dupes",
             "package-cleanup --problems"
-        ])
+        ], cmd_as_tag=True)
 
         # packages installed/erased/updated per transaction
         if self.get_option("yum-history-info"):


### PR DESCRIPTION
This patchset adds tags to several plugins for aiding the Insights project when it analyzes provided sos archives.

Resolves: #2536
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
