### PR TITLE
[report,collect,Plugin] Add global namespaces options

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -18,6 +18,7 @@ sos report \- Collect and package diagnostic and support data
           [--threads threads]\fR
           [--plugin-timeout TIMEOUT]\fR
           [--cmd-timeout TIMEOUT]\fR
+          [--namespaces NAMESPACES]\fR
           [-s|--sysroot SYSROOT]\fR
           [-c|--chroot {auto|always|never}\fR
           [--tmp-dir directory]\fR
@@ -289,6 +290,15 @@ Note that setting --cmd-timeout (or -k logs.cmd-timeout) high should be followed
 by increasing the --plugin-timeout equivalent, otherwise the plugin can easily
 timeout on slow commands execution.
 .TP
+.B \--namespaces NAMESPACES
+For plugins that iterate collections over namespaces that exist on the system,
+for example the networking plugin collecting `ip` command output for each network
+namespace, use this option to limit the number of namespaces that will be collected.
+
+Use '0' (default) for no limit - all namespaces will be used for collections.
+
+Note that specific plugins may provide a similar `namespaces` plugin option. If
+the plugin option is used, it will override this option.
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.
 Identifiers may include alphanumeric characters, commas and periods ('.').

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -74,6 +74,7 @@ class SoSCollector(SoSComponent):
         'map_file': '/etc/sos/cleaner/default_mapping',
         'master': '',
         'primary': '',
+        'namespaces': None,
         'nodes': [],
         'no_env_vars': False,
         'no_local': False,
@@ -281,6 +282,9 @@ class SoSCollector(SoSComponent):
         sos_grp.add_argument('-o', '--only-plugins', action="extend",
                              default=[],
                              help='Run these plugins only')
+        sos_grp.add_argument('--namespaces', default=None,
+                             help='limit number of namespaces to collect '
+                                  'output for - 0 means unlimited')
         sos_grp.add_argument('--no-env-vars', action='store_true',
                              default=False,
                              help='Do not collect env vars in sosreports')

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -100,6 +100,7 @@ class SoSReport(SoSComponent):
         'skip_commands': [],
         'skip_files': [],
         'skip_plugins': [],
+        'namespaces': None,
         'no_report': False,
         'no_env_vars': False,
         'no_postproc': False,
@@ -250,6 +251,9 @@ class SoSReport(SoSComponent):
                                 type=int, default=25,
                                 help="limit the size of collected logs "
                                      "(in MiB)")
+        report_grp.add_argument("--namespaces", default=None,
+                                help="limit number of namespaces to collect "
+                                     "output for - 0 means unlimited")
         report_grp.add_argument("-n", "--skip-plugins", action="extend",
                                 dest="skip_plugins", type=str,
                                 help="disable these plugins", default=[])

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -18,7 +18,7 @@ from datetime import datetime
 import glob
 import sos.report.plugins
 from sos.utilities import (ImporterHelper, SoSTimeoutError,
-                           sos_get_command_output)
+                           sos_get_command_output, TIMEOUT_DEFAULT)
 from shutil import rmtree
 import hashlib
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
@@ -108,8 +108,8 @@ class SoSReport(SoSComponent):
         'note': '',
         'only_plugins': [],
         'preset': 'auto',
-        'plugin_timeout': 300,
-        'cmd_timeout': 300,
+        'plugin_timeout': TIMEOUT_DEFAULT,
+        'cmd_timeout': TIMEOUT_DEFAULT,
         'profiles': [],
         'since': None,
         'verify': False,
@@ -733,7 +733,10 @@ class SoSReport(SoSComponent):
             self.ui_log.info(_("The following options are available for ALL "
                                "plugins:"))
             for opt in self.all_options[0][0]._default_plug_opts:
-                self.ui_log.info(" %-25s %-15s %s" % (opt[0], opt[3], opt[1]))
+                val = opt[3]
+                if val == -1:
+                    val = TIMEOUT_DEFAULT
+                self.ui_log.info(" %-25s %-15s %s" % (opt[0], val, opt[1]))
             self.ui_log.info("")
 
             self.ui_log.info(_("The following plugin options are available:"))
