### PR TITLE
[cleaner] Add error message when using empty mappings file

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -129,6 +129,11 @@ class SoSCleaner(SoSComponent):
                 self.log_error(
                     "ERROR: map file %s does not exist, will not load any "
                     "obfuscation matches" % self.opts.map_file)
+        if os.stat(self.opts.map_file).st_size == 0:
+            self.log_error(
+                "ERROR: map file %s exists, but it is empty, will not "
+                "load any obfuscation matches" % self.opts.map_file)
+            self.opts.map_file = None
 
     def print_disclaimer(self):
         """When we are directly running `sos clean`, rather than hooking into


### PR DESCRIPTION
This patch solves the situation where we attempt to
use an empty json file for cleaner matches. Before this
it issues the following error:

Could not initialize 'clean': Expecting value: line 1
column 1 (char 0)

With the patch, it prints an error message similar to
the one we use when there's no mapping file.

Resolved: RHBZ#1929172
Resolved: #2598 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?