### PR TITLE
[sos] Read config section for clean when `--clean` is used

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -210,6 +210,14 @@ class SoSComponent():
                 option.default = None
 
         opts.update_from_conf(self.args.config_file, self.args.component)
+
+        # directly check the cmdline options here as they have yet to be loaded
+        # as SoSOptions, and if we do this check after they are loaded we would
+        # need to do a second update from cmdline options for overriding config
+        # file values
+        if '--clean' in self.cmdline or '--mask' in self.cmdline:
+            opts.update_from_conf(self.args.config_file, 'clean')
+
         if os.getuid() != 0:
             userconf = os.path.join(Path.home(), '.config/sos/sos.conf')
             if os.path.exists(userconf):

--- a/tests/test_data/etc/sos/extras.d/sos_clean_config.conf
+++ b/tests/test_data/etc/sos/extras.d/sos_clean_config.conf
@@ -1,0 +1,3 @@
+# sos_extras config file to assist with the clean_config test.
+
+:/var/log/clean_config_test.txt

--- a/tests/test_data/etc/sos/sos.conf
+++ b/tests/test_data/etc/sos/sos.conf
@@ -1,0 +1,16 @@
+[global]
+#verbose = 3
+
+[report]
+#skip-plugins = rpm,selinux,dovecot
+
+[collect]
+#master = myhost.example.com
+
+[clean]
+keywords = shibboleth
+domains = sosexample.com
+#no-update = true
+
+[plugin_options]
+#rpm.rpmva = off

--- a/tests/test_data/var/log/clean_config_test.txt
+++ b/tests/test_data/var/log/clean_config_test.txt
@@ -1,0 +1,10 @@
+This is a test file for use with testing sos.
+
+The clean_config test should use this file for testing that the config section for
+[clean] is loaded when `--clean` is specified on the command line.
+
+This line contains 'shibboleth' which should be scrubbed.
+
+The domain sosexample.com should also be scrubbed. Also subdomains like foobar.sosexample.com should be removed.
+
+The domain example.com should not be removed.

--- a/tests/vendor_tests/redhat/rhbz1950350.py
+++ b/tests/vendor_tests/redhat/rhbz1950350.py
@@ -1,0 +1,35 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos_tests import StageTwoReportTest
+
+
+class rhbz1950350(StageTwoReportTest):
+    """Ensure that when `--clean` is used with report that the config settings
+    from sos.conf under the [clean] section are loaded as well
+
+    :avocado: tags=stagetwo
+    """
+
+    files = ['/etc/sos/sos.conf', '/etc/sos/extras.d/sos_clean_config.conf',
+             '/var/log/clean_config_test.txt']
+
+    sos_cmd = '-v -o sos_extras --clean'
+
+    def test_clean_config_loaded(self):
+        self.assertSosLogContains("effective options now: (.*)? --clean --domains (.*)? --keywords (.*)?")
+
+    def test_clean_config_performed(self):
+        self.assertFileCollected('var/log/clean_config_test.txt')
+        self.assertFileHasContent('var/log/clean_config_test.txt', 'The domain example.com should not be removed.')
+        self.assertFileNotHasContent(
+            'var/log/clean_config_test.txt',
+            "This line contains 'shibboleth' which should be scrubbed."
+        )
+        self.assertFileNotHasContent('var/log/clean_config_test.txt', 'sosexample.com')


### PR DESCRIPTION
When a `report` or `collect` run would use `--clean` or `--mask` to do
in-line obfuscation of collected reports, sos would not read the config
section for clean - it would only be read if `sos clean` was called
directly. As such, users would need to manually specify config file
values for each run.

Alleviate this gap by reading the config section for `clean` if either
of the cleaner options are used. Do this before we apply cmdline options
so that we maintain our order of precedence.

Related: RHBZ#1950350

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?