### PR TITLE
[openstack_octavia] Stop collecting Loadbalancer details

### DIFF
--- a/sos/report/plugins/openstack_octavia.py
+++ b/sos/report/plugins/openstack_octavia.py
@@ -61,37 +61,6 @@ class OpenStackOctavia(Plugin):
                 "/var/log/octavia/*.log",
             ])
 
-        # commands
-        self.add_cmd_output('openstack loadbalancer list',
-                            subdir='loadbalancer')
-
-        for res in self.resources:
-            # get a list for each resource type
-            self.add_cmd_output('openstack loadbalancer %s list' % res,
-                                subdir=res)
-
-            # get details from each resource
-            cmd = "openstack loadbalancer %s list -f value -c id" % res
-            ret = self.exec_cmd(cmd)
-            if ret['status'] == 0:
-                for ent in ret['output'].splitlines():
-                    ent = ent.split()[0]
-                    self.add_cmd_output(
-                        "openstack loadbalancer %s show %s" % (res, ent),
-                        subdir=res
-                    )
-
-        # get capability details from each provider
-        cmd = "openstack loadbalancer provider list -f value -c name"
-        ret = self.exec_cmd(cmd)
-        if ret['status'] == 0:
-            for p in ret['output'].splitlines():
-                p = p.split()[0]
-                self.add_cmd_output(
-                    "openstack loadbalancer provider capability list %s" % p,
-                    subdir='provider_capability'
-                )
-
     def postproc(self):
         protect_keys = [
             "ca_private_key_passphrase", "heartbeat_key", "password",


### PR DESCRIPTION
Currently, we're collecting loadbalancer details from nodes by running
specific commands. Overcloud nodes does not contain octaviaclient
package required for running those loadbalancer commands. Undercloud
node does not have Octavia service / container, running loadbalancer
commands in undercloud would be misleading and failing. This patch
removes those commands being run on nodes completely.

Resolves: #2670

Signed-off-by: Purandhar Sairam Mannidi <pmannidi@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?