### PR TITLE
[libvirt] Gather libvirt's dnsmasq configuration files

### DIFF
--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -42,7 +42,8 @@ class Libvirt(Plugin, IndependentPlugin):
             "/etc/libvirt/storage/*.xml",
             "/etc/libvirt/storage/autostart/*.xml",
             "/etc/libvirt/qemu-lockd.conf",
-            "/etc/libvirt/virtlockd.conf"
+            "/etc/libvirt/virtlockd.conf",
+            "/var/lib/libvirt/dnsmasq/*",
         ])
 
         if not self.get_option("all_logs"):


### PR DESCRIPTION
We are very interested in gathering data about dnsmasq processes that libvirt always spawns for every network.
This will add those kind of configuration files, which can tell us how DNS is actually configured in the internal libvirt networks.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?

An example artifact:
[sosreport.zip](https://github.com/sosreport/sos/files/6701370/sosreport.zip)