### PR TITLE
[convert2rhel] Fix packages and profiles attrs as tuples

### DIFF
--- a/sos/report/plugins/convert2rhel.py
+++ b/sos/report/plugins/convert2rhel.py
@@ -13,8 +13,8 @@ class convert2rhel(Plugin, RedHatPlugin):
 
     short_desc = 'Convert2RHEL'
     plugin_name = 'convert2rhel'
-    profiles = ('system')
-    packages = ('convert2rhel')
+    profiles = ('system',)
+    packages = ('convert2rhel',)
     verify_packages = ('convert2rhel$',)
 
     def setup(self):


### PR DESCRIPTION
Fixes the definition of `packages` and `profiles` within the plugin to
be tuples.

Resolves: #2537

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