@@ -748,6 +751,9 @@ class SoSReport(SoSComponent):
                         tmpopt = "off"
                 else:
                     tmpopt = optparm["enabled"]
+
+                if tmpopt is None:
+                    tmpopt = 0
 
                 self.ui_log.info(" %-25s %-15s %s" % (
                     plugname + "." + optname, tmpopt, optparm["desc"]))

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -11,8 +11,10 @@
 """ This exports methods available for use by plugins for sos """
 
 from sos.utilities import (sos_get_command_output, import_module, grep,
-                           fileobj, tail, is_executable, path_exists,
-                           path_isdir, path_isfile, path_islink, listdir)
+                           fileobj, tail, is_executable, TIMEOUT_DEFAULT,
+                           path_exists, path_isdir, path_isfile, path_islink,
+                           listdir)
+
 import os
 import glob
 import re
@@ -458,8 +460,8 @@ class Plugin(object):
     archive = None
     profiles = ()
     sysroot = '/'
-    plugin_timeout = 300
-    cmd_timeout = 300
+    plugin_timeout = TIMEOUT_DEFAULT
+    cmd_timeout = TIMEOUT_DEFAULT
     _timeout_hit = False
     cmdtags = {}
     filetags = {}
@@ -469,11 +471,8 @@ class Plugin(object):
     predicate = None
     cmd_predicate = None
     _default_plug_opts = [
-        ('timeout', 'Timeout in seconds for plugin. The default value (-1) ' +
-            'defers to the general plugin timeout, 300 seconds', 'fast', -1),
-        ('cmd-timeout', 'Timeout in seconds for a command execution. The ' +
-            'default value (-1) defers to the general cmd timeout, 300 ' +
-            'seconds', 'fast', -1),
+        ('timeout', 'Timeout in seconds for plugin to finish', 'fast', -1),
+        ('cmd-timeout', 'Timeout in seconds for a command', 'fast', -1),
         ('postproc', 'Enable post-processing collected plugin data', 'fast',
          True)
     ]

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1268,6 +1268,11 @@ class Plugin(object):
                 val = parms['enabled']
                 if val is not None:
                     return val
+                else:
+                    # if the value is `None`, use any non-zero default here,
+                    # but still return `None` if no default is given since
+                    # optionname did exist and had a `None` value
+                    return default or val
 
         return default
 
@@ -2843,11 +2848,13 @@ class Plugin(object):
                 continue
         return pids
 
-    def get_network_namespaces(self, ns_pattern=None, ns_max=0):
+    def get_network_namespaces(self, ns_pattern=None, ns_max=None):
+        if ns_max is None and self.commons['cmdlineopts'].namespaces:
+            ns_max = self.commons['cmdlineopts'].namespaces
         return self.filter_namespaces(self.commons['namespaces']['network'],
                                       ns_pattern, ns_max)
 
-    def filter_namespaces(self, ns_list, ns_pattern=None, ns_max=0):
+    def filter_namespaces(self, ns_list, ns_pattern=None, ns_max=None):
         """Filter a list of namespaces by regex pattern or max number of
         namespaces (options originally present in the networking plugin.)
         """
@@ -2859,15 +2866,14 @@ class Plugin(object):
                 '(?:%s$)' % '$|'.join(ns_pattern.split()).replace('*', '.*')
                 )
         for ns in ns_list:
-            # if ns_pattern defined, append only namespaces
-            # matching with pattern
+            # if ns_pattern defined, skip namespaces not matching the pattern
             if ns_pattern:
-                if bool(re.match(pattern, ns)):
-                    out_ns.append(ns)
+                if not bool(re.match(pattern, ns)):
+                    continue
 
