### PR TITLE
[tests] use Avocado "recursive" behavior by default

### DIFF
--- a/tests/vendor_tests/redhat/rhbz1928628.py
+++ b/tests/vendor_tests/redhat/rhbz1928628.py
@@ -17,7 +17,6 @@ class rhbz1928628(NetworkingPluginTest):
 
     https://bugzilla.redhat.com/show_bug.cgi?id=1928628
 
-    :avocado: enable
     :avocado: tags=stageone
     """
 
@@ -34,7 +33,6 @@ class rhbz1928628Enabled(NetworkingPluginTest):
     WARNING: it has been noted (via this rhbz) that certain NICs may pause
     during this collection
 
-    :avocado: enable
     :avocado: tags=stageone
     """
 


### PR DESCRIPTION
Avocado will, by default, use the "recursive" behavior when looking
for tests.  It means that the class hierarchy will be crawled
recursively, until, for "avocado-instrumented" tests, the top-most
parent "avocado.Test" is found.

When the "enable" behavior is activated, it forces the class to be
considered one containing avocado-instrumented tests, but, it disables
the recursive behavior and only the tests local to that specific class
are found.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?