### PR TITLE
[foreman-proxy] split the plugin from foreman

### DIFF
--- a/sos/report/plugins/foreman_installer.py
+++ b/sos/report/plugins/foreman_installer.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2021 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin)
+
+
+class ForemanInstaller(Plugin, DebianPlugin, UbuntuPlugin):
+
+    short_desc = 'Foreman installer and maintainer'
+
+    plugin_name = 'foreman_installer'
+    profiles = ('sysmgmt',)
+    packages = ('foreman-installer', 'rubygem-foreman_maintain')
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/foreman-installer/*",
+            "/var/log/foreman-installer/*",
+            "/var/log/foreman-maintain/*",
+            # specifically collect .applied files
+            # that would be skipped otherwise as hidden files
+            "/etc/foreman-installer/scenarios.d/*/.applied",
+        ])
+
+        # skip collecting individual migration scripts;
+        # .applied file in each dir is still
+        self.add_forbidden_path(
+                "/etc/foreman-installer/scenarios.d/*.migrations/*.rb"
+        )
+
+        self.add_cmd_output([
+            'foreman-maintain service status',
+        ])
+
+    def postproc(self):
+        install_logs = "/var/log/foreman-installer/"
+        logsreg = r"((foreman.*)?(\"::(foreman(.*?)|katello).*)?((::(.*)::.*" \
+                  r"(passw|cred|token|secret|key).*(\")?:)|(storepass )" \
+                  r"|(password =)))(.*)"
+        self.do_path_regex_sub(install_logs, logsreg, r"\1 ********")
+        # need to do two passes here, debug output has different formatting
+        logs_debug_reg = (r"(\s)+(Found key: (\"(foreman(.*?)|katello)"
+                          r"::(.*(token|secret|key|passw).*)\") value:) "
+                          r"(.*)")
+        self.do_path_regex_sub(install_logs, logs_debug_reg, r"\1 \2 ********")
+        # also hide passwords in yet different formats
+        self.do_path_regex_sub(
+            install_logs,
+            r"(\.|_|-)password(=\'|=|\", \")(\w*)",
+            r"\1password\2********")
+        self.do_path_regex_sub(
+            "/var/log/foreman-installer/foreman-proxy*",
+            r"(\s*proxy_password\s=) (.*)",
+            r"\1 ********")
+        self.do_path_regex_sub(
+            "/var/log/foreman-maintain/foreman-maintain.log*",
+            r"(((passw|cred|token|secret)=)|(password ))(.*)",
+            r"\1********")
+        # all scrubbing applied to configs must be applied to installer logs
+        # as well, since logs contain diff of configs
+        self.do_path_regex_sub(
+            r"(/etc/foreman-(installer|maintain)/(.*)((conf)(.*)?))|(%s)"
+            % install_logs,
+            r"((\:|\s*)(passw|cred|token|secret|key).*(\:\s|=))(.*)",
+            r"\1********")
+        # yaml values should be alphanumeric
+        self.do_path_regex_sub(
+            r"(/etc/foreman-(installer|maintain)/(.*)((yaml|yml)(.*)?))|(%s)"
+            % install_logs,
+            r"((\:|\s*)(passw|cred|token|secret|key).*(\:\s|=))(.*)",
+            r'\1"********"')
+
+
+# Add Red Hat Insights tags for RedHatPlugin only
+
+class RedHatForemanInstaller(ForemanInstaller, RedHatPlugin):
+
+    def setup(self):
+
+        self.add_file_tags({
+            '/var/log/foreman-installer/satellite.log.*':
+                ['insights_satellite_log' 'satellite_installer_log'],
+            '/var/log/foreman-installer/capsule.log.*':
+                ['insights_capsule_log' 'capsule_installer_log'],
+        })
+
+        super(RedHatForemanInstaller, self).setup()
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/foreman_proxy.py
+++ b/sos/report/plugins/foreman_proxy.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2021 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin)
+
+
+class ForemanProxy(Plugin):
+
+    short_desc = 'Foreman Smart Proxy systems management'
+
+    plugin_name = 'foreman_proxy'
+    profiles = ('sysmgmt',)
+    packages = ('foreman-proxy',)
+
+    def setup(self):
+        self.add_file_tags({
+            '/var/log/foreman-proxy/proxy.log.*': 'foreman_proxy_log',
+            '/etc/foreman-proxy/settings.yml': 'foreman_proxy_conf'
+        })
+
+        self.add_forbidden_path([
+            "/etc/foreman-proxy/*key.pem"
+        ])
+
+        self.add_copy_spec([
+            "/etc/foreman-proxy/",
+            "/etc/smart_proxy_dynflow_core/settings.yml",
+            "/var/log/foreman-proxy/*log*",
+            "/var/log/{}*/katello-reverse-proxy_access_ssl.log*".format(
+                self.apachepkg),
+            "/var/log/{}*/katello-reverse-proxy_error_ssl.log*".format(
+                self.apachepkg),
+        ])
+
+        # collect http[|s]_proxy env.variables
+        self.add_env_var(["http_proxy", "https_proxy"])
+
+    def postproc(self):
+        self.do_path_regex_sub(
+            r"/etc/foreman-proxy/(.*)((conf)(.*)?)",
+            r"((\:|\s*)(passw|cred|token|secret|key).*(\:\s|=))(.*)",
+            r"\1********")
+        # yaml values should be alphanumeric
+        self.do_path_regex_sub(
+            r"/etc/foreman-proxy/(.*)((yaml|yml)(.*)?)",
+            r"((\:|\s*)(passw|cred|token|secret|key).*(\:\s|=))(.*)",
+            r'\1"********"')
+
+
+# Child classes needed to declare the apachepkg attr properly per distro
+
+class RedHatForemanProxy(ForemanProxy, RedHatPlugin):
+
+    apachepkg = 'httpd'
+
+
+class DebianForemanProxy(ForemanProxy, DebianPlugin, UbuntuPlugin):
+
+    apachepkg = 'apache'
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -20,6 +20,9 @@ class Puppet(Plugin, IndependentPlugin):
                 'puppetserver', 'puppetmaster', 'puppet-master')
 
     def setup(self):
