### PR TITLE
[veritas] Fix "veritas" plugin check_enabled() with correct path

### DIFF
--- a/sos/report/plugins/veritas.py
+++ b/sos/report/plugins/veritas.py
@@ -20,14 +20,19 @@ class Veritas(Plugin, RedHatPlugin):
     # Information about VRTSexplorer obtained from
     # http://seer.entsupport.symantec.com/docs/243150.htm
     option_list = [("script", "Define VRTSexplorer script path", "",
-                    "/opt/VRTSspt/VRTSexplorer")]
+                    "/opt/VRTSspt/VRTSexplorer/VRTSexplorer")]
 
     def check_enabled(self):
-        return os.path.isfile(self.get_option("script"))
+        return (os.path.isfile(self.get_option("script")) or
+                os.path.isfile("/opt/VRTSspt/VRTSexplorer"))
 
     def setup(self):
         """ interface with vrtsexplorer to capture veritas related data """
-        r = self.exec_cmd(self.get_option("script"))
+        path = self.get_option("script")
+        if not os.path.isfile(path) :
+            path = "/opt/VRTSspt/VRTSexplorer"
+
+        r = self.exec_cmd([path, '-silent'])
         if r['status'] == 0:
             tarfile = ""
             for line in r['output']:


### PR DESCRIPTION
Veritas plugin use wrong "/opt/VRTSspt/VRTSexplorer" path.
Instead actual path is "/opt/VRTSspt/VRTSexplorer/VRTSexplorer".

Signed-off-by: Rajanikant Chirmade <rajanikantchirmade@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
