### PR TITLE
[collect,clean,ocp] Enhance OCP cluster collection and archive cleaning

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -226,8 +226,7 @@ third party.
         nested_archives = []
         for _file in archive.getmembers():
             if (re.match('sosreport-.*.tar', _file.name.split('/')[-1]) and not
-               (_file.name.endswith('.md5') or
-               _file.name.endswith('.sha256'))):
+                    (_file.name.endswith(('.md5', '.sha256')))):
                 nested_archives.append(_file.name.split('/')[-1])
 
         if nested_archives:
@@ -235,6 +234,8 @@ third party.
             nested_path = self.extract_archive(archive)
             for arc_file in os.listdir(nested_path):
                 if re.match('sosreport.*.tar.*', arc_file):
+                    if arc_file.endswith(('.md5', '.sha256')):
+                        continue
                     self.report_paths.append(os.path.join(nested_path,
                                                           arc_file))
             # add the toplevel extracted archive

--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -20,8 +20,10 @@ class SoSMap():
     corresponding SoSMap() object, to allow for easy retrieval of obfuscated
     items.
     """
-
+    # used for regex skips in parser.parse_line()
     ignore_matches = []
+    # used for filename obfuscations in parser.parse_string_for_keys()
+    skip_keys = []
 
     def __init__(self):
         self.dataset = {}

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -35,6 +35,11 @@ class SoSHostnameMap(SoSMap):
         '^com..*'
     ]
 
+    skip_keys = [
+        'www',
+        'api'
+    ]
+
     host_count = 0
     domain_count = 0
     _domains = {}

--- a/sos/cleaner/obfuscation_archive.py
+++ b/sos/cleaner/obfuscation_archive.py
@@ -58,6 +58,7 @@ class SoSObfuscationArchive():
         Returns: list of files and file regexes
         """
         return [
+            'sosreport-',
             'sys/firmware',
             'sys/fs',
             'sys/kernel/debug',

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -82,10 +82,12 @@ class SoSCleanerParser():
         for pattern in self.regex_patterns:
             matches = [m[0] for m in re.findall(pattern, line, re.I)]
             if matches:
+                matches.sort(reverse=True, key=lambda x: len(x))
                 count += len(matches)
                 for match in matches:
-                    new_match = self.mapping.get(match.strip())
-                    line = line.replace(match.strip(), new_match)
+                    match = match.strip()
+                    new_match = self.mapping.get(match)
+                    line = line.replace(match, new_match)
         return line, count
 
     def parse_string_for_keys(self, string_data):
@@ -102,7 +104,9 @@ class SoSCleanerParser():
         :returns: The obfuscated line
         :rtype: ``str``
         """
-        for key, val in self.mapping.dataset.items():
+        for pair in sorted(self.mapping.dataset.items(), reverse=True,
+                           key=lambda x: len(x[0])):
+            key, val = pair
             if key in string_data:
                 string_data = string_data.replace(key, val)
         return string_data

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -107,6 +107,8 @@ class SoSCleanerParser():
         for pair in sorted(self.mapping.dataset.items(), reverse=True,
                            key=lambda x: len(x[0])):
             key, val = pair
+            if key in self.mapping.skip_keys:
+                continue
             if key in string_data:
                 string_data = string_data.replace(key, val)
         return string_data

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -87,7 +87,8 @@ class SoSCleanerParser():
                 for match in matches:
                     match = match.strip()
                     new_match = self.mapping.get(match)
-                    line = line.replace(match, new_match)
+                    if new_match != match:
+                        line = line.replace(match, new_match)
         return line, count
 
     def parse_string_for_keys(self, string_data):

--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -42,7 +42,7 @@ class SoSKeywordParser(SoSCleanerParser):
 
     def parse_line(self, line):
         count = 0
-        for keyword in self.user_keywords:
+        for keyword in sorted(self.user_keywords, reverse=True):
             if keyword in line:
                 line = line.replace(keyword, self.mapping.get(keyword))
                 count += 1

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -28,6 +28,7 @@ class SoSUsernameParser(SoSCleanerParser):
     prep_map_file = 'sos_commands/login/lastlog_-u_1000-60000'
     regex_patterns = []
     skip_list = [
+        'core',
         'nobody',
         'nfsnobody',
         'root',

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -51,7 +51,7 @@ class SoSUsernameParser(SoSCleanerParser):
 
     def parse_line(self, line):
         count = 0
-        for username in self.mapping.dataset.keys():
+        for username in sorted(self.mapping.dataset.keys(), reverse=True):
             if username in line:
                 count = line.count(username)
                 line = line.replace(username, self.mapping.get(username))

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -137,6 +137,16 @@ class Cluster():
         """
         self.cluster_ssh_key = key
 
+    def set_node_options(self, node):
+        """If there is a need to set specific options on ONLY the non-primary
+        nodes in a collection, override this method in the cluster profile
+        and do that here.
+
+        :param node:        The non-primary node
+        :type node:         ``SoSNode``
+        """
+        pass
+
     def set_master_options(self, node):
         """If there is a need to set specific options in the sos command being
         run on the cluster's master nodes, override this method in the cluster

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -11,6 +11,7 @@
 import logging
 
 from sos.options import ClusterOption
+from threading import Lock
 
 
 class Cluster():
@@ -66,6 +67,7 @@ class Cluster():
             if cls.__name__ != 'Cluster':
                 self.cluster_type.append(cls.__name__)
         self.node_list = None
+        self.lock = Lock()
         self.soslog = logging.getLogger('sos')
         self.ui_log = logging.getLogger('sos_ui')
         self.options = []

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -8,6 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
+
 from pipes import quote
 from sos.collector.clusters import Cluster
 
@@ -18,10 +20,14 @@ class ocp(Cluster):
     cluster_name = 'OpenShift Container Platform v4'
     packages = ('openshift-hyperkube', 'openshift-clients')
 
+    api_collect_enabled = False
+    token = None
+
     option_list = [
         ('label', '', 'Colon delimited list of labels to select nodes with'),
         ('role', '', 'Colon delimited list of roles to select nodes with'),
-        ('kubeconfig', '', 'Path to the kubeconfig file')
+        ('kubeconfig', '', 'Path to the kubeconfig file'),
+        ('token', '', 'Service account token to use for oc authorization')
     ]
 
     def fmt_oc_cmd(self, cmd):
@@ -32,9 +38,20 @@ class ocp(Cluster):
             return "oc --config %s %s" % (self.get_option('kubeconfig'), cmd)
         return "oc %s" % cmd
 
+    def _attempt_oc_login(self):
+        """Attempt to login to the API using the oc command using a provided
+        token
+        """
+        _res = self.exec_primary_cmd("oc login --insecure-skip-tls-verify=True"
+                                     " --token=%s" % self.token)
+        return _res['status'] == 0
+
     def check_enabled(self):
         if super(ocp, self).check_enabled():
             return True
+        self.token = self.get_option('token') or os.getenv('SOSOCPTOKEN', None)
+        if self.token:
+            self._attempt_oc_login()
         _who = self.fmt_oc_cmd('whoami')
         return self.exec_master_cmd(_who)['status'] == 0
 
@@ -106,4 +123,48 @@ class ocp(Cluster):
         return 'master' in self.node_dict[sosnode.address]['roles']
 
     def set_master_options(self, node):
-        node.opts.enable_plugins.append('openshift')
+        node.enable_plugins.append('openshift')
+        if self.api_collect_enabled:
+            # a primary has already been enabled for API collection, disable
+            # it among others
+            node.plugin_options.append('openshift.no-oc=on')
+        else:
+            _oc_cmd = 'oc'
+            if node.host.containerized:
+                _oc_cmd = '/host/bin/oc'
+                # when run from a container, the oc command does not inherit
+                # the default config, so if it's present then pass it here to
+                # detect a funcitonal oc command. This is sidestepped in sos
+                # report by being able to chroot the `oc` execution which we
+                # cannot do remotely
+                if node.file_exists('/root/.kube/config', need_root=True):
+                    _oc_cmd += ' --kubeconfig /host/root/.kube/config'
+            can_oc = node.run_command("%s whoami" % _oc_cmd,
+                                      use_container=node.host.containerized,
+                                      # container is available only to root
+                                      # and if rhel, need to run sos as root
+                                      # anyways which will run oc as root
+                                      need_root=True)
+            if can_oc['status'] == 0:
+                # the primary node can already access the API
+                self.api_collect_enabled = True
+            elif self.token:
+                node.sos_env_vars['SOSOCPTOKEN'] = self.token
+                self.api_collect_enabled = True
+            elif self.get_option('kubeconfig'):
+                kc = self.get_option('kubeconfig')
+                if node.file_exists(kc):
+                    if node.host.containerized:
+                        kc = "/host/%s" % kc
+                    node.sos_env_vars['KUBECONFIG'] = kc
+                    self.api_collect_enabled = True
+            if self.api_collect_enabled:
+                msg = ("API collections will be performed on %s\nNote: API "
+                       "collections may extend runtime by 10s of minutes\n"
+                       % node.address)
+                self.soslog.info(msg)
+                self.ui_log.info(msg)
+
+    def set_node_options(self, node):
+        # don't attempt OC API collections on non-primary nodes
+        node.plugin_options.append('openshift.no-oc=on')

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -657,6 +657,8 @@ class SosNode():
         # set master-only options
         if self.cluster.check_node_is_master(self):
             self.cluster.set_master_options(self)
+        else:
+            self.cluster.set_node_options(self)
 
     def finalize_sos_cmd(self):
         """Use host facts and compare to the cluster type to modify the sos
@@ -713,12 +715,12 @@ class SosNode():
                 sos_opts.append('--cmd-timeout=%s'
                                 % quote(str(self.opts.cmd_timeout)))
 
+        self.update_cmd_from_cluster()
+
         sos_cmd = sos_cmd.replace(
             'sosreport',
             os.path.join(self.host.sos_bin_path, self.sos_bin)
         )
-
-        self.update_cmd_from_cluster()
 
         if self.opts.only_plugins:
             plugs = [o for o in self.opts.only_plugins

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -202,11 +202,11 @@ class SosNode():
                 self.opts.registry_authfile or self.host.container_authfile
             )
 
-    def file_exists(self, fname):
+    def file_exists(self, fname, need_root=False):
         """Checks for the presence of fname on the remote node"""
         if not self.local:
             try:
-                res = self.run_command("stat %s" % fname)
+                res = self.run_command("stat %s" % fname, need_root=need_root)
                 return res['status'] == 0
             except Exception:
                 return False


### PR DESCRIPTION
This patchset touches several aspects of `collect` and `clean` that do not solely related to OCP or the (new) cluster profile, however the enhancements added we discovered as needed (or needed to be improved/fixed) as part of further enhancements to the OCP profile. Normally, these would be broken out into separate PRs, however given how linked these are to the ultimate changes being made for OCP collections and cleaning, it would be drastically higher overhead to split these out.

Of particular note, is the fix for not clobbering sos command options between nodes, which was inadvertently using a shared variable scope rather than private copies for each node.

Further, this includes allowing cluster profiles to individually set master/worker options, command env vars, and vastly improved handling of cleaning symlinks (of which OCP collections have a heavy presence of). Additionally, we will now explicitly go through directory name obfuscation rather than relying on it being performed as part of file renaming.

Finally, there is a vast improvement to the detection and enablement of `oc` command output among cluster nodes returned by the OCP cluster profile.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [x] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
