### PR TITLE
[collect|ocp] Add an OCP4 collect profile, add registry auth options, improve containerized execution

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -26,6 +26,11 @@ sos collect \- Collect sosreports from multiple (cluster) nodes
     [\-\-no\-pkg\-check]
     [\-\-no\-local]
     [\-\-master MASTER]
+    [\-\-image IMAGE]
+    [\-\-force-pull-image]
+    [\-\-registry-user USER]
+    [\-\-registry-password PASSWORD]
+    [\-\-registry-authfile FILE]
     [\-o ONLY_PLUGINS]
     [\-p SSH_PORT]
     [\-\-password]
@@ -244,6 +249,31 @@ Specify a master node for the cluster.
 
 If provided, then sos collect will check the master node, not localhost, for determining
 the type of cluster in use.
+.TP
+\fB\-\-image IMAGE\fR
+Specify an image to use for the temporary container created for collections on
+containerized host, if you do not want to use the default image specifed by the
+host's policy. Note that this should include the registry.
+.TP
+\fB\-\-force-pull-image\fR
+Use this option to force the container runtime to pull the specified image (even
+if it is the policy default image) even if the image already exists on the host.
+This may be useful to update an older container image on containerized hosts.
+.TP
+\fB\-\-registry-user USER\fR
+Specify the username to authenticate to the registry with in order to pull the container
+image
+.TP
+\fB\-\-registry-password PASSWORD\fR
+Specify the password to authenticate to the registry with in order to pull the container
+image. If no password is required, leave this blank.
+.TP
+\fB\-\-registry-authfile FILE\fR
+Specify the filename to use for providing authentication credentials to the registry
+to pull the container image.
+
+Note that this file must exist on the node(s) performing the pull operations, not the
+node from which \fBsos collect\fR was run.
 .TP
 \fB\-o\fR ONLY_PLUGINS, \fB\-\-only\-plugins\fR ONLY_PLUGINS
 Sosreport option. Run ONLY the plugins listed.

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -63,6 +63,7 @@ class SoSCollector(SoSComponent):
         'encrypt_pass': '',
         'group': None,
         'image': '',
+        'force_pull_image': False,
         'jobs': 4,
         'keywords': [],
         'keyword_file': None,
@@ -84,6 +85,9 @@ class SoSCollector(SoSComponent):
         'plugin_timeout': None,
         'cmd_timeout': None,
         'preset': '',
+        'registry_user': None,
+        'registry_password': None,
+        'registry_authfile': None,
         'save_group': '',
         'since': '',
         'skip_commands': [],
@@ -316,6 +320,19 @@ class SoSCollector(SoSComponent):
         collect_grp.add_argument('--image',
                                  help=('Specify the container image to use for'
                                        ' containerized hosts.'))
+        collect_grp.add_argument('--force-pull-image', '--pull', default=False,
+                                 action='store_true',
+                                 help='Force pull the container image even if '
+                                      'it already exists on the host')
+        collect_grp.add_argument('--registry-user', default=None,
+                                 help='Username to authenticate to the '
+                                      'registry with for pulling an image')
+        collect_grp.add_argument('--registry-password', default=None,
+                                 help='Password to authenticate to the '
+                                      'registry with for pulling an image')
+        collect_grp.add_argument('--registry-authfile', default=None,
+                                 help='Use this authfile to provide registry '
+                                      'authentication when pulling an image')
         collect_grp.add_argument('-i', '--ssh-key', help='Specify an ssh key')
         collect_grp.add_argument('-j', '--jobs', default=4, type=int,
                                  help='Number of concurrent nodes to collect')

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -137,6 +137,27 @@ class Cluster():
         """
         self.cluster_ssh_key = key
 
+    def set_master_options(self, node):
+        """If there is a need to set specific options in the sos command being
+        run on the cluster's master nodes, override this method in the cluster
+        profile and do that here.
+
+        :param node:       The master node
+        :type node:        ``SoSNode``
+        """
+        pass
+
+    def check_node_is_master(self, node):
+        """In the event there are multiple masters, or if the collect command
+        is being run from a system that is technically capable of enumerating
+        nodes but the cluster profiles needs to specify master-specific options
+        for other nodes, override this method in the cluster profile
+
+        :param node:        The node for the cluster to check
+        :type node:         ``SoSNode``
+        """
+        return node.address == self.master.address
+
     def exec_master_cmd(self, cmd, need_root=False):
         """Used to retrieve command output from a (master) node in a cluster
 

