### PR TITLE
[sssd] sssd plugin when sssd-common

### DIFF
--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -19,7 +19,7 @@ class Sssd(Plugin):
 
     plugin_name = "sssd"
     profiles = ('services', 'security', 'identity')
-    packages = ('sssd',)
+    packages = ('sssd', 'sssd-common')
 
     def setup(self):
         self.add_copy_spec([


### PR DESCRIPTION
We have reports that sssd logs are not
collected, when we investigated
we found associate wants to collect
sssd related logs also when only
sssd-common package is installed.

We got this confirmed by sbr-idm.

Resolves: #2571

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
