### PR TITLE
[Plugin] Rework get_container_logs to be more useful

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2366,20 +2366,32 @@ class Plugin():
             return _runtime.volumes
         return []
 
-    def get_container_logs(self, container, **kwargs):
-        """Helper to get the ``logs`` output for a given container
+    def add_container_logs(self, containers, get_all=False, **kwargs):
+        """Helper to get the ``logs`` output for a given container or list
+        of container names and/or regexes.
 
         Supports passthru of add_cmd_output() options
 
-        :param container:   The name of the container to retrieve logs from
-        :type container: ``str``
+        :param containers:   The name of the container to retrieve logs from,
+                             may be a single name or a regex
+        :type containers:    ``str`` or ``list` of strs
+
+        :param get_all:     Should non-running containers also be queried?
+                            Default: False
+        :type get_all:      ``bool``
 
         :param kwargs:      Any kwargs supported by ``add_cmd_output()`` are
                             supported here
         """
         _runtime = self._get_container_runtime()
         if _runtime is not None:
-            self.add_cmd_output(_runtime.get_logs_command(container), **kwargs)
+            if isinstance(containers, str):
+                containers = [containers]
+            for container in containers:
+                _cons = self.get_all_containers_by_regex(container, get_all)
+                for _con in _cons:
+                    cmd = _runtime.get_logs_command(_con[1])
+                    self.add_cmd_output(cmd, **kwargs)
 
     def fmt_container_cmd(self, container, cmd, quotecmd=False):
         """Format a command to be executed by the loaded ``ContainerRuntime``

--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -32,7 +32,7 @@ class RabbitMQ(Plugin, IndependentPlugin):
 
         if in_container:
             for container in container_names:
-                self.get_container_logs(container)
+                self.add_container_logs(container)
                 self.add_cmd_output(
                     self.fmt_container_cmd(container, 'rabbitmqctl report'),
                     foreground=True


### PR DESCRIPTION
`get_container_logs()` is now `add_container_logs()` to align it better
with our more common `add_*` methods for plugin collections.

Additionally, it has been extended to accept either a single string or a
list of strings like the other methods, and plugin authors may now
specify either specific container names or regexes.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?