### PR TITLE
[utilities,plugins] Provider wrappers for common `os.path` methods

### DIFF
--- a/sos/report/plugins/anaconda.py
+++ b/sos/report/plugins/anaconda.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-import os
 
 
 class Anaconda(Plugin, RedHatPlugin):
@@ -29,7 +28,7 @@ class Anaconda(Plugin, RedHatPlugin):
             "/root/anaconda-ks.cfg"
         ]
 
-        if os.path.isdir('/var/log/anaconda'):
+        if self.path_isdir('/var/log/anaconda'):
             # new anaconda
             paths.append('/var/log/anaconda')
         else:

--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -52,7 +52,7 @@ class RedHatAzure(Azure, RedHatPlugin):
     def setup(self):
         super(RedHatAzure, self).setup()
 
-        if os.path.isfile('/etc/yum.repos.d/rh-cloud.repo'):
+        if self.path_isfile('/etc/yum.repos.d/rh-cloud.repo'):
             curl_cmd = ('curl -s -m 5 -vvv '
                         'https://rhui-%s.microsoft.com/pulp/repos/%s')
             self.add_cmd_output([
@@ -62,7 +62,7 @@ class RedHatAzure(Azure, RedHatPlugin):
             ])
 
         crt_path = '/etc/pki/rhui/product/content.crt'
-        if os.path.isfile(crt_path):
+        if self.path_isfile(crt_path):
             self.add_cmd_output([
                 'openssl x509 -noout -text -in ' + crt_path
             ])

--- a/sos/report/plugins/corosync.py
+++ b/sos/report/plugins/corosync.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-import os.path
 import re
 
 
@@ -38,7 +37,7 @@ class Corosync(Plugin):
         self.exec_cmd("killall -USR2 corosync")
 
         corosync_conf = "/etc/corosync/corosync.conf"
-        if not os.path.exists(corosync_conf):
+        if not self.path_exists(corosync_conf):
             return
 
         # collect user-defined logfiles, matching either of pattern:

--- a/sos/report/plugins/cs.py
+++ b/sos/report/plugins/cs.py
@@ -11,7 +11,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-from os.path import exists
 from glob import glob
 
 
@@ -38,7 +37,8 @@ class CertificateSystem(Plugin, RedHatPlugin):
     )
 
     def checkversion(self):
-        if self.is_installed("redhat-cs") or exists("/opt/redhat-cs"):
+        if (self.is_installed("redhat-cs") or
+                self.path_exists("/opt/redhat-cs")):
             return 71
         elif self.is_installed("rhpki-common") or \
                 len(glob("/var/lib/rhpki-*")):

--- a/sos/report/plugins/docker_distribution.py
+++ b/sos/report/plugins/docker_distribution.py
@@ -8,7 +8,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-import os
 
 
 class DockerDistribution(Plugin):
@@ -20,7 +19,7 @@ class DockerDistribution(Plugin):
     def setup(self):
         self.add_copy_spec('/etc/docker-distribution/')
         self.add_journal('docker-distribution')
-        if os.path.exists('/etc/docker-distribution/registry/config.yml'):
+        if self.path_exists('/etc/docker-distribution/registry/config.yml'):
             with open('/etc/docker-distribution/registry/config.yml') as f:
                 for line in f:
                     if 'rootdirectory' in line:

--- a/sos/report/plugins/ds.py
+++ b/sos/report/plugins/ds.py
@@ -26,10 +26,10 @@ class DirectoryServer(Plugin, RedHatPlugin):
 
     def check_version(self):
         if self.is_installed("redhat-ds-base") or \
-                os.path.exists("/etc/dirsrv"):
+                self.path_exists("/etc/dirsrv"):
             return "ds8"
         elif self.is_installed("redhat-ds-7") or \
-                os.path.exists("/opt/redhat-ds"):
+                self.path_exists("/opt/redhat-ds"):
             return "ds7"
         return False
 
@@ -45,7 +45,7 @@ class DirectoryServer(Plugin, RedHatPlugin):
         ])
 
         try:
