### PR TITLE
[Plugin] Add tagging class for openEuler distro

### DIFF
--- a/sos/policies/distros/openeuler.py
+++ b/sos/policies/distros/openeuler.py
@@ -6,6 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+from sos.report.plugins import OpenEulerPlugin
 from sos.policies.distros.redhat import RedHatPolicy, OS_RELEASE
 import os
 
@@ -20,6 +21,8 @@ class OpenEulerPolicy(RedHatPolicy):
         super(OpenEulerPolicy, self).__init__(sysroot=sysroot, init=init,
                                               probe_runtime=probe_runtime,
                                               remote_exec=remote_exec)
+
+        self.valid_subclasses += [OpenEulerPlugin]
 
     @classmethod
     def check(cls, remote=''):

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3070,6 +3070,11 @@ class SuSEPlugin(object):
     pass
 
 
+class OpenEulerPlugin(object):
+    """Tagging class for openEuler linux distributions"""
+    pass
+
+
 class CosPlugin(object):
     """Tagging class for Container-Optimized OS"""
     pass


### PR DESCRIPTION
I'm planning to do more works on add support for openEuler distribution, including making some plugins and improve existing openEuler policy. Adding this tagging class for the first step.

openEuler has made some projects that not published on other distros yet, like iSulad, A-Tune, stratovirt , etc. So I think make a tagging might be necessary

Signed-off-by: lijingwei <lijingwei@uniontech.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?