### PR TITLE
[collect] fix moved get_upload_url under Policy class

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1184,7 +1184,7 @@ this utility or remote systems that it connects to.
             self.cluster.cleanup()
             self.exit(msg, 1)
 
-        if self.opts.upload and self.get_upload_url():
+        if self.opts.upload and self.policy.get_upload_url():
             try:
                 self.policy.upload_archive(arc_name)
                 self.ui_log.info("Uploaded archive successfully")


### PR DESCRIPTION
SoSCollector does not further declare get_upload_url method
as that was moved under Policy class(es).

Resolves: #2766

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?