### PR TITLE
[insights] collect connection check command output

### DIFF
--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -32,6 +32,11 @@ class RedHatInsights(Plugin, RedHatPlugin):
         else:
             self.add_copy_spec("/var/log/insights-client/insights-client.log")
 
+        self.add_cmd_output(
+            "insights-client --test-connection --net-debug",
+            timeout=30
+        )
+
     def postproc(self):
         for conf in self.config:
             self.do_file_sub(


### PR DESCRIPTION
Collect 'insights-client --test-connection --net-debug' cmdout
with a limited timeout to prevent plugin stuck for too long in case
of a networking/proxy issue.

Resolves: #2704

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?