### PR TITLE
[Plugin,plugins] Allow plugins to influence command execution order

### DIFF
--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -46,7 +46,7 @@ class Boot(Plugin, IndependentPlugin):
             for image in glob('/boot/initr*.img'):
                 if image[-9:] == "kdump.img":
                     continue
-                self.add_cmd_output("lsinitrd %s" % image)
+                self.add_cmd_output("lsinitrd %s" % image, priority=100)
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -81,7 +81,7 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
             self.add_cmd_output("crictl inspect %s" % container)
             if self.get_option('logs'):
                 self.add_cmd_output("crictl logs -t %s" % container,
-                                    subdir="containers")
+                                    subdir="containers", priority=100)
 
         for image in images:
             self.add_cmd_output("crictl inspecti %s" % image, subdir="images")

--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -62,8 +62,8 @@ class Docker(Plugin, CosPlugin):
 
         # separately grab these separately as they can take a *very* long time
         if self.get_option('size'):
-            self.add_cmd_output('docker ps -as')
-            self.add_cmd_output('docker system df')
+            self.add_cmd_output('docker ps -as', priority=100)
+            self.add_cmd_output('docker system df', priority=100)
 
         nets = self.collect_cmd_output('docker network ls')
 

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -46,7 +46,8 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         self.add_forbidden_path('/proc/fs/panfs')
 
         if self.get_option('lsof'):
-            self.add_cmd_output("lsof -b +M -n -l -P", root_symlink="lsof")
+            self.add_cmd_output("lsof -b +M -n -l -P", root_symlink="lsof",
+                                priority=50)
 
         dumpe2fs_opts = '-h'
         if self.get_option('dumpe2fs'):
@@ -57,7 +58,7 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             self.add_cmd_output("dumpe2fs %s %s" % (dumpe2fs_opts, dev))
 
             if self.get_option('frag'):
-                self.add_cmd_output("e2freefrag %s" % (dev))
+                self.add_cmd_output("e2freefrag %s" % (dev), priority=100)
 
     def postproc(self):
         self.do_file_sub(

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -64,7 +64,7 @@ class Logs(Plugin, IndependentPlugin):
         journal = any([os.path.exists(p + "/log/journal/")
                       for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
-            self.add_journal(since=since, tags='journal_full')
+            self.add_journal(since=since, tags='journal_full', priority=100)
             self.add_journal(boot="this", catalog=True, since=since,
                              tags='journal_since_boot')
             self.add_journal(boot="last", catalog=True, since=since,

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -179,7 +179,8 @@ class Networking(Plugin):
         ])
 
         if self.get_option("traceroute"):
-            self.add_cmd_output("/bin/traceroute -n %s" % self.trace_host)
+            self.add_cmd_output("/bin/traceroute -n %s" % self.trace_host,
+                                priority=100)
 
         # Capture additional data from namespaces; each command is run
         # per-namespace.
@@ -200,7 +201,7 @@ class Networking(Plugin):
                 ns_cmd_prefix + "netstat -s",
                 ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,
                 ns_cmd_prefix + "nstat -zas",
-            ])
+            ], priority=50)
 
             ss_cmd = ns_cmd_prefix + "ss -peaonmi"
             # --allow-system-changes is handled directly in predicate
@@ -231,7 +232,7 @@ class Networking(Plugin):
                         ns_cmd_prefix + "ethtool -i " + eth,
                         ns_cmd_prefix + "ethtool -k " + eth,
                         ns_cmd_prefix + "ethtool -S " + eth
-                    ])
+                    ], priority=50)
 
         return
 
@@ -271,7 +272,8 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
         ])
 
         if self.get_option("traceroute"):
-            self.add_cmd_output("/usr/sbin/traceroute -n %s" % self.trace_host)
+            self.add_cmd_output("/usr/sbin/traceroute -n %s" % self.trace_host,
+                                priority=100)
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -51,7 +51,7 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
         # separately grab ps -s as this can take a *very* long time
         if self.get_option('size'):
-            self.add_cmd_output('podman ps -as')
+            self.add_cmd_output('podman ps -as', priority=100)
 
         self.add_cmd_output([
             "ls -alhR /etc/cni",
@@ -88,7 +88,7 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
         if self.get_option('logs'):
             for con in containers:
                 self.add_cmd_output("podman logs -t %s" % con,
-                                    subdir='containers')
+                                    subdir='containers', priority=50)
 
     def postproc(self):
         # Attempts to match key=value pairs inside container inspect output

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -59,14 +59,14 @@ class Process(Plugin, IndependentPlugin):
 
         self.add_cmd_output("ps auxwwwm", root_symlink="ps",
                             tags=['ps_aux', 'ps_auxww', 'ps_auxwww',
-                                  'ps_auxwwwm'])
+                                  'ps_auxwwwm'], priority=1)
         self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
             self.add_cmd_output("lsof +M -n -l -c ''", root_symlink="lsof",
-                                timeout=15)
+                                timeout=15, priority=50)
 
         if self.get_option("lsof-threads"):
