### PR TITLE
[sos] Add a new `help` component

### DIFF
--- a/man/en/sos-help.1
+++ b/man/en/sos-help.1
@@ -1,0 +1,41 @@
+.TH SOS HELP 1 "Fri Nov 05 2021"
+.SH NAME
+sos help - get detailed help information on sos commands and components
+.SH SYNOPSIS
+.B sos help TOPIC
+
+.SH DESCRIPTION
+\fBsos help\fR is used to retrieve more detailed information on the various SoS
+commands and components than is directly available in either other manpages or
+--help output.
+
+This information could for example be investigating a specific plugin to learn more
+about its purpose, use case, collections, available plugin options, edge cases, and
+more.
+.LP
+Most aspects of SoS' operation can be investigated this way - the top level functions
+such as \fB report, clean,\fR and \fBcollect\fR, as well as constructs that allow those
+functions to work; e.g. \fBtransports\fR within \fBsos collect\fR that define how that
+function connects to remote nodes.
+
+.SH REQUIRED ARGUMENTS
+.B TOPIC
+.TP
+The section or topic to retrieve detailed help information for. TOPIC takes the general
+form of \fBcommand.component.entity\fR, with \fBcomponent\fR and \fBentity\fR
+being optional.
+.LP
+Top-level \fBcommand\fR help sections will often direct users to \fBcomponent\fR sections
+which in turn may point to further \fBentity\fR subsections.
+
+Some of the more useful or interesting sections are listed below:
+
+    \fBTopic\fR                     \fBDescription\fR
+
+    \fBreport\fR                    The \fBsos report\fR command
+    \fBreport.plugins\fR            Information on what report plugins are
+    \fBreport.plugins.$plugin\fR    Information on a specific plugin
+    \fBclean\fR or \fBmask\fR             The \fBsos clean|mask\fR command
+    \fBcollect\fR                   The \fBsos collect\fR command
+    \fBcollect.clusters\fR          How \fBcollect\fR enumerates nodes in a cluster
+    \fBpolicies\fR                  How SoS behaves on different distributions

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -59,9 +59,11 @@ class SoS():
         # if no aliases are desired, pass an empty list
         import sos.report
         import sos.cleaner
+        import sos.help
         self._components = {
             'report': (sos.report.SoSReport, ['rep']),
-            'clean': (sos.cleaner.SoSCleaner, ['cleaner', 'mask'])
+            'clean': (sos.cleaner.SoSCleaner, ['cleaner', 'mask']),
+            'help': (sos.help.SoSHelper, [])
         }
         # some distros do not want pexpect as a default dep, so try to load
         # collector here, and if it fails add an entry that implies it is at

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -11,6 +11,7 @@
 import logging
 
 from sos.options import ClusterOption
+from sos.utilities import bold
 from threading import Lock
 
 
@@ -80,6 +81,107 @@ class Cluster():
         if cls.cluster_name:
             return cls.cluster_name
         return cls.__name__.lower()
+
+    @classmethod
+    def display_help(cls, section):
+        if cls is Cluster:
+            cls.display_self_help(section)
+            return
+        section.set_title("%s Cluster Profile Detailed Help"
+                          % cls.cluster_name)
+        if cls.__doc__ and cls.__doc__ is not Cluster.__doc__:
+            section.add_text(cls.__doc__)
+        # [1] here is the actual cluster profile
+        elif cls.__mro__[1].__doc__ and cls.__mro__[1] is not Cluster:
+            section.add_text(cls.__mro__[1].__doc__)
+        else:
+            section.add_text(
+                "\n\tDetailed help not available for this profile\n"
+            )
+
+        if cls.packages:
+            section.add_text(
+                "Enabled by the following packages: %s"
+                % ', '.join(p for p in cls.packages),
+                newline=False
+            )
+
+        if cls.sos_preset:
+            section.add_text(
+                "Uses the following sos preset: %s" % cls.sos_preset,
+                newline=False
+            )
+
+        if cls.sos_plugins:
+            section.add_text(
+                "Enables the following plugins: %s"
+                % ', '.join(plug for plug in cls.sos_plugins),
+                newline=False
+            )
+
+        if cls.sos_plugin_options:
+            _opts = cls.sos_plugin_options
+            opts = ', '.join("%s=%s" % (opt, _opts[opt]) for opt in _opts)
+            section.add_text(
+                "Sets the following plugin options: %s" % opts,
+                newline=False
+            )
+
+        if cls.option_list:
+            optsec = section.add_section("Available cluster options")
+            optsec.add_text(
+                "These options may be toggled or changed using '%s'"
+                % bold("-c %s.$option=$value" % cls.__name__)
+            )
+            optsec.add_text(bold(
+                "\n{:<4}{:<20}{:<30}{:<20}\n".format(
+                    ' ', "Option Name", "Default", "Description")
+                ), newline=False
+            )
+            for opt in cls.option_list:
+                val = opt[1]
+                if isinstance(val, bool):
+                    if val:
+                        val = 'True/On'
+                    else:
+                        val = 'False/Off'
+                _ln = "{:<4}{:<20}{:<30}{:<20}".format(' ', opt[0], val,
+                                                       opt[2])
+                optsec.add_text(_ln, newline=False)
+
+    @classmethod
+    def display_self_help(cls, section):
+        section.set_title('SoS Collect Cluster Profiles Detailed Help')
+        section.add_text(
+            '\nCluster profiles are used to represent different clustering '
+            'technologies or platforms. Profiles define how cluster nodes are '
+            'discovered, and optionally filtered, for default executions of '
+            'collector.'
+        )
+        section.add_text(
+            'Cluster profiles are enabled similarly to SoS report plugins; '
+            'usually by package, command, or configuration file presence. '
+            'Clusters may also define default transports for SoS collect.'
+        )
+
+        from sos.collector import SoSCollector
+        import inspect
+        clusters = SoSCollector._load_modules(inspect.getmodule(cls),
+                                              'clusters')
+
+        section.add_text(
+            'The following cluster profiles are locally available:\n'
+        )
+        section.add_text(
+            "{:>8}{:<40}{:<30}".format(' ', 'Name', 'Description'),
+            newline=False
+        )
+        for cluster in clusters:
+            _sec = bold("collect.clusters.%s" % cluster[0])
+            section.add_text(
+                "{:>8}{:<40}{:<30}".format(' ', _sec, cluster[1].cluster_name),
+                newline=False
+            )
 
     def _get_options(self):
         """Loads the options defined by a cluster and sets the default value"""

