### PR TITLE
[report] shutdown threads for timeouted plugins

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1046,6 +1046,7 @@ class SoSReport(SoSComponent):
                 self.ui_log.error("\n Plugin %s timed out\n" % plugin[1])
                 self.running_plugs.remove(plugin[1])
                 self.loaded_plugins[plugin[0]-1][1].set_timeout_hit()
+                pool.shutdown(wait=True)
                 pool._threads.clear()
         if self.opts.estimate_only:
             from pathlib import Path


### PR DESCRIPTION
Wait for shutting down threads of timeouted plugins, to prevent
them in writing to moved auxiliary files like sos_logs/sos.log

Resolves: #2722
Closes: #2746

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?