### PR TITLE
[tests] Improve failed command reporting in test output

### DIFF
--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -39,7 +39,7 @@ class LogLevelTest(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '-vvv'
+    sos_cmd = '-vvv -o kernel,host,boot,filesys'
 
     def test_archive_logging_enabled(self):
         self.assertSosLogContains('DEBUG: \[archive:.*\]')

--- a/tests/report_tests/smoke_tests.py
+++ b/tests/report_tests/smoke_tests.py
@@ -64,7 +64,7 @@ class ExpectedDefaultPluginsTest(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '-v '
+    sos_cmd = ' '
 
     def test_default_plugins_enabled(self):
         """These plugins should run on all supported hosts by default everytime


### PR DESCRIPTION
Improves error reporting for failed sos commands by logging stderr (or
stdout if stderr is not populated) to the console, which was previously
being truncated by the builtin error handling of avocado. Printed output
is limited to the last 8k to avoid dumping several MBs at a time for
scenarios such as timeouts where command failure may generate
significant logging prior to failing.

Included with this are 2 minor changes to existing tests. First, remove
verbose output from the expected plugins test to reduce otherwise
irrelevant output for command failures. Second limit the number of
plugins run for the LogLevelTest, both to reduce overall run time for a
test where we aren't testing specific plugins and to improve readability
of failures for such a test.

Resolves: #2556

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
