### PR TITLE
[sapnw] Fix IndexError exception

### DIFF
--- a/sos/report/plugins/sapnw.py
+++ b/sos/report/plugins/sapnw.py
@@ -35,7 +35,8 @@ class sapnw(Plugin, RedHatPlugin):
         # Cycle through all the instances, get 'sid', 'instance_number'
         # and 'vhost' to determine the proper profile
         for inst_line in inst_out['output'].splitlines():
-            if "DAA" not in inst_line:
+            if ("DAA" not in inst_line and not
+                    inst_line.startswith("No instances found")):
                 fields = inst_line.strip().split()
                 sid = fields[3]
                 inst = fields[5]


### PR DESCRIPTION
This patch solves the situation where the
command:

/usr/sap/hostctrl/exe/saphostctrl
		-function ListInstances

returns:

No instances found

And a non-zero return code.

Fixes: RHBZ#1992938
Closes: #2643 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?