### PR TITLE
[collect] Abstract transport protocol from SoSNode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,8 +101,8 @@ setup(
         'sos.policies.distros', 'sos.policies.runtimes',
         'sos.policies.package_managers', 'sos.policies.init_systems',
         'sos.report', 'sos.report.plugins', 'sos.collector',
-        'sos.collector.clusters', 'sos.cleaner', 'sos.cleaner.mappings',
-        'sos.cleaner.parsers', 'sos.cleaner.archives'
+        'sos.collector.clusters', 'sos.collector.transports', 'sos.cleaner',
+        'sos.cleaner.mappings', 'sos.cleaner.parsers', 'sos.cleaner.archives'
     ],
     cmdclass=cmdclass,
     command_options=command_options,

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -183,8 +183,8 @@ class Cluster():
         :rtype: ``dict``
         """
         res = self.primary.run_command(cmd, get_pty=True, need_root=need_root)
-        if res['stdout']:
-            res['stdout'] = res['stdout'].replace('Password:', '')
+        if res['output']:
+            res['output'] = res['output'].replace('Password:', '')
         return res
 
     def setup(self):

--- a/sos/collector/clusters/jbon.py
+++ b/sos/collector/clusters/jbon.py
@@ -28,3 +28,5 @@ class jbon(Cluster):
         # This should never be called, but as insurance explicitly never
         # allow this to be enabled via the determine_cluster() path
         return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/clusters/kubernetes.py
+++ b/sos/collector/clusters/kubernetes.py
@@ -34,7 +34,7 @@ class kubernetes(Cluster):
         if res['status'] == 0:
             nodes = []
             roles = [x for x in self.get_option('role').split(',') if x]
-            for nodeln in res['stdout'].splitlines()[1:]:
+            for nodeln in res['output'].splitlines()[1:]:
                 node = nodeln.split()
                 if not roles:
                     nodes.append(node[0])
@@ -44,3 +44,5 @@ class kubernetes(Cluster):
             return nodes
         else:
             raise Exception('Node enumeration did not return usable output')
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -93,7 +93,7 @@ class ocp(Cluster):
         res = self.exec_primary_cmd(self.fmt_oc_cmd(cmd))
         if res['status'] == 0:
             roles = [r for r in self.get_option('role').split(':')]
-            self.node_dict = self._build_dict(res['stdout'].splitlines())
+            self.node_dict = self._build_dict(res['output'].splitlines())
             for node in self.node_dict:
                 if roles:
                     for role in roles:
@@ -103,7 +103,7 @@ class ocp(Cluster):
                     nodes.append(node)
         else:
             msg = "'oc' command failed"
-            if 'Missing or incomplete' in res['stdout']:
+            if 'Missing or incomplete' in res['output']:
                 msg = ("'oc' failed due to missing kubeconfig on primary node."
                        " Specify one via '-c ocp.kubeconfig=<path>'")
             raise Exception(msg)
@@ -168,3 +168,5 @@ class ocp(Cluster):
     def set_node_options(self, node):
         # don't attempt OC API collections on non-primary nodes
         node.plugin_options.append('openshift.no-oc=on')
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -98,7 +98,7 @@ class ovirt(Cluster):
             return []
         res = self._run_db_query(self.dbquery)
         if res['status'] == 0:
-            nodes = res['stdout'].splitlines()[2:-1]
+            nodes = res['output'].splitlines()[2:-1]
             return [n.split('(')[0].strip() for n in nodes]
         else:
             raise Exception('database query failed, return code: %s'
@@ -114,7 +114,7 @@ class ovirt(Cluster):
         engconf = '/etc/ovirt-engine/engine.conf.d/10-setup-database.conf'
         res = self.exec_primary_cmd('cat %s' % engconf, need_root=True)
         if res['status'] == 0:
-            config = res['stdout'].splitlines()
+            config = res['output'].splitlines()
             for line in config:
                 try:
                     k = str(line.split('=')[0])
@@ -141,7 +141,7 @@ class ovirt(Cluster):
                '--batch -o postgresql {}'
                ).format(self.conf['ENGINE_DB_PASSWORD'], sos_opt)
         db_sos = self.exec_primary_cmd(cmd, need_root=True)
-        for line in db_sos['stdout'].splitlines():
+        for line in db_sos['output'].splitlines():
             if fnmatch.fnmatch(line, '*sosreport-*tar*'):
                 _pg_dump = line.strip()
                 self.primary.manifest.add_field('postgresql_dump',
@@ -180,5 +180,7 @@ class rhhi_virt(rhv):
         ret = self._run_db_query('SELECT count(server_id) FROM gluster_server')
         if ret['status'] == 0:
             # if there are any entries in this table, RHHI-V is in use
-            return ret['stdout'].splitlines()[2].strip() != '0'
+            return ret['output'].splitlines()[2].strip() != '0'
         return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/clusters/pacemaker.py
+++ b/sos/collector/clusters/pacemaker.py
@@ -27,7 +27,7 @@ class pacemaker(Cluster):
             self.log_error('Cluster status could not be determined. Is the '
                            'cluster running on this node?')
             return []
-        if 'node names do not match' in self.res['stdout']:
+        if 'node names do not match' in self.res['output']:
             self.log_warn('Warning: node name mismatch reported. Attempts to '
                           'connect to some nodes may fail.\n')
         return self.parse_pcs_output()
@@ -41,17 +41,19 @@ class pacemaker(Cluster):
         return nodes
 
     def get_online_nodes(self):
-        for line in self.res['stdout'].splitlines():
+        for line in self.res['output'].splitlines():
             if line.startswith('Online:'):
                 nodes = line.split('[')[1].split(']')[0]
                 return [n for n in nodes.split(' ') if n]
 
     def get_offline_nodes(self):
         offline = []
-        for line in self.res['stdout'].splitlines():
+        for line in self.res['output'].splitlines():
             if line.startswith('Node') and line.endswith('(offline)'):
                 offline.append(line.split()[1].replace(':', ''))
             if line.startswith('OFFLINE:'):
                 nodes = line.split('[')[1].split(']')[0]
                 offline.extend([n for n in nodes.split(' ') if n])
         return offline
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/clusters/satellite.py
+++ b/sos/collector/clusters/satellite.py
@@ -28,7 +28,7 @@ class satellite(Cluster):
         res = self.exec_primary_cmd(cmd, need_root=True)
         if res['status'] == 0:
             nodes = [
-                n.strip() for n in res['stdout'].splitlines()
+                n.strip() for n in res['output'].splitlines()
                 if 'could not change directory' not in n
             ]
             return nodes
@@ -38,3 +38,5 @@ class satellite(Cluster):
         if node.address == self.primary.address:
             return 'satellite'
         return 'capsule'
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -1,0 +1,317 @@
+# Copyright Red Hat 2021, Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import inspect
+import logging
+import pexpect
+import re
+
+from pipes import quote
+from sos.collector.exceptions import (ConnectionException,
+                                      CommandTimeoutException)
+
+
+class RemoteTransport():
+    """The base class used for defining supported remote transports to connect
+    to remote nodes in conjunction with `sos collect`.
+
+    This abstraction is used to manage the backend connections to nodes so that
+    SoSNode() objects can be leveraged generically to connect to nodes, inspect
+    those nodes, and run commands on them.
+    """
+
+    name = 'undefined'
+
+    def __init__(self, address, commons):
+        self.address = address
+        self.opts = commons['cmdlineopts']
+        self.tmpdir = commons['tmpdir']
+        self.need_sudo = commons['need_sudo']
+        self._hostname = None
+        self.soslog = logging.getLogger('sos')
+        self.ui_log = logging.getLogger('sos_ui')
+
+    def _sanitize_log_msg(self, msg):
+        """Attempts to obfuscate sensitive information in log messages such as
+        passwords"""
+        reg = r'(?P<var>(pass|key|secret|PASS|KEY|SECRET).*?=)(?P<value>.*?\s)'
+        return re.sub(reg, r'\g<var>****** ', msg)
+
+    def log_info(self, msg):
+        """Used to print and log info messages"""
+        caller = inspect.stack()[1][3]
+        lmsg = '[%s:%s] %s' % (self.hostname, caller, msg)
+        self.soslog.info(lmsg)
+
+    def log_error(self, msg):
+        """Used to print and log error messages"""
+        caller = inspect.stack()[1][3]
+        lmsg = '[%s:%s] %s' % (self.hostname, caller, msg)
+        self.soslog.error(lmsg)
+
+    def log_debug(self, msg):
+        """Used to print and log debug messages"""
+        msg = self._sanitize_log_msg(msg)
+        caller = inspect.stack()[1][3]
+        msg = '[%s:%s] %s' % (self.hostname, caller, msg)
+        self.soslog.debug(msg)
+
+    @property
+    def hostname(self):
+        if self._hostname and 'localhost' not in self._hostname:
+            return self._hostname
+        return self.address
+
+    @property
+    def connected(self):
+        """Is the transport __currently__ connected to the node, or otherwise
+        capable of seamlessly running a command or similar on the node?
+        """
+        return False
+
+    @property
+    def remote_exec(self):
+        """This is the command string needed to leverage the remote transport
+        when executing commands. For example, for an SSH transport this would
+        be the `ssh <options>` string prepended to any command so that the
+        command is executed by the ssh binary.
+
+        This is also referenced by the `remote_exec` parameter for policies
+        when loading a policy for a remote node
+        """
+        return None
+
+    def connect(self, password):
+        """Perform the connection steps in order to ensure that we are able to
+        connect to the node for all future operations. Note that this should
+        not provide an interactive shell at this time.
+        """
+        if self._connect(password):
+            if not self._hostname:
+                self._get_hostname()
+            return True
+        return False
+
+    def _connect(self, password):
+        """Actually perform the connection requirements. Should be overridden
+        by specific transports that subclass RemoteTransport
+        """
+        raise NotImplementedError("Transport %s does not define connect"
+                                  % self.name)
+
+    def reconnect(self, password):
+        """Attempts to reconnect to the node using the standard connect()
+        but does not do so indefinitely. This imposes a strict number of retry
+        attempts before failing out
+        """
+        attempts = 1
+        last_err = 'unknown'
+        while attempts < 5:
+            self.log_debug("Attempting reconnect (#%s) to node" % attempts)
+            try:
+                if self.connect(password):
+                    return True
+            except Exception as err:
+                self.log_debug("Attempt #%s exception: %s" % (attempts, err))
+                last_err = err
+            attempts += 1
+        self.log_error("Unable to reconnect to node after 5 attempts, "
+                       "aborting.")
+        raise ConnectionException("last exception from transport: %s"
+                                  % last_err)
+
+    def disconnect(self):
+        """Perform whatever steps are necessary, if any, to terminate any
+        connection to the node
+        """
+        try:
+            if self._disconnect():
+                self.log_debug("Successfully disconnected from node")
+            else:
+                self.log_error("Unable to successfully disconnect, see log for"
+                               " more details")
+        except Exception as err:
+            self.log_error("Failed to disconnect: %s" % err)
+
+    def _disconnect(self):
+        raise NotImplementedError("Transport %s does not define disconnect"
+                                  % self.name)
+
+    def run_command(self, cmd, timeout=180, need_root=False, env=None):
+        """Run a command on the node, returning its output and exit code.
+        This should return the exit code of the command being executed, not the
+        exit code of whatever mechanism the transport uses to execute that
+        command
+
+        :param cmd:         The command to run
+        :type cmd:          ``str``
+
+        :param timeout:     The maximum time in seconds to allow the cmd to run
+        :type timeout:      ``int``
+
+        :param get_pty:     Does ``cmd`` require a pty?
+        :type get_pty:      ``bool``
+
+        :param need_root:   Does ``cmd`` require root privileges?
+        :type neeed_root:   ``bool``
+
+        :param env:         Specify env vars to be passed to the ``cmd``
+        :type env:          ``dict``
+
+        :returns:           Output of ``cmd`` and the exit code
+        :rtype:             ``dict`` with keys ``output`` and ``status``
+        """
+        self.log_debug('Running command %s' % cmd)
+        # currently we only use/support the use of pexpect for handling the
+        # execution of these commands, as opposed to directly invoking
+        # subprocess.Popen() in conjunction with tools like sshpass.
+        # If that changes in the future, we'll add decision making logic here
+        # to route to the appropriate handler, but for now we just go straight
+        # to using pexpect
+        return self._run_command_with_pexpect(cmd, timeout, need_root, env)
+
+    def _format_cmd_for_exec(self, cmd):
+        """Format the command in the way needed for the remote transport to
+        successfully execute it as one would when manually executing it
+
+        :param cmd:     The command being executed, as formatted by SoSNode
+        :type cmd:      ``str``
+
+
+        :returns:       The command further formatted as needed by this
+                        transport
+        :rtype:         ``str``
+        """
+        cmd = "%s %s" % (self.remote_exec, quote(cmd))
+        cmd = cmd.lstrip()
+        return cmd
+
+    def _run_command_with_pexpect(self, cmd, timeout, need_root, env):
+        """Execute the command using pexpect, which allows us to more easily
+        handle prompts and timeouts compared to directly leveraging the
+        subprocess.Popen() method.
+
+        :param cmd:     The command to execute. This will be automatically
+                        formatted to use the transport.
+        :type cmd:      ``str``
+
+        :param timeout: The maximum time in seconds to run ``cmd``
+        :type timeout:  ``int``
+
+        :param need_root:   Does ``cmd`` need to run as root or with sudo?
+        :type need_root:    ``bool``
+
+        :param env:     Any env vars that ``cmd`` should be run with
+        :type env:      ``dict``
+        """
+        cmd = self._format_cmd_for_exec(cmd)
+        result = pexpect.spawn(cmd, encoding='utf-8', env=env)
+
+        _expects = [pexpect.EOF, pexpect.TIMEOUT]
+        if need_root and self.opts.ssh_user != 'root':
+            _expects.extend([
+                '\\[sudo\\] password for .*:',
+                'Password:'
+            ])
+
+        index = result.expect(_expects, timeout=timeout)
+
+        if index in [2, 3]:
+            self._send_pexpect_password(index, result)
+            index = result.expect(_expects, timeout=timeout)
+
+        if index == 0:
+            out = result.before
+            result.close()
+            return {'status': result.exitstatus, 'output': out}
+        elif index == 1:
+            raise CommandTimeoutException(cmd)
+
+    def _send_pexpect_password(self, index, result):
+        """Handle password prompts for sudo and su usage for non-root SSH users
+
+        :param index:       The index pexpect.spawn returned to match against
+                            either a sudo or su prompt
+        :type index:        ``int``
+
+        :param result:      The spawn running the command
+        :type result:       ``pexpect.spawn``
+        """
+        if index == 2:
+            if not self.opts.sudo_pw and not self.opt.nopasswd_sudo:
+                msg = ("Unable to run command: sudo password "
+                       "required but not provided")
+                self.log_error(msg)
+                raise Exception(msg)
+            result.sendline(self.opts.sudo_pw)
+        elif index == 3:
+            if not self.opts.root_password:
+                msg = ("Unable to run command as root: no root password given")
+                self.log_error(msg)
+                raise Exception(msg)
+            result.sendline(self.opts.root_password)
+
+    def _get_hostname(self):
+        """Determine the hostname of the node and set that for future reference
+        and logging
+
+        :returns:   The hostname of the system, per the `hostname` command
+        :rtype:     ``str``
+        """
+        _out = self.run_command('hostname')
+        if _out['status'] == 0:
+            self._hostname = _out['output'].strip()
+        self.log_info("Hostname set to %s" % self._hostname)
+        return self._hostname
+
+    def retrieve_file(self, fname, dest):
+        """Copy a remote file, fname, to dest on the local node
+
+        :param fname:   The name of the file to retrieve
+        :type fname:    ``str``
+
+        :param dest:    Where to save the file to locally
+        :type dest:     ``str``
+
+        :returns:   True if file was successfully copied from remote, or False
+        :rtype:     ``bool``
+        """
+        return self._retrieve_file(fname, dest)
+
+    def _retrieve_file(self, fname, dest):
+        raise NotImplementedError("Transport %s does not support file copying"
+                                  % self.name)
+
+    def read_file(self, fname):
+        """Read the given file fname and return its contents
+
+        :param fname:   The name of the file to read
+        :type fname:    ``str``
+
+        :returns:   The content of the file
+        :rtype:     ``str``
+        """
+        self.log_debug("Reading file %s" % fname)
+        return self._read_file(fname)
+
+    def _read_file(self, fname):
+        res = self.run_command("cat %s" % fname, timeout=5)
+        if res['status'] == 0:
+            return res['output']
+        else:
+            if 'No such file' in res['output']:
+                self.log_debug("File %s does not exist on node"
+                               % fname)
+            else:
+                self.log_error("Error reading %s: %s" %
+                               (fname, res['output'].split(':')[1:]))
+            return ''
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/transports/control_persist.py
+++ b/sos/collector/transports/control_persist.py
@@ -1,0 +1,199 @@
+# Copyright Red Hat 2021, Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+import os
+import pexpect
+import subprocess
+
+from sos.collector.transports import RemoteTransport
+from sos.collector.exceptions import (InvalidPasswordException,
+                                      TimeoutPasswordAuthException,
+                                      PasswordRequestException,
+                                      AuthPermissionDeniedException,
+                                      ConnectionException,
+                                      ConnectionTimeoutException,
+                                      ControlSocketMissingException,
+                                      ControlPersistUnsupportedException)
+from sos.utilities import sos_get_command_output
+
+
+class SSHControlPersist(RemoteTransport):
+    """A transport for collect that leverages OpenSSH's Control Persist
+    functionality which uses control sockets to transparently keep a connection
+    open to the remote host without needing to rebuild the SSH connection for
+    each and every command executed on the node
+    """
+
+    name = 'control_persist'
+
+    def _check_for_control_persist(self):
+        """Checks to see if the local system supported SSH ControlPersist.
+
+        ControlPersist allows OpenSSH to keep a single open connection to a
+        remote host rather than building a new session each time. This is the
+        same feature that Ansible uses in place of paramiko, which we have a
+        need to drop in sos-collector.
+
+        This check relies on feedback from the ssh binary. The command being
+        run should always generate stderr output, but depending on what that
+        output reads we can determine if ControlPersist is supported or not.
+
+        For our purposes, a host that does not support ControlPersist is not
+        able to run sos-collector.
+
+        Returns
+            True if ControlPersist is supported, else raise Exception.
+        """
+        ssh_cmd = ['ssh', '-o', 'ControlPersist']
+        cmd = subprocess.Popen(ssh_cmd, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+        out, err = cmd.communicate()
+        err = err.decode('utf-8')
+        if 'Bad configuration option' in err or 'Usage:' in err:
+            raise ControlPersistUnsupportedException
+        return True
+
+    def _connect(self, password=''):
+        """
+        Using ControlPersist, create the initial connection to the node.
+
+        This will generate an OpenSSH ControlPersist socket within the tmp
+        directory created or specified for sos-collector to use.
+
+        At most, we will wait 30 seconds for a connection. This involves a 15
+        second wait for the initial connection attempt, and a subsequent 15
+        second wait for a response when we supply a password.
+
+        Since we connect to nodes in parallel (using the --threads value), this
+        means that the time between 'Connecting to nodes...' and 'Beginning
+        collection of sosreports' that users see can be up to an amount of time
+        equal to 30*(num_nodes/threads) seconds.
+
+        Returns
+            True if session is successfully opened, else raise Exception
+        """
+        try:
+            self._check_for_control_persist()
+        except ControlPersistUnsupportedException:
+            self.log_error("OpenSSH ControlPersist is not locally supported. "
+                           "Please update your OpenSSH installation.")
+            raise
+        self.log_info('Opening SSH session to create control socket')
+        self.control_path = ("%s/.sos-collector-%s" % (self.tmpdir,
+                                                       self.address))
+        self.ssh_cmd = ''
+        connected = False
+        ssh_key = ''
+        ssh_port = ''
+        if self.opts.ssh_port != 22:
+            ssh_port = "-p%s " % self.opts.ssh_port
+        if self.opts.ssh_key:
+            ssh_key = "-i%s" % self.opts.ssh_key
+
+        cmd = ("ssh %s %s -oControlPersist=600 -oControlMaster=auto "
+               "-oStrictHostKeyChecking=no -oControlPath=%s %s@%s "
+               "\"echo Connected\"" % (ssh_key,
+                                       ssh_port,
+                                       self.control_path,
+                                       self.opts.ssh_user,
+                                       self.address))
+        res = pexpect.spawn(cmd, encoding='utf-8')
+
+        connect_expects = [
+            u'Connected',
+            u'password:',
+            u'.*Permission denied.*',
+            u'.* port .*: No route to host',
+            u'.*Could not resolve hostname.*',
+            pexpect.TIMEOUT
+        ]
+
+        index = res.expect(connect_expects, timeout=15)
+
+        if index == 0:
+            connected = True
+        elif index == 1:
+            if password:
+                pass_expects = [
+                    u'Connected',
+                    u'Permission denied, please try again.',
+                    pexpect.TIMEOUT
+                ]
+                res.sendline(password)
+                pass_index = res.expect(pass_expects, timeout=15)
+                if pass_index == 0:
+                    connected = True
+                elif pass_index == 1:
+                    # Note that we do not get an exitstatus here, so matching
+                    # this line means an invalid password will be reported for
+                    # both invalid passwords and invalid user names
+                    raise InvalidPasswordException
+                elif pass_index == 2:
+                    raise TimeoutPasswordAuthException
+            else:
+                raise PasswordRequestException
+        elif index == 2:
+            raise AuthPermissionDeniedException
+        elif index == 3:
+            raise ConnectionException(self.address, self.opts.ssh_port)
+        elif index == 4:
+            raise ConnectionException(self.address)
+        elif index == 5:
+            raise ConnectionTimeoutException
+        else:
+            raise Exception("Unknown error, client returned %s" % res.before)
+        if connected:
+            if not os.path.exists(self.control_path):
+                raise ControlSocketMissingException
+            self.log_debug("Successfully created control socket at %s"
+                           % self.control_path)
+            return True
+        return False
+
+    def _disconnect(self):
+        if os.path.exists(self.control_path):
+            try:
+                os.remove(self.control_path)
+                return True
+            except Exception as err:
+                self.log_debug("Could not disconnect properly: %s" % err)
+                return False
+        self.log_debug("Control socket not present when attempting to "
+                       "terminate session")
+
+    @property
+    def connected(self):
+        """Check if the SSH control socket exists
+
+        The control socket is automatically removed by the SSH daemon in the
+        event that the last connection to the node was greater than the timeout
+        set by the ControlPersist option. This can happen for us if we are
+        collecting from a large number of nodes, and the timeout expires before
+        we start collection.
+        """
+        return os.path.exists(self.control_path)
+
+    @property
+    def remote_exec(self):
+        if not self.ssh_cmd:
+            self.ssh_cmd = "ssh -oControlPath=%s %s@%s" % (
+                self.control_path, self.opts.ssh_user, self.address
+            )
+        return self.ssh_cmd
+
+    def _retrieve_file(self, fname, dest):
+        cmd = "/usr/bin/scp -oControlPath=%s %s@%s:%s %s" % (
+            self.control_path, self.opts.ssh_user, self.address, fname, dest
+        )
+        res = sos_get_command_output(cmd)
+        return res['status'] == 0
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/transports/local.py
+++ b/sos/collector/transports/local.py
@@ -1,0 +1,49 @@
+# Copyright Red Hat 2021, Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+import shutil
+
+from sos.collector.transports import RemoteTransport
+
+
+class LocalTransport(RemoteTransport):
+    """A 'transport' to represent a local node. This allows us to more easily
+    extend SoSNode() without having a ton of 'if local' or similar checks in
+    more places than we actually need them
+    """
+
+    name = 'local_node'
+
+    def _connect(self, password):
+        return True
+
+    def _disconnect(self):
+        return True
+
+    @property
+    def connected(self):
+        return True
+
+    def _retrieve_file(self, fname, dest):
+        self.log_debug("Moving %s to %s" % (fname, dest))
+        shutil.copy(fname, dest)
+
+    def _format_cmd_for_exec(self, cmd):
+        return cmd
+
+    def _read_file(self, fname):
+        if os.path.exists(fname):
+            with open(fname, 'r') as rfile:
+                return rfile.read()
+        self.log_debug("No such file: %s" % fname)
+        return ''
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Since its addition to sos, collect has assumed the use of a system
installation of SSH in order to connect to the nodes identified for
collection. However, there may be use cases and desires to use other
transport protocols.

As such, provide an abstraction for these protocols in the form of the
new `RemoteTransport` class that `SoSNode` will now leverage. So far an
abstraction for the currently used SSH ControlPersist function is
provided, along with a psuedo abstraction for local execution so that
SoSNode does not directly need to make more "if local then foo" checks
than are absolutely necessary.

Related: #2668

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?