### PR TITLE
[cleaner] Fix username casing and sourcing, simplify hostname casing

### DIFF
--- a/sos/cleaner/archives/sos.py
+++ b/sos/cleaner/archives/sos.py
@@ -35,7 +35,9 @@ class SoSReportArchive(SoSObfuscationArchive):
             'sos_commands/login/lastlog_-u_65537-4294967295',
             # AD users will be reported here, but favor the lastlog files since
             # those will include local users who have not logged in
-            'sos_commands/login/last'
+            'sos_commands/login/last',
+            'etc/cron.allow',
+            'etc/cron.deny'
         ]
     }
 

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -169,16 +169,15 @@ class SoSHostnameMap(SoSMap):
 
     def sanitize_item(self, item):
         host = item.split('.')
-        if len(host) > 1 and all([h.isupper() for h in host]):
-            # by convention we have just a domain
-            _host = [h.lower() for h in host]
-            return self.sanitize_domain(_host).upper()
         if len(host) == 1:
             # we have a shortname for a host
             return self.sanitize_short_name(host[0].lower())
         if len(host) == 2:
             # we have just a domain name, e.g. example.com
-            return self.sanitize_domain(host)
+            dname = self.sanitize_domain(host)
+            if all([h.isupper() for h in host]):
+                dname = dname.upper()
+            return dname
         if len(host) > 2:
             # we have an FQDN, e.g. foo.example.com
             hostname = host[0]
@@ -194,7 +193,10 @@ class SoSHostnameMap(SoSMap):
                 ob_hostname = 'unknown'
             ob_domain = self.sanitize_domain(domain)
             self.dataset[item] = ob_domain
-            return '.'.join([ob_hostname, ob_domain])
+            _fqdn = '.'.join([ob_hostname, ob_domain])
+            if all([h.isupper() for h in host]):
+                _fqdn = _fqdn.upper()
+            return _fqdn
 
     def sanitize_short_name(self, hostname):
         """Obfuscate the short name of the host with an incremented counter

--- a/sos/cleaner/mappings/username_map.py
+++ b/sos/cleaner/mappings/username_map.py
@@ -33,5 +33,5 @@ class SoSUsernameMap(SoSMap):
         ob_name = "obfuscateduser%s" % self.name_count
         self.name_count += 1
         if ob_name in self.dataset.values():
-            return self.sanitize_item(username)
+            return self.sanitize_item(username.lower())
         return ob_name

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -8,6 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import re
 
 from sos.cleaner.parsers import SoSCleanerParser
 from sos.cleaner.mappings.username_map import SoSUsernameMap
@@ -34,6 +35,7 @@ class SoSUsernameParser(SoSCleanerParser):
         'reboot',
         'root',
         'ubuntu',
+        'username',
         'wtmp'
     ]
 
@@ -47,12 +49,12 @@ class SoSUsernameParser(SoSCleanerParser):
         this parser, we need to override the initial parser prepping here.
         """
         users = set()
-        for line in content.splitlines()[1:]:
+        for line in content.splitlines():
             try:
                 user = line.split()[0]
             except Exception:
                 continue
-            if user in self.skip_list:
+            if user.lower() in self.skip_list:
                 continue
             users.add(user)
         for each in users:
@@ -61,7 +63,9 @@ class SoSUsernameParser(SoSCleanerParser):
     def parse_line(self, line):
         count = 0
         for username in sorted(self.mapping.dataset.keys(), reverse=True):
-            if username in line:
-                count = line.count(username)
-                line = line.replace(username, self.mapping.get(username))
+            _reg = re.compile(username, re.I)
+            if _reg.search(line):
+                line, count = _reg.subn(
+                    self.mapping.get(username.lower()), line
+                )
         return line, count


### PR DESCRIPTION
First, simplify the case matching of hostnames to all upper case conventions for domains.

Second, make username matching similarly case insensitive like we did with hostnames. Additionally, fix and extend the sourcing of usernames to not skip the first entry in `last` by erroneously accounting for a header that is only in `lastlog`, and include `/etc/cron.{allow|deny}` as a source for usernames for an edge case where (ldap/ad) users are allowed or denied to modify crontab but have not actually logged in.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?