### PR TITLE
[cleaner] Use a nested ProcessPoolExecutor for extraction

### DIFF
--- a/tests/cleaner_tests/existing_archive.py
+++ b/tests/cleaner_tests/existing_archive.py
@@ -1,0 +1,84 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+import re
+import json
+from sos_tests import StageTwoReportTest
+
+ARCHIVE = 'sosreport-cleanertest-2021-08-03-qpkxdid'
+
+class ExistingArchiveCleanTest(StageTwoReportTest):
+    """Ensure that we can extract an already created archive and clean it the
+    same as we would an in-line run of `report --clean`.
+
+    Note that this copies heavily from the full_report_run test.
+
+    :avocado: tags=stagetwo
+    """
+
+    sos_cmd = '-v tests/test_data/%s.tar.xz' % ARCHIVE
+    sos_component = 'clean'
+
+    def test_obfuscation_log_created(self):
+        self.assertFileExists(os.path.join(self.tmpdir, '%s-obfuscation.log' % ARCHIVE))
+
+    def test_from_cmdline_logged(self):
+        with open(os.path.join(self.tmpdir, '%s-obfuscation.log' % ARCHIVE), 'r') as log:
+            for line in log:
+                if 'From cmdline' in line:
+                    assert 'From cmdline: True' in line, "Did not properly log cmdline run"
+                    break
+
+    def test_extraction_completed_successfully(self):
+        with open(os.path.join(self.tmpdir, '%s-obfuscation.log' % ARCHIVE), 'r') as log:
+            for line in log:
+                if 'Extracted path is' in line:
+                    path = line.split('Extracted path is')[-1].strip()
+                    assert path.startswith(self.tmpdir), "Extracted path appears wrong: %s (tmpdir: %s)" % (path, self.tmpdir)
+                    return
+            self.fail("Extracted path not logged")
+
+    def test_private_map_was_generated(self):
+        self.assertOutputContains('A mapping of obfuscated elements is available at')
+        map_file = re.findall('/.*sosreport-.*-private_map', self.cmd_output.stdout)[-1]
+        self.assertFileExists(map_file)
+
+    def test_tarball_named_obfuscated(self):
+        self.assertTrue('obfuscated' in self.archive)
+
+    def test_hostname_not_in_any_file(self):
+        # much faster to just use grep here
+        content = self.grep_for_content('cleanertest')
+        if not content:
+            assert True
+        else:
+            self.fail("Hostname appears in files: %s"
+                      % "\n".join(f for f in content))
+
+    def test_no_empty_obfuscations(self):
+        # get the private map file name
+        map_file = re.findall('/.*sosreport-.*-private_map', self.cmd_output.stdout)[-1]
+        with open(map_file, 'r') as mf:
+            map_json = json.load(mf)
+        for mapping in map_json:
+            for key, val in map_json[mapping].items():
+                assert key, "Empty key found in %s" % mapping
+                assert val, "%s mapping for '%s' empty" % (mapping, key)
+
+    def test_ip_not_in_any_file(self):
+        content = self.grep_for_content('10.0.0.15')
+        if not content:
+            assert True
+        else:
+            self.fail("IP appears in files: %s" % "\n".join(f for f in content))
+
+    def test_user_is_obfuscated(self):
+        """Ensure that the 'testuser1' user created at install is obfuscated
+        """
+        self.assertFileNotHasContent('var/log/anaconda/journal.log', 'testuser1')

--- a/tests/cleaner_tests/full_report_run.py
+++ b/tests/cleaner_tests/full_report_run.py
@@ -27,28 +27,6 @@ class FullCleanTest(StageTwoReportTest):
     # influenced by previous clean runs
     files = ['/etc/sos/cleaner/default_mapping']
 
-    def _grep_for_content(self, search):
-        """Call out to grep for finding a specific string 'search' in any place
-        in the archive
-        """
-        cmd = "grep -ril '%s' %s" % (search, self.archive_path)
-        try:
-            out = process.run(cmd)
-            rc = out.exit_status
-        except process.CmdError as err:
-            out = err.result
-            rc = err.result.exit_status
-
-        if rc == 1:
-            # grep will return an exit code of 1 if no matches are found,
-            # which is what we want
-            return False
-        else:
-            flist = []
-            for ln in out.stdout.decode('utf-8').splitlines():
-                flist.append(ln.split(self.tmpdir)[-1])
-            return flist
-
     def test_private_map_was_generated(self):
         self.assertOutputContains('A mapping of obfuscated elements is available at')
         map_file = re.findall('/.*sosreport-.*-private_map', self.cmd_output.stdout)[-1]
@@ -60,7 +38,7 @@ class FullCleanTest(StageTwoReportTest):
     def test_hostname_not_in_any_file(self):
         host = self.sysinfo['pre']['networking']['hostname']
         # much faster to just use grep here
-        content = self._grep_for_content(host)
+        content = self.grep_for_content(host)
         if not content:
             assert True
         else:
@@ -79,7 +57,7 @@ class FullCleanTest(StageTwoReportTest):
 
     def test_ip_not_in_any_file(self):
         ip = self.sysinfo['pre']['networking']['ip_addr']
-        content = self._grep_for_content(ip)
+        content = self.grep_for_content(ip)
         if not content:
             assert True
         else:


### PR DESCRIPTION
This commit inserts a nested ProcessPoolExecutor into the extraction
workflow for archives that are being obfuscated by `sos clean`.

Previously, the extraction was handled inside the same thread as the
rest of the obfuscation routines for each archive. However, it has been
found that when very large archives are manipulated concurrently,
performance can take a massive hit during the extraction process. This
is due to GIL limitations.

In this aspect 'very large archives' implies many tens of thousands of
files - e.g. 50K+. Because TarFile uses a 10K internal buffer, we end up
spinning a lot of time processing each file via the interpreter.

By shunting each extraction off into a new process space, we can avoid
the GIL issues altogether.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?