### PR TITLE
kata_containers: Update to the 2.x release

### DIFF
--- a/sos/report/plugins/kata_containers.py
+++ b/sos/report/plugins/kata_containers.py
@@ -15,7 +15,7 @@ class KataContainers(Plugin, IndependentPlugin):
 
     plugin_name = 'kata_containers'
     profiles = ('system', 'virt', 'container')
-    packages = ('kata-runtime',)
+    packages = ('kata-containers',)
 
     def setup(self):
         self.limit = self.get_option('log_size')
@@ -42,10 +42,5 @@ class KataContainers(Plugin, IndependentPlugin):
                     config_files.add(config)
 
             self.add_copy_spec(config_files)
-
-        self.add_journal(identifier='kata-proxy')
-        self.add_journal(identifier='kata-shim')
-        self.add_journal(identifier='kata-runtime')
-        self.add_journal(units='kata-ksm-throttler')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Kata Containers 1.x, which is the base for this plugin, has reached its
EOL on May 12th 2021*.

Based on that, let's update the sos plugin to match the current Fedora
RPM (kata-containers, instead of kata-runtime), and set the identifiers
we'd be interested in, which are the crio and containerd ones.

Currently, kata-containers can only be used in the kubernetes world and
it'll always be spawn either by CRI-O or containerd, and then it'll log
to the journal using their identifier.

*: https://medium.com/kata-containers/about-kata-containers-releases-8b3d91d1166e

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?