### PR TITLE
[global] Refactor sysroot determination and usage across different components

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -153,7 +153,7 @@ class FileCacheArchive(Archive):
         return (os.path.join(self._archive_root, name))
 
     def join_sysroot(self, path):
-        if path.startswith(self.sysroot):
+        if not self.sysroot or path.startswith(self.sysroot):
             return path
         if path[0] == os.sep:
             path = path[1:]

--- a/sos/component.py
+++ b/sos/component.py
@@ -109,7 +109,7 @@ class SoSComponent():
             try:
                 import sos.policies
                 self.policy = sos.policies.load(sysroot=self.opts.sysroot)
-                self.sysroot = self.policy.host_sysroot()
+                self.sysroot = self.policy.sysroot
             except KeyboardInterrupt:
                 self._exit(0)
             self._is_root = self.policy.is_root()

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -110,7 +110,6 @@ any third party.
     presets = {"": PresetDefaults()}
     presets_path = PRESETS_PATH
     _in_container = False
-    _host_sysroot = '/'
 
     def __init__(self, sysroot=None, probe_runtime=True):
         """Subclasses that choose to override this initializer should call
@@ -124,7 +123,7 @@ any third party.
         self.package_manager = PackageManager()
         self.valid_subclasses = [IndependentPlugin]
         self.set_exec_path()
-        self._host_sysroot = sysroot
+        self.sysroot = sysroot
         self.register_presets(GENERIC_PRESETS)
 
     def check(self, remote=''):
@@ -176,14 +175,6 @@ any third party.
         :rtype: ``bool``
         """
         return self._in_container
-
-    def host_sysroot(self):
-        """Get the host's default sysroot
-
-        :returns: Host sysroot
-        :rtype: ``str`` or ``None``
-        """
-        return self._host_sysroot
 
     def dist_version(self):
         """

--- a/sos/policies/distros/debian.py
+++ b/sos/policies/distros/debian.py
@@ -27,7 +27,7 @@ class DebianPolicy(LinuxPolicy):
                  remote_exec=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot, init=init,
                                            probe_runtime=probe_runtime)
-        self.package_manager = DpkgPackageManager(chroot=sysroot,
+        self.package_manager = DpkgPackageManager(chroot=self.sysroot,
                                                   remote_exec=remote_exec)
         self.valid_subclasses += [DebianPlugin]
 

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -42,7 +42,6 @@ class RedHatPolicy(LinuxPolicy):
     _redhat_release = '/etc/redhat-release'
     _tmp_dir = "/var/tmp"
     _in_container = False
-    _host_sysroot = '/'
     default_scl_prefix = '/opt/rh'
     name_pattern = 'friendly'
     upload_url = None
@@ -57,7 +56,7 @@ class RedHatPolicy(LinuxPolicy):
                                            probe_runtime=probe_runtime)
         self.usrmove = False
 
-        self.package_manager = RpmPackageManager(chroot=sysroot,
+        self.package_manager = RpmPackageManager(chroot=self.sysroot,
                                                  remote_exec=remote_exec)
 
         self.valid_subclasses += [RedHatPlugin]

--- a/sos/policies/runtimes/__init__.py
+++ b/sos/policies/runtimes/__init__.py
@@ -64,7 +64,7 @@ class ContainerRuntime():
         :returns: ``True`` if the runtime is active, else ``False``
         :rtype: ``bool``
         """
-        if is_executable(self.binary):
+        if is_executable(self.binary, self.policy.sysroot):
             self.active = True
             return True
         return False
@@ -78,7 +78,7 @@ class ContainerRuntime():
         containers = []
         _cmd = "%s ps %s" % (self.binary, '-a' if get_all else '')
         if self.active:
-            out = sos_get_command_output(_cmd)
+            out = sos_get_command_output(_cmd, chroot=self.policy.sysroot)
             if out['status'] == 0:
                 for ent in out['output'].splitlines()[1:]:
                     ent = ent.split()
@@ -112,8 +112,10 @@ class ContainerRuntime():
         images = []
         fmt = '{{lower .Repository}}:{{lower .Tag}} {{lower .ID}}'
         if self.active:
