### PR TITLE
[cleaner] Don't strip empty lines from substituted files

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -603,8 +603,6 @@ third party.
         tfile = tempfile.NamedTemporaryFile(mode='w', dir=self.tmpdir)
         with open(filename, 'r') as fname:
             for line in fname:
-                if not line.strip():
-                    continue
                 try:
                     line, count = self.obfuscate_line(line)
                     subs += count
@@ -642,7 +640,11 @@ third party.
 
         Returns the fully obfuscated line and the number of substitutions made
         """
+        # don't iterate over blank lines, but still write them to the tempfile
+        # to maintain the same structure when we write a scrubbed file back
         count = 0
+        if not line.strip():
+            return line, count
         for parser in self.parsers:
             try:
                 line, _count = parser.parse_line(line)


### PR DESCRIPTION
Fixes an issue where empty lines would be stripped from files that have
other obfuscations in them. Those empty lines may be important for file
structure and/or readability, so we should instead simply not pass empty
lines to the parsers rather than skipping them wholesale in the flow of
writing obfuscations to a temp file before replacing the source file
with a potentially changed temp file.

Resolves: #2562

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
