### PR TITLE
[libvirt] Collect containerized logs

### DIFF
--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -50,10 +50,15 @@ class Libvirt(Plugin, IndependentPlugin):
                 "/var/log/libvirt/libvirtd.log",
                 "/var/log/libvirt/qemu/*.log*",
                 "/var/log/libvirt/lxc/*.log",
-                "/var/log/libvirt/uml/*.log"
+                "/var/log/libvirt/uml/*.log",
+                "/var/log/containers/libvirt/libvirtd.log",
+                "/var/log/containers/libvirt/qemu/*.log*",
+                "/var/log/containers/libvirt/lxc/*.log",
+                "/var/log/containers/libvirt/uml/*.log",
             ])
         else:
             self.add_copy_spec("/var/log/libvirt")
+            self.add_copy_spec("/var/log/containers/libvirt")
 
         if self.path_exists(self.path_join(libvirt_keytab)):
             self.add_cmd_output("klist -ket %s" % libvirt_keytab)


### PR DESCRIPTION
Update the libvirt plugin to collect logs from /var/log/containers,
which may be populated in certain environments, like
OpenStack TripleO

This is an addition to #1130 where a couple of things got missed

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?