### PR TITLE
[ceph_mgr] Add more data collection to ceph_mgr

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -34,6 +34,9 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
         ])
 
         self.add_cmd_output([
+            # The ceph_mon plugin will collect all the "ceph ..." commands
+            # which typically require the keyring.
+
             "ceph mon stat",
             "ceph quorum_status",
             "ceph report",
@@ -50,7 +53,12 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph osd metadata",
             "ceph osd erasure-code-profile ls",
             "ceph osd crush show-tunables",
-            "ceph osd crush dump"
+            "ceph osd crush dump",
+            "ceph mgr dump",
+            "ceph mgr metadata",
+            "ceph mgr module ls",
+            "ceph mgr services",
+            "ceph mgr versions"
         ])
 
         ceph_cmds = [


### PR DESCRIPTION
Enhance the ceph_mgr plugin to collect more data specific to
mgr nodes. Also collect some additional manager data in the
ceph_mon plugin.

Related: #1945
Resolves: #2759

Signed-off-by: Nikhil Kshirsagar <nkshirsagar@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?