### PR TITLE
[Plugin] Add container enablement trigger

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -452,6 +452,7 @@ class Plugin(object):
     commands = ()
     kernel_mods = ()
     services = ()
+    containers = ()
     architectures = None
     archive = None
     profiles = ()
@@ -2595,7 +2596,7 @@ class Plugin(object):
         """
         # some files or packages have been specified for this package
         if any([self.files, self.packages, self.commands, self.kernel_mods,
-                self.services, self.architectures]):
+                self.services, self.containers, self.architectures]):
             if isinstance(self.files, str):
                 self.files = [self.files]
 
@@ -2622,7 +2623,9 @@ class Plugin(object):
                     if self._check_plugin_triggers(files,
                                                    packages,
                                                    commands,
-                                                   services):
+                                                   services,
+                                                   # SCL containers don't exist
+                                                   ()):
                         type(self)._scls_matched.append(scl)
                     if type(self)._scls_matched:
                         return True
@@ -2630,7 +2633,8 @@ class Plugin(object):
             return self._check_plugin_triggers(self.files,
                                                self.packages,
                                                self.commands,
-                                               self.services)
+                                               self.services,
+                                               self.containers)
 
         if isinstance(self, SCLPlugin):
             # if files and packages weren't specified, we take all SCLs
@@ -2638,9 +2642,10 @@ class Plugin(object):
 
         return True
 
-    def _check_plugin_triggers(self, files, packages, commands, services):
+    def _check_plugin_triggers(self, files, packages, commands, services,
+                               containers):
 
-        if not any([files, packages, commands, services]):
+        if not any([files, packages, commands, services, containers]):
             # no checks beyond architecture restrictions
             return self.check_is_architecture()
 
@@ -2648,7 +2653,8 @@ class Plugin(object):
                 any(self.is_installed(pkg) for pkg in packages) or
                 any(is_executable(cmd) for cmd in commands) or
                 any(self.is_module_loaded(mod) for mod in self.kernel_mods) or
-                any(self.is_service(svc) for svc in services)) and
+                any(self.is_service(svc) for svc in services) or
+                any(self.container_exists(cntr) for cntr in containers)) and
                 self.check_is_architecture())
 
     def check_is_architecture(self):

--- a/sos/report/plugins/openstack_cinder.py
+++ b/sos/report/plugins/openstack_cinder.py
@@ -20,6 +20,7 @@ class OpenStackCinder(Plugin):
     short_desc = 'OpenStack cinder'
     plugin_name = "openstack_cinder"
     profiles = ('openstack', 'openstack_controller')
+    containers = ('.*cinder_api',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/cinder"
 

--- a/sos/report/plugins/openstack_glance.py
+++ b/sos/report/plugins/openstack_glance.py
@@ -21,6 +21,7 @@ class OpenStackGlance(Plugin):
     short_desc = 'OpenStack Glance'
     plugin_name = "openstack_glance"
     profiles = ('openstack', 'openstack_controller')
+    containers = ('glance_api',)
 
     option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated/glance_api"

--- a/sos/report/plugins/openstack_heat.py
+++ b/sos/report/plugins/openstack_heat.py
@@ -18,6 +18,7 @@ class OpenStackHeat(Plugin):
     short_desc = 'OpenStack Heat'
     plugin_name = "openstack_heat"
     profiles = ('openstack', 'openstack_controller')
+    containers = ('.*heat_api',)
 
     option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated/heat"

--- a/sos/report/plugins/openstack_ironic.py
+++ b/sos/report/plugins/openstack_ironic.py
@@ -18,6 +18,7 @@ class OpenStackIronic(Plugin):
     short_desc = 'OpenStack Ironic'
     plugin_name = "openstack_ironic"
     profiles = ('openstack', 'openstack_undercloud')
+    containers = ('.*ironic_api',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/ironic"
     ins_puppet_gen = var_puppet_gen + "_inspector"

--- a/sos/report/plugins/openstack_manila.py
+++ b/sos/report/plugins/openstack_manila.py
@@ -16,6 +16,7 @@ class OpenStackManila(Plugin):
     short_desc = 'OpenStack Manila'
     plugin_name = "openstack_manila"
     profiles = ('openstack', 'openstack_controller')
+    containers = ('.*manila_api',)
     option_list = []
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/manila"

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -22,6 +22,7 @@ class OpenStackNova(Plugin):
     short_desc = 'OpenStack Nova'
     plugin_name = "openstack_nova"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
+    containers = ('.*nova_api',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/nova"
     service_name = "openstack-nova-api.service"

--- a/sos/report/plugins/openstack_placement.py
+++ b/sos/report/plugins/openstack_placement.py
@@ -16,6 +16,7 @@ class OpenStackPlacement(Plugin):
     short_desc = 'OpenStack Placement'
     plugin_name = "openstack_placement"
     profiles = ('openstack', 'openstack_controller')
+    containers = ('.*placement_api',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/placement"
     service_name = 'openstack-placement-api'

--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -24,6 +24,7 @@ class OVNCentral(Plugin):
     short_desc = 'OVN Northd'
     plugin_name = "ovn_central"
     profiles = ('network', 'virt')
+    containers = ('ovs-db-bundle.*',)
 
     def get_tables_from_schema(self, filename, skip=[]):
         if self._container_name:
@@ -63,10 +64,6 @@ class OVNCentral(Plugin):
             return
         for table in tables:
             cmds.append('%s list %s' % (ovn_cmd, table))
-
-    def check_enabled(self):
-        return (self.container_exists('ovs-dbs-bundle.*') or
-                super(OVNCentral, self).check_enabled())
 
     def setup(self):
         self._container_name = self.get_container_by_name('ovs-dbs-bundle.*')

--- a/tests/unittests/conformance_tests.py
+++ b/tests/unittests/conformance_tests.py
@@ -26,7 +26,7 @@ class PluginConformance(unittest.TestCase):
 
     def test_plugin_tuples_set_correctly(self):
         for plug in self.plug_classes:
-            for tup in ['packages', 'commands', 'files', 'profiles', 'kernel_mods']:
+            for tup in ['packages', 'commands', 'files', 'profiles', 'kernel_mods', 'containers']:
                 _attr = getattr(plug, tup)
                 self.assertIsInstance(
                     _attr, tuple,


### PR DESCRIPTION
Adds an enablement trigger tuple, `containers`, that can be used to enable plugins based on the presence of a running container matching any of the names or regexes in the tuple.

Also updates several plugins to make use of this new enablement tuple.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
