### PR TITLE
[unpackaged] Limit package_manager file list to relevant paths

### DIFF
--- a/sos/report/plugins/unpackaged.py
+++ b/sos/report/plugins/unpackaged.py
@@ -26,7 +26,7 @@ class Unpackaged(Plugin, RedHatPlugin):
             return os.environ['PATH'].split(':')
 
         def all_files_system(path, exclude=None):
-            """Retrun a list of all files present on the system, excluding
+            """Return a list of all files present on the system, excluding
                 any directories listed in `exclude`.
 
             :param path: the starting path
@@ -67,12 +67,15 @@ class Unpackaged(Plugin, RedHatPlugin):
         if not self.test_predicate(cmd=True):
             return
 
+        paths = get_env_path_list()
         all_fsystem = []
-        all_frpm = set(os.path.realpath(x)
-                       for x in self.policy.mangle_package_path(
-                       self.policy.package_manager.all_files()))
+        all_frpm = set(
+            os.path.realpath(x) for x in self.policy.mangle_package_path(
+                self.policy.package_manager.all_files()
+            ) if any([x.startswith(p) for p in paths])
+        )
 
-        for d in get_env_path_list():
+        for d in paths:
             all_fsystem += all_files_system(d)
         not_packaged = [x for x in all_fsystem if x not in all_frpm]
         not_packaged_expanded = format_output(not_packaged)


### PR DESCRIPTION
Since the `unpackaged` plugin looks for all files within $PATH, we
should in turn limit the list of files returned by the package manager
that we're comparing against to the same paths.

Otherwise, we are iterating over a needlessly large list of packaged
files outside of the filesystem paths that we actually care about.

On systems with a large number of installed packages, this can result in
a packaged file list that is smaller by tens or even hundreds of
thousands of entries and in turn results in a much faster `setup()` time
for the plugin.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?