### PR TITLE
[tests] Workaround for current Avocado safeloader issue

### DIFF
--- a/tests/vendor_tests/redhat/rhbz1928628.py
+++ b/tests/vendor_tests/redhat/rhbz1928628.py
@@ -17,7 +17,6 @@ class rhbz1928628(NetworkingPluginTest):
 
     https://bugzilla.redhat.com/show_bug.cgi?id=1928628
 
-    :avocado: enable
     :avocado: tags=stageone
     """
 
@@ -34,7 +33,6 @@ class rhbz1928628Enabled(NetworkingPluginTest):
     WARNING: it has been noted (via this rhbz) that certain NICs may pause
     during this collection
 
-    :avocado: enable
     :avocado: tags=stageone
     """
 

--- a/tests/vendor_tests/redhat/rhbz1928628.py
+++ b/tests/vendor_tests/redhat/rhbz1928628.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-from report_tests.plugin_tests.networking import NetworkingPluginTest
+from ...report_tests.plugin_tests.networking import NetworkingPluginTest
 
 
 class rhbz1928628(NetworkingPluginTest):


### PR DESCRIPTION
This is a workaround, hopefully short lived, for an Avocado [issue](https://github.com/avocado-framework/avocado/issues/4625) that is hiding some of the tests defined on base classes.

FIY, there's been major work on making the Avocado's "safeloader" more robust, and the report from @TurboTurtle is greatly appreciated, as it is your patience in waiting for its resolution.

The fix may, or may not, make it into Avocado release 89.0, to be released next June 21th 2021.  In case the fixes makes into 89.0 and this been applied, it can be used to prove the fix with the revert of the workaround.  If it does not make, it will enable the hidden tests until 90.0 is released.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?