### PR TITLE
[cirrus] Update CentOS Stream 8 image in GCE testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ env:
     FOREMAN_DEBIAN_IMAGE_NAME: "foreman-24-debian-sos-testing"
 
     # Images exist on GCP already
-    CENTOS_IMAGE_NAME: "centos-stream-8-v20210316"
+    CENTOS_IMAGE_NAME: "centos-stream-8-v20210609"
     UBUNTU_IMAGE_NAME: "ubuntu-2004-focal-v20201111"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-1804-bionic-v20201111"
 


### PR DESCRIPTION
Updates the image used for CentOS Stream 8 testing to the latest release
for that distro.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?