### PR TITLE
[tests] Enable default verbosity and increase logs test timeout

### DIFF
--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -15,7 +15,7 @@ class NormalSoSReport(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '-v --label thisismylabel'
+    sos_cmd = '--label thisismylabel'
 
     def test_debug_in_logs_verbose(self):
         self.assertSosLogContains('DEBUG')

--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -41,6 +41,7 @@ class LogsSizeLimitTest(StageTwoReportTest):
     """
 
     sos_cmd = '-o logs'
+    sos_timeout = 500
     packages = {
         'rhel': ['python3-systemd'],
         'ubuntu': ['python3-systemd']

--- a/tests/report_tests/plugin_tests/string_collection_tests.py
+++ b/tests/report_tests/plugin_tests/string_collection_tests.py
@@ -17,7 +17,7 @@ class CollectStringTest(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '-v -o unpackaged,python -k python.hashes'
+    sos_cmd = '-o unpackaged,python -k python.hashes'
     # unpackaged is only a RedHatPlugin
     redhat_only = True
 

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -409,7 +409,7 @@ class BaseSoSReportTest(BaseSoSTest):
         return os.path.join(self.tmpdir, "sosreport-%s" % self.__class__.__name__)
         
     def _generate_sos_command(self):
-        return "%s %s --batch --tmp-dir %s %s" % (SOS_BIN, self.sos_component, self.tmpdir, self.sos_cmd)
+        return "%s %s -v --batch --tmp-dir %s %s" % (SOS_BIN, self.sos_component, self.tmpdir, self.sos_cmd)
 
     def _execute_sos_cmd(self):
         super(BaseSoSReportTest, self)._execute_sos_cmd()


### PR DESCRIPTION
Minor two-patch set that first enables verbosity by default to produce more helpful logs from test failures, and second provides a stopgap measure of increasing the stagetwo logs test timeout until we can determine a better path forward there.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?