### PR TITLE
[cirrus] Enable auto-cancellation of jobs and specify type for GCE

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,10 @@
 # Main environment vars to set for all tasks
 env:
 
+    # enable auto cancelling concurrent builds on master when multiple PRs are
+    # merged at once
+    auto_cancellation: true
+
     FEDORA_VER: "33"
     FEDORA_PRIOR_VER: "32"
     FEDORA_NAME: "fedora-${FEDORA_VER}"
@@ -73,8 +77,7 @@ report_stageone_task:
     gce_instance: &standardvm
         image_project: "${PROJECT}"
         image_name: "${VM_IMAGE_NAME}"
-        cpu: 2
-        memory: "4Gb"
+        type: e2-medium
         # minimum disk size is 20
         disk: 20
     matrix:
@@ -140,7 +143,7 @@ report_foreman_task:
     depends_on: stageone_report
     gce_instance: &bigvm
         <<: *standardvm
-        memory: "8Gb"
+        type: e2-standard-2
     matrix:
         - env:
             PROJECT: ${SOS_PROJECT}


### PR DESCRIPTION
Modifies the cirrus configuration to enable auto-cancellation of jobs
for the master branch (it is already enabled for PR branches by
default). This will prevent batch merges from kicking off a test job for
each merge. While it may arise that two or more independent commits that
pass testing on their own branches combine to form an unexpected
failure, this possibility seems remote for sos.

This is a cost saving decision - currently for each commit to master we
are spinning up a minimum of 13 VMs, which can very quickly snowball if
we do multiple merges in a short amount of time (which is historically
how the project does merges).

Second, modify the `gce_instance` fields in the cirrus config to use
pre-defined machine types, as these match our current "custom"
specifications already, and are cheaper to run.

Resolves: #2541

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
