### PR TITLE
[cleaner] Read map file only once for parsers

### DIFF
--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -8,7 +8,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import json
 import re
 
 
@@ -52,18 +51,9 @@ class SoSCleanerParser():
     map_file_key = 'unset'
     prep_map_file = 'unset'
 
-    def __init__(self, conf_file=None):
-        # attempt to load previous run data into the mapping for the parser
-        if conf_file:
-            try:
-                with open(conf_file, 'r') as map_file:
-                    _default_mappings = json.load(map_file)
-                if self.map_file_key in _default_mappings:
-                    self.mapping.conf_update(
-                        _default_mappings[self.map_file_key]
-                    )
-            except (IOError, json.decoder.JSONDecodeError):
-                pass
+    def __init__(self, config={}):
+        if self.map_file_key in config:
+            self.mapping.conf_update(config[self.map_file_key])
 
     def parse_line(self, line):
         """This will be called for every line in every file we process, so that

--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -21,9 +21,9 @@ class SoSHostnameParser(SoSCleanerParser):
         r'(((\b|_)[a-zA-Z0-9-\.]{1,200}\.[a-zA-Z]{1,63}(\b|_)))'
     ]
 
-    def __init__(self, conf_file=None, opt_domains=None):
+    def __init__(self, config, opt_domains=None):
         self.mapping = SoSHostnameMap()
-        super(SoSHostnameParser, self).__init__(conf_file)
+        super(SoSHostnameParser, self).__init__(config)
         self.mapping.load_domains_from_map()
         self.mapping.load_domains_from_options(opt_domains)
         self.short_names = []

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -43,6 +43,6 @@ class SoSIPParser(SoSCleanerParser):
     map_file_key = 'ip_map'
     prep_map_file = 'sos_commands/networking/ip_-o_addr'
 
-    def __init__(self, conf_file=None):
+    def __init__(self, config):
         self.mapping = SoSIPMap()
-        super(SoSIPParser, self).__init__(conf_file)
+        super(SoSIPParser, self).__init__(config)

--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -22,10 +22,10 @@ class SoSKeywordParser(SoSCleanerParser):
     map_file_key = 'keyword_map'
     prep_map_file = ''
 
-    def __init__(self, conf_file=None, keywords=None, keyword_file=None):
+    def __init__(self, config, keywords=None, keyword_file=None):
         self.mapping = SoSKeywordMap()
         self.user_keywords = []
-        super(SoSKeywordParser, self).__init__(conf_file)
+        super(SoSKeywordParser, self).__init__(config)
         for _keyword in self.mapping.dataset.keys():
             self.user_keywords.append(_keyword)
         if keywords:

--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -32,9 +32,9 @@ class SoSMacParser(SoSCleanerParser):
     map_file_key = 'mac_map'
     prep_map_file = 'sos_commands/networking/ip_-d_address'
 
-    def __init__(self, conf_file=None):
+    def __init__(self, config):
         self.mapping = SoSMacMap()
-        super(SoSMacParser, self).__init__(conf_file)
+        super(SoSMacParser, self).__init__(config)
 
     def reduce_mac_match(self, match):
         """Strips away leading and trailing non-alphanum characters from any

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -35,9 +35,9 @@ class SoSUsernameParser(SoSCleanerParser):
         'ubuntu'
     ]
 
-    def __init__(self, conf_file=None, opt_names=None):
+    def __init__(self, config, opt_names=None):
         self.mapping = SoSUsernameMap()
-        super(SoSUsernameParser, self).__init__(conf_file)
+        super(SoSUsernameParser, self).__init__(config)
         self.mapping.load_names_from_options(opt_names)
 
     def load_usernames_into_map(self, content):

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -100,11 +100,11 @@ class CleanerMapTests(unittest.TestCase):
 class CleanerParserTests(unittest.TestCase):
 
     def setUp(self):
-        self.ip_parser = SoSIPParser()
-        self.mac_parser = SoSMacParser()
-        self.host_parser = SoSHostnameParser(opt_domains='foobar.com')
-        self.kw_parser = SoSKeywordParser(keywords=['foobar'])
-        self.kw_parser_none = SoSKeywordParser()
+        self.ip_parser = SoSIPParser(config={})
+        self.mac_parser = SoSMacParser(config={})
+        self.host_parser = SoSHostnameParser(config={}, opt_domains='foobar.com')
+        self.kw_parser = SoSKeywordParser(config={}, keywords=['foobar'])
+        self.kw_parser_none = SoSKeywordParser(config={})
 
     def test_ip_parser_valid_ipv4_line(self):
         line = 'foobar foo 10.0.0.1/24 barfoo bar'


### PR DESCRIPTION
Instead of re-reading the mapping file for each parser, read it once and
store the contents, then hand those contents over to each parser.

This allows us to side-step handling the same exception for malformed
config files over and over for each parser loaded.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?