--- a/sos/collector/clusters/jbon.py
+++ b/sos/collector/clusters/jbon.py
@@ -12,11 +12,14 @@ from sos.collector.clusters import Cluster
 
 
 class jbon(Cluster):
-    '''Just a Bunch of Nodes
+    """
+    Used when --cluster-type=none (or jbon) to avoid cluster checks, and just
+    use the provided --nodes list.
 
-    Used when --cluster-type=none (or jbon), to avoid cluster checks, and just
-    use the provided --nodes list
-    '''
+    Using this profile will skip any and all operations that a cluster profile
+    normally performs, and will not set any plugins, plugin options, or presets
+    for the sos report generated on the nodes provided by --nodes.
+    """
 
     cluster_name = 'Just a Bunch Of Nodes (no cluster)'
     packages = None

--- a/sos/collector/clusters/kubernetes.py
+++ b/sos/collector/clusters/kubernetes.py
@@ -13,7 +13,12 @@ from sos.collector.clusters import Cluster
 
 
 class kubernetes(Cluster):
-
+    """
+    The kuberentes cluster profile is intended to be used on kubernetes
+    clusters built from the upstream/source kubernetes (k8s) project. It is
+    not intended for use with other projects or platforms that are built ontop
+    of kubernetes.
+    """
     cluster_name = 'Community Kubernetes'
     packages = ('kubernetes-master',)
     sos_plugins = ['kubernetes']

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -16,7 +16,40 @@ from sos.utilities import is_executable
 
 
 class ocp(Cluster):
-    """OpenShift Container Platform v4"""
+    """
+    This profile is for use with OpenShift Container Platform (v4) clusters
+    instead of the kubernetes profile.
+
+    This profile will favor using the `oc` transport type, which means it will
+    leverage a locally installed `oc` binary. This is also how node enumeration
+    is done. To instead use SSH to connect to the nodes, use the
+    '--transport=control_persist' option.
+
+    Thus, a functional `oc` binary for the user executing sos collect is
+    required. Functional meaning that the user can run `oc` commands with
+    clusterAdmin privileges.
+
+    If this requires the use of a secondary configuration file, specify that
+    path with the 'kubeconfig' cluster option.
+
+    Alternatively, provide a clusterAdmin access token either via the 'token'
+    cluster option or, preferably, the SOSOCPTOKEN environment variable.
+
+    By default, this profile will enumerate only master nodes within the
+    cluster, and this may be changed by overriding the 'role' cluster option.
+    To collect from all nodes in the cluster regardless of role, use the form
+    -c ocp.role=''.
+
+    Filtering nodes by a label applied to that node is also possible via the
+    label cluster option, though be aware that this is _combined_ with the role
+    option mentioned above.
+
+    To avoid redundant collections of OCP API information (e.g. 'oc get'
+    commands), this profile will attempt to enable the openshift plugin on only
+    a single master node. If the none of the master nodes have a functional
+    'oc' binary available, *and* the --no-local option is used, that means that
+    no API data will be collected.
+    """
 
     cluster_name = 'OpenShift Container Platform v4'
     packages = ('openshift-hyperkube', 'openshift-clients')

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -17,6 +17,33 @@ ENGINE_KEY = '/etc/pki/ovirt-engine/keys/engine_id_rsa'
 
 
 class ovirt(Cluster):
+    """
+    This cluster profile is for the oVirt/RHV project which provides for a
+    virtualization cluster built ontop of KVM.
+
+    Nodes enumerated will be hypervisors within the envrionment, not virtual
+    machines running on those hypervisors. By default, ALL hypervisors within
+    the environment are returned. This may be influenced by the 'cluster' and
+    'datacenter' cluster options, which will limit enumeration to hypervisors
+    within the specific cluster and/or datacenter. The spm-only cluster option
+    may also be used to only collect from hypervisors currently holding the
+    SPM role.
+
+    Optionally, to only collect an archive from manager and the postgresql
+    database, use the no-hypervisors cluster option.
+
+    By default, a second archive from the manager will be collected that is
+    just the postgresql plugin configured in such a way that a dump of the
+    manager's database that can be explored and restored to other systems will
+    be collected.
+
+    The ovirt profile focuses on the upstream, community ovirt project.
+
+    The rhv profile is for Red Hat customers running RHV (formerly RHEV).
+
+    The rhhi_virt profile is for Red Hat customers running RHV in a
+    hyper-converged setup and enables gluster collections.
+    """
 
     cluster_name = 'Community oVirt'
     packages = ('ovirt-engine',)

--- a/sos/collector/clusters/satellite.py
+++ b/sos/collector/clusters/satellite.py
@@ -13,7 +13,14 @@ from sos.collector.clusters import Cluster
 
 
 class satellite(Cluster):
-    """Red Hat Satellite 6"""
+    """
+    This profile is specifically for Red Hat Satellite 6, and not earlier
+    releases of Satellite.
+
+    While note technically a 'cluster' in the traditional sense, Satellite
+    does provide for 'capsule' nodes which is what this profile aims to
+    enumerate beyond the 'primary' Satellite system.
+    """
 
     cluster_name = 'Red Hat Satellite 6'
     packages = ('satellite', 'satellite-installer')

--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -16,6 +16,7 @@ import re
 from pipes import quote
 from sos.collector.exceptions import (ConnectionException,
                                       CommandTimeoutException)
+from sos.utilities import bold
 
 
 class RemoteTransport():
@@ -87,6 +88,53 @@ class RemoteTransport():
         when loading a policy for a remote node
         """
         return None
