### PR TITLE
[lgtm] Suppress false positive alerts

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -83,7 +83,7 @@ class SoSComponent():
 
         # update args from component's arg_defaults defintion
         self._arg_defaults.update(self.arg_defaults)
-        self.opts = self.load_options()
+        self.opts = self.load_options()  # lgtm [py/init-calls-subclass]
 
         if self.configure_logging:
             tmpdir = self.get_tmpdir_default()

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -333,8 +333,12 @@ support representative.
                 resp = json.loads(anon.text)
                 _user = resp['username']
                 _token = resp['token']
-                print("Using anonymous user %s for upload. Please inform your "
-                      "support engineer." % _user)
+                print(
+                    "User '%s'"  # lgtm [py/clear-text-logging-sensitive-data]
+                    "used for anonymous upload. Please inform your support "
+                    "engineer so they may retrieve the data."
+                    % _user
+                )
         if _user and _token:
             return super(RHELPolicy, self).upload_sftp(user=_user,
                                                        password=_token)


### PR DESCRIPTION
Adds an alert suppression for 2 LGTM.com alerts. First, one involving
the overriding of `load_options()` when we're initializing the
placeholder component for `collect` on systems that do not have the
proper support for it.

Second, an alert about logging sensitive data when we are reporting the
temporary anonymous user used to leverage the RH SFTP server when the
user does not provide credentials.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?