### PR TITLE
[man] unify some syntax in manpages

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -81,6 +81,7 @@ Do not write the mapping file contents to /etc/sos/cleaner/default_mapping
 .BR sos (1)
 .BR sos-report (1)
 .BR sos-collect (1)
+.BR sos.conf (5)
 
 .SH MAINTAINER
 .nf

--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -1,4 +1,4 @@
-.TH sos collect 1 "April 2020"
+.TH SOS COLLECT 1 "April 2020"
 
 .SH NAME
 sos collect \- Collect sosreports from multiple (cluster) nodes
@@ -374,6 +374,7 @@ Sosreport option. Override the default compression type.
 .BR sos (1)
 .BR sos-report (1)
 .BR sos-clean (1)
+.BR sos.conf (5)
 
 .SH MAINTAINER
     Jake Hunsaker <jhunsake@redhat.com>

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -1,8 +1,8 @@
-.TH SOSREPORT 1 "Mon Mar 25 2013"
+.TH SOS REPORT 1 "Mon Mar 25 2013"
 .SH NAME
-sosreport \- Collect and package diagnostic and support data
+sos report \- Collect and package diagnostic and support data
 .SH SYNOPSIS
-.B sosreport
+.B sos report
           [-l|--list-plugins]\fR
           [-n|--skip-plugins plugin-names]\fR
           [-e|--enable-plugins plugin-names]\fR
@@ -409,6 +409,7 @@ Display usage message.
 .BR sos (1)
 .BR sos-clean (1)
 .BR sos-collect (1)
+.BR sos.conf (5)
 
 .SH MAINTAINER
 .nf

--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -133,6 +133,8 @@ Compression type to use when compression the final archive output
 .TP
 .B \--help
 Display usage message.
+.SH SEE ALSO
+.BR sos.conf (5)
 .SH MAINTAINER
 .nf
 Jake Hunsaker <jhunsake@redhat.com>


### PR DESCRIPTION
Unify capitalisation of name and synopsis.

Add references to sos.conf to SEE ALSO of all binaries.

Resolves: #2581

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
