### PR TITLE
[Plugin] Ensure specific plugin timeouts are only set for that plugin

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -775,7 +775,7 @@ class SoSReport(SoSComponent):
         if self.all_options:
             self.ui_log.info(_("The following options are available for ALL "
                                "plugins:"))
-            _defaults = self.loaded_plugins[0][1]._default_plug_opts
+            _defaults = self.loaded_plugins[0][1].get_default_plugin_opts()
             for _opt in _defaults:
                 opt = _defaults[_opt]
                 val = opt.default

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -553,14 +553,6 @@ class Plugin():
     # Default predicates
     predicate = None
     cmd_predicate = None
-    _default_plug_opts = {
-        'timeout': PluginOpt('timeout', default=-1, val_type=int,
-                             desc='Timeout in seconds for plugin to finish'),
-        'cmd-timeout': PluginOpt('cmd-timeout', default=-1, val_type=int,
-                                 desc='Timeout in seconds for cmds to finish'),
-        'postproc': PluginOpt('postproc', default=True, val_type=bool,
-                              desc='Enable post-processing of collected data')
-    }
 
     def __init__(self, commons):
 
@@ -586,7 +578,7 @@ class Plugin():
             else logging.getLogger('sos')
 
         # add the default plugin opts
-        self.options.update(self._default_plug_opts)
+        self.options.update(self.get_default_plugin_opts())
         for popt in self.options:
             self.options[popt].plugin = self.name()
         for opt in self.option_list:
@@ -595,6 +587,22 @@ class Plugin():
 
         # Initialise the default --dry-run predicate
         self.set_predicate(SoSPredicate(self))
+
+    def get_default_plugin_opts(self):
+        return {
+            'timeout': PluginOpt(
+                'timeout', default=-1, val_type=int,
+                desc='Timeout in seconds for plugin to finish all collections'
+            ),
+            'cmd-timeout': PluginOpt(
+                'cmd-timeout', default=-1, val_type=int,
+                desc='Timeout in seconds for individual commands to finish'
+            ),
+            'postproc': PluginOpt(
+                'postproc', default=True, val_type=bool,
+                desc='Enable post-processing of collected data'
+            )
+        }
 
     def set_plugin_manifest(self, manifest):
         """Pass in a manifest object to the plugin to write to
@@ -610,7 +618,9 @@ class Plugin():
         self.manifest.add_field('setup_start', '')
         self.manifest.add_field('setup_end', '')
         self.manifest.add_field('setup_time', '')
+        self.manifest.add_field('timeout', self.timeout)
         self.manifest.add_field('timeout_hit', False)
+        self.manifest.add_field('command_timeout', self.cmdtimeout)
         self.manifest.add_list('commands', [])
         self.manifest.add_list('files', [])
         self.manifest.add_field('strings', {})

--- a/tests/vendor_tests/redhat/rhbz2018033.py
+++ b/tests/vendor_tests/redhat/rhbz2018033.py
@@ -1,0 +1,35 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+
+class rhbz2018033(StageTwoReportTest):
+    """Test that control of plugin timeouts is independent of other plugin
+    timeouts. See #2744.
+
+    https://bugzilla.redhat.com/show_bug.cgi?id=2018033
+
+    :avocado: tags=stagetwo
+    """
+
+    install_plugins = ['timeout_test']
+    sos_cmd = '-vvv -o timeout_test,networking -k timeout_test.timeout=1 --plugin-timeout=123'
+
+    def test_timeouts_separate(self):
+        self.assertSosUILogContains('Plugin timeout_test timed out')
+        self.assertSosUILogNotContains('Plugin networking timed out')
+
+    def test_timeout_manifest_recorded(self):
+        testm = self.get_plugin_manifest('timeout_test')
+        self.assertTrue(testm['timeout_hit'])
+        self.assertTrue(testm['timeout'] == 1)
+
+        netm = self.get_plugin_manifest('networking')
+        self.assertFalse(netm['timeout_hit'])
+        self.assertTrue(netm['timeout'] == 123)


### PR DESCRIPTION
It was discovered that setting a specific plugin timeout via the `-k
$plugin.timeout` option could influence the timeout setting for other
plugins that are not also having their timeout explicitly set. Fix this
by moving the default plugin opts into `Plugin.__init__()` so that each
plugin is ensured a private copy of these default plugin options.

Additionally, add more timeout data to plugin manifest entries to allow
for better tracking of this setting.

Adds a test case for this scenario.

Closes: #2744

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?