### PR TITLE
[processor] Apply sizelimit to /sys/devices/system/cpu/cpuX

### DIFF
--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, IndependentPlugin
+import os
 
 
 class Processor(Plugin, IndependentPlugin):
@@ -34,7 +35,13 @@ class Processor(Plugin, IndependentPlugin):
         self.add_copy_spec([
             "/proc/cpuinfo",
             "/sys/class/cpuid",
-            "/sys/devices/system/cpu"
+        ])
+        # copy /sys/devices/system/cpu/cpuX with separately applied sizelimit
+        # this is required for systems with tens/hundreds of CPUs where the
+        # cumulative directory size exceeds 25MB or even 100MB.
+        cdirs = self.listdir('/sys/devices/system/cpu')
+        self.add_copy_spec([
+            os.path.join('/sys/devices/system/cpu', cdir) for cdir in cdirs
         ])
 
         self.add_cmd_output([


### PR DESCRIPTION
Copy /sys/devices/system/cpu/cpuX with separately applied sizelimit.

This is required for systems with tens/hundreds of CPUs where the
cumulative directory size exceeds 25MB or even 100MB.

Resolves: #2639
Closes: #2665

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?