-            self.add_cmd_output("lsof +M -n -l", timeout=15)
+            self.add_cmd_output("lsof +M -n -l", timeout=15, priority=50)
 
         self.add_cmd_output([
             "ps alxwww",
@@ -77,7 +77,7 @@ class Process(Plugin, IndependentPlugin):
 
         if self.get_option("samples"):
             self.add_cmd_output("iotop -b -o -d 0.5 -t -n %s"
-                                % self.get_option("samples"))
+                                % self.get_option("samples"), priority=100)
 
         self.add_cmd_output([
             "pidstat -p ALL -rudvwsRU --human -h",

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -58,7 +58,7 @@ class Rpm(Plugin, RedHatPlugin):
         if self.get_option("rpmva"):
             self.plugin_timeout = 1000
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",
-                                timeout=900)
+                                timeout=900, priority=100)
 
         if self.get_option("rpmdb"):
             self.add_cmd_output("lsof +D /var/lib/rpm",

--- a/sos/report/plugins/selinux.py
+++ b/sos/report/plugins/selinux.py
@@ -56,6 +56,7 @@ class SELinux(Plugin, RedHatPlugin):
                 self.add_cmd_output("semanage %s -l" % subcmd)
 
             if self.get_option('fixfiles'):
-                self.add_cmd_output("restorecon -Rvn /", stderr=False)
+                self.add_cmd_output("restorecon -Rvn /", stderr=False,
+                                    priority=100)
 
 # vim: set et ts=4 sw=4 :

--- a/tests/report_tests/command_priority_tests.py
+++ b/tests/report_tests/command_priority_tests.py
@@ -1,0 +1,54 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos_tests import StageOneReportTest
+
+
+class CommandPriorityTest(StageOneReportTest):
+    """Ensure that the priority parameter for command execution is functioning
+    as expected
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o logs,process'
+
+    def test_logs_full_journal_correct_priority(self):
+        cmds = self.get_plugin_manifest('logs')['commands']
+        fullj = cmds[-1]
+        self.assertEqual(fullj['priority'], 100)
+
+    def test_logs_full_journal_run_last(self):
+        cmds = self.get_plugin_manifest('logs')['commands']
+        cmds.sort(key=lambda x: x['start_time'])
+        # journal_full should be the last command executed
+        self.assertTrue('journal_full' in cmds[-1]['tags'])
+
+    def test_process_correct_priorities(self):
+        cmds = self.get_plugin_manifest('process')['commands']
+        # ensure root symlinked ps ran first
+        self.assertTrue(cmds[0]['priority'] == 1 and 'ps_aux' in cmds[0]['tags'])
+
+        # get lsof and iotop command entries
+        _lsof = None
+        _iotop = None
+        for cmd in cmds:
+            if cmd['command'] == 'lsof':
+                _lsof = cmd
+            elif cmd['command'] == 'iotop':
+                _iotop = cmd
+
+        self.assertTrue(_lsof and _iotop, "lsof or iotop output missing")
+
+        self.assertEqual(_lsof['priority'], 50)
+        self.assertEqual(_iotop['priority'], 100)
+        self.assertTrue(_lsof['start_time'] < _iotop['start_time'])
+
+            
+        

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -479,6 +479,20 @@ class BaseSoSReportTest(BaseSoSTest):
         for j in _executed:
             assert j in plugins, "Unrequested plugin '%s' ran as well" % j
 
+    def get_plugin_manifest(self, plugin):
+        """Get the manifest data for the specified plugin
+
+        :param plugin:  The name of the plugin
+        :type plugin:   ``str``
+
+        :returns: The section of the manifest for the plugin
+        :rtype:   ``dict``
+        """
+        if not self.manifest['components']['report']['plugins'][plugin]:
+            raise Exception("Manifest for %s not present" % plugin)
+        return self.manifest['components']['report']['plugins'][plugin]
+
+
 class StageOneReportTest(BaseSoSReportTest):
     """This is the test class to subclass for all Stage One (no mocking) tests
     within the sos test suite.


### PR DESCRIPTION
Adds a `priority` parameter to `add_cmd_output()` and `add_journal()`,
that can be used to influence the order in which commands are executed
within a plugin. This allows for plugins to specify that long-running
commands should be run last, regardless of where in the plugin those
commands are defined.

As part of accounting for this, minor fixups in the evaluation of run
times for individual commands and how those are reflected in the
report's manifest are included.

Assigns new `priority` values to known long running commands, to ensure
those commands run last in their respective plugins' execution.

Finally, adds a new test to ensure all of this is and remains working.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
