### PR TITLE
[github] Merge Closes and Resolves lines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,4 @@ Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor G
 - [ ] Is the subject and message clear and concise?
 - [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
 - [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
-- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
-- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
+- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?


### PR DESCRIPTION
While using Github merging we don't need to track Resolves to
close PRs anymore. If existing (and not the PR currently on)
it still makes sense to use Resolves though.

Signed-off-by: Bryan Quigley <code@bryanquigley.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] If this commit closes an existing issue, is the line `Closes: #ISSUENUMBER` included in an independent line?
- [ ] If this commit resolves an existing pull request, is the line `Resolves: #PRNUMBER` included in an independent line?
