### PR TITLE
[report] Increase readability and reliability of top-level ThreadPool

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -963,11 +963,10 @@ class SoSReport(SoSComponent):
             plugruncount += 1
             self.pluglist.append((plugruncount, i[0]))
         try:
-            self.plugpool = ThreadPoolExecutor(self.opts.threads)
-            # Pass the plugpool its own private copy of self.pluglist
-            results = self.plugpool.map(self._collect_plugin,
-                                        list(self.pluglist))
-            self.plugpool.shutdown(wait=True)
+            results = []
+            with ThreadPoolExecutor(self.opts.threads) as executor:
+                results = executor.map(self._collect_plugin,
+                                       list(self.pluglist))
             for res in results:
                 if not res:
                     self.soslog.debug("Unexpected plugin task result: %s" %


### PR DESCRIPTION
In the "top-level" `ThreadPoolExecutor` used for threading plugin
execution, increase readability and reliability by wrapping it in a
`with` context manager, so that the pool's cleanup is run in all
situations explicitly.

This is a continuation of #2294, bringing it up to date with the current
state of the project and iterating over the plugin list as a discreet
unit rather than individual plugins.

Closes: #2294
Resolves: #2578

Co-authored-by: Erik Bernoth <ebernoth@redhat.com>
Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
