### PR TITLE
[sosnode] Fix passing of plugin options when using `--only-plugins`

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -84,7 +84,7 @@ class SoSCollector(SoSComponent):
         'only_plugins': [],
         'password': False,
         'password_per_node': False,
-        'plugin_options': [],
+        'plugopts': [],
         'plugin_timeout': None,
         'cmd_timeout': None,
         'preset': '',
@@ -273,7 +273,8 @@ class SoSCollector(SoSComponent):
                              help="chroot executed commands to SYSROOT")
         sos_grp.add_argument('-e', '--enable-plugins', action="extend",
                              help='Enable specific plugins for sosreport')
-        sos_grp.add_argument('-k', '--plugin-option', action="extend",
+        sos_grp.add_argument('-k', '--plugin-option', '--plugopts',
+                             action="extend", dest='plugopts',
                              help='Plugin option as plugname.option=value')
         sos_grp.add_argument('--log-size', default=0, type=int,
                              help='Limit the size of individual logs (in MiB)')


### PR DESCRIPTION
Fixes the handling of plugin options passed by `sos collect` to each
node by first aligning the SoSOption name to those of `report`
(`plugopts`), and second re-arranges the handling of plugin options and
preset options passed by the user when also using `--only-plugins` so
that the former are preserved and passed only with the `--only-plugins`
option value.

Resolves: #2641

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?