### PR TITLE
[block] Capture udisks configuration and output

### DIFF
--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -66,4 +66,14 @@ class Block(Plugin, IndependentPlugin):
                     dev = line.split()[0]
                     self.add_cmd_output('cryptsetup luksDump /dev/%s' % dev)
 
+        # if udisks is installed, capture configuration,
+        # status, and information about all objects
+        self.add_copy_spec([
+            "/etc/udisks2/",
+        ])
+        self.add_cmd_output([
+            "udisksctl status",
+            "udisksctl dump",
+        ])
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch enables the capture of the udisks config
in:

/etc/udisks/

And status and object dump via udisksctl command.

Resolved: #2651 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?