### PR TITLE
[yum] Fix potential traceback when yum history is empty

### DIFF
--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -91,7 +91,7 @@ class Yum(Plugin, RedHatPlugin):
         # packages installed/erased/updated per transaction
         if self.get_option("yum-history-info"):
             history = self.exec_cmd("yum history")
-            transactions = None
+            transactions = -1
             if history['status'] == 0:
                 for line in history['output'].splitlines():
                     try:


### PR DESCRIPTION
Like we did in #969 for `dnf`, fix a potential issue where we would
generate a traceback in the plugin when `yum history` is empty.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?