### PR TITLE
[build,tests] Include .po files for manual builds, add cirrus test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,6 +70,20 @@ py_break_task:
     setup_script: pip install -r requirements.txt
     main_script: ./bin/sos report --batch
 
+# Make sure a user can manually build an rpm from the checkout
+rpm_build_task:
+    alias: "rpm_build"
+    name: "RPM Build From Checkout"
+    container:
+        image: "fedora"
+    setup_script: dnf -y install rpm-build rpmdevtools gettext python3-devel
+    main_script: |
+        rpmdev-setuptree
+        python3 setup.py sdist
+        cp dist/sos*.tar.gz ~/rpmbuild/SOURCES
+        rpmbuild -bs sos.spec
+        rpmbuild -bb sos.spec
+
 # Run the stage one (no mocking) tests across all distros on GCP
 report_stageone_task:
     alias: "stageone_report"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include po/*.po


### PR DESCRIPTION
First, adds a MANIFEST.in file for distutils to reference, so that we
can easily ensure that the .po files are included in any manual build
from the git checkout.

Second, add a cirrus task to ensure that basic rpm builds from the git
checkout can be done by the user.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?