### PR TITLE
[foreman] Follow sizelimit to foreman maintain and installer logs

### DIFF
--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -99,8 +99,8 @@ class Foreman(Plugin):
             "/var/log/foreman-proxy/smart_proxy_dynflow_core*log*",
             "/var/log/foreman-selinux-install.log",
             "/var/log/foreman-proxy-certs-generate*",
-            "/var/log/foreman-installer/",
-            "/var/log/foreman-maintain/",
+            "/var/log/foreman-installer/*",
+            "/var/log/foreman-maintain/*",
             "/var/log/syslog*",
             # Specific to TFM, _all_ catalina logs are relevant. Adding this
             # here rather than the tomcat plugin to ease maintenance and not

--- a/sos/plugins/foreman.py
+++ b/sos/plugins/foreman.py
@@ -114,7 +114,7 @@ class Foreman(Plugin):
             "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
             "/etc/puppetlabs/puppet/ssl/certs/{}.pem".format(_hostname),
             "/var/lib/puppet/ssl/certs/{}.pem".format(_hostname),
-            "/var/log/{}*/foreman-ssl_*_ssl*log[.-]*".format(self.apachepkg),
+            "/var/log/{}*/foreman*".format(self.apachepkg),
             "/var/log/{}*/katello-reverse-proxy_access_ssl.log*".format(
                 self.apachepkg),
             "/var/log/{}*/katello-reverse-proxy_error_ssl.log*".format(


### PR DESCRIPTION
Specifying add_copy_spec to a directory means all files from the
directory are collected. That is ridiculous for foremain-installer and
namely foreman-maintain logs, where we should stick to the size limit by
default. Hence collect files from the dir "specifically".

Related: #2554 
Resolves: #2557

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