-            for d in os.listdir("/etc/dirsrv"):
+            for d in self.listdir("/etc/dirsrv"):
                 if d[0:5] == 'slapd':
                     certpath = os.path.join("/etc/dirsrv", d)
                     self.add_cmd_output("certutil -L -d %s" % certpath)

--- a/sos/report/plugins/etcd.py
+++ b/sos/report/plugins/etcd.py
@@ -10,7 +10,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-from os import path
 
 
 class etcd(Plugin, RedHatPlugin):
@@ -23,7 +22,7 @@ class etcd(Plugin, RedHatPlugin):
     files = ('/etc/origin/node/pods/etcd.yaml',)
 
     def setup(self):
-        if path.exists('/etc/origin/node/pods/etcd.yaml'):
+        if self.path_exists('/etc/origin/node/pods/etcd.yaml'):
             etcd_cmd = 'master-exec etcd etcd etcdctl'
         else:
             etcd_cmd = 'etcdctl'

--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 import time
-import os.path
 import os
 import glob
 import string
@@ -30,7 +29,7 @@ class Gluster(Plugin, RedHatPlugin):
     def wait_for_statedump(self, name_dir):
         statedumps_present = 0
         statedump_entries = [
-                f for f in os.listdir(name_dir) if os.path.isfile(f)
+                f for f in self.listdir(name_dir) if self.path_isfile(f)
         ]
         for statedump_file in statedump_entries:
             statedumps_present = statedumps_present+1
@@ -42,7 +41,7 @@ class Gluster(Plugin, RedHatPlugin):
 
     def postproc(self):
         if self.get_option("dump"):
-            if not os.path.exists(self.statedump_dir):
+            if not self.path_exists(self.statedump_dir):
                 return
             try:
                 remove_files = glob.glob(self.statedump_dir + '/*.dump.[0-9]*')
@@ -90,7 +89,7 @@ class Gluster(Plugin, RedHatPlugin):
             self.add_copy_spec("/var/log/glusterfs")
 
         if self.get_option("dump"):
-            if os.path.exists(self.statedump_dir):
+            if self.path_exists(self.statedump_dir):
                 statedump_cmd = "killall -USR1 glusterfs glusterfsd glusterd"
                 if self.exec_cmd(statedump_cmd)['status'] == 0:
                     # let all the processes catch the signal and create

--- a/sos/report/plugins/infiniband.py
+++ b/sos/report/plugins/infiniband.py
@@ -8,7 +8,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
@@ -45,7 +44,7 @@ class Infiniband(Plugin, IndependentPlugin):
             "perfquery"
         ]
         IB_SYS_DIR = "/sys/class/infiniband/"
