### PR TITLE
[Plugin] Convert plugin options to a new PluginOpt class

### DIFF
--- a/sos/report/plugins/abrt.py
+++ b/sos/report/plugins/abrt.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Abrt(Plugin, RedHatPlugin):
@@ -21,7 +21,8 @@ class Abrt(Plugin, RedHatPlugin):
     files = ('/var/spool/abrt',)
 
     option_list = [
-        ("detailed", 'collect detailed info for every report', 'slow', False)
+        PluginOpt("detailed", default=False,
+                  desc="collect detailed information for every report")
     ]
 
     def setup(self):

--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 
 
 class Apache(Plugin):
@@ -18,7 +19,7 @@ class Apache(Plugin):
     files = ('/var/www/',)
 
     option_list = [
-        ("log", "gathers all apache logs", "slow", False)
+        PluginOpt(name="log", default=False, desc="gathers all apache logs")
     ]
 
     def setup(self):

--- a/sos/report/plugins/atomichost.py
+++ b/sos/report/plugins/atomichost.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class AtomicHost(Plugin, RedHatPlugin):
@@ -18,7 +18,8 @@ class AtomicHost(Plugin, RedHatPlugin):
     plugin_name = "atomichost"
     profiles = ('container',)
     option_list = [
-        ("info", "gather atomic info for each image", "fast", False)
+        PluginOpt("info", default=False,
+                  desc="gather atomic info for each image")
     ]
 
     def check_enabled(self):

--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 from glob import glob
 
 
@@ -19,7 +19,8 @@ class Boot(Plugin, IndependentPlugin):
     packages = ('grub', 'grub2', 'grub-common', 'grub2-common', 'zipl')
 
     option_list = [
-        ("all-images", "collect lsinitrd for all images", "slow", False)
+        PluginOpt("all-images", default=False,
+                  desc="collect lsinitrd for all images")
     ]
 
     def setup(self):

--- a/sos/report/plugins/conntrack.py
+++ b/sos/report/plugins/conntrack.py
@@ -7,7 +7,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Conntrack(Plugin, IndependentPlugin):
@@ -19,8 +19,8 @@ class Conntrack(Plugin, IndependentPlugin):
     packages = ('conntrack-tools', 'conntrack', 'conntrackd')
 
     option_list = [
-        ('namespaces', 'Number of namespaces to collect, 0 for unlimited',
-            'slow', None)
+        PluginOpt("namespaces", default=None, val_type=int,
+                  desc="Number of namespaces to collect, 0 for unlimited"),
     ]
 
     def setup(self):

--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
 import os
 
 
@@ -19,8 +19,8 @@ class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
     profiles = ('container', )
     packages = ('containers-common', )
     option_list = [
-        ('rootlessusers', 'colon-separated list of users\' containers info',
-         '', ''),
+        PluginOpt('rootlessusers', default='', val_type=str,
+                  desc='colon-delimited list of users to collect for')
     ]
 
     def setup(self):

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -8,7 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, SoSPredicate
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                SoSPredicate, PluginOpt)
 
 
 class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -20,10 +21,10 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
     services = ('crio',)
 
     option_list = [
-        ("all", "enable capture for all containers, even containers "
-            "that have terminated", 'fast', False),
-        ("logs", "capture logs for running containers",
-            'fast', False),
+        PluginOpt('all', default=False,
+                  desc='collect for all containers, even terminated ones'),
+        PluginOpt('logs', default=False,
+                  desc='collect stdout/stderr logs for containers')
     ]
 
     def setup(self):

--- a/sos/report/plugins/dlm.py
+++ b/sos/report/plugins/dlm.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 import re
 
 
@@ -18,7 +18,7 @@ class Dlm(Plugin, IndependentPlugin):
     profiles = ("cluster", )
     packages = ("cman", "dlm", "pacemaker")
     option_list = [
-        ("lockdump", "capture lock dumps for DLM", "slow", False),
+        PluginOpt('lockdump', default=False, desc='capture lock dumps for DLM')
     ]
 
     def setup(self):

--- a/sos/report/plugins/dmraid.py
+++ b/sos/report/plugins/dmraid.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Dmraid(Plugin, IndependentPlugin):
@@ -18,7 +18,7 @@ class Dmraid(Plugin, IndependentPlugin):
     packages = ('dmraid',)
 
     option_list = [
-        ("metadata", "capture dmraid device metadata", "slow", False)
+        PluginOpt('metadata', default=False, desc='collect dmraid metadata')
     ]
 
     # V - {-V/--version}

--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class DNFPlugin(Plugin, RedHatPlugin):
@@ -21,8 +21,10 @@ class DNFPlugin(Plugin, RedHatPlugin):
     packages = ('dnf',)
 
     option_list = [
-        ("history", "captures transaction history", "fast", False),
-        ("history-info", "detailed transaction history", "slow", False),
+        PluginOpt('history', default=False,
+                  desc='collect transaction history'),
+        PluginOpt('history-info', default=False,
+                  desc='collect detailed transaction history')
     ]
 
     def get_modules_info(self, modules):

--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -9,7 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
-                                SoSPredicate, CosPlugin)
+                                SoSPredicate, CosPlugin, PluginOpt)
 
 
 class Docker(Plugin, CosPlugin):
@@ -19,11 +19,12 @@ class Docker(Plugin, CosPlugin):
     profiles = ('container',)
 
     option_list = [
-        ("all", "enable capture for all containers, even containers "
-            "that have terminated", 'fast', False),
-        ("logs", "capture logs for running containers",
-            'fast', False),
-        ("size", "capture image sizes for docker ps", 'slow', False)
+        PluginOpt('all', default=False,
+                  desc='collect for all containers, even terminated ones'),
+        PluginOpt('logs', default=False,
+                  desc='collect stdout/stderr logs for containers'),
+        PluginOpt('size', default=False,
+                  desc='collect image sizes for docker ps')
     ]
 
     def setup(self):

--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 import json
 
 
@@ -17,8 +17,8 @@ class Ebpf(Plugin, IndependentPlugin):
     profiles = ('system', 'kernel', 'network')
 
     option_list = [
-        ('namespaces', 'Number of namespaces to collect, 0 for unlimited',
-            'slow', None)
+        PluginOpt("namespaces", default=None, val_type=int,
+                  desc="Number of namespaces to collect, 0 for unlimited"),
     ]
 
     def get_bpftool_prog_ids(self, prog_json):

