### PR TITLE
[Policy] Fix assignment of case id prompt

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -193,11 +193,12 @@ class LinuxPolicy(Policy):
                 cmdline_opts.quiet:
             try:
                 if caseid:
-                    self.case_id = caseid
+                    self.commons['cmdlineopts'].case_id = caseid
                 else:
-                    self.case_id = input(_("Optionally, please enter the case "
-                                           "id that you are generating this "
-                                           "report for [%s]: ") % caseid)
+                    self.commons['cmdlineopts'].case_id = input(
+                        _("Optionally, please enter the case id that you are "
+                          "generating this report for [%s]: ") % caseid
+                    )
                 # Policies will need to handle the prompts for user information
                 if cmdline_opts.upload and self.get_upload_url():
                     self.prompt_for_upload_user()


### PR DESCRIPTION
When prompting for a case id, `Policy` was not properly updating the
option value, only assigning the value to `Policy` which meant that
aspects outside of `Policy` could not always properly reference the
(updated) case id.

Fix this by assigning the case id prompt response back to the case_id
option value. `Policy` still retains a local reference to case_id as
existing logic was setting that based on the (assumed-to-be-updated)
option value, which until this commit would have been superfluous.

Closes: #2707

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?