-        ibs = os.listdir(IB_SYS_DIR) if os.path.isdir(IB_SYS_DIR) else []
+        ibs = self.listdir(IB_SYS_DIR) if self.path_isdir(IB_SYS_DIR) else []
         for ib in ibs:
             """
             Skip OPA hardware, as infiniband-diags tools does not understand
@@ -55,7 +54,7 @@ class Infiniband(Plugin, IndependentPlugin):
             if ib.startswith("hfi"):
                 continue
 
-            for port in os.listdir(IB_SYS_DIR + ib + "/ports"):
+            for port in self.listdir(IB_SYS_DIR + ib + "/ports"):
                 # skip IWARP and RoCE devices
                 try:
                     p = open(IB_SYS_DIR + ib + "/ports/" + port +

--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -10,7 +10,6 @@
 
 from sos.report.plugins import Plugin, RedHatPlugin, SoSPredicate
 from glob import glob
-from os.path import exists
 
 
 class Ipa(Plugin, RedHatPlugin):
@@ -28,18 +27,18 @@ class Ipa(Plugin, RedHatPlugin):
 
     def check_ipa_server_version(self):
         if self.is_installed("pki-server") \
-                or exists("/var/lib/pki") \
-                or exists("/usr/share/doc/ipa-server-4.2.0"):
+                or self.path_exists("/var/lib/pki") \
+                or self.path_exists("/usr/share/doc/ipa-server-4.2.0"):
             return "v4"
         elif self.is_installed("pki-common") \
-                or exists("/var/lib/pki-ca/"):
+                or self.path_exists("/var/lib/pki-ca/"):
             return "v3"
         return None
 
     def ca_installed(self):
         # Follow the same checks as IPA CA installer code
-        if exists("%s/conf/ca/CS.cfg" % self.pki_tomcat_dir_v4) \
-                or exists("%s/conf/CS.cfg" % self.pki_tomcat_dir_v3):
+        if self.path_exists("%s/conf/ca/CS.cfg" % self.pki_tomcat_dir_v4) \
+                or self.path_exists("%s/conf/CS.cfg" % self.pki_tomcat_dir_v3):
             return True
 
     def ipa_server_installed(self):

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -6,7 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 import platform
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
@@ -65,7 +64,7 @@ class RedHatKDump(KDump, RedHatPlugin):
 
         initramfs_img = "/boot/initramfs-" + platform.release() \
                         + "kdump.img"
-        if os.path.exists(initramfs_img):
+        if self.path_exists(initramfs_img):
             self.add_cmd_output("lsinitrd %s" % initramfs_img)
 
         self.add_copy_spec([
@@ -94,7 +93,7 @@ class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
         super(DebianKDump, self).setup()
 
         initramfs_img = "/var/lib/kdump/initrd.img-" + platform.release()
-        if os.path.exists(initramfs_img):
+        if self.path_exists(initramfs_img):
             self.add_cmd_output("lsinitramfs -l %s" % initramfs_img)
 
         self.add_cmd_output("kdump-config show")

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, IndependentPlugin
-import os
 import glob
 
 
@@ -33,7 +32,7 @@ class Kernel(Plugin, IndependentPlugin):
         self.add_cmd_output("ls -lt /sys/kernel/slab")
 
         try:
-            modules = os.listdir(self.sys_module)
+            modules = self.listdir(self.sys_module)
             self.add_cmd_output("modinfo " + " ".join(modules),
                                 suggest_filename="modinfo_ALL_MODULES")
         except OSError:

--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -8,7 +8,6 @@
 
 from sos.report.plugins import Plugin, IndependentPlugin
 import glob
-import os
 
 
 class Libvirt(Plugin, IndependentPlugin):
@@ -55,7 +54,7 @@ class Libvirt(Plugin, IndependentPlugin):
         else:
             self.add_copy_spec("/var/log/libvirt")
 
-        if os.path.exists(self.join_sysroot(libvirt_keytab)):
+        if self.path_exists(self.join_sysroot(libvirt_keytab)):
             self.add_cmd_output("klist -ket %s" % libvirt_keytab)
 
         self.add_cmd_output("ls -lR /var/lib/libvirt/qemu")

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -6,7 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 import glob
 from sos.report.plugins import Plugin, IndependentPlugin
 
@@ -24,14 +23,14 @@ class Logs(Plugin, IndependentPlugin):
 
         since = self.get_option("since")
 
-        if os.path.exists('/etc/rsyslog.conf'):
+        if self.path_exists('/etc/rsyslog.conf'):
             with open('/etc/rsyslog.conf', 'r') as conf:
                 for line in conf.readlines():
                     if line.startswith('$IncludeConfig'):
                         confs += glob.glob(line.split()[1])
 
         for conf in confs:
-            if not os.path.exists(conf):
+            if not self.path_exists(conf):
                 continue
             config = self.join_sysroot(conf)
             logs += self.do_regex_find_all(r"^\S+\s+(-?\/.*$)\s+", config)
@@ -39,7 +38,7 @@ class Logs(Plugin, IndependentPlugin):
         for i in logs:
             if i.startswith("-"):
                 i = i[1:]
-            if os.path.isfile(i):
+            if self.path_isfile(i):
                 self.add_copy_spec(i)
 
         self.add_copy_spec([
@@ -61,7 +60,7 @@ class Logs(Plugin, IndependentPlugin):
         # - there is some data present, either persistent or runtime only
         # - systemd-journald service exists
         # otherwise fallback to collecting few well known logfiles directly
-        journal = any([os.path.exists(p + "/log/journal/")
+        journal = any([self.path_exists(p + "/log/journal/")
                       for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
             self.add_journal(since=since, tags='journal_full')

--- a/sos/report/plugins/mssql.py
+++ b/sos/report/plugins/mssql.py
@@ -9,7 +9,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-import os
 
 
 class MsSQL(Plugin, RedHatPlugin):
@@ -66,7 +65,7 @@ class MsSQL(Plugin, RedHatPlugin):
         keytab_err = ('keytab file is specfieid in mssql_conf'
                       ' but not found in %s' % kerberoskeytabfile)
         if kerberoskeytabfile is not None:
-            if os.path.isfile(kerberoskeytabfile):
+            if self.path_isfile(kerberoskeytabfile):
                 self.add_cmd_output('ls -l %s' % kerberoskeytabfile)
                 self.add_cmd_output('klist -e -k %s' % kerberoskeytabfile)
             else:

--- a/sos/report/plugins/named.py
+++ b/sos/report/plugins/named.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
-from os.path import exists, join, normpath
+from os.path import join, normpath
 
 
 class Named(Plugin):
@@ -25,7 +25,7 @@ class Named(Plugin):
             "/var/log/named*.log"
         ])
         for cfg in self.config_files:
-            if exists(cfg):
+            if self.path_exists(cfg):
                 self.add_copy_spec([
                     cfg,
                     self.get_dns_dir(cfg)

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -8,8 +8,6 @@
 
 from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
                                 DebianPlugin, SoSPredicate)
-from os import listdir
-from os import path
 
 
 class Networking(Plugin):
@@ -107,7 +105,7 @@ class Networking(Plugin):
             "tc -s qdisc show",
         ])
 
-        if path.isdir('/sys/class/devlink'):
+        if self.path_isdir('/sys/class/devlink'):
             self.add_cmd_output([
                 "devlink dev param show",
                 "devlink dev info",
@@ -136,7 +134,7 @@ class Networking(Plugin):
 
         # Get ethtool output for every device that does not exist in a
         # namespace.
-        for eth in listdir("/sys/class/net/"):
+        for eth in self.listdir("/sys/class/net/"):
             # skip 'bonding_masters' file created when loading the bonding
             # module but the file does not correspond to a device
             if eth == "bonding_masters":

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -53,7 +53,7 @@ class OpenStackKeystone(Plugin):
                 "identity domain_config_dir")
         self.domain_config_dir = exec_out['output']
         if exec_out['status'] != 0 or \
-                not(os.path.isdir(self.domain_config_dir)):
+                not(self.path_isdir(self.domain_config_dir)):
             self.domain_config_dir = "/etc/keystone/domains"
         self.add_copy_spec(self.domain_config_dir)
 

--- a/sos/report/plugins/origin.py
+++ b/sos/report/plugins/origin.py
@@ -70,19 +70,19 @@ class OpenShiftOrigin(Plugin):
     # installation)
     def is_master(self):
         """Determine if we are on a master"""
-        return os.path.exists(self.master_cfg)
+        return self.path_exists(self.master_cfg)
 
     def is_node(self):
         """Determine if we are on a node"""
-        return os.path.exists(self.node_cfg)
+        return self.path_exists(self.node_cfg)
 
     def is_static_etcd(self):
         """Determine if we are on a node running etcd"""
-        return os.path.exists(os.path.join(self.static_pod_dir, "etcd.yaml"))
+        return self.path_exists(os.path.join(self.static_pod_dir, "etcd.yaml"))
 
     def is_static_pod_compatible(self):
         """Determine if a node is running static pods"""
-        return os.path.exists(self.static_pod_dir)
+        return self.path_exists(self.static_pod_dir)
 
     def setup(self):
         bstrap_node_cfg = os.path.join(self.node_base_dir,

--- a/sos/report/plugins/ovn_host.py
+++ b/sos/report/plugins/ovn_host.py
@@ -48,7 +48,7 @@ class OVNHost(Plugin):
         self.add_journal(units="ovn-controller")
 
     def check_enabled(self):
-        return (any([os.path.isfile(
+        return (any([self.path_isfile(
             os.path.join(pp, pidfile)) for pp in pid_paths]) or
             super(OVNHost, self).check_enabled())
 

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -9,7 +9,6 @@
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 from datetime import datetime, timedelta
 import re
-import os.path
 
 
 class Pacemaker(Plugin):
@@ -112,7 +111,7 @@ class Pacemaker(Plugin):
         #   PCMK_logfile=filename
         # specified in the pacemaker start-up environment file.
         pattern = r'^\s*PCMK_logfile=[\'\"]?(\S+)[\'\"]?\s*(\s#.*)?$'
-        if os.path.isfile(self.envfile):
+        if self.path_isfile(self.envfile):
             self.add_copy_spec(self.envfile)
             with open(self.envfile) as f:
                 for line in f:

--- a/sos/report/plugins/pci.py
+++ b/sos/report/plugins/pci.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, IndependentPlugin
-import os
 
 
 class Pci(Plugin, IndependentPlugin):
@@ -18,11 +17,11 @@ class Pci(Plugin, IndependentPlugin):
     profiles = ('hardware', 'system')
 
     def check_for_bus_devices(self):
-        if not os.path.isdir('/proc/bus/pci'):
+        if not self.path_isdir('/proc/bus/pci'):
             return False
         # ensure that more than just the 'devices' file, which can be empty,
         # exists in the pci directory. This implies actual devices are present
-        content = os.listdir('/proc/bus/pci')
+        content = self.listdir('/proc/bus/pci')
         if 'devices' in content:
             content.remove('devices')
         return len(content) > 0

--- a/sos/report/plugins/pcp.py
+++ b/sos/report/plugins/pcp.py
@@ -10,7 +10,6 @@
 
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
 import os
-import os.path
 from socket import gethostname
 
 

--- a/sos/report/plugins/postgresql.py
+++ b/sos/report/plugins/postgresql.py
@@ -100,7 +100,7 @@ class RedHatPostgreSQL(PostgreSQL, SCLPlugin):
             scl = pkg.split('-postgresql-')[0]
             _dir = self.convert_copyspec_scl(scl, pghome)
             dirs.append(_dir)
-            if os.path.isdir(_dir):
+            if self.path_isdir(_dir):
                 self.add_cmd_output("du -sh %s" % _dir)
             if (self.is_service_running(pkg.replace('-server', '')) and
                     scl in self.scls_matched):

--- a/sos/report/plugins/powerpath.py
+++ b/sos/report/plugins/powerpath.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, os
+from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class PowerPath(Plugin, RedHatPlugin):
@@ -53,7 +53,7 @@ class PowerPath(Plugin, RedHatPlugin):
         self.get_pp_files()
         # If PowerPath is running collect additional PowerPath specific
         # information
-        if os.path.isdir("/proc/emcp"):
+        if self.path_isdir("/proc/emcp"):
             self.get_pp_config()
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -9,7 +9,6 @@
 # This plugin enables collection of logs for Power systems and more
 # specific logs for Pseries, PowerNV platforms.
 
-import os
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
@@ -92,7 +91,7 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/var/log/opal-prd",
                 "/var/log/opal-prd.log*"
             ])
-            if os.path.isdir("/var/log/dump"):
+            if self.path_isdir("/var/log/dump"):
                 self.add_cmd_output("ls -l /var/log/dump")
 
 

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -6,7 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 import re
 
 from sos.report.plugins import Plugin, IndependentPlugin
@@ -41,7 +40,7 @@ class Process(Plugin, IndependentPlugin):
             "/proc/stat"
         ])
 
-        procs = [p for p in os.listdir("/proc") if re.match("[0-9]", p)]
+        procs = [p for p in self.listdir("/proc") if re.match("[0-9]", p)]
         if self.get_option("numprocs"):
             procs = procs[:self.get_option("numprocs")]
 

--- a/sos/report/plugins/saphana.py
+++ b/sos/report/plugins/saphana.py
@@ -6,7 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 from sos.report.plugins import Plugin, RedHatPlugin
 
 
@@ -21,8 +20,8 @@ class saphana(Plugin, RedHatPlugin):
 
         sids = []
 
-        if os.path.isdir("/hana/shared"):
-            s = os.listdir("/hana/shared")
+        if self.path_isdir("/hana/shared"):
+            s = self.listdir("/hana/shared")
             for sid in s:
                 if len(sid) == 3:
                     sid = sid.strip()
@@ -45,8 +44,8 @@ class saphana(Plugin, RedHatPlugin):
                                     "replication info"\'' % prefix,
                                     suggest_filename="%s_replicainfo" % sid)
 
-                if os.path.isdir("/hana/shared/%s/" % sid):
-                    for inst in os.listdir("/hana/shared/%s/" % sid):
+                if self.path_isdir("/hana/shared/%s/" % sid):
+                    for inst in self.listdir("/hana/shared/%s/" % sid):
                         if "HDB" in inst:
                             inst = inst.strip()[-2:]
                             self.get_inst_info(sid, sidadm, inst)
@@ -60,7 +59,7 @@ class saphana(Plugin, RedHatPlugin):
         )
 
         path = "/usr/sap/%s/HDB%s/exe/python_support" % (sid, inst)
-        if os.path.isdir(path):
+        if self.path_isdir(path):
             py_cmd = 'su - %s -c "python %s/landscapeHostConfiguration.py"'
             py_fname = "%s_%s_landscapeConfig" % (sid, inst)
             self.add_cmd_output(

--- a/sos/report/plugins/sapnw.py
+++ b/sos/report/plugins/sapnw.py
@@ -6,7 +6,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import os
 from sos.report.plugins import Plugin, RedHatPlugin
 
 
@@ -43,9 +42,9 @@ class sapnw(Plugin, RedHatPlugin):
                 vhost = fields[7]
                 sidsunique.add(sid)
                 path = "/usr/sap/%s/SYS/profile/" % sid
-                if not os.path.exists(path):
+                if not self.path_exists(path):
                     continue
-                for line in os.listdir(path):
+                for line in self.listdir(path):
                     if all(f in line for f in [sid, inst, vhost]):
                         ldenv = 'LD_LIBRARY_PATH=/usr/sap/%s/SYS/exe/run' % sid
                         # TODO: I am assuming unicode here
@@ -132,7 +131,7 @@ class sapnw(Plugin, RedHatPlugin):
         #
         # since the command creates a limits.d file on its own,
         # we must predicate it by presence of the file
-        if os.path.exists('/etc/security/limits.d/99-sap-limits.conf') \
+        if self.path_exists('/etc/security/limits.d/99-sap-limits.conf') \
                 or self.get_option('allow_system_changes'):
             self.add_cmd_output("sapconf -n",
                                 suggest_filename="sapconf_checkmode")

--- a/sos/report/plugins/sar.py
+++ b/sos/report/plugins/sar.py
@@ -28,7 +28,7 @@ class Sar(Plugin,):
                            tailit=False)
 
         try:
-            dir_list = os.listdir(self.sa_path)
+            dir_list = self.listdir(self.sa_path)
         except OSError:
             self._log_warn("sar: could not list %s" % self.sa_path)
             return

--- a/sos/report/plugins/unpackaged.py
+++ b/sos/report/plugins/unpackaged.py
@@ -57,7 +57,7 @@ class Unpackaged(Plugin, RedHatPlugin):
             """
             expanded = []
             for f in files:
