### PR TITLE
[ovn_central] Fix OVN DBs Schema Path

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -102,7 +102,7 @@ class OVNCentral(Plugin):
             'ovn-sbctl get-connection',
         ]
 
-        schema_dir = '/usr/share/openvswitch'
+        schema_dir = '/usr/share/ovn'
 
         nb_tables = self.get_tables_from_schema(os.path.join(
             schema_dir, 'ovn-nb.ovsschema'))


### PR DESCRIPTION
Currently sosreport tries to search for OVN DB schemas in
/usr/share/openvswitch instead of /usr/share/ovn. Since the schemas are
not available in /usr/share/openvswitch, they are not collected.

This patch fixes the schema path.

Resolves: #2696

Signed-off-by: Purandhar Sairam Mannidi <pmannidi@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?