### PR TITLE
[unpackaged] deal with recursive loop of symlinks properly

### DIFF
--- a/sos/report/plugins/unpackaged.py
+++ b/sos/report/plugins/unpackaged.py
@@ -10,6 +10,7 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 import os
 import stat
+from pathlib import Path
 
 
 class Unpackaged(Plugin, RedHatPlugin):
@@ -41,8 +42,8 @@ class Unpackaged(Plugin, RedHatPlugin):
                 for name in files:
                     path = os.path.join(root, name)
                     try:
-                        while stat.S_ISLNK(os.lstat(path).st_mode):
-                            path = os.path.abspath(os.readlink(path))
+                        if stat.S_ISLNK(os.lstat(path).st_mode):
+                            path = Path(path).resolve()
                     except Exception:
                         continue
                     file_list.append(os.path.realpath(path))


### PR DESCRIPTION
When the plugin processes a recursive loop of symlinks, it currently
hangs in an infinite loop trying to follow the symlinks. Use
pathlib.Path.resolve() method to return the target directly.

Resolves: #2664

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?