### PR TITLE
[openvswitch] Get userspace datapath implementations

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -131,7 +131,13 @@ class OpenVSwitch(Plugin):
             # Capture OVS offload enabled flows
             "ovs-dpctl dump-flows --name -m type=offloaded",
             # Capture OVS slowdatapth flows
-            "ovs-dpctl dump-flows --name -m type=ovs"
+            "ovs-dpctl dump-flows --name -m type=ovs",
+            # Capture dpcls implementations
+            "ovs-appctl dpif-netdev/subtable-lookup-prio-get",
+            # Capture dpif implementations
+            "ovs-appctl dpif-netdev/dpif-impl-get",
+            # Capture miniflow extract implementations
+            "ovs-appctl dpif-netdev/miniflow-parser-get"
         ])
 
         # Gather systemd services logs


### PR DESCRIPTION
OVS has options for the userspace datapath so certain functionality
can use implementations based on SIMD instructions if available.

Add some commands which show the implementations available and used.

Signed-off-by: Kevin Traynor <ktraynor@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?