### PR TITLE
Catch exceptions on user prompt for ENTER / Ctrl+C

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -184,6 +184,8 @@ third party.
             except KeyboardInterrupt:
                 self.ui_log.info("\nExiting on user cancel")
                 self._exit(130)
+            except Exception as e:
+                self._exit(1, e)
 
     @classmethod
     def add_parser_options(cls, parser):

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -852,6 +852,8 @@ class SoSCollector(SoSComponent):
             except KeyboardInterrupt:
                 self.cluster.cleanup()
                 self.exit("Exiting on user cancel", 130)
+            except Exception as e:
+                self.exit(repr(e), 1)
 
     def configure_sos_cmd(self):
         """Configures the sosreport command that is run on the nodes"""
@@ -1080,6 +1082,8 @@ this utility or remote systems that it connects to.
                 self.ui_log.info("")
             except KeyboardInterrupt:
                 self.exit("Exiting on user cancel", 130)
+            except Exception as e:
+                self._exit(1, e)
 
     def execute(self):
         if self.opts.list_options:

--- a/sos/component.py
+++ b/sos/component.py
@@ -133,7 +133,10 @@ class SoSComponent():
             self._exit()
         return exit_handler
 
-    def _exit(self, error=0):
+    def _exit(self, error=0, msg=None):
+        if msg:
+            self.ui_log.error("")
+            self.ui_log.error(msg)
         raise SystemExit(error)
 
     def get_tmpdir_default(self):

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -922,9 +922,7 @@ class SoSReport(SoSComponent):
                 self.ui_log.error("Exiting on user cancel")
                 self._exit(130)
             except Exception as e:
-                self.ui_log.info("")
-                self.ui_log.error(e)
-                self._exit(e)
+                self._exit(1, e)
 
     def _log_plugin_exception(self, plugin, method):
         trace = traceback.format_exc()


### PR DESCRIPTION
Catch unhandled EOFError in collector and cleaner.

Update the behaviour in report that redundantly prints
the error message twice.

Resolves: #2751

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?