-                if os.path.islink(f):
+                if self.path_islink(f):
                     expanded.append("{} -> {}".format(f, os.readlink(f)))
                 else:
                     expanded.append(f)

--- a/sos/report/plugins/veritas.py
+++ b/sos/report/plugins/veritas.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-import os
 
 
 class Veritas(Plugin, RedHatPlugin):
@@ -23,7 +22,7 @@ class Veritas(Plugin, RedHatPlugin):
                     "/opt/VRTSspt/VRTSexplorer")]
 
     def check_enabled(self):
-        return os.path.isfile(self.get_option("script"))
+        return self.path_isfile(self.get_option("script"))
 
     def setup(self):
         """ interface with vrtsexplorer to capture veritas related data """

--- a/sos/report/plugins/vhostmd.py
+++ b/sos/report/plugins/vhostmd.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin
-import os
 
 
 class vhostmd(Plugin, RedHatPlugin):
@@ -33,9 +32,9 @@ class vhostmd(Plugin, RedHatPlugin):
             else:
                 # otherwise use the raw vhostmd disk presented (256k size)
                 sysblock = "/sys/block"
-                if not os.path.isdir(sysblock):
+                if not self.path_isdir(sysblock):
                     return
-                for disk in os.listdir(sysblock):
+                for disk in self.listdir(sysblock):
                     if "256K" in disk:
                         dev = disk.split()[0]
                         r = self.exec_cmd("dd if=/dev/%s bs=25 count=1" % dev)