--- a/sos/collector/clusters/kubernetes.py
+++ b/sos/collector/clusters/kubernetes.py
@@ -44,11 +44,3 @@ class kubernetes(Cluster):
             return nodes
         else:
             raise Exception('Node enumeration did not return usable output')
-
-
-class openshift(kubernetes):
-
-    cluster_name = 'OpenShift Container Platform'
-    packages = ('atomic-openshift',)
-    sos_preset = 'ocp'
-    cmd = 'oc'

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -1,0 +1,109 @@
+# Copyright Red Hat 2021, Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from pipes import quote
+from sos.collector.clusters import Cluster
+
+
+class ocp(Cluster):
+    """OpenShift Container Platform v4"""
+
+    cluster_name = 'OpenShift Container Platform v4'
+    packages = ('openshift-hyperkube', 'openshift-clients')
+
+    option_list = [
+        ('label', '', 'Colon delimited list of labels to select nodes with'),
+        ('role', '', 'Colon delimited list of roles to select nodes with'),
+        ('kubeconfig', '', 'Path to the kubeconfig file')
+    ]
+
+    def fmt_oc_cmd(self, cmd):
+        """Format the oc command to optionall include the kubeconfig file if
+        one is specified
+        """
+        if self.get_option('kubeconfig'):
+            return "oc --config %s %s" % (self.get_option('kubeconfig'), cmd)
+        return "oc %s" % cmd
+
+    def check_enabled(self):
+        if super(ocp, self).check_enabled():
+            return True
+        _who = self.fmt_oc_cmd('whoami')
+        return self.exec_master_cmd(_who)['status'] == 0
+
+    def _build_dict(self, nodelist):
+        """From the output of get_nodes(), construct an easier-to-reference
+        dict of nodes that will be used in determining labels, master status,
+        etc...
+
+        :param nodelist:        The split output of `oc get nodes`
+        :type nodelist:         ``list``
+
+        :returns:           A dict of nodes with `get nodes` columns as keys
+        :rtype:             ``dict``
+        """
+        nodes = {}
+        if 'NAME' in nodelist[0]:
+            # get the index of the fields
+            statline = nodelist.pop(0).split()
+            idx = {}
+            for state in ['status', 'roles', 'version', 'os-image']:
+                try:
+                    idx[state] = statline.index(state.upper())
+                except Exception:
+                    pass
+            for node in nodelist:
+                _node = node.split()
+                nodes[_node[0]] = {}
+                for column in idx:
+                    nodes[_node[0]][column] = _node[idx[column]]
+        return nodes
+
+    def get_nodes(self):
+        nodes = []
+        self.node_dict = {}
+        cmd = 'get nodes -o wide'
+        if self.get_option('label'):
+            labels = ','.join(self.get_option('label').split(':'))
+            cmd += " -l %s" % quote(labels)
+        res = self.exec_master_cmd(self.fmt_oc_cmd(cmd))
+        if res['status'] == 0:
+            roles = [r for r in self.get_option('role').split(':')]
+            self.node_dict = self._build_dict(res['stdout'].splitlines())
+            for node in self.node_dict:
+                if roles:
+                    for role in roles:
+                        if role in node:
+                            nodes.append(node)
+                else:
+                    nodes.append(node)
+        else:
+            msg = "'oc' command failed"
+            if 'Missing or incomplete' in res['stdout']:
+                msg = ("'oc' failed due to missing kubeconfig on master node."
+                       " Specify one via '-c ocp.kubeconfig=<path>'")
+            raise Exception(msg)
+        return nodes
+
+    def set_node_label(self, node):
+        if node.address not in self.node_dict:
+            return ''
+        for label in ['master', 'worker']:
+            if label in self.node_dict[node.address]['roles']:
+                return label
+        return ''
+
+    def check_node_is_master(self, sosnode):
+        if sosnode.address not in self.node_dict:
+            return False
+        return 'master' in self.node_dict[sosnode.address]['roles']
+
+    def set_master_options(self, node):
+        node.opts.enable_plugins.append('openshift')

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -647,6 +647,10 @@ class SosNode():
                                         self.cluster.sos_plugin_options[opt])
                     self.opts.plugin_options.append(option)
 