--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Fibrechannel(Plugin, RedHatPlugin):
@@ -19,7 +19,7 @@ class Fibrechannel(Plugin, RedHatPlugin):
     profiles = ('hardware', 'storage', 'system')
     files = ('/sys/class/fc_host', '/sys/class/fc_remote_ports')
     option_list = [
-        ("debug", "enable debug logs", "fast", True)
+        PluginOpt('debug', default=True, desc='collect debugging logs')
     ]
 
     # vendor specific debug paths

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin, CosPlugin)
+                                UbuntuPlugin, CosPlugin, PluginOpt)
 
 
 class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
@@ -18,9 +18,11 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
     profiles = ('storage',)
 
     option_list = [
-        ("lsof", 'gathers information on all open files', 'slow', False),
-        ("dumpe2fs", 'dump filesystem information', 'slow', False),
-        ("frag", 'filesystem fragmentation status', 'slow', False)
+        PluginOpt('lsof', default=False,
+                  desc='collect information on all open files'),
+        PluginOpt('dumpe2fs', default=False, desc='dump filesystem info'),
+        PluginOpt('frag', default=False,
+                  desc='collect filesystem fragmentation status')
     ]
 
     def setup(self):

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -10,7 +10,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin)
+                                UbuntuPlugin, PluginOpt)
 from pipes import quote
 from re import match
 
@@ -24,8 +24,10 @@ class Foreman(Plugin):
     profiles = ('sysmgmt',)
     packages = ('foreman',)
     option_list = [
-        ('months', 'number of months for dynflow output', 'fast', 1),
-        ('proxyfeatures', 'collect features of smart proxies', 'slow', False),
+        PluginOpt('months', default=1,
+                  desc='number of months for dynflow output'),
+        PluginOpt('proxyfeatures', default=False,
+                  desc='collect features of smart proxies')
     ]
 
     def setup(self):

--- a/sos/report/plugins/gfs2.py
+++ b/sos/report/plugins/gfs2.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Gfs2(Plugin, IndependentPlugin):
@@ -18,9 +18,8 @@ class Gfs2(Plugin, IndependentPlugin):
     packages = ("gfs2-utils",)
 
     option_list = [
-        ("lockdump",
-         "capture lock dumps for all GFS2 filesystems",
-         "slow", False),
+        PluginOpt('lockdump', default=False,
+                  desc='collect lock dumps for all GFS2 filesystems')
     ]
 
     def setup(self):

--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -10,7 +10,7 @@ import time
 import os
 import glob
 import string
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Gluster(Plugin, RedHatPlugin):
@@ -24,7 +24,9 @@ class Gluster(Plugin, RedHatPlugin):
     packages = ("glusterfs", "glusterfs-core")
     files = ("/etc/glusterd", "/var/lib/glusterd")
 
-    option_list = [("dump", "enable glusterdump support", "slow", False)]
+    option_list = [
+        PluginOpt("dump", default=False, desc="enable glusterdump support")
+    ]
 
     def wait_for_statedump(self, name_dir):
         statedumps_present = 0

--- a/sos/report/plugins/jars.py
+++ b/sos/report/plugins/jars.py
@@ -14,7 +14,7 @@ import os
 import re
 import zipfile
 from functools import partial
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Jars(Plugin, RedHatPlugin):
@@ -24,9 +24,10 @@ class Jars(Plugin, RedHatPlugin):
     plugin_name = "jars"
     profiles = ("java",)
     option_list = [
-        ("append_locations", "colon-separated list of additional JAR paths",
-         "fast", ""),
-        ("all_known_locations", "scan all known paths", "slow", False)
+        PluginOpt('append_locations', default="", val_type=str,
+                  desc='colon-delimited list of additional JAR paths'),
+        PluginOpt('all_known_locations', default=False,
+                  desc='scan all known paths')
     ]
 
     # There is no standard location for JAR files and scanning

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 import glob
 
 
@@ -21,8 +21,10 @@ class Kernel(Plugin, IndependentPlugin):
     sys_module = '/sys/module'
 
     option_list = [
-        ("with-timer", "gather /proc/timer* statistics", "slow", False),
-        ("trace", "gather /sys/kernel/debug/tracing/trace file", "slow", False)
+        PluginOpt('with-timer', default=False,
+                  desc='gather /proc/timer* statistics'),
+        PluginOpt('trace', default=False,
+                  desc='gather /sys/kernel/debug/tracing/trace file')
     ]
 
     def setup(self):

--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -9,7 +9,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
 from fnmatch import translate
 import re
 
@@ -22,13 +22,14 @@ class Kubernetes(Plugin):
     profiles = ('container',)
 
     option_list = [
-        ("all", "also collect all namespaces output separately",
-            'slow', False),
-        ("describe", "capture descriptions of all kube resources",
-            'fast', False),
-        ("podlogs", "capture logs for pods", 'slow', False),
-        ("podlogs-filter", "only capture logs for pods matching this string",
-            'fast', '')
+        PluginOpt('all', default=False,
+                  desc='collect all namespace output separately'),
+        PluginOpt('describe', default=False,
+                  desc='collect describe output of all resources'),
+        PluginOpt('podlogs', default=False,
+                  desc='capture stdout/stderr logs from pods'),
+        PluginOpt('podlogs-filter', default='', val_type=str,
+                  desc='only collect logs from pods matching this pattern')
     ]
 
     kube_cmd = "kubectl"

--- a/sos/report/plugins/libraries.py
+++ b/sos/report/plugins/libraries.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Libraries(Plugin, IndependentPlugin):
@@ -17,7 +17,8 @@ class Libraries(Plugin, IndependentPlugin):
     profiles = ('system',)
 
     option_list = [
-        ('ldconfigv', 'collect verbose ldconfig output', "slow", False)
+        PluginOpt('ldconfigv', default=False,
+                  desc='collect verbose ldconfig output')
     ]
 
     def setup(self):

--- a/sos/report/plugins/libreswan.py
+++ b/sos/report/plugins/libreswan.py
@@ -9,7 +9,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
+from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate,
+                                PluginOpt)
 
 
 class Libreswan(Plugin, IndependentPlugin):