+        _hostname = self.exec_cmd('hostname')['output']
+        _hostname = _hostname.strip()
+
         self.add_copy_spec([
             "/etc/puppet/*.conf",
             "/etc/puppet/rack/*",
@@ -33,7 +36,11 @@ class Puppet(Plugin, IndependentPlugin):
             "/etc/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/log/puppetlabs/puppetserver/*.log*",
             "/var/lib/puppetlabs/puppet/ssl/ca/inventory.txt",
-            "/var/lib/puppet/ssl/ca/inventory.txt"
+            "/var/lib/puppet/ssl/ca/inventory.txt",
+            "/var/lib/puppet/ssl/certs/ca.pem",
+            "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+            "/etc/puppetlabs/puppet/ssl/certs/{}.pem".format(_hostname),
+            "/var/lib/puppet/ssl/certs/{}.pem".format(_hostname),
         ])
 
         self.add_cmd_output([

--- a/tests/product_tests/foreman/foreman_tests.py
+++ b/tests/product_tests/foreman/foreman_tests.py
@@ -31,6 +31,8 @@ class ForemanBasicTest(StageOneReportTest):
         self.assertPluginIncluded([
             'apache',
             'foreman',
+            'foreman_installer',
+            'foreman_proxy',
             'postgresql',
             'puppet',
             'ruby'
@@ -104,3 +106,27 @@ class ForemanWithOptionsTest(StageOneReportTest):
     @redhat_only
     def test_proxyfeatures_collected(self):
         self.assertFileGlobInArchive("sos_commands/foreman/smart_proxies_features/*")
+
+class ForemanInstallerTest(StageOneReportTest):
+    """Check whether foreman-installer related data are properly collected
+    independently on main foreman plugin.
+
+    :avocado: tags=foreman
+    """
+
+    sos_cmd = '-v -o foreman_installer'
+
+    def test_foreman_installer_etc_collected(self):
+        self.assertFileCollected("/etc/foreman-installer/scenarios.d")
+
+class ForemanProxyTest(StageOneReportTest):
+    """Check whether foreman-proxy related data are properly collected
+    independently on main foreman plugin.
+
+    :avocado: tags=foreman
+    """
+
+    sos_cmd = '-v -o foreman_proxy'
+
+    def test_foreman_proxy_settings_collected(self):
+        self.assertFileCollected("/etc/foreman-proxy/settings.yml")


### PR DESCRIPTION
Most of foreman plugin is not applicable to a smart proxy, so
split that functionality to a separate plugin.

Resolves: #2546
Closes: #2423

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
