### PR TITLE
[policy,collector] State explicitly that caseid is optional

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1061,7 +1061,8 @@ this utility or remote systems that it connects to.
                 self.exit("Exiting on user cancel", 130)
 
         if not self.opts.case_id and not self.opts.batch:
-            msg = 'Please enter the case id you are collecting reports for: '
+            msg = 'Optionally, please enter the case id you are collecting ' \
+                  'reports for: '
             self.opts.case_id = input(msg)
 
     def execute(self):

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -194,8 +194,8 @@ class LinuxPolicy(Policy):
                 if caseid:
                     self.case_id = caseid
                 else:
-                    self.case_id = input(_("Please enter the case id "
-                                           "that you are generating this "
+                    self.case_id = input(_("Optionally, please enter the case "
+                                           "id that you are generating this "
                                            "report for [%s]: ") % caseid)
                 # Policies will need to handle the prompts for user information
                 if cmdline_opts.upload and self.get_upload_url():


### PR DESCRIPTION
While providing case id is fully optional, the current phrasing
might be insintepreted it is mandatory.

Resolves: #2542

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
