### PR TITLE
[sosnode] Properly format skip-commands and skip-files on nodes

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -734,11 +734,12 @@ class SosNode():
         if self.check_sos_version('4.1'):
             if self.opts.skip_commands:
                 sos_opts.append(
-                    '--skip-commands=%s' % (quote(self.opts.skip_commands))
+                    '--skip-commands=%s' % (
+                        quote(','.join(self.opts.skip_commands)))
                 )
             if self.opts.skip_files:
                 sos_opts.append(
-                    '--skip-files=%s' % (quote(self.opts.skip_files))
+                    '--skip-files=%s' % (quote(','.join(self.opts.skip_files)))
                 )
 
         if self.check_sos_version('4.2'):


### PR DESCRIPTION
Fixes an issue where options provided for `skip-commands` and
`skip-files` were not properly formatted, thus causing an exception
during the finalization of the node's sos command.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?