### PR TITLE
[report,collect] Add option to control default container runtime

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -11,6 +11,7 @@ sos collect \- Collect sosreports from multiple (cluster) nodes
     [\-\-chroot CHROOT]
     [\-\-case\-id CASE_ID]
     [\-\-cluster\-type CLUSTER_TYPE]
+    [\-\-container\-runtime RUNTIME]
     [\-e ENABLE_PLUGINS]
     [--encrypt-key KEY]\fR
     [--encrypt-pass PASS]\fR
@@ -112,6 +113,11 @@ for node names will be ignored.
 Example: \fBsos collect --cluster-type=kubernetes\fR will force the kubernetes profile
 to be run, and thus set sosreport options and attempt to determine a list of nodes using
 that profile. 
+.TP
+\fB\-\-container\-runtime\fR RUNTIME
+\fB sos report\fR option. Using this with \fBcollect\fR will pass this option thru
+to nodes with sos version 4.3 or later. This option controls the default container
+runtime plugins will use for collections. See \fBman sos-report\fR.
 .TP
 \fB\-e\fR ENABLE_PLUGINS, \fB\-\-enable\-plugins\fR ENABLE_PLUGINS
 Sosreport option. Use this to enable a plugin that would otherwise not be run.

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -19,6 +19,7 @@ sos report \- Collect and package diagnostic and support data
           [--plugin-timeout TIMEOUT]\fR
           [--cmd-timeout TIMEOUT]\fR
           [--namespaces NAMESPACES]\fR
+          [--container-runtime RUNTIME]\fR
           [-s|--sysroot SYSROOT]\fR
           [-c|--chroot {auto|always|never}\fR
           [--tmp-dir directory]\fR
@@ -299,6 +300,24 @@ Use '0' (default) for no limit - all namespaces will be used for collections.
 
 Note that specific plugins may provide a similar `namespaces` plugin option. If
 the plugin option is used, it will override this option.
+.TP
+.B \--container-runtime RUNTIME
+Force the use of the specified RUNTIME as the default runtime that plugins will
+use to collect data from and about containers and container images. By default,
+the setting of \fBauto\fR results in the local policy determining what runtime
+will be the default runtime (in configurations where multiple runtimes are installed
+and active).
+
+If no container runtimes are active, this option is ignored. If there are runtimes
+active, but not one with a name matching RUNTIME, sos will abort.
+
+Setting this to \fBnone\fR, \fBoff\fR, or \fBdisabled\fR will cause plugins to
+\fBNOT\fR leverage any active runtimes for collections. Note that if disabled, plugins
+specifically for runtimes (e.g. the podman or docker plugins) will still collect
+general data about the runtime, but will not inspect existing containers or images.
+
+Default: 'auto' (policy determined)
+.TP
 .B \--case-id NUMBER
 Specify a case identifier to associate with the archive.
 Identifiers may include alphanumeric characters, commas and periods ('.').

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -55,6 +55,7 @@ class SoSCollector(SoSComponent):
         'clean': False,
         'cluster_options': [],
         'cluster_type': None,
+        'container_runtime': 'auto',
         'domains': [],
         'enable_plugins': [],
         'encrypt_key': '',
@@ -268,6 +269,9 @@ class SoSCollector(SoSComponent):
         sos_grp.add_argument('--chroot', default='',
                              choices=['auto', 'always', 'never'],
                              help="chroot executed commands to SYSROOT")
+        sos_grp.add_argument("--container-runtime", default="auto",
+                             help="Default container runtime to use for "
+                                  "collections. 'auto' for policy control.")
         sos_grp.add_argument('-e', '--enable-plugins', action="extend",
                              help='Enable specific plugins for sosreport')
         sos_grp.add_argument('-k', '--plugin-option', '--plugopts',

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -586,6 +586,12 @@ class SosNode():
                 sos_opts.append('--cmd-timeout=%s'
                                 % quote(str(self.opts.cmd_timeout)))
 
+        if self.check_sos_version('4.3'):
+            if self.opts.container_runtime != 'auto':
+                sos_opts.append(
+                    "--container-runtime=%s" % self.opts.container_runtime
+                )
+
         self.update_cmd_from_cluster()
 
         sos_cmd = sos_cmd.replace(


### PR DESCRIPTION
Adds a new `--container-runtime` option that allows users to control
what default container runtime is used by plugins for container based
collections, effectively overriding policy defaults.

If no runtimes are active, this option is effectively ignored. If
however runtimes are active, but the requested one is not, raise an
exception to abort collection with an appropriate message to the user.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?