--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -46,9 +46,10 @@ class Yum(Plugin, RedHatPlugin):
         self.add_cmd_output("yum -C repolist --verbose")
 
         # Get list of available plugins and their configuration files.
-        if os.path.exists(YUM_PLUGIN_PATH) and os.path.isdir(YUM_PLUGIN_PATH):
+        if (self.path_exists(YUM_PLUGIN_PATH) and
+                self.path_isdir(YUM_PLUGIN_PATH)):
             plugins = ""
-            for p in os.listdir(YUM_PLUGIN_PATH):
+            for p in self.listdir(YUM_PLUGIN_PATH):
                 if not p.endswith(".py"):
                     continue
                 plugins = plugins + " " if len(plugins) else ""
@@ -56,7 +57,9 @@ class Yum(Plugin, RedHatPlugin):
             if len(plugins):
                 self.add_cmd_output("rpm -qf %s" % plugins,
                                     suggest_filename="plugin-packages")
-                plugnames = [os.path.basename(p)[:-3] for p in plugins.split()]
+                plugnames = [
+                    os.path.basename(p)[:-3] for p in plugins.split()
+                ]
                 plugnames = "%s\n" % "\n".join(plugnames)
                 self.add_string_as_file(plugnames, "plugin-names")
 

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -213,6 +213,33 @@ def get_human_readable(size, precision=2):
     return "%.*f%s" % (precision, size, suffixes[suffixindex])
 
 