+
+    @classmethod
+    def display_help(cls, section):
+        if cls is RemoteTransport:
+            return cls.display_self_help(section)
+        section.set_title("%s Transport Detailed Help"
+                          % cls.name.title().replace('_', ' '))
+        if cls.__doc__ and cls.__doc__ is not RemoteTransport.__doc__:
+            section.add_text(cls.__doc__)
+        else:
+            section.add_text(
+                'Detailed information not available for this transport'
+            )
+
+    @classmethod
+    def display_self_help(cls, section):
+        section.set_title('SoS Remote Transport Help')
+        section.add_text(
+            "\nTransports define how SoS connects to nodes and executes "
+            "commands on them for the purposes of an %s run. Generally, "
+            "this means transports define how commands are wrapped locally "
+            "so that they are executed on the remote node(s) instead."
+            % bold('sos collect')
+        )
+
+        section.add_text(
+            "Transports are generally selected by the cluster profile loaded "
+            "for a given execution, however users may explicitly set one "
+            "using '%s'. Note that not all transports will function for all "
+            "cluster/node types."
+            % bold('--transport=$transport_name')
+        )
+
+        section.add_text(
+            'By default, OpenSSH Control Persist is attempted. Additional '
+            'information for each supported transport is available in the '
+            'following help sections:\n'
+        )
+
+        from sos.collector.sosnode import TRANSPORTS
+        for transport in TRANSPORTS:
+            _sec = bold("collect.transports.%s" % transport)
+            _desc = "The '%s' transport" % transport.lower()
+            section.add_text(
+                "{:>8}{:<45}{:<30}".format(' ', _sec, _desc),
+                newline=False
+            )
 
     def connect(self, password):
         """Perform the connection steps in order to ensure that we are able to

--- a/sos/collector/transports/control_persist.py
+++ b/sos/collector/transports/control_persist.py
@@ -26,10 +26,18 @@ from sos.utilities import sos_get_command_output
 
 
 class SSHControlPersist(RemoteTransport):
-    """A transport for collect that leverages OpenSSH's Control Persist
+    """
+    A transport for collect that leverages OpenSSH's ControlPersist
     functionality which uses control sockets to transparently keep a connection
     open to the remote host without needing to rebuild the SSH connection for
-    each and every command executed on the node
+    each and every command executed on the node.
+
+    This transport will by default assume the use of SSH keys, meaning keys
+    have already been distributed to target nodes. If this is not the case,
+    users will need to provide a password using the --password or
+    --password-per-node option, depending on if the password to connect to all
+    nodes is the same or not. Note that these options prevent the use of the
+    --batch option, as they require user input.
     """
 
     name = 'control_persist'

--- a/sos/collector/transports/local.py
+++ b/sos/collector/transports/local.py
@@ -15,9 +15,10 @@ from sos.collector.transports import RemoteTransport
 
 
 class LocalTransport(RemoteTransport):
