### PR TITLE
[omnipath_client] Ensure opacapture runs only with allow-system-changes

### DIFF
--- a/sos/report/plugins/omnipath_client.py
+++ b/sos/report/plugins/omnipath_client.py
@@ -45,7 +45,12 @@ class OmnipathClient(Plugin, RedHatPlugin):
         # rather than storing it somewhere under /var/tmp and copying it via
         # add_copy_spec, add it directly to sos_commands/<plugin> dir by
         # building a path argument using self.get_cmd_output_path().
-        self.add_cmd_output("opacapture %s" % join(self.get_cmd_output_path(),
-                                                   "opacapture.tgz"))
+        # This command calls 'depmod -a', so lets make sure we
+        # specified the 'allow-system-changes' option before running it.
+        if self.get_option('allow_system_changes'):
+            self.add_cmd_output("opacapture %s" %
+                                join(self.get_cmd_output_path(),
+                                     "opacapture.tgz"),
+                                changes=True)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
While omnipath_client plugin is collecting "opacapture",
`depmod -a` command is executed to regenerates some files
under /usr/lib/modules/$kernel.

modules.dep
modules.dep.bin
modules.devname
modules.softdep
modules.symbols
modules.symbols.bin

This patch ensures that the command is only run when
the option --allow-system-changes is used.

Fixes: RHBZ#1998433
Closes: #2662 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?