-            out = sos_get_command_output("%s images --format '%s'"
-                                         % (self.binary, fmt))
+            out = sos_get_command_output(
+                "%s images --format '%s'" % (self.binary, fmt),
+                chroot=self.policy.sysroot
+            )
             if out['status'] == 0:
                 for ent in out['output'].splitlines():
                     ent = ent.split()
@@ -129,7 +131,10 @@ class ContainerRuntime():
         """
         vols = []
         if self.active:
-            out = sos_get_command_output("%s volume ls" % self.binary)
+            out = sos_get_command_output(
+                "%s volume ls" % self.binary,
+                chroot=self.policy.sysroot
+            )
             if out['status'] == 0:
                 for ent in out['output'].splitlines()[1:]:
                     ent = ent.split()

--- a/sos/policies/runtimes/docker.py
+++ b/sos/policies/runtimes/docker.py
@@ -18,9 +18,9 @@ class DockerContainerRuntime(ContainerRuntime):
     name = 'docker'
     binary = 'docker'
 
-    def check_is_active(self):
+    def check_is_active(self, sysroot=None):
         # the daemon must be running
-        if (is_executable('docker') and
+        if (is_executable('docker', sysroot) and
                 (self.policy.init_system.is_running('docker') or
                  self.policy.init_system.is_running('snap.docker.dockerd'))):
             self.active = True

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -173,14 +173,12 @@ class SoSReport(SoSComponent):
         self._set_directories()
 
         msg = "default"
-        host_sysroot = self.policy.host_sysroot()
+        self.sysroot = self.policy.sysroot
         # set alternate system root directory
         if self.opts.sysroot:
             msg = "cmdline"
-            self.sysroot = self.opts.sysroot
-        elif self.policy.in_container() and host_sysroot != os.sep:
+        elif self.policy.in_container() and self.sysroot != os.sep:
             msg = "policy"
-            self.sysroot = host_sysroot
         self.soslog.debug("set sysroot to '%s' (%s)" % (self.sysroot, msg))
 
         if self.opts.chroot not in chroot_modes:

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -724,7 +724,7 @@ class Plugin():
         """
         if not self.use_sysroot():
             return path
-        if path.startswith(self.sysroot):
+        if self.sysroot and path.startswith(self.sysroot):
             return path[len(self.sysroot):]
         return path
 
@@ -743,8 +743,10 @@ class Plugin():
                   ``False``
         :rtype: ``bool``
         """
-        paths = [self.sysroot, self.archive.get_tmp_dir()]
-        return os.path.commonprefix(paths) == self.sysroot
+        # if sysroot is still None, that implies '/'
+        _sysroot = self.sysroot or '/'
+        paths = [_sysroot, self.archive.get_tmp_dir()]
+        return os.path.commonprefix(paths) == _sysroot
 
     def is_installed(self, package_name):
         """Is the package $package_name installed?
@@ -2621,7 +2623,7 @@ class Plugin():
         return list(set(expanded))
 
     def _collect_copy_specs(self):
-        for path in self.copy_paths:
+        for path in sorted(self.copy_paths, reverse=True):
             self._log_info("collecting path '%s'" % path)
             self._do_copy_path(path)
         self.generate_copyspec_tags()
