### PR TITLE
[date,systemd] Switch 'date' root symlink to timedatectl

### DIFF
--- a/sos/report/plugins/date.py
+++ b/sos/report/plugins/date.py
@@ -18,9 +18,9 @@ class Date(Plugin, IndependentPlugin):
     plugin_name = 'date'
 
     def setup(self):
-        self.add_cmd_output('date', root_symlink='date')
 
         self.add_cmd_output([
+            'date',
             'date --utc',
             'hwclock'
         ])

--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -51,9 +51,10 @@ class Systemd(Plugin, IndependentPlugin):
             "systemd-analyze dump",
             "systemd-inhibit --list",
             "journalctl --list-boots",
-            "ls -lR /lib/systemd",
-            "timedatectl"
+            "ls -lR /lib/systemd"
         ])
+
+        self.add_cmd_output('timedatectl', root_symlink='date')
 
         # resolvectl command starts systemd-resolved service if that
         # is not running, so gate the commands by this predicate


### PR DESCRIPTION
Changes which collection the `date` root symlink points to. It will now
reference the `timedatectl` command run via the `systemd` plugin, as it
provides more complete and accurate information.

Closes: #2559

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?