+        # set master-only options
+        if self.cluster.check_node_is_master(self):
+            self.cluster.set_master_options(self)
+
     def finalize_sos_cmd(self):
         """Use host facts and compare to the cluster type to modify the sos
         command if needed"""
@@ -706,6 +710,8 @@ class SosNode():
             'sosreport',
             os.path.join(self.host.sos_bin_path, self.sos_bin)
         )
+
+        self.update_cmd_from_cluster()
 
         if self.opts.only_plugins:
             plugs = [o for o in self.opts.only_plugins

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -287,13 +287,20 @@ class SosNode():
             # use the containerized policy's command
             pkgs = self.run_command(self.host.container_version_command,
                                     use_container=True, need_root=True)
-            ver = pkgs['stdout'].strip().split('-')[1]
-            if ver:
-                self.sos_info['version'] = ver
-        if 'version' in self.sos_info:
+            if pkgs['status'] == 0:
+                ver = pkgs['stdout'].strip().split('-')[1]
+                if ver:
+                    self.sos_info['version'] = ver
+            else:
+                self.sos_info['version'] = None
+        if self.sos_info['version']:
             self.log_info('sos version is %s' % self.sos_info['version'])
         else:
-            self.log_error('sos is not installed on this node')
+            if not self.address == self.opts.master:
+                # in the case where the 'master' enumerates nodes but is not
+                # intended for collection (bastions), don't worry about sos not
+                # being present
+                self.log_error('sos is not installed on this node')
             self.connected = False
             return False
         cmd = 'sosreport -l'

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -304,7 +304,7 @@ class SosNode():
             self.connected = False
             return False
         cmd = 'sosreport -l'
-        sosinfo = self.run_command(cmd, use_container=True)
+        sosinfo = self.run_command(cmd, use_container=True, need_root=True)
         if sosinfo['status'] == 0:
             self._load_sos_plugins(sosinfo['stdout'])
         if self.check_sos_version('3.6'):
@@ -312,7 +312,7 @@ class SosNode():
 
     def _load_sos_presets(self):
         cmd = 'sosreport --list-presets'
-        res = self.run_command(cmd, use_container=True)
+        res = self.run_command(cmd, use_container=True, need_root=True)
         if res['status'] == 0:
             for line in res['stdout'].splitlines():
                 if line.strip().startswith('name:'):
@@ -965,7 +965,7 @@ class SosNode():
                     self.remove_file(self.sos_path + ext)
         cleanup = self.host.set_cleanup_cmd()
         if cleanup:
-            self.run_command(cleanup)
+            self.run_command(cleanup, need_root=True)
 
     def collect_extra_cmd(self, filenames):
         """Collect the file created by a cluster outside of sos"""

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -62,6 +62,7 @@ class LinuxPolicy(Policy):
     sos_bin_path = '/usr/bin'
     sos_container_name = 'sos-collector-tmp'
     container_version_command = None
+    container_authfile = None
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True):
         super(LinuxPolicy, self).__init__(sysroot=sysroot,
@@ -530,13 +531,26 @@ class LinuxPolicy(Policy):
         """
         return ''
 
-    def create_sos_container(self):
+    def create_sos_container(self, image=None, auth=None, force_pull=False):
         """Returns the command that will create the container that will be
         used for running commands inside a container on hosts that require it.
 
         This will use the container runtime defined for the host type to
         launch a container. From there, we use the defined runtime to exec into
         the container's namespace.
+
+        :param image:   The name of the image if not using the policy default
+        :type image:    ``str`` or ``None``
+
+        :param auth:    The auth string required by the runtime to pull an
+                        image from the registry
+        :type auth:     ``str`` or ``None``
+
+        :param force_pull:  Should the runtime forcibly pull the image
+        :type force_pull:   ``bool``
+
+        :returns:   The command to execute to launch the temp container
+        :rtype:     ``str``
         """
         return ''
 

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -414,15 +414,19 @@ support representative.
 
         return self.find_preset(ATOMIC)
 
-    def create_sos_container(self):
+    def create_sos_container(self, image=None, auth=None, force_pull=False):
         _cmd = ("{runtime} run -di --name {name} --privileged --ipc=host"
                 " --net=host --pid=host -e HOST=/host -e NAME={name} -e "
-                "IMAGE={image} -v /run:/run -v /var/log:/var/log -v "
+                "IMAGE={image} {pull} -v /run:/run -v /var/log:/var/log -v "
                 "/etc/machine-id:/etc/machine-id -v "
-                "/etc/localtime:/etc/localtime -v /:/host {image}")
+                "/etc/localtime:/etc/localtime -v /:/host {auth} {image}")
+        _image = image or self.container_image
+        _pull = '--pull=always' if force_pull else ''
         return _cmd.format(runtime=self.container_runtime,
                            name=self.sos_container_name,
-                           image=self.container_image)
+                           image=_image,
+                           pull=_pull,
+                           auth=auth or '')
 
     def set_cleanup_cmd(self):
         return 'docker rm --force sos-collector-tmp'
@@ -444,6 +448,7 @@ support representative.
     container_image = 'registry.redhat.io/rhel8/support-tools'
     sos_path_strip = '/host'
     container_version_command = 'rpm -q sos'
+    container_authfile = '/var/lib/kubelet/config.json'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
@@ -473,15 +478,19 @@ support representative.
         # RH OCP environments.
         return self.find_preset(RHOCP)
 
-    def create_sos_container(self):
+    def create_sos_container(self, image=None, auth=None, force_pull=False):
         _cmd = ("{runtime} run -di --name {name} --privileged --ipc=host"
                 " --net=host --pid=host -e HOST=/host -e NAME={name} -e "
-                "IMAGE={image} -v /run:/run -v /var/log:/var/log -v "
+                "IMAGE={image} {pull} -v /run:/run -v /var/log:/var/log -v "
                 "/etc/machine-id:/etc/machine-id -v "
-                "/etc/localtime:/etc/localtime -v /:/host {image}")
+                "/etc/localtime:/etc/localtime -v /:/host {auth} {image}")
+        _image = image or self.container_image
+        _pull = '--pull=always' if force_pull else ''
         return _cmd.format(runtime=self.container_runtime,
                            name=self.sos_container_name,
-                           image=self.container_image)
+                           image=_image,
+                           pull=_pull,
+                           auth=auth or '')
 
     def set_cleanup_cmd(self):
         return 'podman rm --force %s' % self.sos_container_name

--- a/sos/policies/runtimes/__init__.py
+++ b/sos/policies/runtimes/__init__.py
@@ -157,6 +157,31 @@ class ContainerRuntime():
             quoted_cmd = cmd
         return "%s %s %s" % (self.run_cmd, container, quoted_cmd)
 
+    def fmt_registry_credentials(self, username, password):
+        """Format a string to pass to the 'run' command of the runtime to
+        enable authorization for pulling the image during `sos collect`, if
+        needed using username and optional password creds
+
+        :param username:    The name of the registry user
+        :type username:     ``str``
+
+        :param password:    The password of the registry user
+        :type password:     ``str`` or ``None``
+
+        :returns:  The string to use to enable a run command to pull the image
+        :rtype:    ``str``
+        """
+        return "--creds=%s%s" % (username, ':' + password if password else '')
+
+    def fmt_registry_authfile(self, authfile):
+        """Format a string to pass to the 'run' command of the runtime to
+        enable authorization for pulling the image during `sos collect`, if
+        needed using an authfile.
+        """
+        if authfile:
+            return "--authfile %s" % authfile
+        return ''
+
     def get_logs_command(self, container):
         """Get the command string used to dump container logs from the
         runtime


### PR DESCRIPTION
This patchset adds several options to facilitate pulling an image that does not already exist on containerized hosts when those hosts need to provide authentication to the registry where the image will be pulled from. Fixes some cases around sos inspection on containerized hosts.

Additionally, adds a cluster profile for OpenShift Container Platform v4.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
