### PR TITLE
Sos pmoravec upload sftp portal minor changes

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -473,7 +473,8 @@ class LinuxPolicy(Policy):
         put_expects = [
             u'100%',
             pexpect.TIMEOUT,
-            pexpect.EOF
+            pexpect.EOF,
+            u'No such file or directory'
         ]
 
         put_success = ret.expect(put_expects, timeout=180)
@@ -485,6 +486,8 @@ class LinuxPolicy(Policy):
             raise Exception("Timeout expired while uploading")
         elif put_success == 2:
             raise Exception("Unknown error during upload: %s" % ret.before)
+        elif put_success == 3:
+            raise Exception("Unable to write archive to destination")
         else:
             raise Exception("Unexpected response from server: %s" % ret.before)
 

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -250,7 +250,7 @@ support representative.
         elif self.commons['cmdlineopts'].upload_protocol == 'sftp':
             return RH_SFTP_HOST
         else:
-            rh_case_api = "/hydra/rest/cases/%s/attachments"
+            rh_case_api = "/support/v1/cases/%s/attachments"
             return RH_API_HOST + rh_case_api % self.case_id
 
     def _get_upload_headers(self):


### PR DESCRIPTION
Two minor but important changes to upload functionality:

- revert back wrong change in URI of Red Hat Customer portal
- react better when FTP upload fails on remote file write error

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?