-    """A 'transport' to represent a local node. This allows us to more easily
-    extend SoSNode() without having a ton of 'if local' or similar checks in
-    more places than we actually need them
+    """
+    A 'transport' to represent a local node. No remote connection is actually
+    made, and all commands set to be run by this transport are executed locally
+    without any wrappers.
     """
 
     name = 'local_node'

--- a/sos/collector/transports/oc.py
+++ b/sos/collector/transports/oc.py
@@ -18,15 +18,29 @@ from sos.utilities import (is_executable, sos_get_command_output,
 
 
 class OCTransport(RemoteTransport):
-    """This transport leverages the execution of commands via a locally
+    """
+    This transport leverages the execution of commands via a locally
     available and configured ``oc`` binary for OCPv4 environments.
+
+    The location of the oc binary MUST be in the $PATH used by the locally
+    loaded SoS policy. Specifically this means that the binary cannot be in the
+    running user's home directory, such as ~/.local/bin.
 
     OCPv4 clusters generally discourage the use of SSH, so this transport may
     be used to remove our use of SSH in favor of the environment provided
     method of connecting to nodes and executing commands via debug pods.
 
-    Note that this approach will generate multiple debug pods over the course
-    of our execution
+    The debug pod created will be a privileged pod that mounts the host's
+    filesystem internally so that sos report collections reflect the host, and
+    not the container in which it runs.
+
+    This transport will execute within a temporary 'sos-collect-tmp' project
+    created by the OCP cluster profile. The project will be removed at the end
+    of execution.
+
+    In the event of failures due to a misbehaving OCP API or oc binary, it is
+    recommended to fallback to the control_persist transport by manually
+    setting the --transport option.
     """
 
     name = 'oc'

--- a/sos/component.py
+++ b/sos/component.py
@@ -50,6 +50,7 @@ class SoSComponent():
     arg_defaults = {}
     configure_logging = True
     load_policy = True
