### PR TITLE
[firewalld] collect nft rules in firewall_tables only

### DIFF
--- a/sos/report/plugins/firewall_tables.py
+++ b/sos/report/plugins/firewall_tables.py
@@ -40,10 +40,11 @@ class firewall_tables(Plugin, IndependentPlugin):
         """ Collects nftables rulesets with 'nft' commands if the modules
         are present """
 
-        self.add_cmd_output(
-            "nft list ruleset",
-            pred=SoSPredicate(self, kmods=['nf_tables'])
-        )
+        # collect nftables ruleset
+        nft_pred = SoSPredicate(self,
+                                kmods=['nf_tables', 'nfnetlink'],
+                                required={'kmods': 'all'})
+        self.add_cmd_output("nft list ruleset", pred=nft_pred, changes=True)
 
     def setup(self):
         # collect iptables -t for any existing table, if we can't read the

--- a/sos/report/plugins/firewalld.py
+++ b/sos/report/plugins/firewalld.py
@@ -9,7 +9,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, SoSPredicate
+from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class FirewallD(Plugin, RedHatPlugin):
@@ -34,12 +34,6 @@ class FirewallD(Plugin, RedHatPlugin):
             "/etc/sysconfig/firewalld",
             "/var/log/firewalld",
         ])
-
-        # collect nftables ruleset
-        nft_pred = SoSPredicate(self,
-                                kmods=['nf_tables', 'nfnetlink'],
-                                required={'kmods': 'all'})
-        self.add_cmd_output("nft list ruleset", pred=nft_pred, changes=True)
 
         # use a 10s timeout to workaround dbus problems in
         # docker containers.


### PR DESCRIPTION
We collect 'nft list ruleset' in both plugins, while:

- nft is not shipped by firewalld package, so we should not collect
it in firewalld plugin
- running the command requires both nf_tables and nfnetlink kmods, so
we should use both kmods in the predicate

Resolves: #2679

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?