### PR TITLE
[Ceph] Add support for containerized Ceph setup

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -8,6 +8,7 @@
 
 from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 from socket import gethostname
+import re
 
 
 class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -15,7 +16,8 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
     """
 
     plugin_name = 'ceph'
-    profiles = ('storage', 'virt')
+    profiles = ('storage', 'virt', 'container')
+    containers = ('ceph-(mon|rgw|osd)*',)
     ceph_hostname = gethostname()
 
     packages = (
@@ -35,6 +37,12 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
         'ceph-mgr@%s' % ceph_hostname,
         'ceph-radosgw@*',
         'ceph-osd@*'
+    )
+
+    # This check will enable the plugin regardless of being
+    # containerized or not
+    files = (
+        '/etc/ceph/ceph.conf',
     )
 
     def setup(self):
@@ -108,9 +116,9 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "pg stat",
         ]
 
-        self.add_cmd_output([
-            "ceph %s" % s for s in ceph_cmds
-        ])
+        ceph_osd_cmds = [
+            "ceph-volume lvm list",
+        ]
 
         self.add_cmd_output([
             "ceph %s --format json-pretty" % s for s in ceph_cmds
@@ -131,5 +139,31 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
             "/var/lib/ceph/tmp/*mnt*",
             "/etc/ceph/*bindpass*"
         ])
+
+        # If containerized, run commands in containers
+        containers_list = self.get_all_containers_by_regex("ceph-*")
+        if containers_list:
+            # Avoid retrieving multiple times the same data
+            got_ceph_cmds = False
+            for container in containers_list:
+                if re.match("ceph-(mon|rgw|osd)", container[1]) and \
+                        not got_ceph_cmds:
+                    self.add_cmd_output([
+                        self.fmt_container_cmd(container[1], "ceph %s" % s)
+                        for s in ceph_cmds
+                    ])
+                    got_ceph_cmds = True
+                if re.match("ceph-osd", container[1]):
+                    self.add_cmd_output([
+                        self.fmt_container_cmd(container[1], "%s" % s)
+                        for s in ceph_osd_cmds
+                    ])
+                    break
+        # Not containerized
+        else:
+            self.add_cmd_output([
+                "ceph %s" % s for s in ceph_cmds
+            ])
+
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
RH Ceph 4 can either be installed as RPM or as containers.
The changes permits to collect the ceph config
on both kind of setup.

Resolves: #2680
Related: #2646

Signed-off-by: Barbora Vassova <bvassova@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?