### PR TITLE
[collect] Catch command not found exceptions from pexpect

### DIFF
--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -225,7 +225,11 @@ class RemoteTransport():
         if not env:
             env = None
 
-        result = pexpect.spawn(cmd, encoding='utf-8', env=env)
+        try:
+            result = pexpect.spawn(cmd, encoding='utf-8', env=env)
+        except pexpect.exceptions.ExceptionPexpect as err:
+            self.log_debug(err.value)
+            return {'status': 127, 'output': ''}
 
         _expects = [pexpect.EOF, pexpect.TIMEOUT]
         if need_root and self.opts.ssh_user != 'root':


### PR DESCRIPTION
When running a command that does not exist on the system, catch the
resulting pexpect exception and return the proper status code rather
than allowing an untrapped exception.

Closes: #2768

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?