### PR TITLE
[networking] retrieve devlink port attributes

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -112,6 +112,7 @@ class Networking(Plugin):
             self.add_cmd_output([
                 "devlink dev param show",
                 "devlink dev info",
+                "devlink port show",
             ])
 
             devlinks = self.collect_cmd_output("devlink dev")


### PR DESCRIPTION
When using sub-functions[1] gathering the devlink port attributes does provide value when debugging. If there is no devlink port, the output is empty.

Example:

```
pci/0000:04:00.0/65535: type eth netdev enp4s0f0 flavour physical port 0 splittable false
pci/0000:04:00.0/32768: type eth netdev en4f0pf0sf42 flavour pcisf controller 0 pfnum 0 sfnum 42 splittable false
  function:
    hw_addr 00:00:00:00:88:88 state active opstate attached
pci/0000:04:00.0/32769: type eth netdev en4f0pf0sf1 flavour pcisf controller 0 pfnum 0 sfnum 1 splittable false
  function:
    hw_addr 00:00:00:00:00:00 state active opstate attached
auxiliary/mlx5_core.sf.4/131072: type eth netdev enp4s0f0s42 flavour virtual port 0 splittable false
auxiliary/mlx5_core.sf.5/196608: type eth netdev enp4s0f0s1 flavour virtual port 0 splittable false
```

[1] https://www.kernel.org/doc/html/latest/networking/devlink/devlink-port.html#subfunction

Signed-off-by: Antoine Tenart <atenart@kernel.org>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
  - Except for the example output, I think that's a valid exception.
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?