### PR TITLE
[block] Add information about loop devices

### DIFF
--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -34,6 +34,7 @@ class Block(Plugin, IndependentPlugin):
             "ls -lanR /dev",
             "ls -lanR /sys/block",
             "lsblk -O -P",
+            "losetup -a",
         ])
 
         # legacy location for non-/run distributions
@@ -46,6 +47,7 @@ class Block(Plugin, IndependentPlugin):
             "/sys/block/sd*/device/timeout",
             "/sys/block/hd*/device/timeout",
             "/sys/block/sd*/device/state",
+            "/sys/block/loop*/loop/",
         ])
 
         cmds = [


### PR DESCRIPTION
This patch captures information from loop devices
via 'losetup -a' and the content of
/sys/block/loopN/loop/ directory.

Resolves: #2570 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
