### PR TITLE
[auditd] Capture missing files in /etc/auditd/

### DIFF
--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -22,6 +22,8 @@ class Auditd(Plugin, IndependentPlugin):
         self.add_copy_spec([
             "/etc/audit/auditd.conf",
             "/etc/audit/audit.rules",
+            "/etc/audit/audit-stop.rules",
+            "/etc/audit/rules.d/",
             "/etc/audit/plugins.d/",
             "/etc/audisp/",
         ])


### PR DESCRIPTION
This commit captures the file audit-stop.rules, and
directory plugins.d.

Resolves: #2538 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
