### PR TITLE
[cirrus] Upload logs from failed tests to GCE storage bucket

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,6 +124,11 @@ report_stageone_task:
         fi
     setup_script: &setup 'pip3 install avocado-framework'
     main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
+    on_failure:
+        fail_script: &faillogs |
+            tar cf sos-fail-logs.tar /var/tmp/avocado*
+        log_artifacts:
+            path: "sos-fail-logs.tar"
 
 # IFF the stage one tests all pass, then run stage two for latest distros
 report_stagetwo_task:
@@ -154,6 +159,10 @@ report_stagetwo_task:
         fi
     setup_script: *setup
     main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stagetwo tests/{cleaner,collect,report,vendor}_tests
+    on_failure:
+        fail_script: *faillogs
+        log_artifacts:
+            path: "sos-fail-logs.tar"
 
 report_foreman_task:
     skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py')"
@@ -175,3 +184,7 @@ report_foreman_task:
     remove_sos_script: *remove_sos
     setup_script: *setup
     main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t foreman tests/product_tests/foreman/
+    on_failure:
+        fail_script: *faillogs
+        log_artifacts:
+            path: "sos-fail-logs.tar"


### PR DESCRIPTION
Adds a failure handling to cirrus tasks that actually run sos so that if
an error is encountered in the test suite, the logs from the tests are
uploaded to the GCE cloud storage bucket associated with the GCE sos
project.

Note this initial push includes a temporary commit to force a failure of the stage 1 tasks in order to test this change. Once verified, that commit will be dropped.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?