### PR TITLE
[report] fix filter_namespace per pattern

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2953,21 +2953,20 @@ class Plugin():
                 )
         for ns in ns_list:
             # if ns_pattern defined, skip namespaces not matching the pattern
-            if ns_pattern:
-                if not bool(re.match(pattern, ns)):
-                    continue
+            if ns_pattern and not bool(re.match(pattern, ns)):
+                continue
+            out_ns.append(ns)
 
-            # if ns_max is defined at all, limit returned list to that number
+            # if ns_max is defined at all, break the loop when the limit is
+            # reached
             # this allows the use of both '0' and `None` to mean unlimited
-            elif ns_max:
-                out_ns.append(ns)
+            if ns_max:
                 if len(out_ns) == ns_max:
                     self._log_warn("Limiting namespace iteration "
                                    "to first %s namespaces found"
                                    % ns_max)
                     break
-            else:
-                out_ns.append(ns)
+
         return out_ns
 
 


### PR DESCRIPTION
Curently, -k networking.namespace_pattern=.. is broken as the R.E. test
forgets to add the namespace in case of positive match.

Resolves: #2748

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?