### PR TITLE
[openvswitch] Add collection for OVS datapaths

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -127,7 +127,11 @@ class OpenVSwitch(Plugin):
             # Capture ipsec tunnel information
             "ovs-appctl -t ovs-monitor-ipsec tunnels/show",
             "ovs-appctl -t ovs-monitor-ipsec xfrm/state",
-            "ovs-appctl -t ovs-monitor-ipsec xfrm/policies"
+            "ovs-appctl -t ovs-monitor-ipsec xfrm/policies",
+            # Capture OVS offload enabled flows
+            "ovs-dpctl dump-flows --name -m type=offloaded",
+            # Capture OVS slowdatapth flows
+            "ovs-dpctl dump-flows --name -m type=ovs"
         ])
 
         # Gather systemd services logs


### PR DESCRIPTION
Updates PR #1820 to bring in additional command collection for the
openvswitch plugin. Note that the `ovs-appctl` command added in that
original PR is not brought forward, as subsequent changes since that PR
have added an iterative collection of that command.

Resolves: #1820

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?