### PR TITLE
[Plugin, utilities] Allow writing command output directly to disk

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -251,7 +251,7 @@ class FileCacheArchive(Archive):
 
         return dest
 
-    def _check_path(self, src, path_type, dest=None, force=False):
+    def check_path(self, src, path_type, dest=None, force=False):
         """Check a new destination path in the archive.
 
             Since it is possible for multiple plugins to collect the same
@@ -345,7 +345,7 @@ class FileCacheArchive(Archive):
             if not dest:
                 dest = src
 
-            dest = self._check_path(dest, P_FILE)
+            dest = self.check_path(dest, P_FILE)
             if not dest:
                 return
 
@@ -384,7 +384,7 @@ class FileCacheArchive(Archive):
             # over any exixting content in the archive, since it is used by
             # the Plugin postprocessing hooks to perform regex substitution
             # on file content.
-            dest = self._check_path(dest, P_FILE, force=True)
+            dest = self.check_path(dest, P_FILE, force=True)
 
             f = codecs.open(dest, mode, encoding='utf-8')
             if isinstance(content, bytes):
@@ -397,7 +397,7 @@ class FileCacheArchive(Archive):
 
     def add_binary(self, content, dest):
         with self._path_lock:
-            dest = self._check_path(dest, P_FILE)
+            dest = self.check_path(dest, P_FILE)
             if not dest:
                 return
 
@@ -409,7 +409,7 @@ class FileCacheArchive(Archive):
     def add_link(self, source, link_name):
         self.log_debug("adding symlink at '%s' -> '%s'" % (link_name, source))
         with self._path_lock:
-            dest = self._check_path(link_name, P_LINK)
+            dest = self.check_path(link_name, P_LINK)
             if not dest:
                 return
 
@@ -484,10 +484,10 @@ class FileCacheArchive(Archive):
         """
         # Establish path structure
         with self._path_lock:
-            self._check_path(path, P_DIR)
+            self.check_path(path, P_DIR)
 
     def add_node(self, path, mode, device):
-        dest = self._check_path(path, P_NODE)
+        dest = self.check_path(path, P_NODE)
         if not dest:
             return
 

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -476,7 +476,8 @@ class SoSReport(SoSComponent):
             'verbosity': self.opts.verbosity,
             'cmdlineopts': self.opts,
             'devices': self.devices,
-            'namespaces': self.namespaces
+            'namespaces': self.namespaces,
+            'tempfile_util': self.tempfile_util
         }
 
     def get_temp_file(self):
@@ -1075,7 +1076,12 @@ class SoSReport(SoSComponent):
                 _plug.manifest.add_field('end_time', end)
                 _plug.manifest.add_field('run_time', end - start)
             except TimeoutError:
-                self.ui_log.error("\n Plugin %s timed out\n" % plugin[1])
+                msg = "Plugin %s timed out" % plugin[1]
+                # log to ui_log.error to show the user, log to soslog.info
+                # so that someone investigating the sos execution has it all
+                # in one place, but without double notifying the user.
+                self.ui_log.error("\n %s\n" % msg)
+                self.soslog.info(msg)
                 self.running_plugs.remove(plugin[1])
                 self.loaded_plugins[plugin[0]-1][1].set_timeout_hit()
                 pool.shutdown(wait=True)

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2493,7 +2493,7 @@ class Plugin():
         :param services: Service name(s) to collect statuses for
         :type services: ``str`` or a ``list`` of strings
 
-        :param kwargs:   Optional arguments to pass to _add_cmd_output
+        :param kwargs:   Optional arguments to pass to add_cmd_output
                          (timeout, predicate, suggest_filename,..)
 
         """
@@ -2508,7 +2508,7 @@ class Plugin():
             return
 
         for service in services:
-            self._add_cmd_output(cmd="%s %s" % (query, service), **kwargs)
+            self.add_cmd_output("%s %s" % (query, service), **kwargs)
 
     def add_journal(self, units=None, boot=None, since=None, until=None,
                     lines=None, allfields=False, output=None,


### PR DESCRIPTION
This patchset aims to address a long standing ask for sos - that command output is not _required_ to be stored entirely in memory while we are collecting it.

With these commits, when `--all-logs` is used, or if `sizelimit` is zero for specific commands, `sos_get_command_output()` will write the output directly to a temp file rather than storing the output in memory and returning that.

This is so far only exposed via `add_cmd_output()` by a new `to_file` parameter, but this is automatically handled in the cases above for both `add_cmd_output()` and `add_journal()`. This functionality is not exposed via `exec_cmd()` or `collect_cmd_output()`.

After the command output temp file has been copied to the archive, the temp file is removed via the second commit extending `TempFileUtil`.

Resolves: #1506

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?