### PR TITLE
[kernel] Capture Pressure Stall Information

### DIFF
--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -112,7 +112,8 @@ class Kernel(Plugin, IndependentPlugin):
             "/sys/kernel/debug/extfrag/unusable_index",
             "/sys/kernel/debug/extfrag/extfrag_index",
             clocksource_path + "available_clocksource",
-            clocksource_path + "current_clocksource"
+            clocksource_path + "current_clocksource",
+            "/proc/pressure/"
         ])
 
         if self.get_option("with-timer"):


### PR DESCRIPTION
Kernel 4.20 includes PSI metrics for CPU, memory and IO.
The feature is enabled after adding "psi=1" as
kernel boot parameter.
The information is captured in files
in the directory /proc/pressure.

Closes: #2677
Closes: RHBZ #2002145

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?