@@ -2749,7 +2751,7 @@ class Plugin():
 
         return ((any(self.path_exists(fname) for fname in files) or
                 any(self.is_installed(pkg) for pkg in packages) or
-                any(is_executable(cmd) for cmd in commands) or
+                any(is_executable(cmd, self.sysroot) for cmd in commands) or
                 any(self.is_module_loaded(mod) for mod in self.kernel_mods) or
                 any(self.is_service(svc) for svc in services) or
                 any(self.container_exists(cntr) for cntr in containers)) and
@@ -2817,7 +2819,7 @@ class Plugin():
         :returns:           True if the path exists in sysroot, else False
         :rtype:             ``bool``
         """
-        return path_exists(path, self.commons['cmdlineopts'].sysroot)
+        return path_exists(path, self.sysroot)
 
     def path_isdir(self, path):
         """Helper to call the sos.utilities wrapper that allows the
@@ -2830,7 +2832,7 @@ class Plugin():
         :returns:           True if the path is a dir, else False
         :rtype:             ``bool``
         """
-        return path_isdir(path, self.commons['cmdlineopts'].sysroot)
+        return path_isdir(path, self.sysroot)
 
     def path_isfile(self, path):
         """Helper to call the sos.utilities wrapper that allows the
@@ -2843,7 +2845,7 @@ class Plugin():
         :returns:           True if the path is a file, else False
         :rtype:             ``bool``
         """
-        return path_isfile(path, self.commons['cmdlineopts'].sysroot)
+        return path_isfile(path, self.sysroot)
 
     def path_islink(self, path):
         """Helper to call the sos.utilities wrapper that allows the
@@ -2856,7 +2858,7 @@ class Plugin():
         :returns:           True if the path is a link, else False
         :rtype:             ``bool``
         """
-        return path_islink(path, self.commons['cmdlineopts'].sysroot)
+        return path_islink(path, self.sysroot)
 
     def listdir(self, path):
         """Helper to call the sos.utilities wrapper that allows the
@@ -2869,7 +2871,7 @@ class Plugin():
         :returns:           Contents of path, if it is a directory
         :rtype:             ``list``
         """
-        return listdir(path, self.commons['cmdlineopts'].sysroot)
+        return listdir(path, self.sysroot)
 
     def path_join(self, path, *p):
         """Helper to call the sos.utilities wrapper that allows the

--- a/sos/report/plugins/unpackaged.py
+++ b/sos/report/plugins/unpackaged.py
@@ -58,10 +58,11 @@ class Unpackaged(Plugin, RedHatPlugin):
             """
             expanded = []
             for f in files:
-                if self.path_islink(f):
-                    expanded.append("{} -> {}".format(f, os.readlink(f)))
+                fp = self.path_join(f)
+                if self.path_islink(fp):
+                    expanded.append("{} -> {}".format(fp, os.readlink(fp)))
                 else:
-                    expanded.append(f)
+                    expanded.append(fp)
             return expanded
 
         # Check command predicate to avoid costly processing

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -96,11 +96,15 @@ def grep(pattern, *files_or_paths):
     return matches
 
 
-def is_executable(command):
+def is_executable(command, sysroot=None):
     """Returns if a command matches an executable on the PATH"""
 
     paths = os.environ.get("PATH", "").split(os.path.pathsep)
     candidates = [command] + [os.path.join(p, command) for p in paths]
+    if sysroot:
+        candidates += [
+            os.path.join(sysroot, c.lstrip('/')) for c in candidates
+        ]
     return any(os.access(path, os.X_OK) for path in candidates)
 
 
@@ -216,8 +220,9 @@ def get_human_readable(size, precision=2):
 
 
 def _os_wrapper(path, sysroot, method, module=os.path):
-    if sysroot not in [None, '/']:
-        path = os.path.join(sysroot, path.lstrip('/'))
+    if sysroot and sysroot != os.sep:
+        if not path.startswith(sysroot):
+            path = os.path.join(sysroot, path.lstrip('/'))
     _meth = getattr(module, method)
     return _meth(path)
 
@@ -243,7 +248,7 @@ def listdir(path, sysroot):
 
 
 def path_join(path, *p, sysroot=os.sep):
-    if not path.startswith(sysroot):
+    if sysroot and not path.startswith(sysroot):
         path = os.path.join(sysroot, path.lstrip(os.sep))
     return os.path.join(path, *p)
 


### PR DESCRIPTION
This patchset addresses a small number of issues surrounding sysroot handling inside containers:

1. Use the correct sysroot (the policy determined sysroot, not just blindly passing the default) for `PackageManager`. I am unsure where/when this broke, but this resolves sos using the container-local package list instead of the host package list.
2. Extend kmod detection to account for non-`/` sysroots.
3. Enable `ContainerRuntime`s to activate when sos is run in a container, and the runtime is accessible through the policy-determined sysroot.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?