### PR TITLE
[build] Remove old libxml2 dependency

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -12,7 +12,6 @@ BuildArch: noarch
 Url: https://github.com/sosreport/sos/
 BuildRequires: python3-devel
 BuildRequires: gettext
-Requires: python3-libxml2
 Requires: python3-rpm
 Requires: tar
 Requires: xz


### PR DESCRIPTION
Removes an old dependency on python-libxml2 that has not been required
for some time.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?