+    load_probe = True
     root_required = False
 
     _arg_defaults = {
@@ -106,13 +107,7 @@ class SoSComponent():
             self._setup_logging()
 
         if self.load_policy:
-            try:
-                import sos.policies
-                self.policy = sos.policies.load(sysroot=self.opts.sysroot)
-                self.sysroot = self.policy.sysroot
-            except KeyboardInterrupt:
-                self._exit(0)
-            self._is_root = self.policy.is_root()
+            self.load_local_policy()
 
         if self.manifest is not None:
             self.manifest.add_field('version', __version__)
@@ -126,6 +121,16 @@ class SoSComponent():
             self.manifest.add_field('tmpdir_fs_type', self.tmpfstype)
             self.manifest.add_field('policy', self.policy.distro)
             self.manifest.add_section('components')
+
+    def load_local_policy(self):
+        try:
+            import sos.policies
+            self.policy = sos.policies.load(sysroot=self.opts.sysroot,
+                                            probe_runtime=self.load_probe)
+            self.sysroot = self.policy.sysroot
+        except KeyboardInterrupt:
+            self._exit(0)
+        self._is_root = self.policy.is_root()
 
     def execute(self):
         raise NotImplementedError

--- a/sos/help/__init__.py
+++ b/sos/help/__init__.py
@@ -1,0 +1,302 @@
+# Copyright 2020 Red Hat, Inc. Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import inspect
+import importlib
+import sys
+import os
+
+from collections import OrderedDict
+from sos.component import SoSComponent
+from sos.policies import import_policy
+from sos.report.plugins import Plugin
+from sos.utilities import bold, ImporterHelper
+from textwrap import fill
+
+try:
+    TERMSIZE = min(os.get_terminal_size().columns, 120)
+except Exception:
+    TERMSIZE = 120
+
+
+class SoSHelper(SoSComponent):
+    """Provide better, more in-depth help for specific parts of sos than is
+    provided in either standard --help output or in manpages.
+    """
+
+    desc = 'Detailed help infomation'
+    configure_logging = False
+    load_policy = False
+    load_probe = False
+
+    arg_defaults = {
+        'topic': ''
+    }
+
+    def __init__(self, parser, args, cmdline):
+        super(SoSHelper, self).__init__(parser, args, cmdline)
+        self.topic = self.opts.topic
+
+    @classmethod
+    def add_parser_options(cls, parser):
+        parser.usage = 'sos help TOPIC [options]'
+        help_grp = parser.add_argument_group(
+            'Help Information Options',
+            'These options control what detailed information is displayed'
+        )
+        help_grp.add_argument('topic', metavar='TOPIC', default='', nargs='?',
+                              help=('name of the topic or component to show '
+                                    'help for'))
+
+    def sanitize_topic_component(self):
+        _com = self.opts.topic.split('.')[0]
+        _replace = {
+            'clean': 'cleaner',
+            'mask': 'cleaner',
+            'collect': 'collector'
+        }
+        if _com in _replace:
+            self.opts.topic = self.opts.topic.replace(_com, _replace[_com])
+
+    def execute(self):
+        if not self.opts.topic:
+            self.display_self_help()
+            sys.exit(0)
+
+        # standardize the command to the module naming pattern
+        self.sanitize_topic_component()
+
+        try:
+            klass = self.get_obj_for_topic()
+        except Exception as err:
+            print("Could not load help for '%s': %s" % (self.opts.topic, err))
+            sys.exit(1)
+
+        if klass:
+            try:
+                ht = HelpSection()
+                klass.display_help(ht)
+                ht.display()
+            except Exception as err:
+                print("Error loading help: %s" % err)
+        else:
+            print("No help section found for '%s'" % self.opts.topic)
+
+    def get_obj_for_topic(self):
+        """Based on the help topic we're after, try to smartly decide which
+        object we need to manipulate in order to get help information.
+        """
+        static_map = {
+            'report': 'SoSReport',
+            'report.plugins': 'Plugin',
+            'cleaner': 'SoSCleaner',
+            'collector': 'SoSCollector',
+            'collector.transports': 'RemoteTransport',
+            'collector.clusters': 'Cluster',
+            'policies': 'Policy'
+        }
+
+        cls = None
+
+        if self.opts.topic in static_map:
+            mod = importlib.import_module('sos.' + self.opts.topic)
+            cls = getattr(mod, static_map[self.opts.topic])
+        else:
+            _help = {
+                'report.plugins.': self._get_plugin_variant,
+                'policies.': self._get_policy_by_name,
+                'collector.transports.': self._get_collect_transport,
+                'collector.clusters.': self._get_collect_cluster,
+            }
+            for _sec in _help:
+                if self.opts.topic.startswith(_sec):
+                    cls = _help[_sec]()
+                    break
+        return cls
+
+    def _get_collect_transport(self):
+        from sos.collector.sosnode import TRANSPORTS
+        _transport = self.opts.topic.split('.')[-1]
+        if _transport in TRANSPORTS:
+            return TRANSPORTS[_transport]
+
+    def _get_collect_cluster(self):
+        from sos.collector import SoSCollector
+        import sos.collector.clusters
+        clusters = SoSCollector._load_modules(sos.collector.clusters,
+                                              'clusters')
+        for cluster in clusters:
+            if cluster[0] == self.opts.topic.split('.')[-1]:
+                return cluster[1]
+
+    def _get_plugin_variant(self):
+        mod = importlib.import_module('sos.' + self.opts.topic)
+        self.load_local_policy()
+        mems = inspect.getmembers(mod, inspect.isclass)
+        plugins = [m[1] for m in mems if issubclass(m[1], Plugin)]
+        for plugin in plugins:
+            if plugin.__subclasses__():
+                cls = self.policy.match_plugin(plugin.__subclasses__())
+                return cls
+
+    def _get_policy_by_name(self):
+        _topic = self.opts.topic.split('.')[-1]
+        # mimic policy loading to discover all policiy classes without
+        # needing to manually define each here
+        import sos.policies.distros
+        _helper = ImporterHelper(sos.policies.distros)
+        for mod in _helper.get_modules():
+            for policy in import_policy(mod):
+                _p = policy.__name__.lower().replace('policy', '')
+                if _p == _topic:
+                    return policy
+
+    def display_self_help(self):
+        """Displays the help information for this component directly, that is
+        help for `sos help`.
+        """
+        self_help = HelpSection(
+            'Detailed help for sos help',
+            ('The \'help\' sub-command is used to provide more detailed '
+             'information on different sub-commands available to sos as well '
+             'as different components at play within those sub-commands.')
+        )
+        self_help.add_text(
+            'SoS - officially pronounced "ess-oh-ess" - is a diagnostic and '
+            'supportability utility used by several Linux distributions as an '
+            'easy-to-use tool for standardized data collection. The most known'
+            ' component of which is %s (formerly sosreport) which is used to '
+            'collect troubleshooting information into an archive for review '
+            'by sysadmins or technical support teams.'
+            % bold('sos report')
+        )
+
+        subsect = self_help.add_section('How to search using sos help')
+        usage = bold('$component.$topic.$subtopic')
+        subsect.add_text(
+            'To get more information on a given topic, use the form \'%s\'.'
+            % usage
+        )
+
+        rep_ex = bold('sos help report.plugins.kernel')
+        subsect.add_text("For example '%s' will provide more information on "
+                         "the kernel plugin for the report function." % rep_ex)
+
+        avail_help = self_help.add_section('Available Help Sections')
+        avail_help.add_text(
+            'The following help sections are available. Additional help'
+            ' topics and subtopics may be displayed within their respective '
+            'help section.\n'
+        )
+
+        sections = {
+            'report':   'Detailed help on the report command',
+            'report.plugins': 'Information on the plugin design of sos',
+            'report.plugins.$plugin': 'Information on a specific $plugin',
+            'clean':    'Detailed help on the clean command',
+            'collect':  'Detailed help on the collect command',
+            'policies': 'How sos operates on different distributions'
+        }
+
+        for sect in sections:
+            avail_help.add_text(
+                "\t{:<36}{}".format(bold(sect), sections[sect]),
+                newline=False
+            )
+
+        self_help.display()
+
+
+class HelpSection():
+    """This class is used to build the output displayed by `sos help` in a
+    standard fashion that provides easy formatting controls.
+    """
+
+    def __init__(self, title='', content='', indent=''):
+        """
+        :param title:   The title of the output section, will be prominently
+                        displayed
+        :type title:    ``str``
+
+        :param content: The text content to be displayed with this section
+        :type content:  ``str``
+
+        :param indent:  If the section should be nested, set this to a multiple
+                        of 4.
+        :type indent:   ``int``
+        """
+        self.title = title
+        self.content = content
+        self.indent = indent
+        self.sections = OrderedDict()
+
+    def set_title(self, title):
+        """Set or override the title for this help section
+
+        :param title:   The name to set for this help section
+        :type title:    ``str``
+        """
+        self.title = title
+
+    def add_text(self, content, newline=True):
+        """Add body text to this section. If content for this section already
+        exists, append the new ``content`` after a newline.
+
+        :param content:     The text to add to the section
+        :type content:      ``str``
+        """
+        if self.content:
+            ln = '\n\n' if newline else '\n'
+            content = ln + content
+        self.content += content
+
+    def add_section(self, title, content='', indent=''):
+        """Add a section of text to the help section that will be displayed
+        when the HelpSection object is printed.
+
+        Sections will be printed *in the order added*.
+
+        This will return a subsection object with which block(s) of text may be
+        added to the subsection associated with ``title``.
+
+        :param title:   The title of the subsection being added
+        :type title:    ``str``
+
+        :param content: The text the new section should contain
+        :type content:  ``str``
+
+        :returns:   The newly created subsection for ``title``
+        :rtype:     ``HelpSection``
+        """
+        self._add_section(title, content, indent)
+        return self.sections[title]
+
+    def _add_section(self, title, content='', indent=''):
+        """Internal method used to add a new subsection to this help output
+
+        :param title:   The title of the subsection being added
+        :type title:    ``str`
+        """
+        if title in self.sections:
+            raise Exception('A section with that title already exists')
+        self.sections[title] = HelpSection(title, content, indent)
+
+    def display(self):
+        """Print the HelpSection contents, including any subsections, to
+        console.
+        """
+        print(fill(
+            bold(self.title), width=TERMSIZE, initial_indent=self.indent
+        ))
+        for ln in self.content.splitlines():
+            print(fill(ln, width=TERMSIZE, initial_indent=self.indent))
+        for section in self.sections:
+            print('')
+            self.sections[section].display()

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -10,7 +10,8 @@ from pwd import getpwuid
 from sos.presets import (NO_PRESET, GENERIC_PRESETS, PRESETS_PATH,
                          PresetDefaults, DESC, NOTE, OPTS)
 from sos.policies.package_managers import PackageManager
-from sos.utilities import ImporterHelper, import_module, get_human_readable
+from sos.utilities import (ImporterHelper, import_module, get_human_readable,
+                           bold)
 from sos.report.plugins import IndependentPlugin, ExperimentalPlugin
 from sos.options import SoSOptions
 from sos import _sos as _
@@ -354,6 +355,49 @@ any third party.
         """Returns the string name of the hashlib-supported checksum algorithm
         to use"""
         return "sha256"
+
+    @classmethod
+    def display_help(self, section):
+        section.set_title('SoS Policies')
+        section.add_text(
+            'Policies help govern how SoS operates on across different distri'
+            'butions of Linux. They control aspects such as plugin enablement,'
+            ' $PATH determination, how/which package managers are queried, '
+            'default upload specifications, and more.'
+        )
+
+        section.add_text(
+            "When SoS intializes most functions, for example %s and %s, one "
+            "of the first operations is to determine the correct policy to "
+            "load for the local system. Policies will determine the proper "
+            "package manager to use, any applicable container runtime(s), and "
+            "init systems so that SoS and report plugins can properly function"
+            " for collections. Generally speaking a single policy will map to"
+            " a single distribution; for example there are separate policies "
+            "for Debian, Ubuntu, RHEL, and Fedora."
+            % (bold('sos report'), bold('sos collect'))
+        )
+
+        section.add_text(
+            "It is currently not possible for users to directly control which "
+            "policy is loaded."
+        )
+
+        pols = {
+            'policies.cos': 'The Google Cloud-Optimized OS distribution',
+            'policies.debian': 'The Debian distribution',
+            'policies.redhat': ('Red Hat family distributions, not necessarily'
+                                ' including forks'),
+            'policies.ubuntu': 'Ubuntu/Canonical distributions'
+        }
+
+        seealso = section.add_section('See Also')
+        seealso.add_text(
+            "For more information on distribution policies, see below\n"
+        )
+        for pol in pols:
+            seealso.add_text("{:>8}{:<20}{:<30}".format(' ', pol, pols[pol]),
+                             newline=False)
 
     def display_results(self, archive, directory, checksum, archivestat=None,
                         map_file=None):

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -174,7 +174,7 @@ class LinuxPolicy(Policy):
         # information like $PATH and loaded presets
         _pol = cls(None, None, False)
         section.add_text(
-            "\nDefault --upload location: %s" % _pol._upload_url
+            "Default --upload location: %s" % _pol._upload_url
         )
         section.add_text(
             "Default container runtime: %s" % _pol.default_container_runtime,

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -19,6 +19,7 @@ from sos.presets.redhat import (RHEL_PRESETS, ATOMIC_PRESETS, RHV, RHEL,
                                 ATOMIC)
 from sos.policies.distros import LinuxPolicy, ENV_HOST_SYSROOT
 from sos.policies.package_managers.rpm import RpmPackageManager
+from sos.utilities import bold
 from sos import _sos as _
 
 try:
@@ -92,6 +93,31 @@ class RedHatPolicy(LinuxPolicy):
         available one.
         """
         return False
+
+    @classmethod
+    def display_distro_help(cls, section):
+        if cls is not RedHatPolicy:
+            super(RedHatPolicy, cls).display_distro_help(section)
+            return
+        section.add_text(
+            'This policy is a building block for all other Red Hat family '
+            'distributions. You are likely looking for one of the '
+            'distributions listed below.\n'
+        )
+
+        subs = {
+            'centos': CentOsPolicy,
+            'rhel': RHELPolicy,
+            'redhatcoreos': RedHatCoreOSPolicy,
+            'fedora': FedoraPolicy
+        }
+
+        for subc in subs:
+            subln = bold("policies.%s" % subc)
+            section.add_text(
+                "{:>8}{:<35}{:<30}".format(' ', subln, subs[subc].distro),
+                newline=False
+            )
 
     def check_usrmove(self, pkgs):
         """Test whether the running system implements UsrMove.

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -17,7 +17,7 @@ import logging
 from datetime import datetime
 import glob
 import sos.report.plugins
-from sos.utilities import (ImporterHelper, SoSTimeoutError,
+from sos.utilities import (ImporterHelper, SoSTimeoutError, bold,
                            sos_get_command_output, TIMEOUT_DEFAULT)
 from shutil import rmtree
 import hashlib
@@ -367,6 +367,62 @@ class SoSReport(SoSComponent):
         cleaner_grp.add_argument('--usernames', dest='usernames', default=[],
                                  action='extend',
                                  help='List of usernames to obfuscate')
+
+    @classmethod
+    def display_help(cls, section):
+        section.set_title('SoS Report Detailed Help')
+        section.add_text(
+            'The report command is the most common use case for SoS, and aims '
+            'to collect relevant diagnostic and troubleshooting data to assist'
+            ' with issue analysis without actively performing that analysis on'
+            ' the system while it is in use.'
+        )
+        section.add_text(
+            'Additionally, sos report archives can be used for ongoing '
+            'inspection for pre-emptive issue monitoring, such as that done '
+            'by the Insights project.'
+        )
+
+        section.add_text(
+            'The typical result of an execution of \'sos report\' is a tarball'
+            ' that contains troubleshooting command output, copies of config '
+            'files, and copies of relevant sections of the host filesystem. '
+            'Root privileges are required for collections.'
+        )
+
+        psec = section.add_section(title='How Collections Are Determined')
+        psec.add_text(
+            'SoS report performs it\'s collections by way of \'plugins\' that '
+            'individually specify what files to copy and what commands to run.'
+            ' Plugins typically map to specific components or software '
+            'packages.'
+        )
+        psec.add_text(
+            'Plugins may specify different collections on different distribu'
+            'tions, and some plugins may only be for specific distributions. '
+            'Distributions are represented within SoS by \'policies\' and may '
+            'influence how other SoS commands or options function. For example'
+            'policies can alter where the --upload option defaults to or '
+            'functions.'
+        )
+
+        ssec = section.add_section(title='See Also')
+        ssec.add_text(
+            "For information on available options for report, see %s and %s"
+            % (bold('sos report --help'), bold('man sos-report'))
+        )
+        ssec.add_text("The following %s sections may be of interest:\n"
+                      % bold('sos help'))
+        help_lines = {
+            'report.plugins': 'Information on the plugin design of sos',
+            'report.plugins.$plugin': 'Information on a specific $plugin',
+            'policies': 'How sos operates on different distributions'
+        }
+        helpln = ''
+        for ln in help_lines:
+            ssec.add_text("\t{:<36}{}".format(ln, help_lines[ln]),
+                          newline=False)
+        ssec.add_text(helpln)
 
     def print_header(self):
         print("\n%s\n" % _("sosreport (version %s)" % (__version__,)))

--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -11,6 +11,19 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class Apache(Plugin):
+    """The Apache plugin covers the upstream Apache webserver project,
+    regardless of the packaged name; apache2 for Debian and Ubuntu, or httpd
+    for Red Hat family distributions.
+
+    The aim of this plugin is for Apache-specific information, not necessarily
+    other projects that happen to place logs or similar files within the
+    standardized apache directories. For example, OpenStack components that log
+    to apache logging directories are excluded from this plugin and collected
+    via their respective OpenStack plugins.
+
+    Users can expect the collection of apachectl command output, apache server
+    logs, and apache configuration files from this plugin.
+    """
 
     short_desc = 'Apache http daemon'
     plugin_name = "apache"
@@ -49,6 +62,15 @@ class Apache(Plugin):
 
 
 class RedHatApache(Apache, RedHatPlugin):
+    """
+    On Red Hat distributions, the Apache plugin will also attempt to collect
+    JBoss Web Server logs and configuration files.
+
+    Note that for Red Hat distributions, this plugin explicitly collects for
+    'httpd' installations. If you have installed apache from source or via any
+    method that uses the name 'apache' instead of 'httpd', these collections
+    will fail.
+    """
     files = (
         '/etc/httpd/conf/httpd.conf',
         '/etc/httpd22/conf/httpd.conf',

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -11,6 +11,15 @@ from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
 
 
 class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
+    """Collects general information about the local filesystem(s) and mount
+    points as well as optional information about EXT filesystems. Note that
+    information specific filesystems such as XFS or ZFS is not collected by
+    this plugin, as there are specific plugins for those filesystem types.
+
+    This plugin will collect /etc/fstab as well as mount information within
+    /proc/, and is responsible for the 'mount' and 'df' symlinks that appear
+    in an sos archive's root.
+    """
 
     short_desc = 'Local file systems'
 

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -11,6 +11,20 @@ import glob
 
 
 class Kernel(Plugin, IndependentPlugin):
+    """The Kernel plugin is aimed at collecting general information about
+    the locally running kernel. This information should be distribution-neutral
+    using commands and filesystem collections that are ubiquitous across
+    distributions.
+
+    Debugging information from /sys/kernel/debug is collected by default,
+    however care is taken so that these collections avoid areas like
+    /sys/kernel/debug/tracing/trace_pipe which would otherwise cause the
+    sos collection attempt to appear to 'hang'.
+
+    The 'trace' option will enable the collection of the
+    /sys/kernel/debug/tracing/trace file specfically, but will not change the
+    behavior stated above otherwise.
+    """
 
     short_desc = 'Linux kernel'
 

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -12,6 +12,16 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
 
 
 class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
+    """Podman is a daemonless container management engine, and this plugin is
+    meant to provide diagnostic information for both the engine and the
+    containers that podman is managing.
+
+    General status information will be collected from podman commands, while
+    detailed inspections of certain components will provide more insight
+    into specific container problems. This detailed inspection is provided for
+    containers, images, networks, and volumes. Per-entity inspections will be
+    recorded in subdirs within sos_commands/podman/ for each of those types.
+    """
 
     short_desc = 'Podman containers'
     plugin_name = 'podman'
@@ -20,9 +30,19 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
     option_list = [
         PluginOpt('all', default=False,
-                  desc='collect for all containers, even terminated ones'),
+                  desc='collect for all containers, even terminated ones',
+                  long_desc=(
+                    'Enable collection for all containers that exist on the '
+                    'system regardless of their running state. This may cause '
+                    'a significant increase in sos archive size, especially '
+                    'when combined with the \'logs\' option.')),
         PluginOpt('logs', default=False,
-                  desc='collect stdout/stderr logs for containers'),
+                  desc='collect stdout/stderr logs for containers',
+                  long_desc=(
+                    'Capture \'podman logs\' output for discovered containers.'
+                    ' This may be useful or not depending on how/if the '
+                    'container produces stdout/stderr output. Use cautiously '
+                    'when also using the \'all\' option.')),
         PluginOpt('size', default=False,
                   desc='collect image sizes for podman ps')
     ]

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -285,6 +285,19 @@ def path_join(path, *p, sysroot=os.sep):
     return os.path.join(path, *p)
 
 
+def bold(text):
+    """Helper to make text bold in console output, without pulling in
+    dependencies to the project unneccessarily.
+
+    :param text:    The text to make bold
+    :type text:     ``str``
+
+    :returns:       The text wrapped in the ASCII codes to display as bold
+    :rtype:         ``str``
+    """
+    return '\033[1m' + text + '\033[0m'
+
+
 class FakeReader():
     """Used as a replacement AsyncReader for when we are writing directly to
     disk, and allows us to keep more simplified flows for executing,


### PR DESCRIPTION
This patchset adds a new `help` component, enabling the execution of `sos help $topic`.

This subcommand is intended to provide more detailed information on the various parts of the SoS project that cannot reasonably be maintained in a manpage or `--help` output.

For this initial implementation, I have added help for `report`, `collect`, `clean|mask`, as well as various constructs within those commands. I have not yet however added help sections for parsers within `clean`, as there is very little user control or interaction there. As we build that out, we can add help sections at that time.

Generally speaking, this makes it so items like plugins have help pages built automatically from the plugins themselves - i.e. enablement criteria, available options, etc... I would eventually like to see if we can include a basic representation of collections the plugin will do. For automatically constructed help sections (plugins, cluster profiles, transports, policies, etc...) the class docstrings are used, so this implies we should put a greater emphasis on including those in future development.

I have updated a few common plugins to serve as examples of how to build out this documentation. Doing this for all 300+ plugins currently in the project is out of scope for this PR, and we can extend those over time.

Closes: #2205 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?