### PR TITLE
[collect] Remove double prompt for case ID

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1104,11 +1104,6 @@ this utility or remote systems that it connects to.
             except KeyboardInterrupt:
                 self.exit("Exiting on user cancel", 130)
 
-        if not self.opts.case_id and not self.opts.batch:
-            msg = 'Optionally, please enter the case id you are collecting ' \
-                  'reports for: '
-            self.opts.case_id = input(msg)
-
     def execute(self):
         if self.opts.list_options:
             self.list_options()


### PR DESCRIPTION
Remove the case ID prompt within `collect`, since the one from `Policy`
will always apply. This avoids a double prompt for a case ID if the user
does not originally provide one.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?