### PR TITLE
[report] Log a warning message when trying to encrypt with --build

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1245,6 +1245,9 @@ class SoSReport(SoSComponent):
             finally:
                 os.umask(old_umask)
         else:
+            if self.opts.encrypt_pass or self.opts.encrypt_key:
+                self.ui_log.warn("\nUnable to encrypt when using --build. "
+                                 "Encryption is only available for archives.")
             # move the archive root out of the private tmp directory.
             directory = self.archive.get_archive_path()
             dir_name = os.path.basename(directory)


### PR DESCRIPTION
Since --build does not produce a tarball, we cannot encrypt any
collections. However, the encryption options are set in the global
option group so we cannot add a report-only option to that mutex group.
Instead, print a warning informing the user of this limitation.

Closes: #2568

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?