### PR TITLE
[report] Implement --estimate-mode

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -14,7 +14,7 @@ sos report \- Collect and package diagnostic and support data
           [--preset preset] [--add-preset add_preset]\fR
           [--del-preset del_preset] [--desc description]\fR
           [--batch] [--build] [--debug] [--dry-run]\fR
-          [--label label] [--case-id id]\fR
+          [--estimate-only] [--label label] [--case-id id]\fR
           [--threads threads]\fR
           [--plugin-timeout TIMEOUT]\fR
           [--cmd-timeout TIMEOUT]\fR
@@ -316,6 +316,17 @@ Execute plugins as normal, but do not collect any file content, command
 output, or string data from the system. The resulting logs may be used
 to understand the actions that sos would have taken without the dry run
 option.
+.TP
+.B \--estimate-only
+Estimate disk space requirements when running sos report. This can be valuable
+to prevent sosreport working dir to consume all free disk space. No plugin data
+is available at the end.
+
+Plugins will be collected sequentially, size of collected files and commands outputs
+will be calculated and the plugin files will be immediatelly deleted prior execution
+of the next plugin. This still can consume whole free disk space, though. Please note,
+size estimations may not be accurate for highly utilized systems due to changes between
+an estimate and a real execution.
 .TP
 .B \--upload
 If specified, attempt to upload the resulting archive to a vendor defined location.


### PR DESCRIPTION
Add report option `--estimate-mode` to estimate disk space requirements
when running a sos report.

Reasoning for changing some cmdline options when `--estimate-mode` is used:

- `--threads=1` is required to limit disk usage during the estimation and to simplify the calculation
- `--build` enabled as the outcome is rather in UI logs than in packing the (almost empty) tarball; anyway we can agree on any solution here (to optionally pack the almost empty directory, or to delete the tarball/directory (but it contains `sos.log` that can be valuable for understanding of the disk space consumption)
- `--no-postproc` enabled as we dont care about any password obfuscation (in files we will delete either way)
- `--clean` disabled due to the same reason
- `--upload` disabled as a redundant feature (or does it make sense to upload the almost-empty dir/tarball?)

Resolves: #2673

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?