### PR TITLE
[cleaner] Use built-in TarFile compression functionality

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -556,11 +556,7 @@ third party.
                     archive.rename_top_dir(
                         self.obfuscate_string(archive.archive_name)
                     )
-                    cmd = self.policy.get_cmd_for_compress_method(
-                        method,
-                        self.opts.threads
-                    )
-                    archive.compress(cmd)
+                    archive.compress(method)
                 except Exception as err:
                     self.log_debug("Archive %s failed to compress: %s"
                                    % (archive.archive_name, err))


### PR DESCRIPTION
As we did with `report` in #2523, update `clean` to use the built-in
compression capability of TarFile to re-compress unpacked archives.

Resolves: #2576

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
