### PR TITLE
[networking] Add nstat command support

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -88,6 +88,7 @@ class Networking(Plugin):
                             root_symlink="netstat")
 
         self.add_cmd_output([
+            "nstat -zas",
             "netstat -s",
             "netstat %s -agn" % self.ns_wide,
             "networkctl status -a",
@@ -198,6 +199,7 @@ class Networking(Plugin):
                 ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
                 ns_cmd_prefix + "netstat -s",
                 ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,
+                ns_cmd_prefix + "nstat -zas",
             ])
 
             ss_cmd = ns_cmd_prefix + "ss -peaonmi"


### PR DESCRIPTION
As netstat command is being deprecated,
we need nstat as an alternative to "netstat -s".

Signed-off-by: Seiichi Ikarashi <s.ikarashi@fujitsu.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