+def _os_wrapper(path, sysroot, method, module=os.path):
+    if sysroot not in [None, '/']:
+        path = os.path.join(sysroot, path.lstrip('/'))
+    _meth = getattr(module, method)
+    return _meth(path)
+
+
+def path_exists(path, sysroot):
+    return _os_wrapper(path, sysroot, 'exists')
+
+
+def path_isdir(path, sysroot):
+    return _os_wrapper(path, sysroot, 'isdir')
+
+
+def path_isfile(path, sysroot):
+    return _os_wrapper(path, sysroot, 'isfile')
+
+
+def path_islink(path, sysroot):
+    return _os_wrapper(path, sysroot, 'islink')
+
+
+def listdir(path, sysroot):
+    return _os_wrapper(path, sysroot, 'listdir', os)
+
+
 class AsyncReader(threading.Thread):
     """Used to limit command output to a given size without deadlocking
     sos.

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -117,6 +117,7 @@ class MockOptions(object):
     no_postproc = False
     skip_files = []
     skip_commands = []
+    sysroot = None
 
 
 class PluginToolTests(unittest.TestCase):


### PR DESCRIPTION
Use of `os.path.exists` or similar methods is fairly prevalent in plugins today, however the issue is that these do not account for the use of `--sysroot` (e.g. when sos is run in a container), and expecting plugins to manually check for a sysroot for everything path needing validation in untenable.

These commits add wrapper methods to `sos.utilities`, and then provider helper methods in `Plugin` to make this as easy as possible on plugin authors.

The new plugin method names follow their `os.path` names in a hopefully logical manner, for example `os.path.exists` becomes `self.path_exists`.

For this iteration, plugins using the `exists`, `isfile`, `isdir`, `islink` methods of `os.path`, or `os.listdir`, have been updated to use the new wrapper methods. Many internals of `Plugin` have also been updated. I have not however extended this to either `archive` or the base `SoSReport` or `SoSCollector` methods involving policy/plugin/cluster module discovery as those are not use cases to check for containerization.

 Closes #494

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
