### PR TITLE
[docs] Clarify profile in manpage and how to enable further plugins

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -61,8 +61,13 @@ Disable the specified plugin(s). Multiple plug-ins may be specified
 by repeating the option or as a comma-separated list.
 .TP
 .B \-e, --enable-plugins PLUGNAME[,PLUGNAME]
-Enable the specified plugin(s). Multiple plug-ins may be specified
-by repeating the option or as a comma-separated list.
+Enable the specified plugin(s) that would otherwise be disabled. Multiple plugins
+may be specified by repeating the option or as a comma-separated list.
+
+Note that if using \fB-p, --profile\fR this option will \fBnot\fR enable further
+plugins. Use \fB-o, --only-plugins\fR to extend the list of plugins enabled by
+profiles.
+
 .TP
 .B \-o, --only-plugins PLUGNAME[,PLUGNAME]
 Enable the specified plugin(s) only (all other plugins should be
@@ -156,10 +161,13 @@ Display a list of available profiles and the plugins that they enable.
 .B \-p, \--profile, \--profiles NAME
 Only run plugins that correspond to the given profile. Multiple profiles
 may be specified as a comma-separated list; the set of plugins executed
-is the union of each of the profile's plugin sets. Currently defined
-profiles include: boot, cluster, desktop, debug, hardware, identity,
-network, openstack, packagemanager, security, services, storage,
-sysmgmt, system, performance, virt, and webserver.
+is the union of each of the profile's plugin sets.
+
+Note that if there are specific plugins outside of the profile(s) passed to this
+option that you would also want to enable, use \fB-o, --only-plugins\fR to add those
+plugins to the list.
+
+See \fBsos report --list-profiles\fR for a list of currently supported profiles.
 .TP
 .B \--verify
 Instructs plugins to perform plugin-specific verification during data


### PR DESCRIPTION
Updates the language in the manpage to clarify that in order to enable
additional plugins outside of a profile when a profile is specified,
that users must use `-o` instead of `-e`.

Remove the 'current profiles' list from the manpage as it is outdated
and it is better to refer users to the list reported by the local
installation.

Closes: #504
Resolves: #2543

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
