### PR TITLE
[report] Improve logging skipped commands during dry run

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -326,7 +326,11 @@ class SoSPredicate(object):
         """Used by `Plugin()` to obtain the error string based on if the reason
         was a failed check or a forbidden check
         """
-        msg = [self._report_failed(), self._report_forbidden()]
+        msg = [
+            self._report_failed(),
+            self._report_forbidden(),
+            '(dry run)' if self.dry_run else ''
+        ]
         return " ".join(msg).lstrip()
 
     def __nonzero__(self):
@@ -1633,6 +1637,8 @@ class Plugin(object):
         pred = kwargs.pop('pred') if 'pred' in kwargs else SoSPredicate(self)
         if 'priority' not in kwargs:
             kwargs['priority'] = 10
+        if 'changes' not in kwargs:
+            kwargs['changes'] = False
         soscmd = SoSCommand(**kwargs)
         self._log_debug("packed command: " + soscmd.__str__())
         for _skip_cmd in self.skip_commands:


### PR DESCRIPTION
Set default value for the attribute 'changes' when_add_cmd_output is
called without that argument.

Further, add reason to "skipped command" log due to --dry-run.

Resolves: #2626

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?