### PR TITLE
[tests] Pin avocado test runner to known working version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,7 +123,7 @@ report_stageone_task:
             dnf -y remove sos
         fi
     setup_script: &setup 'pip3 install avocado-framework'
-    main_script: PYTHONPATH=tests/ avocado run -t stageone tests/{cleaner,collect,report,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
 
 # IFF the stage one tests all pass, then run stage two for latest distros
 report_stagetwo_task:
@@ -153,7 +153,7 @@ report_stagetwo_task:
             dnf -y install python3-pexpect
         fi
     setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run -t stagetwo tests/{cleaner,collect,report,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stagetwo tests/{cleaner,collect,report,vendor}_tests
 
 report_foreman_task:
     skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py')"
@@ -174,4 +174,4 @@ report_foreman_task:
             FOREMAN_VER: "2.5 - Debian 10"
     remove_sos_script: *remove_sos
     setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run -t foreman tests/product_tests/foreman/
+    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t foreman tests/product_tests/foreman/


### PR DESCRIPTION
Avocado has been developing a new test runner (dubbed nrunner) and the
upcoming release 91.0 will activate the new runner as the default one.

While most of the tests and jobs should work under the new runner,
there are a few caveats, and possibly unknown issues.

To avoid regressions in the test execution and CI status, let's pin
the test runner to the known working version.  A switch to use the new
runner may be done as a separate future change after compatibility is
fully investigated and validated.

Reference: https://avocado-framework.readthedocs.io/en/90.0/releases/90_0.html#important-announcement
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?