### PR TITLE
[rhui] add plugin to RHUI

### DIFF
--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -77,7 +77,12 @@ class PulpCore(Plugin, IndependentPlugin):
     def setup(self):
         self.parse_settings_config()
 
-        self.add_copy_spec("/etc/pulp/settings.py")
+        self.add_copy_spec([
+            "/etc/pulp/settings.py",
+            "/etc/pki/pulp/*"
+        ])
+        # skip collecting certificate keys
+        self.add_forbidden_path("/etc/pki/pulp/*.key")
 
         self.add_cmd_output("rq info -u redis://localhost:6379/8",
                             env={"LC_ALL": "en_US.UTF-8"},

--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2021 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class Rhui(Plugin, RedHatPlugin):
+
+    short_desc = 'Red Hat Update Infrastructure'
+
+    plugin_name = "rhui"
+    commands = ("rhui-manager",)
+    files = ("/etc/ansible/facts.d/rhui_auth.fact", "/usr/lib/rhui/cds.py")
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/rhui/rhui-tools.conf",
+            "/etc/rhui/registered_subscriptions.conf",
+            "/etc/pki/rhui/*",
+            "/var/log/rhui-subscription-sync.log",
+            "/var/cache/rhui/*",
+            "/root/.rhui/*",
+        ])
+        # skip collecting certificate keys
+        self.add_forbidden_path("/etc/pki/rhui/*.key")
+
+        self.add_cmd_output([
+            "rhui-manager status",
+            "rhui-manager cert info",
+            "ls -lR /var/lib/rhui/remote_share",
+        ])
+
+    def postproc(self):
+        # obfuscate admin_pw and secret_key values
+        for prop in ["admin_pw", "secret_key"]:
+            self.do_path_regex_sub(
+                "/etc/ansible/facts.d/rhui_auth.fact",
+                r"(%s\s*=\s*)(.*)" % prop,
+                r"\1********")
+
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add a new/revoked plugin for RHUI (newly based on python3 and pulp-3).

Edditionally, collect /etc/pki/pulp certificates except for RSA keys.

Resolves: #2590

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?