### PR TITLE
[Policy] Correct internal HTTPS language and add SSL verify toggle

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -362,6 +362,13 @@ be used provided all other required values (case number, upload user) are provid
 Specify a directory to upload to, if one is not specified by a vendor default location
 or if your destination server does not allow writes to '/'.
 .TP
+.B \--upload-method METHOD
+Specify the HTTP method to use for uploading to the provided --upload-url. Valid
+values are 'auto' (default), 'put', or 'post'. The use of 'auto' will default to
+the method required by the policy-default upload location, if one exists.
+
+This option has no effect on upload methods other than HTTPS.
+.TP
 .B \--experimental
 Enable plugins marked as experimental. Experimental plugins may not have
 been tested for this port or may still be under active development.

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -35,6 +35,7 @@ sosreport \- Collect and package diagnostic and support data
           [--encrypt-pass PASS]\fR
           [--upload] [--upload-url url] [--upload-user user]\fR
           [--upload-directory dir] [--upload-pass pass]\fR
+          [--upload-no-ssl-verify] [--upload-method]\fR
           [--experimental]\fR
           [-h|--help]\fR
 
@@ -367,7 +368,14 @@ Specify the HTTP method to use for uploading to the provided --upload-url. Valid
 values are 'auto' (default), 'put', or 'post'. The use of 'auto' will default to
 the method required by the policy-default upload location, if one exists.
 
-This option has no effect on upload methods other than HTTPS.
+This option has no effect on upload protocols other than HTTPS.
+.TP
+.B \--upload-no-ssl-verify
+Disable SSL verification for HTTPS uploads. This may be used to allow uploading
+to locations that have self-signed certificates, or certificates that are otherwise
+untrusted by the local system.
+
+Default behavior is to perform SSL verification against all upload locations.
 .TP
 .B \--experimental
 Enable plugins marked as experimental. Experimental plugins may not have

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -101,6 +101,7 @@ class SoSCollector(SoSComponent):
         'upload_directory': None,
         'upload_user': None,
         'upload_pass': None,
+        'upload_method': 'auto'
     }
 
     def __init__(self, parser, parsed_args, cmdline_args):
@@ -364,6 +365,9 @@ class SoSCollector(SoSComponent):
                                  help="Username to authenticate with")
         collect_grp.add_argument("--upload-pass", default=None,
                                  help="Password to authenticate with")
+        collect_grp.add_argument("--upload-method", default='auto',
+                                 choices=['auto', 'put', 'post'],
+                                 help="HTTP method to use for uploading")
 
         # Group the cleaner options together
         cleaner_grp = parser.add_argument_group(

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -101,7 +101,8 @@ class SoSCollector(SoSComponent):
         'upload_directory': None,
         'upload_user': None,
         'upload_pass': None,
-        'upload_method': 'auto'
+        'upload_method': 'auto',
+        'upload_no_ssl_verify': False
     }
 
     def __init__(self, parser, parsed_args, cmdline_args):
@@ -368,7 +369,10 @@ class SoSCollector(SoSComponent):
         collect_grp.add_argument("--upload-method", default='auto',
                                  choices=['auto', 'put', 'post'],
                                  help="HTTP method to use for uploading")
-
+        collect_grp.add_argument("--upload-no-ssl-verify", default=False,
+                                 action='store_true',
+                                 help="Disable SSL verification for upload url"
+                                 )
         # Group the cleaner options together
         cleaner_grp = parser.add_argument_group(
             'Cleaner/Masking Options',

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -373,7 +373,7 @@ class LinuxPolicy(Policy):
         """
         raise NotImplementedError("SFTP support is not yet implemented")
 
-    def _upload_https_put(self, archive):
+    def _upload_https_put(self, archive, verify=True):
         """If upload_https() needs to use requests.put(), use this method.
 
         Policies should override this method instead of the base upload_https()
@@ -381,14 +381,15 @@ class LinuxPolicy(Policy):
         :param archive:     The open archive file object
         """
         return requests.put(self.get_upload_url(), data=archive,
-                            auth=self.get_upload_https_auth())
+                            auth=self.get_upload_https_auth(),
+                            verify=verify)
 
     def _get_upload_headers(self):
         """Define any needed headers to be passed with the POST request here
         """
         return {}
 
-    def _upload_https_post(self, archive):
+    def _upload_https_post(self, archive, verify=True):
         """If upload_https() needs to use requests.post(), use this method.
 
         Policies should override this method instead of the base upload_https()
@@ -400,7 +401,8 @@ class LinuxPolicy(Policy):
                      self._get_upload_headers())
         }
         return requests.post(self.get_upload_url(), files=files,
-                             auth=self.get_upload_https_auth())
+                             auth=self.get_upload_https_auth(),
+                             verify=verify)
 
     def upload_https(self):
         """Attempts to upload the archive to an HTTPS location.
@@ -419,10 +421,11 @@ class LinuxPolicy(Policy):
                 method = self._upload_method
             else:
                 method = self.commons['cmdlineopts'].upload_method
+            verify = self.commons['cmdlineopts'].upload_no_ssl_verify is False
             if method == 'put':
-                r = self._upload_https_put(arc)
+                r = self._upload_https_put(arc, verify)
             else:
-                r = self._upload_https_post(arc)
+                r = self._upload_https_post(arc, verify)
             if r.status_code != 201:
                 if r.status_code == 401:
                     raise Exception(

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -214,6 +214,7 @@ support representative.
     _upload_url = RH_FTP_HOST
     _upload_user = 'anonymous'
     _upload_directory = '/incoming'
+    _upload_method = 'post'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):

--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -24,7 +24,7 @@ class UbuntuPolicy(DebianPolicy):
     _upload_url = "https://files.support.canonical.com/uploads/"
     _upload_user = "ubuntu"
     _upload_password = "ubuntu"
-    _use_https_streaming = True
+    _upload_method = 'put'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -119,6 +119,7 @@ class SoSReport(SoSComponent):
         'upload_user': None,
         'upload_pass': None,
         'upload_method': 'auto',
+        'upload_no_ssl_verify': False,
         'add_preset': '',
         'del_preset': ''
     }
@@ -303,6 +304,9 @@ class SoSReport(SoSComponent):
         report_grp.add_argument("--upload-method", default='auto',
                                 choices=['auto', 'put', 'post'],
                                 help="HTTP method to use for uploading")
+        report_grp.add_argument("--upload-no-ssl-verify", default=False,
+                                action='store_true',
+                                help="Disable SSL verification for upload url")
 
         # Group to make add/del preset exclusive
         preset_grp = report_grp.add_mutually_exclusive_group()

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -118,6 +118,7 @@ class SoSReport(SoSComponent):
         'upload_directory': None,
         'upload_user': None,
         'upload_pass': None,
+        'upload_method': 'auto',
         'add_preset': '',
         'del_preset': ''
     }
@@ -299,6 +300,9 @@ class SoSReport(SoSComponent):
                                 help="Username to authenticate to server with")
         report_grp.add_argument("--upload-pass", default=None,
                                 help="Password to authenticate to server with")
+        report_grp.add_argument("--upload-method", default='auto',
+                                choices=['auto', 'put', 'post'],
+                                help="HTTP method to use for uploading")
 
         # Group to make add/del preset exclusive
         preset_grp = report_grp.add_mutually_exclusive_group()


### PR DESCRIPTION
First, corrects the internal language used around HTTPS uploads.

Second, adds `--no-ssl-verify` to skip ssl verification for HTTPS uploads

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
