### PR TITLE
[tests] Add full execution clean test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,7 +111,7 @@ report_stageone_task:
             dnf -y remove sos
         fi
     setup_script: &setup 'pip3 install avocado-framework'
-    main_script: PYTHONPATH=tests/ avocado run -t stageone tests/{report,cleaner,collect,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run -t stageone tests/{cleaner,collect,report,vendor}_tests
 
 # IFF the stage one tests all pass, then run stage two for latest distros
 report_stagetwo_task:
@@ -141,7 +141,7 @@ report_stagetwo_task:
             dnf -y install python3-pexpect
         fi
     setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run -t stagetwo tests/{report,cleaner,collect,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run -t stagetwo tests/{cleaner,collect,report,vendor}_tests
 
 report_foreman_task:
     skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py')"

--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -129,6 +129,16 @@ class SoSCleaner(SoSComponent):
                 self.log_error(
                     "ERROR: map file %s does not exist, will not load any "
                     "obfuscation matches" % self.opts.map_file)
+        else:
+            with open(self.opts.map_file, 'r') as mf:
+                try:
+                    json.load(mf)
+                except json.JSONDecodeError:
+                    self.log_error("ERROR: Unable to parse map file, json is "
+                                   "malformed. Will not load any mappings.")
+                except Exception as err:
+                    self.log_error("ERROR: Could not load '%s': %s"
+                                   % (self.opts.map_file, err))
 
     def print_disclaimer(self):
         """When we are directly running `sos clean`, rather than hooking into

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -62,7 +62,7 @@ class SoSCleanerParser():
                     self.mapping.conf_update(
                         _default_mappings[self.map_file_key]
                     )
-            except IOError:
+            except (IOError, json.decoder.JSONDecodeError):
                 pass
 
     def parse_line(self, line):

--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -25,6 +25,10 @@ class SoSMacParser(SoSCleanerParser):
         # IPv4, avoiding matching a substring within IPv6 addresses
         r'(([^:|-])([0-9a-fA-F]{2}([:-])){5}([0-9a-fA-F]){2}(.)?(\s|$|\W))'
     ]
+    obfuscated_patterns = (
+        '53:4f:53',
+        '534f:53'
+    )
     map_file_key = 'mac_map'
     prep_map_file = 'sos_commands/networking/ip_-d_address'
 
@@ -53,6 +57,9 @@ class SoSMacParser(SoSCleanerParser):
             if matches:
                 count += len(matches)
                 for match in matches:
+                    if match.startswith(self.obfuscated_patterns):
+                        # avoid double scrubbing
+                        continue
                     stripped_match = self.reduce_mac_match(match)
                     new_match = self.mapping.get(stripped_match)
                     line = line.replace(stripped_match, new_match)

--- a/tests/cleaner_tests/full_report_run.py
+++ b/tests/cleaner_tests/full_report_run.py
@@ -1,0 +1,86 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import json
+import re
+
+from avocado.utils import process
+from sos_tests import StageTwoReportTest
+
+
+class FullCleanTest(StageTwoReportTest):
+    """Run an unrestricted report execution through sos clean, ensuring that
+    our obfuscation is reliable across arbitrary plugin sets and not just the
+    'main' plugins that tend to collect data needing obfuscation
+
+    :avocado: tags=stagetwo
+    """
+
+    sos_cmd = '-v --clean'
+    sos_timeout = 600
+    # replace with an empty placeholder, make sure that this test case is not
+    # influenced by previous clean runs
+    files = ['/etc/sos/cleaner/default_mapping']
+
+    def _grep_for_content(self, search):
+        """Call out to grep for finding a specific string 'search' in any place
+        in the archive
+        """
+        cmd = "grep -ril '%s' %s" % (search, self.archive_path)
+        try:
+            out = process.run(cmd)
+            rc = out.exit_status
+        except process.CmdError as err:
+            out = err.result
+            rc = err.result.exit_status
+
+        if rc == 1:
+            # grep will return an exit code of 1 if no matches are found,
+            # which is what we want
+            return False
+        else:
+            flist = []
+            for ln in out.stdout.decode('utf-8').splitlines():
+                flist.append(ln.split(self.tmpdir)[-1])
+            return flist
+
+    def test_private_map_was_generated(self):
+        self.assertOutputContains('A mapping of obfuscated elements is available at')
+        map_file = re.findall('/.*sosreport-.*-private_map', self.cmd_output.stdout)[-1]
+        self.assertFileExists(map_file)
+
+    def test_tarball_named_obfuscated(self):
+        self.assertTrue('obfuscated' in self.archive)
+
+    def test_hostname_not_in_any_file(self):
+        host = self.sysinfo['pre']['networking']['hostname']
+        # much faster to just use grep here
+        content = self._grep_for_content(host)
+        if not content:
+            assert True
+        else:
+            self.fail("Hostname appears in files: %s"
+                      % "\n".join(f for f in content))
+
+    def test_no_empty_obfuscations(self):
+        # get the private map file name
+        map_file = re.findall('/.*sosreport-.*-private_map', self.cmd_output.stdout)[-1]
+        with open(map_file, 'r') as mf:
+            map_json = json.load(mf)
+        for mapping in map_json:
+            for key, val in map_json[mapping].items():
+                assert key, "Empty key found in %s" % mapping
+                assert val, "%s mapping for '%s' empty" % (mapping, key)
+
+    def test_ip_not_in_any_file(self):
+        ip = self.sysinfo['pre']['networking']['ip_addr']
+        content = self._grep_for_content(ip)
+        if not content:
+            assert True
+        else:
+            self.fail("IP appears in files: %s" % "\n".join(f for f in content))

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -120,6 +120,9 @@ class BaseSoSTest(Test):
         try:
             self.cmd_output = process.run(exec_cmd, timeout=self.sos_timeout)
         except Exception as err:
+            if not hasattr(err, 'result'):
+                # can't inspect the exception raised, just bail out
+                raise
             if self._exception_expected:
                 self.cmd_output = err.result
             else:

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -65,6 +65,7 @@ class BaseSoSTest(Test):
     _tmpdir = None
     _exception_expected = False
     sos_cmd = ''
+    sos_timeout = 300
 
     @property
     def klass_name(self):
@@ -117,7 +118,7 @@ class BaseSoSTest(Test):
         """
         exec_cmd = self._generate_sos_command()
         try:
-            self.cmd_output = process.run(exec_cmd, timeout=300)
+            self.cmd_output = process.run(exec_cmd, timeout=self.sos_timeout)
         except Exception as err:
             if self._exception_expected:
                 self.cmd_output = err.result


### PR DESCRIPTION
Adds a full `sos report --clean` execution test, that is one that does not limit what the report is gathering like the current tests do. Then, inspect the contents of the archive more deeply, ensuring the local hostname and primary IP address do not appear anywhere within the archive. 

Also includes two fixes found during test case development. First, catch a json decoding exception like we do a non-existing file exception. Second, allow test cases to define their own timeout if needed, still defaulting back to 300 seconds.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?