### PR TITLE
[cirrus] Update Fedora testing for F34

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@
 # Main environment vars to set for all tasks
 env:
 
-    FEDORA_VER: "33"
-    FEDORA_PRIOR_VER: "32"
+    FEDORA_VER: "34"
+    FEDORA_PRIOR_VER: "33"
     FEDORA_NAME: "fedora-${FEDORA_VER}"
     FEDORA_PRIOR_NAME: "fedora-${FEDORA_PRIOR_VER}"
 


### PR DESCRIPTION
Updates the testing matrix for F34, dropping F32.

Resolves: #2574

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
