### PR TITLE
[clean] Improve hostname obfuscation sourcing and reliability

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -523,9 +523,14 @@ third party.
                         if isinstance(_parser, SoSUsernameParser):
                             _parser.load_usernames_into_map(content)
                         elif isinstance(_parser, SoSHostnameParser):
-                            _parser.load_hostname_into_map(
-                                content.splitlines()[0]
-                            )
+                            if 'hostname' in parse_file:
+                                _parser.load_hostname_into_map(
+                                    content.splitlines()[0]
+                                )
+                            elif 'etc/hosts' in parse_file:
+                                _parser.load_hostname_from_etc_hosts(
+                                    content
+                                )
                         else:
                             for line in content.splitlines():
                                 self.obfuscate_line(line)

--- a/sos/cleaner/archives/sos.py
+++ b/sos/cleaner/archives/sos.py
@@ -23,7 +23,10 @@ class SoSReportArchive(SoSObfuscationArchive):
     type_name = 'report'
     description = 'sos report archive'
     prep_files = {
-        'hostname': 'sos_commands/host/hostname',
+        'hostname': [
+            'sos_commands/host/hostname',
+            'etc/hosts'
+        ],
         'ip': 'sos_commands/networking/ip_-o_addr',
         'mac': 'sos_commands/networking/ip_-d_address',
         'username': [

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -169,13 +169,13 @@ class SoSHostnameMap(SoSMap):
 
     def sanitize_item(self, item):
         host = item.split('.')
-        if all([h.isupper() for h in host]):
+        if len(host) > 1 and all([h.isupper() for h in host]):
             # by convention we have just a domain
             _host = [h.lower() for h in host]
             return self.sanitize_domain(_host).upper()
         if len(host) == 1:
             # we have a shortname for a host
-            return self.sanitize_short_name(host[0])
+            return self.sanitize_short_name(host[0].lower())
         if len(host) == 2:
             # we have just a domain name, e.g. example.com
             return self.sanitize_domain(host)
@@ -185,7 +185,7 @@ class SoSHostnameMap(SoSMap):
             domain = host[1:]
             # obfuscate the short name
             if len(hostname) > 2:
-                ob_hostname = self.sanitize_short_name(hostname)
+                ob_hostname = self.sanitize_short_name(hostname.lower())
             else:
                 # by best practice it appears the host part of the fqdn was cut
                 # off due to some form of truncating, as such don't obfuscate

--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -61,6 +61,25 @@ class SoSHostnameParser(SoSCleanerParser):
             self.mapping.add(high_domain)
         self.mapping.add(hostname_string)
 
+    def load_hostname_from_etc_hosts(self, content):
+        """Parse an archive's copy of /etc/hosts, which requires handling that
+        is separate from the output of the `hostname` command. Just like
+        load_hostname_into_map(), this has to be done explicitly and we
+        cannot rely upon the more generic methods to do this reliably.
+        """
+        lines = content.splitlines()
+        for line in lines:
+            if line.startswith('#') or 'localhost' in line:
+                continue
+            hostln = line.split()[1:]
+            for host in hostln:
+                if len(host.split('.')) == 1:
+                    # only generate a mapping for fqdns but still record the
+                    # short name here for later obfuscation with parse_line()
+                    self.short_names.append(host)
+                else:
+                    self.mapping.add(host)
+
     def parse_line(self, line):
         """Override the default parse_line() method to also check for the
         shortname of the host derived from the hostname.

--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -8,6 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import re
+
 from sos.cleaner.parsers import SoSCleanerParser
 from sos.cleaner.mappings.hostname_map import SoSHostnameMap
 
@@ -91,9 +93,9 @@ class SoSHostnameParser(SoSCleanerParser):
             """
             if search in self.mapping.skip_keys:
                 return ln, count
-            if search in ln:
-                count += ln.count(search)
-                ln = ln.replace(search, self.mapping.get(repl or search))
+            _reg = re.compile(search, re.I)
+            if _reg.search(ln):
+                return _reg.subn(self.mapping.get(repl or search), ln)
             return ln, count
 
         count = 0


### PR DESCRIPTION
This patchset addresses two issues:

1. Adds sourcing of `/etc/hosts`, which we aren't doing currently, provides valuable information for prepping the hostname parser, in particular with short names where we would otherwise have a race condition for obfuscation.
2. Fixes a condition where our shortname handling was unintentionally case sensitive.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?