### PR TITLE
[pulpcore] obfuscate two passwords from 'dynaconf list'

### DIFF
--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -115,6 +115,16 @@ class PulpCore(Plugin, IndependentPlugin):
             "/etc/pulp/settings.py",
             r"(PASSWORD\S*\s*:\s*)(.*)",
             r"\1********")
+        # apply the same for "dynaconf list" output that prints settings.py
+        # in a pythonic format
+        self.do_cmd_output_sub(
+            "dynaconf list",
+            r"(SECRET_KEY<str>\s*)'(.*)'",
+            r"\1********")
+        self.do_cmd_output_sub(
+            "dynaconf list",
+            r"(PASSWORD\S*\s*:\s*)(.*)",
+            r"\1********")
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The command also prints content of /etc/pulp/settings.py
where we need to also obfuscate the SECRET_KEY and PASSWORD values.

Resolves: #2583

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [X] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
