### PR TITLE
[presets] Optimise OCP preset for hundreds of network namespaces

### DIFF
--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -29,11 +29,15 @@ RHEL_DESC = RHEL_RELEASE_STR
 
 RHOSP = "rhosp"
 RHOSP_DESC = "Red Hat OpenStack Platform"
+RHOSP_OPTS = SoSOptions(plugopts=[
+                             'process.lsof=off',
+                             'networking.ethtool_namespaces=False',
+                             'networking.namespaces=200'])
 
 RHOCP = "ocp"
 RHOCP_DESC = "OpenShift Container Platform by Red Hat"
-RHOSP_OPTS = SoSOptions(plugopts=[
-                             'process.lsof=off',
+RHOCP_OPTS = SoSOptions(all_logs=True, verify=True, plugopts=[
+                             'networking.timeout=600',
                              'networking.ethtool_namespaces=False',
                              'networking.namespaces=200'])
 
@@ -62,7 +66,7 @@ RHEL_PRESETS = {
     RHEL: PresetDefaults(name=RHEL, desc=RHEL_DESC),
     RHOSP: PresetDefaults(name=RHOSP, desc=RHOSP_DESC, opts=RHOSP_OPTS),
     RHOCP: PresetDefaults(name=RHOCP, desc=RHOCP_DESC, note=NOTE_SIZE_TIME,
-                          opts=_opts_all_logs_verify),
+                          opts=RHOCP_OPTS),
     RH_CFME: PresetDefaults(name=RH_CFME, desc=RH_CFME_DESC, note=NOTE_TIME,
                             opts=_opts_verify),
     RH_SATELLITE: PresetDefaults(name=RH_SATELLITE, desc=RH_SATELLITE_DESC,


### PR DESCRIPTION
Sos report on OCP having hundreds of namespaces timeouts in networking
plugin, as it collects >10 commands for each namespace.

Let use a balanced approach in:
- increasing network.timeout
- limiting namespaces to traverse
- disabling ethtool per namespace

to ensure sos report successfully finish in a reasonable time,
collecting rasonable amount of data.

Resolves: #2754

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?