-            # if ns_max is defined and ns_pattern is not defined
-            # remove from out_ns namespaces with higher index than defined
-            elif ns_max != 0:
+            # if ns_max is defined at all, limit returned list to that number
+            # this allows the use of both '0' and `None` to mean unlimited
+            elif ns_max:
                 out_ns.append(ns)
                 if len(out_ns) == ns_max:
                     self._log_warn("Limiting namespace iteration "

--- a/sos/report/plugins/conntrack.py
+++ b/sos/report/plugins/conntrack.py
@@ -16,8 +16,12 @@ class Conntrack(Plugin, IndependentPlugin):
 
     plugin_name = 'conntrack'
     profiles = ('network', 'cluster')
-
     packages = ('conntrack-tools', 'conntrack', 'conntrackd')
+
+    option_list = [
+        ('namespaces', 'Number of namespaces to collect, 0 for unlimited',
+            'slow', None)
+    ]
 
     def setup(self):
         # Collect info from conntrackd
@@ -42,7 +46,8 @@ class Conntrack(Plugin, IndependentPlugin):
         # Capture additional data from namespaces; each command is run
         # per-namespace
         cmd_prefix = "ip netns exec "
-        for namespace in self.get_network_namespaces():
+        nsps = self.get_option('namespaces')
+        for namespace in self.get_network_namespaces(ns_max=nsps):
             ns_cmd_prefix = cmd_prefix + namespace + " "
             self.add_cmd_output(ns_cmd_prefix + "conntrack -L -o extended")
             self.add_cmd_output(ns_cmd_prefix + "conntrack -S")

--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -16,6 +16,11 @@ class Ebpf(Plugin, IndependentPlugin):
     plugin_name = 'ebpf'
     profiles = ('system', 'kernel', 'network')
 
+    option_list = [
+        ('namespaces', 'Number of namespaces to collect, 0 for unlimited',
+            'slow', None)
+    ]
+
     def get_bpftool_prog_ids(self, prog_json):
         out = []
         try:
@@ -68,7 +73,8 @@ class Ebpf(Plugin, IndependentPlugin):
 
         # Capture list of bpf program attachments from namespaces
         cmd_prefix = "ip netns exec "
-        for namespace in self.get_network_namespaces():
+        nsps = self.get_option('namespaces')
+        for namespace in self.get_network_namespaces(ns_max=nsps):
             ns_cmd_prefix = cmd_prefix + namespace + " "
             self.add_cmd_output(ns_cmd_prefix + "bpftool net list")
 

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -24,7 +24,7 @@ class Networking(Plugin):
          "collected, namespaces pattern should be separated by whitespace " +
          "as for example \"eth* ens2\"", "fast", ""),
         ("namespaces", "Number of namespaces to collect, 0 for unlimited. " +
-         "Incompatible with the namespace_pattern plugin option", "slow", 0),
+         "Incompatible with the namespace_pattern option", "slow", None),
         ("ethtool_namespaces", "Define if ethtool commands should be " +
          "collected for namespaces", "slow", True),
         ("eepromdump", "collect 'ethtool -e' for all devices", "slow", False)

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -23,6 +23,8 @@ import io
 from contextlib import closing
 from collections import deque
 
+TIMEOUT_DEFAULT = 300
+
 
 def tail(filename, number_of_bytes):
     """Returns the last number_of_bytes of filename"""
@@ -102,7 +104,7 @@ def is_executable(command):
     return any(os.access(path, os.X_OK) for path in candidates)
 
 
-def sos_get_command_output(command, timeout=300, stderr=False,
+def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
                            chroot=None, chdir=None, env=None, foreground=False,
                            binary=False, sizelimit=None, poller=None):
     """Execute a command and return a dictionary of status and output,

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -244,7 +244,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_option("opt"), 0)
+        self.assertEquals(p.get_option("opt"), None)
 
     def test_get_unset_plugin_option_with_default(self):
         # this shows that even when we pass in a default to get,


### PR DESCRIPTION
Adds a new `--namespaces` option that controls the number of namespaces to iterate over for anything that calls `get_network_namespaces()` (and in the future, any other `get_*_namespaces()` methods that might be added).

This global option may be overridden by plugin specific options, and plugin options are added for the `ebpf` and `conntrack` plugins. 

Finally, fixup the display of options with magic/non-standard defaults in `--list` output.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
