### PR TITLE
[Policy,redhat] Add support for SFTP uploads, replace legacy RH FTP fallback

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -36,6 +36,7 @@ sosreport \- Collect and package diagnostic and support data
           [--upload] [--upload-url url] [--upload-user user]\fR
           [--upload-directory dir] [--upload-pass pass]\fR
           [--upload-no-ssl-verify] [--upload-method]\fR
+          [--upload-protocol protocol]\fR
           [--experimental]\fR
           [-h|--help]\fR
 
@@ -384,6 +385,19 @@ to locations that have self-signed certificates, or certificates that are otherw
 untrusted by the local system.
 
 Default behavior is to perform SSL verification against all upload locations.
+.TP
+.B \--upload-protocol PROTO
+Manually specify the protocol to use for uploading to the target \fBupload-url\fR.
+
+Normally this is determined via the upload address, assuming that the protocol is part
+of the address provided, e.g. 'https://example.com'. By using this option, sos will skip
+the protocol check and use the method defined for the specified PROTO.
+
+For RHEL systems, setting this option to \fBsftp\fR will skip the initial attempt to
+upload to the Red Hat Customer Portal, and only attempt an upload to Red Hat's SFTP server,
+which is typically used as a fallback target.
+
+Valid values for PROTO are: 'auto' (default), 'https', 'ftp', 'sftp'.
 .TP
 .B \--experimental
 Enable plugins marked as experimental. Experimental plugins may not have

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -102,7 +102,8 @@ class SoSCollector(SoSComponent):
         'upload_user': None,
         'upload_pass': None,
         'upload_method': 'auto',
-        'upload_no_ssl_verify': False
+        'upload_no_ssl_verify': False,
+        'upload_protocol': 'auto'
     }
 
     def __init__(self, parser, parsed_args, cmdline_args):
@@ -373,6 +374,10 @@ class SoSCollector(SoSComponent):
                                  action='store_true',
                                  help="Disable SSL verification for upload url"
                                  )
+        collect_grp.add_argument("--upload-protocol", default='auto',
+                                 choices=['auto', 'https', 'ftp', 'sftp'],
+                                 help="Manually specify the upload protocol")
+
         # Group the cleaner options together
         cleaner_grp = parser.add_argument_group(
             'Cleaner/Masking Options',

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -120,6 +120,7 @@ class SoSReport(SoSComponent):
         'upload_pass': None,
         'upload_method': 'auto',
         'upload_no_ssl_verify': False,
+        'upload_protocol': 'auto',
         'add_preset': '',
         'del_preset': ''
     }
@@ -307,6 +308,9 @@ class SoSReport(SoSComponent):
         report_grp.add_argument("--upload-no-ssl-verify", default=False,
                                 action='store_true',
                                 help="Disable SSL verification for upload url")
+        report_grp.add_argument("--upload-protocol", default='auto',
+                                choices=['auto', 'https', 'ftp', 'sftp'],
+                                help="Manually specify the upload protocol")
 
         # Group to make add/del preset exclusive
         preset_grp = report_grp.add_mutually_exclusive_group()


### PR DESCRIPTION
This patchset adds support for SFTP uploads, using `pexpect` to handle the connection, auth, and upload monitoring.

Further, the `RedHat` policy is updated to drop the legacy FTP server as a fallback and instead use the new SFTP server if there are any issues using the RH Customer Portal, or if credentials are not supplied.

A new `--upload-protocol` option is added which can be used to skip protocol determination and use a specific protocol. In the case of RHEL systems, this means  using `--upload-protocol sftp` will entirely skip any attempts to use the customer portal even if valid credentials are supplied.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
