### PR TITLE
[archive] skip copying SELinux context for /proc and /sys everytime

### DIFF
--- a/tests/vendor_tests/redhat/rhbz1965001.py
+++ b/tests/vendor_tests/redhat/rhbz1965001.py
@@ -1,0 +1,39 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+import tempfile
+import shutil
+from sos_tests import StageOneReportTest
+
+
+class rhbz1965001(StageOneReportTest):
+    """
+    Copying /proc/sys/vm/{compact_memory,drop_caches} must ignore SELinux
+    context, otherwise an attempt to set the context to files under some
+    directories like /tmp raises an AVC denial, and an ERROR
+    "Unable to add '...' to archive: [Errno 13] Permission denied: '...'
+    is raise.
+
+    https://bugzilla.redhat.com/show_bug.cgi?id=1965001
+
+    :avocado: enable
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o system'
+    # it is crucial to run the test case with --tmp-dir=/tmp/... as that is
+    # (an example of) directory exhibiting the relabel permission deny.
+    # /var/tmp directory allows those relabels.
+    #
+    # the directory shouldn't exist at this moment, otherwise
+    # "check to prevent multiple setUp() runs" in sos_tests.py would fail
+    _tmpdir = '/tmp/rhbz1965001_avocado_test'
+
+    def test_no_permission_denied(self):
+        self.assertSosLogNotContains("Permission denied")


### PR DESCRIPTION
A supplement of #1399 fix, now also for adding strings or special
device files.

Resolves: #2560

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
