### PR TITLE
[vmware] Update command and log collections

### DIFF
--- a/sos/report/plugins/vmware.py
+++ b/sos/report/plugins/vmware.py
@@ -15,15 +15,35 @@ class VMWare(Plugin, RedHatPlugin):
 
     plugin_name = 'vmware'
     profiles = ('virt',)
-
-    files = ('vmware', '/usr/init.d/vmware-tools')
+    packages = ('open-vm-tools', 'VMWare-Tools')
+    files = ('/etc/vmware-tools', '/etc/vmware')
+    commands = ('vmware-toolbox-cmd',)
+    services = ('vmtoolsd',)
 
     def setup(self):
-        self.add_cmd_output("vmware -v")
         self.add_copy_spec([
+            "/etc/vmware-tools/",
             "/etc/vmware/locations",
             "/etc/vmware/config",
-            "/proc/vmmemctl"
+            "/proc/vmmemctl",
+            "/sys/kernel/debug/vmmemctl",
+            "/var/log/vmware-network.log",
+            "/var/log/vmware-vgauthsvc.log.0",
+            "/var/log/vmware-vmsvc-root.log",
+            "/var/log/vmware-vmtoolsd-root.log",
+            "/var/log/vmware-vmusr-root.log"
         ])
+
+        self.add_cmd_output([
+            "vmware-checkvm",
+            "vmware-toolbox-cmd device list",
+            "vmware-toolbox-cmd -v"
+        ])
+
+        stats = self.exec_cmd("vmware-toolbox-cmd stat raw")
+        if stats['status'] == 0:
+            for _stat in stats['output'].splitlines():
+                self.add_cmd_output("vmware-toolbox-cmd stat raw text %s"
+                                    % _stat)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Updates the `vmware` plugin for more current collections based on the
use of the `open-vm-tools` package which is the current recommendation
from VMware to use instead of the legacy VMWare-Tools package.

Command collections are expanded and updated to use
`vmware-toolbox-cmd`.

Closes: #2580
Resolves: #2582

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
