### PR TITLE
[Systemd, Policy] Correct InitSystem chrooting when chroot is needed

### DIFF
--- a/sos/policies/init_systems/__init__.py
+++ b/sos/policies/init_systems/__init__.py
@@ -29,9 +29,14 @@ class InitSystem():
                       status of services
     :type query_cmd: ``str``
 
+    :param chroot:  Location to chroot to for any command execution, i.e. the
+                    sysroot if we're running in a container
+    :type chroot:   ``str`` or ``None``
+
     """
 
-    def __init__(self, init_cmd=None, list_cmd=None, query_cmd=None):
+    def __init__(self, init_cmd=None, list_cmd=None, query_cmd=None,
+                 chroot=None):
         """Initialize a new InitSystem()"""
 
         self.services = {}
@@ -39,6 +44,7 @@ class InitSystem():
         self.init_cmd = init_cmd
         self.list_cmd = "%s %s" % (self.init_cmd, list_cmd) or None
         self.query_cmd = "%s %s" % (self.init_cmd, query_cmd) or None
+        self.chroot = chroot
 
     def is_enabled(self, name):
         """Check if given service name is enabled
@@ -108,7 +114,10 @@ class InitSystem():
         """Query an individual service"""
         if self.query_cmd:
             try:
-                return sos_get_command_output("%s %s" % (self.query_cmd, name))
+                return sos_get_command_output(
+                    "%s %s" % (self.query_cmd, name),
+                    chroot=self.chroot
+                )
             except Exception:
                 return None
         return None

--- a/sos/policies/init_systems/systemd.py
+++ b/sos/policies/init_systems/systemd.py
@@ -15,11 +15,12 @@ from sos.utilities import shell_out
 class SystemdInit(InitSystem):
     """InitSystem abstraction for SystemD systems"""
 
-    def __init__(self):
+    def __init__(self, chroot=None):
         super(SystemdInit, self).__init__(
             init_cmd='systemctl',
             list_cmd='list-unit-files --type=service',
-            query_cmd='status'
+            query_cmd='status',
+            chroot=chroot
         )
         self.load_all_services()
 
@@ -30,7 +31,7 @@ class SystemdInit(InitSystem):
         return 'unknown'
 
     def load_all_services(self):
-        svcs = shell_out(self.list_cmd).splitlines()[1:]
+        svcs = shell_out(self.list_cmd, chroot=self.chroot).splitlines()[1:]
         for line in svcs:
             try:
                 name = line.split('.service')[0]


### PR DESCRIPTION
This commit resolves a situation in which `sos` is being run in a
container but the `SystemdInit` InitSystem would not properly load
information from the host, thus causing the `Plugin.is_service*()`
methods to erroneously fail or return `False`.

Fix this scenario by pulling the `_container_init()` and related logic
to check for a containerized host sysroot out of the Red Hat specific
policy and into the base `LinuxPolicy` class so that the init system can
be initialized with the correct sysroot, which is now used to chroot the
calls to the relevant `systemctl` commands.

For now, this does impose the use of looking for the `container` env var
(automatically set by docker, podman, and crio regardless of
distribution) and the use of the `HOST` env var to read where the host's
`/` filesystem is mounted within the container. If desired in the
future, this can be changed to allow policy-specific overrides. For now
however, this extends host collection via an sos container for all
distributions currently shipping sos.

Note that this issue only affected the `InitSystem` abstraction for
loading information about local services, and did not affect init system
related commands called by plugins as part of those collections.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?