### PR TITLE
[networking] Print additional interfaces info in netns

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -205,7 +205,7 @@ class Networking(Plugin):
         for namespace in namespaces:
             ns_cmd_prefix = cmd_prefix + namespace + " "
             self.add_cmd_output([
-                ns_cmd_prefix + "ip address show",
+                ns_cmd_prefix + "ip -d address show",
                 ns_cmd_prefix + "ip route show table all",
                 ns_cmd_prefix + "ip -s -s neigh show",
                 ns_cmd_prefix + "ip rule list",


### PR DESCRIPTION
This commit adds `-d` to the `ip address show` executed in each of the
network namespaces on the host. This prints additonal info per each
interface, the most useful probably being VLAN information.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?