### PR TITLE
[leapp] Capture /etc/migration-results

### DIFF
--- a/sos/report/plugins/leapp.py
+++ b/sos/report/plugins/leapp.py
@@ -24,7 +24,8 @@ class Leapp(Plugin, RedHatPlugin):
             '/var/log/leapp/leapp-preupgrade.log',
             '/var/log/leapp/leapp-upgrade.log',
             '/var/log/leapp/leapp-report.txt',
-            '/var/log/leapp/dnf-plugin-data.txt'
+            '/var/log/leapp/dnf-plugin-data.txt',
+            '/etc/migration-results'
         ])
 
         # capture DB without sizelimit


### PR DESCRIPTION
This patch captures the file /etc/migration-results
when the packages leapp or leapp-repository are
installed in the system.

Fixes: RHBZ #1985552
Closes: #2625 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?