### PR TITLE
[report,options] Fix reporting of plugopts with effective options message

### DIFF
--- a/sos/options.py
+++ b/sos/options.py
@@ -281,6 +281,8 @@ class SoSOptions():
             null_values = ("False", "None", "[]", '""', "''", "0")
             if not value or value in null_values:
                 return False
+            if name == 'plugopts' and value:
+                return True
             if name in self.arg_defaults:
                 if str(value) == str(self.arg_defaults[name]):
                     return False

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -925,20 +925,6 @@ class SoSReport(SoSComponent):
         self._exit(1)
 
     def setup(self):
-        # Log command line options
-        msg = "[%s:%s] executing 'sos %s'"
-        self.soslog.info(msg % (__name__, "setup", " ".join(self.cmdline)))
-
-        # Log active preset defaults
-        preset_args = self.preset.opts.to_args()
-        msg = ("[%s:%s] using '%s' preset defaults (%s)" %
-               (__name__, "setup", self.preset.name, " ".join(preset_args)))
-        self.soslog.info(msg)
-
-        # Log effective options after applying preset defaults
-        self.soslog.info("[%s:%s] effective options now: %s" %
-                         (__name__, "setup", " ".join(self.opts.to_args())))
-
         self.ui_log.info(_(" Setting up plugins ..."))
         for plugname, plug in self.loaded_plugins:
             try:
@@ -1386,11 +1372,27 @@ class SoSReport(SoSComponent):
         self.report_md.add_list('disabled_plugins', self.opts.skip_plugins)
         self.report_md.add_section('plugins')
 
+    def _merge_preset_options(self):
+        # Log command line options
+        msg = "[%s:%s] executing 'sos %s'"
+        self.soslog.info(msg % (__name__, "setup", " ".join(self.cmdline)))
+
+        # Log active preset defaults
+        preset_args = self.preset.opts.to_args()
+        msg = ("[%s:%s] using '%s' preset defaults (%s)" %
+               (__name__, "setup", self.preset.name, " ".join(preset_args)))
+        self.soslog.info(msg)
+
+        # Log effective options after applying preset defaults
+        self.soslog.info("[%s:%s] effective options now: %s" %
+                         (__name__, "setup", " ".join(self.opts.to_args())))
+
     def execute(self):
         try:
             self.policy.set_commons(self.get_commons())
             self.load_plugins()
             self._set_all_options()
+            self._merge_preset_options()
             self._set_tunables()
             self._check_for_unknown_plugins()
             self._set_plugin_options()

--- a/tests/report_tests/options_tests.py
+++ b/tests/report_tests/options_tests.py
@@ -1,0 +1,45 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos_tests import StageTwoReportTest
+
+
+class OptionsFromConfigTest(StageTwoReportTest):
+    """Ensure that we handle options specified in sos.conf properly
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [('/etc/sos/options_tests_sos.conf', '/etc/sos/sos.conf')]
+    sos_cmd = '-v '
+
+    def test_case_id_from_config(self):
+        self.assertTrue('8675309' in self.archive)
+
+    def test_plugins_skipped_from_config(self):
+        self.assertPluginNotIncluded(['networking', 'logs'])
+
+    def test_plugopts_logged_from_config(self):
+        self.assertSosLogContains(
+            "Set kernel plugin option to \(name=with-timer, desc='gather /proc/timer\* statistics', value=True, default=False\)"
+        )
+        self.assertSosLogContains(
+            "Set kernel plugin option to \(name=trace, desc='gather /sys/kernel/debug/tracing/trace file', value=True, default=False\)"
+        )
+
+    def test_disabled_plugopts_not_loaded(self):
+        self.assertSosLogNotContains("Set networking plugin option to")
+
+    def test_plugopts_actually_set(self):
+        self.assertFileCollected('sys/kernel/debug/tracing/trace')
+
+    def test_effective_options_logged_correctly(self):
+        self.assertSosLogContains(
+            "effective options now: --batch --case-id 8675309 --plugopts kernel.with-timer=on,kernel.trace=yes --skip-plugins networking,logs"
+        )

--- a/tests/test_data/etc/sos/options_tests_sos.conf
+++ b/tests/test_data/etc/sos/options_tests_sos.conf
@@ -1,0 +1,18 @@
+[global]
+#verbose = 3
+
+[report]
+skip-plugins = networking,logs
+case-id = 8675309
+
+[collect]
+#primary = myhost.example.com
+
+[clean]
+#no-update = true
+
+[plugin_options]
+#rpm.rpmva = off
+kernel.with-timer = on
+kernel.trace = yes
+networking.traceroute = yes


### PR DESCRIPTION
This patchset fixes the issue raised in #2663 by adding an explicit handler for plugopts in the `to_args()` logic used to generate the command line logged for the ending effective options. We need to do this because the way `SoSOptions()` builds from the `arg_defaults` compared to reading config file sections does not work for how we parse the `plugin_options` section, as it ends up updating the `arg_defaults` inadvertently. During testing however, fixing this more generically lead to either command line values for `plugopts` not being honored or the section handling methods breaking. So, I see this as the least bad option.

Additionally, a new test class is added to ensure logging and option handling from config files behaves as we expect it to. To do this, a companion commit that allows files from `tests/test_data` to be dropped to differently named locations on the test system is included.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?