@@ -19,8 +20,8 @@ class Libreswan(Plugin, IndependentPlugin):
     plugin_name = 'libreswan'
     profiles = ('network', 'security', 'openshift')
     option_list = [
-        ("ipsec-barf", "collect the output of the ipsec barf command",
-         "slow", False)
+        PluginOpt('ipsec-barf', default=False,
+                  desc='collect ipsec barf output')
     ]
 
     files = ('/etc/ipsec.conf',)

--- a/sos/report/plugins/lvm2.py
+++ b/sos/report/plugins/lvm2.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
+from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate,
+                                PluginOpt)
 
 
 class Lvm2(Plugin, IndependentPlugin):
@@ -16,10 +17,12 @@ class Lvm2(Plugin, IndependentPlugin):
     plugin_name = 'lvm2'
     profiles = ('storage',)
 
-    option_list = [("lvmdump", 'collect an lvmdump tarball', 'fast', False),
-                   ("lvmdump-am", 'attempt to collect an lvmdump with '
-                    'advanced options and raw metadata collection', 'slow',
-                    False)]
+    option_list = [
+        PluginOpt('lvmdump', default=False, desc='collect an lvmdump tarball'),
+        PluginOpt('lvmdump-am', default=False,
+                  desc=('attempt to collect lvmdump with advanced options and '
+                        'raw metadata'))
+    ]
 
     def do_lvmdump(self, metadata=False):
         """Collects an lvmdump in standard format with optional metadata

--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin
+from sos.report.plugins import Plugin, UbuntuPlugin, PluginOpt
 
 
 class Maas(Plugin, UbuntuPlugin):
@@ -33,11 +33,12 @@ class Maas(Plugin, UbuntuPlugin):
     )
 
     option_list = [
-        ('profile-name',
-         'The name with which you will later refer to this remote', '', ''),
-        ('url', 'The URL of the remote API', '', ''),
-        ('credentials',
-         'The credentials, also known as the API key', '', '')
+        PluginOpt('profile-name', default='', val_type=str,
+                  desc='Name of the remote API'),
+        PluginOpt('url', default='', val_type=str,
+                  desc='URL of the remote API'),
+        PluginOpt('credentials', default='', val_type=str,
+                  desc='Credentials, or the API key')
     ]
 
     def _has_login_options(self):

--- a/sos/report/plugins/monit.py
+++ b/sos/report/plugins/monit.py
@@ -29,8 +29,6 @@ class Monit(Plugin, RedHatPlugin):
     # Define log files
     monit_log = ["/var/log/monit.log"]
 
-    option_list = []
-
     def setup(self):
         self.add_cmd_output("monit status")
         self.add_copy_spec(self.monit_log + self.monit_conf)

--- a/sos/report/plugins/mssql.py
+++ b/sos/report/plugins/mssql.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class MsSQL(Plugin, RedHatPlugin):
@@ -20,8 +20,8 @@ class MsSQL(Plugin, RedHatPlugin):
     packages = ('mssql-server',)
 
     option_list = [
-        ('mssql_conf', 'SQL Server configuration file.', '',
-         '/var/opt/mssql/mssql.conf')
+        PluginOpt('mssql_conf', default='/var/opt/mssql/mssql.conf',
+                  desc='SQL server configuration file')
     ]
 
     def setup(self):

--- a/sos/report/plugins/mysql.py
+++ b/sos/report/plugins/mysql.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 import os
 
 
@@ -21,9 +22,11 @@ class Mysql(Plugin):
     pw_warn_text = " (password visible in process listings)"
 
     option_list = [
-        ("dbuser", "username for database dumps", "", "mysql"),
-        ("dbpass", "password for database dumps" + pw_warn_text, "", ""),
-        ("dbdump", "collect a database dump", "", False)
+        PluginOpt('dbuser', default='mysql', val_type=str,
+                  desc='username for database dump collection'),
+        PluginOpt('dbpass', default='', val_type=str,
+                  desc='password for data dump collection' + pw_warn_text),
+        PluginOpt('dbdump', default=False, desc='Collect a database dump')
     ]
 
     def setup(self):

--- a/sos/report/plugins/navicli.py
+++ b/sos/report/plugins/navicli.py
@@ -9,7 +9,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 from sos.utilities import is_executable
 
 
@@ -19,8 +19,10 @@ class Navicli(Plugin, RedHatPlugin):
 
     plugin_name = 'navicli'
     profiles = ('storage', 'hardware')
-    option_list = [("ipaddrs", "list of space separated CLARiiON IP addresses",
-                    '', "")]
+    option_list = [
+        PluginOpt('ipaddrs', default='', val_type=str,
+                  desc='space-delimited list of CLARiiON IP addresses')
+    ]
 
     def check_enabled(self):
         return is_executable("navicli")

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
-                                DebianPlugin, SoSPredicate)
+                                DebianPlugin, SoSPredicate, PluginOpt)
 
 
 class Networking(Plugin):
@@ -17,17 +17,20 @@ class Networking(Plugin):
     plugin_name = "networking"
     profiles = ('network', 'hardware', 'system')
     trace_host = "www.example.com"
+
     option_list = [
-        ("traceroute", "collect a traceroute to %s" % trace_host, "slow",
-         False),
-        ("namespace_pattern", "Specific namespaces pattern to be " +
-         "collected, namespaces pattern should be separated by whitespace " +
-         "as for example \"eth* ens2\"", "fast", ""),
-        ("namespaces", "Number of namespaces to collect, 0 for unlimited. " +
-         "Incompatible with the namespace_pattern option", "slow", None),
-        ("ethtool_namespaces", "Define if ethtool commands should be " +
-         "collected for namespaces", "slow", True),
-        ("eepromdump", "collect 'ethtool -e' for all devices", "slow", False)
+        PluginOpt("traceroute", default=False,
+                  desc="collect a traceroute to %s" % trace_host),
+        PluginOpt("namespace_pattern", default="", val_type=str,
+                  desc=("Specific namespace names or patterns to collect, "
+                        "whitespace delimited.")),
+        PluginOpt("namespaces", default=None, val_type=int,
+                  desc="Number of namespaces to collect, 0 for unlimited"),
+        PluginOpt("ethtool_namespaces", default=True,
+                  desc=("Toggle if ethtool commands should be run for each "
+                        "namespace")),
+        PluginOpt("eepromdump", default=False,
+                  desc="Toggle collection of 'ethtool -e' for NICs")
     ]
 
     # switch to enable netstat "wide" (non-truncated) output mode
@@ -39,7 +42,6 @@ class Networking(Plugin):
 
     def setup(self):
         super(Networking, self).setup()
-
         for opt in self.ethtool_shortopts:
             self.add_cmd_tags({
                 'ethtool -%s .*' % opt: 'ethool_%s' % opt

--- a/sos/report/plugins/nginx.py
+++ b/sos/report/plugins/nginx.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Nginx(Plugin, IndependentPlugin):
@@ -17,7 +17,7 @@ class Nginx(Plugin, IndependentPlugin):
     packages = ('nginx',)
 
     option_list = [
-        ("log", "gathers all nginx logs", "slow", False)
+        PluginOpt('log', default=False, desc='collect all nginx logs')
     ]
 
     def setup(self):

--- a/sos/report/plugins/npm.py
+++ b/sos/report/plugins/npm.py
@@ -9,7 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 import os
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Npm(Plugin, IndependentPlugin):
@@ -17,10 +17,10 @@ class Npm(Plugin, IndependentPlugin):
     short_desc = 'Information from available npm modules'
     plugin_name = 'npm'
     profiles = ('system',)
-    option_list = [("project_path",
-                    'List npm modules of a project specified by path',
-                    'fast',
-                    '')]
+    option_list = [
+        PluginOpt('project_path', default='', val_type=str,
+                  desc='Collect npm modules of project at this path')
+    ]
 
     # in Fedora, Debian, Ubuntu and Suse the package is called npm
     packages = ('npm',)

--- a/sos/report/plugins/openshift.py
+++ b/sos/report/plugins/openshift.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 from fnmatch import translate
 import os
 import re
@@ -54,17 +54,19 @@ class Openshift(Plugin, RedHatPlugin):
     packages = ('openshift-hyperkube',)
 
     option_list = [
-        ('token', 'admin token to allow API queries', 'fast', None),
-        ('host', 'host address to use for oc login, including port', 'fast',
-         'https://localhost:6443'),
-        ('no-oc', 'do not collect `oc` command output', 'fast', False),
-        ('podlogs', 'collect logs from each pod', 'fast', True),
-        ('podlogs-filter', ('limit podlogs collection to pods matching this '
-         'regex'), 'fast', ''),
-        ('only-namespaces', 'colon-delimited list of namespaces to collect',
-         'fast', ''),
-        ('add-namespaces', ('colon-delimited list of namespaces to add to the '
-         'default collections'), 'fast', '')
+        PluginOpt('token', default=None, val_type=str,
+                  desc='admin token to allow API queries'),
+        PluginOpt('host', default='https://localhost:6443',
+                  desc='host address to use for oc login, including port'),
+        PluginOpt('no-oc', default=False, desc='do not collect `oc` output'),
+        PluginOpt('podlogs', default=True, desc='collect logs from each pod'),
+        PluginOpt('podlogs-filter', default='', val_type=str,
+                  desc='only collect logs from pods matching this pattern'),
+        PluginOpt('only-namespaces', default='', val_type=str,
+                  desc='colon-delimited list of namespaces to collect from'),
+        PluginOpt('add-namespaces', default='', val_type=str,
+                  desc=('colon-delimited list of namespaces to add to the '
+                        'default collection list'))
     ]
 
     def _check_oc_function(self):

--- a/sos/report/plugins/openstack_ceilometer.py
+++ b/sos/report/plugins/openstack_ceilometer.py
@@ -20,8 +20,6 @@ class OpenStackCeilometer(Plugin):
     short_desc = 'Openstack Ceilometer'
     plugin_name = "openstack_ceilometer"
     profiles = ('openstack', 'openstack_controller', 'openstack_compute')
-
-    option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated/ceilometer"
 
     def setup(self):

--- a/sos/report/plugins/openstack_database.py
+++ b/sos/report/plugins/openstack_database.py
@@ -11,7 +11,7 @@
 import re
 
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class OpenStackDatabase(Plugin):
@@ -21,8 +21,8 @@ class OpenStackDatabase(Plugin):
     profiles = ('openstack', 'openstack_controller')
 
     option_list = [
-        ('dump', 'Dump select databases to a SQL file', 'slow', False),
-        ('dumpall', 'Dump ALL databases to a SQL file', 'slow', False)
+        PluginOpt('dump', default=False, desc='Dump select databases'),
+        PluginOpt('dumpall', default=False, desc='Dump ALL databases')
     ]
 
     databases = [

--- a/sos/report/plugins/openstack_glance.py
+++ b/sos/report/plugins/openstack_glance.py
@@ -23,7 +23,6 @@ class OpenStackGlance(Plugin):
     profiles = ('openstack', 'openstack_controller')
     containers = ('glance_api',)
 
-    option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated/glance_api"
     service_name = "openstack-glance-api.service"
 

--- a/sos/report/plugins/openstack_heat.py
+++ b/sos/report/plugins/openstack_heat.py
@@ -19,8 +19,6 @@ class OpenStackHeat(Plugin):
     plugin_name = "openstack_heat"
     profiles = ('openstack', 'openstack_controller')
     containers = ('.*heat_api',)
-
-    option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated/heat"
     service_name = "openstack-heat-api.service"
 

--- a/sos/report/plugins/openstack_horizon.py
+++ b/sos/report/plugins/openstack_horizon.py
@@ -20,7 +20,6 @@ class OpenStackHorizon(Plugin):
 
     plugin_name = "openstack_horizon"
     profiles = ('openstack', 'openstack_controller')
-    option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated"
 
     def setup(self):

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -9,7 +9,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 import os
 
 
@@ -19,7 +20,10 @@ class OpenStackKeystone(Plugin):
     plugin_name = "openstack_keystone"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = [("nopw", "dont gathers keystone passwords", "slow", True)]
+    option_list = [
+        PluginOpt('nopw', default=True,
+                  desc='do not collect keystone passwords')
+    ]
     var_puppet_gen = "/var/lib/config-data/puppet-generated/keystone"
 
     def setup(self):

--- a/sos/report/plugins/openstack_manila.py
+++ b/sos/report/plugins/openstack_manila.py
@@ -17,8 +17,6 @@ class OpenStackManila(Plugin):
     plugin_name = "openstack_manila"
     profiles = ('openstack', 'openstack_controller')
     containers = ('.*manila_api',)
-    option_list = []
-
     var_puppet_gen = "/var/lib/config-data/puppet-generated/manila"
 
     def setup(self):

--- a/sos/report/plugins/openstack_sahara.py
+++ b/sos/report/plugins/openstack_sahara.py
@@ -16,8 +16,6 @@ class OpenStackSahara(Plugin):
     short_desc = 'OpenStack Sahara'
     plugin_name = 'openstack_sahara'
     profiles = ('openstack', 'openstack_controller')
-
-    option_list = []
     var_puppet_gen = "/var/lib/config-data/puppet-generated/sahara"
 
     def setup(self):

--- a/sos/report/plugins/openstack_swift.py
+++ b/sos/report/plugins/openstack_swift.py
@@ -20,8 +20,6 @@ class OpenStackSwift(Plugin):
     plugin_name = "openstack_swift"
     profiles = ('openstack', 'openstack_controller')
 
-    option_list = []
-
     var_puppet_gen = "/var/lib/config-data/puppet-generated"
 
     def setup(self):

--- a/sos/report/plugins/openstack_trove.py
+++ b/sos/report/plugins/openstack_trove.py
@@ -18,8 +18,6 @@ class OpenStackTrove(Plugin):
 
     plugin_name = "openstack_trove"
     profiles = ('openstack', 'openstack_controller')
-    option_list = []
-
     var_puppet_gen = "/var/lib/config-data/puppet-generated/trove"
 
     def setup(self):

--- a/sos/report/plugins/origin.py
+++ b/sos/report/plugins/origin.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 import os.path
 
 # This plugin collects static configuration and runtime information
@@ -41,12 +41,12 @@ class OpenShiftOrigin(Plugin):
     profiles = ('openshift',)
 
     option_list = [
-        ("diag", "run 'oc adm diagnostics' to collect its output",
-         'fast', True),
-        ("diag-prevent", "set --prevent-modification on 'oc adm diagnostics'",
-         'fast', True),
-        ("all-namespaces", "collect dc output for all namespaces", "fast",
-         False)
+        PluginOpt('diag', default=True,
+                  desc='Collect oc adm diagnostics output'),
+        PluginOpt('diag-prevent', default=True,
+                  desc='Use --prevent-modification with oc adm diagnostics'),
+        PluginOpt('all-namespaces', default=False,
+                  desc='collect dc output for all namespaces')
     ]
 
     master_base_dir = "/etc/origin/master"

--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -16,7 +16,7 @@ import re
 import signal
 
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 from sos.utilities import is_executable
 
 
@@ -55,12 +55,12 @@ class Ovirt(Plugin, RedHatPlugin):
     )
 
     option_list = [
-        ('jbosstrace', 'Enable oVirt Engine JBoss stack trace collection',
-         '', True),
-        ('sensitive_keys', 'Sensitive keys to be masked',
-         '', DEFAULT_SENSITIVE_KEYS),
-        ('heapdump', 'Collect heap dumps from /var/log/ovirt-engine/dump/',
-         '', False)
+        PluginOpt('jbosstrace', default=True,
+                  desc='Enable oVirt Engine JBoss stack trace collection'),
+        PluginOpt('sensitive_keys', default=DEFAULT_SENSITIVE_KEYS,
+                  desc='Sensitive keys to be masked in post-processing'),
+        PluginOpt('heapdump', default=False,
+                  desc='Collect heap dumps from /var/log/ovirt-engine/dump/')
     ]
 
     def setup(self):

--- a/sos/report/plugins/ovirt_engine_backup.py
+++ b/sos/report/plugins/ovirt_engine_backup.py
@@ -9,7 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 import os
-from sos.report.plugins import (Plugin, RedHatPlugin)
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 from datetime import datetime
 
 
@@ -20,10 +20,10 @@ class oVirtEngineBackup(Plugin, RedHatPlugin):
     packages = ("ovirt-engine-tools-backup",)
     plugin_name = "ovirt_engine_backup"
     option_list = [
-        ("backupdir", "Directory where the backup is generated",
-         "fast", "/var/lib/ovirt-engine-backup"),
-        ("tmpdir", "Directory where the intermediate files are generated",
-         "fast", '/tmp'),
+        PluginOpt('backupdir', default='/var/lib/ovirt-engine-backup',
+                  desc='Directory where backups are generated'),
+        PluginOpt('tmpdir', default='/tmp',
+                  desc='temp dir to use for engine-backup')
     ]
     profiles = ("virt",)
 

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 from datetime import datetime, timedelta
 import re
 
@@ -23,8 +24,10 @@ class Pacemaker(Plugin):
     )
 
     option_list = [
-        ("crm_from", "specify the start time for crm_report", "fast", ''),
-        ("crm_scrub", "enable password scrubbing for crm_report", "", True),
+        PluginOpt('crm_from', default='', val_type=str,
+                  desc='specfiy the start time for crm_report'),
+        PluginOpt('crm_scrub', default=True,
+                  desc='enable crm_report password scrubbing')
     ]
 
     envfile = ""

--- a/sos/report/plugins/pcp.py
+++ b/sos/report/plugins/pcp.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, PluginOpt
 import os
 from socket import gethostname
 
@@ -25,8 +25,10 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
 
     # size-limit of PCP logger and manager data collected by default (MB)
     option_list = [
-        ("pmmgrlogs", "size-limit in MB of pmmgr logs", "", 100),
-        ("pmloggerfiles", "number of newest pmlogger files to grab", "", 12),
+        PluginOpt('pmmgrlogs', default=100,
+                  desc='size limit in MB of pmmgr logs'),
+        PluginOpt('pmloggerfiles', default=12,
+                  desc='number of pmlogger files to collect')
     ]
 
     pcp_sysconf_dir = None

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
 
 
 class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -19,11 +19,12 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
     packages = ('podman',)
 
     option_list = [
-        ("all", "enable capture for all containers, even containers "
-            "that have terminated", 'fast', False),
-        ("logs", "capture logs for running containers",
-            'fast', False),
-        ("size", "capture image sizes for podman ps", 'slow', False)
+        PluginOpt('all', default=False,
+                  desc='collect for all containers, even terminated ones'),
+        PluginOpt('logs', default=False,
+                  desc='collect stdout/stderr logs for containers'),
+        PluginOpt('size', default=False,
+                  desc='collect image sizes for podman ps')
     ]
 
     def setup(self):

--- a/sos/report/plugins/postgresql.py
+++ b/sos/report/plugins/postgresql.py
@@ -14,7 +14,8 @@
 
 import os
 
-from sos.report.plugins import (Plugin, UbuntuPlugin, DebianPlugin, SCLPlugin)
+from sos.report.plugins import (Plugin, UbuntuPlugin, DebianPlugin, SCLPlugin,
+                                PluginOpt)
 from sos.utilities import find
 
 
@@ -30,12 +31,18 @@ class PostgreSQL(Plugin):
     password_warn_text = " (password visible in process listings)"
 
     option_list = [
-        ('pghome', 'PostgreSQL server home directory.', '', '/var/lib/pgsql'),
-        ('username', 'username for pg_dump', '', 'postgres'),
-        ('password', 'password for pg_dump' + password_warn_text, '', ''),
-        ('dbname', 'database name to dump for pg_dump', '', ''),
-        ('dbhost', 'database hostname/IP (do not use unix socket)', '', ''),
-        ('dbport', 'database server port number', '', '5432')
+        PluginOpt('pghome', default='/var/lib/pgsql',
+                  desc='psql server home directory'),
+        PluginOpt('username', default='postgres', val_type=str,
+                  desc='username for pg_dump'),
+        PluginOpt('password', default='', val_type=str,
+                  desc='password for pg_dump' + password_warn_text),
+        PluginOpt('dbname', default='', val_type=str,
+                  desc='database name to dump with pg_dump'),
+        PluginOpt('dbhost', default='', val_type=str,
+                  desc='database hostname/IP address (no unix sockets)'),
+        PluginOpt('dbport', default=5432, val_type=[int, str],
+                  desc='database server listening port')
     ]
 
     def do_pg_dump(self, scl=None, filename="pgdump.tar"):

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -8,7 +8,7 @@
 
 import re
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Process(Plugin, IndependentPlugin):
@@ -19,13 +19,14 @@ class Process(Plugin, IndependentPlugin):
     profiles = ('system',)
 
     option_list = [
-        ("lsof", "gathers information on all open files", "slow", True),
-        ("lsof-threads", "gathers threads' open file info if supported",
-         "slow", False),
-        ("smaps", "gathers all /proc/*/smaps files", "", False),
-        ("samples", "specify the number of samples that iotop will capture, "
-            "with an interval of 0.5 seconds between samples", "", "20"),
-        ("numprocs", "number of processes to collect /proc data of", '', 2048)
+        PluginOpt('lsof', default=True, desc='collect info on all open files'),
+        PluginOpt('lsof-threads', default=False,
+                  desc='collect threads\' open file info if supported'),
+        PluginOpt('smaps', default=False, desc='collect /proc/*/smaps files'),
+        PluginOpt('samples', default=20, val_type=int,
+                  desc='number of iotop samples to collect'),
+        PluginOpt('numprocs', default=2048, val_type=int,
+                  desc='number of process to collect /proc data of')
     ]
 
     def setup(self):

--- a/sos/report/plugins/psacct.py
+++ b/sos/report/plugins/psacct.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 
 
 class Psacct(Plugin):
@@ -15,8 +16,9 @@ class Psacct(Plugin):
     plugin_name = "psacct"
     profiles = ('system',)
 
-    option_list = [("all", "collect all process accounting files",
-                    "slow", False)]
+    option_list = [
+        PluginOpt('all', default=False, desc='collect all accounting files')
+    ]
 
     packages = ("psacct", )
 

--- a/sos/report/plugins/pulp.py
+++ b/sos/report/plugins/pulp.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 from pipes import quote
 from re import match
 
@@ -21,7 +21,8 @@ class Pulp(Plugin, RedHatPlugin):
     packages = ("pulp-server", "pulp-katello", "python3-pulpcore")
     files = ("/etc/pulp/settings.py",)
     option_list = [
-        ('tasks', 'number of tasks to collect from DB queries', 'fast', 200)
+        PluginOpt('tasks', default=200,
+                  desc='number of tasks to collect from DB queries')
     ]
 
     def setup(self):

--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 from pipes import quote
 from re import match
 
@@ -21,7 +21,7 @@ class PulpCore(Plugin, IndependentPlugin):
     commands = ("pulpcore-manager",)
     files = ("/etc/pulp/settings.py",)
     option_list = [
-        ('task-days', 'days of tasks history', 'fast', 7)
+        PluginOpt('task-days', default=7, desc='days of task history')
     ]
 
     def parse_settings_config(self):

--- a/sos/report/plugins/pxe.py
+++ b/sos/report/plugins/pxe.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 
 
 class Pxe(Plugin):
@@ -14,8 +15,10 @@ class Pxe(Plugin):
     short_desc = 'PXE service'
     plugin_name = "pxe"
     profiles = ('sysmgmt', 'network')
-    option_list = [("tftpboot", 'gathers content from the tftpboot path',
-                    'slow', False)]
+    option_list = [
+        PluginOpt('tftpboot', default=False,
+                  desc='collect content from tftpboot path')
+    ]
 
 
 class RedHatPxe(Pxe, RedHatPlugin):

--- a/sos/report/plugins/python.py
+++ b/sos/report/plugins/python.py
@@ -8,7 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 from sos.policies.distros.redhat import RHELPolicy
 import os
 import json
@@ -43,8 +44,9 @@ class RedHatPython(Python, RedHatPlugin):
 
     packages = ('python', 'python36', 'python2', 'python3', 'platform-python')
     option_list = [
-        ('hashes', "gather hashes for all python files", 'slow',
-         False)]
+        PluginOpt('hashes', default=False,
+                  desc='collect hashes for all python files')
+    ]
 
     def setup(self):
         self.add_cmd_output(['python2 -V', 'python3 -V'])

--- a/sos/report/plugins/qpid.py
+++ b/sos/report/plugins/qpid.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Qpid(Plugin, RedHatPlugin):
@@ -17,12 +17,15 @@ class Qpid(Plugin, RedHatPlugin):
     profiles = ('services',)
 
     packages = ('qpidd', 'qpid-cpp-server', 'qpid-tools')
-    option_list = [("port", "listening port to connect to", '', ""),
-                   ("ssl-certificate",
-                    "Path to file containing client SSL certificate", '', ""),
-                   ("ssl-key",
-                    "Path to file containing client SSL private key", '', ""),
-                   ("ssl", "enforce SSL / amqps connection", '', False)]
+    option_list = [
+        PluginOpt('port', default='', val_type=int,
+                  desc='listening port to connect to'),
+        PluginOpt('ssl-certificate', default='', val_type=str,
+                  desc='Path to file containing client SSL certificate'),
+        PluginOpt('ssl-key', default='', val_type=str,
+                  desc='Path to file containing client SSL private key'),
+        PluginOpt('ssl', default=False, desc='enforce SSL amqps connection')
+    ]
 
     def setup(self):
         """ performs data collection for qpid broker """

--- a/sos/report/plugins/qpid_dispatch.py
+++ b/sos/report/plugins/qpid_dispatch.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 from socket import gethostname
 
 
@@ -20,12 +20,16 @@ class QpidDispatch(Plugin, RedHatPlugin):
     profiles = ('services',)
 
     packages = ('qdrouterd', 'qpid-dispatch-tools', 'qpid-dispatch-router')
-    option_list = [("port", "listening port to connect to", '', ""),
-                   ("ssl-certificate",
-                    "Path to file containing client SSL certificate", '', ""),
-                   ("ssl-key",
-                    "Path to file containing client SSL private key", '', ""),
-                   ("ssl-trustfile", "trusted CA database file", '', "")]
+    option_list = [
+        PluginOpt('port', default='', val_type=int,
+                  desc='listening port to connect to'),
+        PluginOpt('ssl-certificate', default='', val_type=str,
+                  desc='Path to file containing client SSL certificate'),
+        PluginOpt('ssl-key', default='', val_type=str,
+                  desc='Path to file containing client SSL private key'),
+        PluginOpt('ssl-trustfile', default='', val_type=str,
+                  desc='trusted CA database file')
+    ]
 
     def setup(self):
         """ performs data collection for qpid dispatch router """

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Rpm(Plugin, RedHatPlugin):
@@ -16,10 +16,12 @@ class Rpm(Plugin, RedHatPlugin):
     plugin_name = 'rpm'
     profiles = ('system', 'packagemanager')
 
-    option_list = [("rpmq", "queries for package information via rpm -q",
-                    "fast", True),
-                   ("rpmva", "runs a verify on all packages", "slow", False),
-                   ("rpmdb", "collect /var/lib/rpm", "slow", False)]
+    option_list = [
+        PluginOpt('rpmq', default=True,
+                  desc='query package information with rpm -q'),
+        PluginOpt('rpmva', default=False, desc='verify all packages'),
+        PluginOpt('rpmdb', default=False, desc='collect /var/lib/rpm')
+    ]
 
     verify_packages = ('rpm',)
 

--- a/sos/report/plugins/sar.py
+++ b/sos/report/plugins/sar.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 import os
 import re
 
@@ -20,8 +21,10 @@ class Sar(Plugin,):
 
     packages = ('sysstat',)
     sa_path = '/var/log/sa'
-    option_list = [("all_sar", "gather all system activity records",
-                    "", False)]
+    option_list = [
+        PluginOpt('all_sar', default=False,
+                  desc="gather all system activity records")
+    ]
 
     def setup(self):
         self.add_copy_spec(os.path.join(self.sa_path, '*'),

--- a/sos/report/plugins/selinux.py
+++ b/sos/report/plugins/selinux.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class SELinux(Plugin, RedHatPlugin):
@@ -16,8 +16,10 @@ class SELinux(Plugin, RedHatPlugin):
     plugin_name = 'selinux'
     profiles = ('container', 'system', 'security', 'openshift')
 
-    option_list = [("fixfiles", 'Print incorrect file context labels',
-                    'slow', False)]
+    option_list = [
+        PluginOpt('fixfiles', default=False,
+                  desc='collect incorrect file context labels')
+    ]
     packages = ('libselinux',)
 
     def setup(self):

--- a/sos/report/plugins/services.py
+++ b/sos/report/plugins/services.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 
 
 class Services(Plugin):
@@ -16,8 +17,10 @@ class Services(Plugin):
     plugin_name = "services"
     profiles = ('system', 'boot')
 
-    option_list = [("servicestatus", "get a status of all running services",
-                    "slow", False)]
+    option_list = [
+        PluginOpt('servicestatus', default=False,
+                  desc='collect status of all running services')
+    ]
 
     def setup(self):
         self.add_copy_spec([

--- a/sos/report/plugins/skydive.py
+++ b/sos/report/plugins/skydive.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 import os
 
 
@@ -26,9 +26,12 @@ class Skydive(Plugin, RedHatPlugin):
     password_warn_text = " (password visible in process listings)"
 
     option_list = [
-        ("username", "skydive user name", "", ""),
-        ("password", "skydive password" + password_warn_text, "", ""),
-        ("analyzer", "skydive analyzer address", "", "")
+        PluginOpt('username', default='', val_type=str,
+                  desc='skydive username'),
+        PluginOpt('password', default='', val_type=str,
+                  desc='skydive password' + password_warn_text),
+        PluginOpt('analyzer', default='', val_type=str,
+                  desc='skydive analyzer address')
     ]
 
     def setup(self):

--- a/sos/report/plugins/smclient.py
+++ b/sos/report/plugins/smclient.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class SMcli(Plugin, IndependentPlugin):
@@ -19,7 +19,7 @@ class SMcli(Plugin, IndependentPlugin):
     packages = ('SMclient',)
 
     option_list = [
-        ("debug", "capture support debug data", "slow", False),
+        PluginOpt('debug', default=False, desc='capture support debug data')
     ]
 
     def setup(self):

--- a/sos/report/plugins/storcli.py
+++ b/sos/report/plugins/storcli.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class StorCLI(Plugin, IndependentPlugin):
@@ -18,7 +18,7 @@ class StorCLI(Plugin, IndependentPlugin):
     packages = ('storcli',)
 
     option_list = [
-        ("json", "collect data in JSON format", "fast", False)
+        PluginOpt('json', default=False, desc='collect data in JSON format')
     ]
 
     def setup(self):

--- a/sos/report/plugins/veritas.py
+++ b/sos/report/plugins/veritas.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 
 class Veritas(Plugin, RedHatPlugin):
@@ -18,8 +18,10 @@ class Veritas(Plugin, RedHatPlugin):
 
     # Information about VRTSexplorer obtained from
     # http://seer.entsupport.symantec.com/docs/243150.htm
-    option_list = [("script", "Define VRTSexplorer script path", "",
-                    "/opt/VRTSspt/VRTSexplorer")]
+    option_list = [
+        PluginOpt('script', default='/opt/VRTSspt/VRTSexplorer',
+                  desc='Path to VRTSexploer script')
+    ]
 
     def check_enabled(self):
         return self.path_isfile(self.get_option("script"))

--- a/sos/report/plugins/watchdog.py
+++ b/sos/report/plugins/watchdog.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 
 from glob import glob
 import os
@@ -22,7 +22,8 @@ class Watchdog(Plugin, RedHatPlugin):
     packages = ('watchdog',)
 
     option_list = [
-        ('conf_file', 'watchdog config file', 'fast', '/etc/watchdog.conf'),
+        PluginOpt('conf_file', default='/etc/watchdog.conf',
+                  desc='watchdog config file')
     ]
 
     def get_log_dir(self, conf_file):

--- a/sos/report/plugins/yum.py
+++ b/sos/report/plugins/yum.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
 import os
 
 YUM_PLUGIN_PATH = "/usr/lib/yum-plugins/"
@@ -24,9 +24,10 @@ class Yum(Plugin, RedHatPlugin):
     verify_packages = ('yum',)
 
     option_list = [
-        ("yumlist", "list repositories and packages", "slow", False),
-        ("yumdebug", "gather yum debugging data", "slow", False),
-        ("yum-history-info", "gather yum history info", "slow", False),
+        PluginOpt('yumlist', default=False, desc='list repos and packages'),
+        PluginOpt('yumdebug', default=False, desc='collect yum debug data'),
+        PluginOpt('yum-history-info', default=False,
+                  desc='collect yum history info for all transactions')
     ]
 
     def setup(self):

--- a/tests/unittests/conformance_tests.py
+++ b/tests/unittests/conformance_tests.py
@@ -8,7 +8,7 @@
 import unittest
 
 
-from sos.report.plugins import import_plugin
+from sos.report.plugins import import_plugin, PluginOpt
 from sos.utilities import ImporterHelper
 
 
@@ -50,7 +50,8 @@ class PluginConformance(unittest.TestCase):
         for plug in self.plug_classes:
             self.assertIsInstance(plug.option_list, list)
             for opt in plug.option_list:
-                self.assertIsInstance(opt, tuple)
+                self.assertIsInstance(opt, PluginOpt)
+                self.assertFalse(opt.name == 'undefined')
 
     def test_plugin_architectures_set_correctly(self):
         for plug in self.plug_classes:

--- a/tests/unittests/option_tests.py
+++ b/tests/unittests/option_tests.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 import unittest
 
-from sos.report.plugins import Plugin
+from sos.report.plugins import Plugin, PluginOpt
 from sos.policies.distros import LinuxPolicy
 from sos.policies.init_systems import InitSystem
 
@@ -21,6 +21,18 @@ class MockOptions(object):
     skip_files = []
 
 
+class MockPlugin(Plugin):
+
+    option_list = [
+        PluginOpt('baz', default=False),
+        PluginOpt('empty', default=None),
+        PluginOpt('test_option', default='foobar')
+    ]
+
+    def __init__(self, commons):
+        super(MockPlugin, self).__init__(commons=commons)
+
+
 class GlobalOptionTest(unittest.TestCase):
 
     def setUp(self):
@@ -30,11 +42,7 @@ class GlobalOptionTest(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         }
-        self.plugin = Plugin(self.commons)
-        self.plugin.opt_names = ['baz', 'empty', 'test_option']
-        self.plugin.opt_parms = [
-            {'enabled': False}, {'enabled': None}, {'enabled': 'foobar'}
-        ]
+        self.plugin = MockPlugin(self.commons)
 
     def test_simple_lookup(self):
         self.assertEquals(self.plugin.get_option('test_option'), 'foobar')

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -12,7 +12,7 @@ import shutil
 
 from io import StringIO
 
-from sos.report.plugins import Plugin, regex_findall, _mangle_command
+from sos.report.plugins import Plugin, regex_findall, _mangle_command, PluginOpt
 from sos.archive import TarFileArchive
 from sos.policies.distros import LinuxPolicy
 from sos.policies.init_systems import InitSystem
@@ -64,8 +64,10 @@ class MockArchive(TarFileArchive):
 
 class MockPlugin(Plugin):
 
-    option_list = [("opt", 'an option', 'fast', None),
-                   ("opt2", 'another option', 'fast', False)]
+    option_list = [
+        PluginOpt("opt", default=None, desc='an option', val_type=str),
+        PluginOpt("opt2", default=False, desc='another option')
+    ]
 
     def setup(self):
         pass
@@ -270,35 +272,6 @@ class PluginTests(unittest.TestCase):
             'devices': {}
         })
         self.assertEquals(p.get_option("opt2", True), False)
-
-    def test_get_option_as_list_plugin_option(self):
-        p = MockPlugin({
-            'sysroot': self.sysroot,
-            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
-            'cmdlineopts': MockOptions(),
-            'devices': {}
-        })
-        p.set_option("opt", "one,two,three")
-        self.assertEquals(p.get_option_as_list("opt"), ['one', 'two', 'three'])
-
-    def test_get_option_as_list_plugin_option_default(self):
-        p = MockPlugin({
-            'sysroot': self.sysroot,
-            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
-            'cmdlineopts': MockOptions(),
-            'devices': {}
-        })
-        self.assertEquals(p.get_option_as_list("opt", default=[]), [])
-
-    def test_get_option_as_list_plugin_option_not_list(self):
-        p = MockPlugin({
-            'sysroot': self.sysroot,
-            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
-            'cmdlineopts': MockOptions(),
-            'devices': {}
-        })
-        p.set_option("opt", "testing")
-        self.assertEquals(p.get_option_as_list("opt"), ['testing'])
 
     def test_copy_dir(self):
         self.mp._do_copy_path("tests")


### PR DESCRIPTION
These commits add a new `PluginOpt` class to define plugin options, and then converts existing plugin options to use this new class.

This should allow more flexibility in expanding plugin option handling, as well as make it much easier to report these options in the upcoming `sos info` component.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?