### PR TITLE
[plugins] Set default predicate instead of None for robustness

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1627,7 +1627,7 @@ class Plugin(object):
 
     def _add_cmd_output(self, **kwargs):
         """Internal helper to add a single command to the collection list."""
-        pred = kwargs.pop('pred') if 'pred' in kwargs else None
+        pred = kwargs.pop('pred') if 'pred' in kwargs else SoSPredicate(self)
         if 'priority' not in kwargs:
             kwargs['priority'] = 10
         soscmd = SoSCommand(**kwargs)


### PR DESCRIPTION
Just making the code more robustness, it could be dangerous to
set pred = None and then potentially call log_skipped_cmd that
expects "pred" of SoSPredicate type.

Currently such a call flow can not happen, but it is worth to
make the code more robust for potential future changes.

Resolves: #2601

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?