### PR TITLE
[collect] Deprecate 'master' in favor of 'primary'

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -71,6 +71,7 @@ class SoSCollector(SoSComponent):
         'log_size': 0,
         'map_file': '/etc/sos/cleaner/default_mapping',
         'master': '',
+        'primary': '',
         'nodes': [],
         'no_env_vars': False,
         'no_local': False,
@@ -325,7 +326,12 @@ class SoSCollector(SoSComponent):
                                  help='List options available for profiles')
         collect_grp.add_argument('--label',
                                  help='Assign a label to the archives')
-        collect_grp.add_argument('--master', help='Specify a master node')
+        collect_grp.add_argument('--master',
+                                 help='DEPRECATED: Specify a master node')
+        collect_grp.add_argument('--primary', '--manager', '--controller',
+                                 dest='primary', default='',
+                                 help='Specify a primary node for cluster '
+                                      'enumeration')
         collect_grp.add_argument('--nopasswd-sudo', action='store_true',
                                  help='Use passwordless sudo on nodes')
         collect_grp.add_argument('--nodes', action="append",
@@ -639,7 +645,7 @@ class SoSCollector(SoSComponent):
 
         with open(fname, 'r') as hf:
             _group = json.load(hf)
-            for key in ['master', 'cluster_type']:
+            for key in ['master', 'primary', 'cluster_type']:
                 if _group[key]:
                     self.log_debug("Setting option '%s' to '%s' per host group"
                                    % (key, _group[key]))
@@ -658,7 +664,7 @@ class SoSCollector(SoSComponent):
         """
         cfg = {
             'name': self.opts.save_group,
-            'master': self.opts.master,
+            'primary': self.opts.master,
             'cluster_type': self.cluster.cluster_type[0],
             'nodes': [n for n in self.node_list]
         }
@@ -769,7 +775,7 @@ class SoSCollector(SoSComponent):
                           '--no-local option if localhost should not be '
                           'included.\nAborting...\n', 1)
 
-        self.collect_md.add_field('master', self.master.address)
+        self.collect_md.add_field('primary', self.master.address)
         self.collect_md.add_section('nodes')
         self.collect_md.nodes.add_section(self.master.address)
         self.master.set_node_manifest(getattr(self.collect_md.nodes,
@@ -1060,6 +1066,13 @@ this utility or remote systems that it connects to.
         self.ui_log.info("\nsos-collector (version %s)\n" % __version__)
         intro_msg = self._fmt_msg(disclaimer % self.tmpdir)
         self.ui_log.info(intro_msg)
+
+        if self.opts.master:
+            self.ui_log.info(
+                "NOTE: Use of '--master' is DEPRECATED and will be removed in "
+                "a future release.\nUse '--primary', '--manager', or "
+                "'--controller' instead.")
+
         prompt = "\nPress ENTER to continue, or CTRL-C to quit\n"
         if not self.opts.batch:
             try:
@@ -1080,6 +1093,13 @@ this utility or remote systems that it connects to.
             raise SystemExit
 
         self.intro()
+
+        if self.opts.primary:
+            # for now, use the new option name and simply override the existing
+            # value that the rest of the component references. Full conversion
+            # of master -> primary is a 4.3 item.
+            self.opts.master = self.opts.primary
+
         self.configure_sos_cmd()
         self.prep()
         self.display_nodes()

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -138,7 +138,12 @@ class Cluster():
         self.cluster_ssh_key = key
 
     def exec_master_cmd(self, cmd, need_root=False):
-        """Used to retrieve command output from a (master) node in a cluster
+        self.log_debug("Use of exec_master_cmd() is deprecated and will be "
+                       "removed. Use exec_primary_cmd() instead")
+        return self.exec_primary_cmd(cmd, need_root)
+
+    def exec_primary_cmd(self, cmd, need_root=False):
+        """Used to retrieve command output from a (primary) node in a cluster
 
         :param cmd: The command to run
         :type cmd: ``str``

--- a/sos/collector/clusters/kubernetes.py
+++ b/sos/collector/clusters/kubernetes.py
@@ -30,7 +30,7 @@ class kubernetes(Cluster):
         self.cmd += ' get nodes'
         if self.get_option('label'):
             self.cmd += ' -l %s ' % quote(self.get_option('label'))
-        res = self.exec_master_cmd(self.cmd)
+        res = self.exec_primary_cmd(self.cmd)
         if res['status'] == 0:
             nodes = []
             roles = [x for x in self.get_option('role').split(',') if x]

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -36,7 +36,7 @@ class ovirt(Cluster):
         query should be done _before_ passing the query to this method.
         '''
         cmd = "%s %s" % (self.db_exec, quote(query))
-        return self.exec_master_cmd(cmd, need_root=True)
+        return self.exec_primary_cmd(cmd, need_root=True)
 
     def _sql_scrub(self, val):
         '''
@@ -112,7 +112,7 @@ class ovirt(Cluster):
     def parse_db_conf(self):
         conf = {}
         engconf = '/etc/ovirt-engine/engine.conf.d/10-setup-database.conf'
-        res = self.exec_master_cmd('cat %s' % engconf, need_root=True)
+        res = self.exec_primary_cmd('cat %s' % engconf, need_root=True)
         if res['status'] == 0:
             config = res['stdout'].splitlines()
             for line in config:
@@ -140,7 +140,7 @@ class ovirt(Cluster):
         cmd = ('PGPASSWORD={} /usr/sbin/sosreport --name=postgresql '
                '--batch -o postgresql {}'
                ).format(self.conf['ENGINE_DB_PASSWORD'], sos_opt)
-        db_sos = self.exec_master_cmd(cmd, need_root=True)
+        db_sos = self.exec_primary_cmd(cmd, need_root=True)
         for line in db_sos['stdout'].splitlines():
             if fnmatch.fnmatch(line, '*sosreport-*tar*'):
                 _pg_dump = line.strip()

--- a/sos/collector/clusters/pacemaker.py
+++ b/sos/collector/clusters/pacemaker.py
@@ -22,7 +22,7 @@ class pacemaker(Cluster):
     ]
 
     def get_nodes(self):
-        self.res = self.exec_master_cmd('pcs status')
+        self.res = self.exec_primary_cmd('pcs status')
         if self.res['status'] != 0:
             self.log_error('Cluster status could not be determined. Is the '
                            'cluster running on this node?')

--- a/sos/collector/clusters/satellite.py
+++ b/sos/collector/clusters/satellite.py
@@ -25,7 +25,7 @@ class satellite(Cluster):
 
     def get_nodes(self):
         cmd = self._psql_cmd('copy (select name from smart_proxies) to stdout')
-        res = self.exec_master_cmd(cmd, need_root=True)
+        res = self.exec_primary_cmd(cmd, need_root=True)
         if res['status'] == 0:
             nodes = [
                 n.strip() for n in res['stdout'].splitlines()


### PR DESCRIPTION
This commit begins the deprecation of the use of `master` in favor of
`primary`. For this initial step, `sos collect` will deprecate the
`--master` option and print a notice whenever it is used. This option is
being replaced by `--primary` with aliases `--manager` and
`--controller`.

This deprecation will last through 4.2, with `--master` being removed in
4.3.

Additionally, the `exec_master_cmd()` method for cluster profiles has
been similarly deprecated in favor of `exec_primary_cmd()`, with a
deprecation note logged whenever a cluster profile uses the former
method.

The internal assignment of the `SoSNode` object as `master` remains
for now, as this initial step is to deprecate the user-visible bits. By
full removal of `--master` in 4.3, these internal assignments should all
be changed to `primary` as well.

Related: #2329
Resolves: #2555

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
