### PR TITLE
[discovery] Add new discovery plugin

### DIFF
--- a/sos/report/plugins/discovery.py
+++ b/sos/report/plugins/discovery.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2021 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class Discovery(Plugin, RedHatPlugin):
+
+    short_desc = 'Discovery inspection and reporting tool'
+    plugin_name = 'discovery'
+    packages = ('discovery', 'discovery-tools',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/root/discovery/db/volume/data/userdata/pg_log/",
+            "/root/discovery/server/volumes/log/app.log",
+            "/root/discovery/server/volumes/log/discovery-server.log"
+        ])
+
+        self.add_container_logs([
+            'discovery',
+            'dsc-db'
+        ])
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This commit creates as new plugin for the
discovery tool. This tool is an inspection
and reporting tool, designed to find, identify,
and report environment data.

Fixes: RHBZ#2018549

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?