### PR TITLE
[MigrationResults] collect info about conversions and upgrades

### DIFF
--- a/sos/plugins/migration_results.py
+++ b/sos/plugins/migration_results.py
@@ -1,0 +1,21 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class MigrationResults(Plugin, RedHatPlugin):
+
+    """Information about conversions and upgrades"""
+
+    plugin_name = 'migration_results'
+    profiles = ('system',)
+
+    files = ('/etc/migration-results',)
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
A new tiny plugin independent on leapp and convert2rhel is proposed.

It should collect /etc/migration-results with info about RHEL
conversions and upgrades, whenever the file is present.

Resolves: #2631
Related: #2627
Relevant to: rhbz#1959598

Signed-off-by: Barbora Vassova <bvassova@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?