### PR TITLE
[juju] Don't allow collection of kvm

### DIFF
--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -46,6 +46,7 @@ class Juju(Plugin, UbuntuPlugin):
                 "/var/log/juju",
                 "/var/lib/juju"
             ])
+            self.add_forbidden_path("/var/lib/juju/kvm")
         else:
             # We need this because we want to collect to the limit of all
             # logs in the directory.


### PR DESCRIPTION
With --all-logs, it could potentially collect the kvms that are created
by juju, and hence the sos report size could be significant. This
change will ensure that the kvm images are not collected as part of sos
report.

Closes: #2563

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
