### PR TITLE
[runtimes:crio][plugins:openshift_ovn] Add crio runtime and openshift_ovn plugin

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -17,6 +17,7 @@ from sos import _sos as _
 from sos.policies import Policy
 from sos.policies.init_systems import InitSystem
 from sos.policies.init_systems.systemd import SystemdInit
+from sos.policies.runtimes.crio import CrioContainerRuntime
 from sos.policies.runtimes.podman import PodmanContainerRuntime
 from sos.policies.runtimes.docker import DockerContainerRuntime
 
@@ -90,7 +91,8 @@ class LinuxPolicy(Policy):
         if self.probe_runtime:
             _crun = [
                 PodmanContainerRuntime(policy=self),
-                DockerContainerRuntime(policy=self)
+                DockerContainerRuntime(policy=self),
+                CrioContainerRuntime(policy=self)
             ]
             for runtime in _crun:
                 if runtime.check_is_active():

--- a/sos/policies/runtimes/__init__.py
+++ b/sos/policies/runtimes/__init__.py
@@ -100,7 +100,7 @@ class ContainerRuntime():
             return None
         for c in self.containers:
             if re.match(name, c[1]):
-                return c[1]
+                return c[0]
         return None
 
     def get_images(self):

--- a/sos/policies/runtimes/crio.py
+++ b/sos/policies/runtimes/crio.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2021 Red Hat, Inc., Nadia Pinaeva <npinaeva@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.policies.runtimes import ContainerRuntime
+from sos.utilities import sos_get_command_output
+from pipes import quote
+
+
+class CrioContainerRuntime(ContainerRuntime):
+    """Runtime class to use for systems running crio"""
+
+    name = 'crio'
+    binary = 'crictl'
+
+    def get_containers(self, get_all=False):
+        """Get a list of containers present on the system.
+
+        :param get_all: If set, include stopped containers as well
+        :type get_all: ``bool``
+        """
+        containers = []
+        _cmd = "%s ps %s" % (self.binary, '-a' if get_all else '')
+        if self.active:
+            out = sos_get_command_output(_cmd, chroot=self.policy.sysroot)
+            if out['status'] == 0:
+                for ent in out['output'].splitlines()[1:]:
+                    ent = ent.split()
+                    # takes the form (container_id, container_name)
+                    containers.append((ent[0], ent[-3]))
+        return containers
+
+    def get_images(self):
+        """Get a list of images present on the system
+
+        :returns: A list of 2-tuples containing (image_name, image_id)
+        :rtype: ``list``
+        """
+        images = []
+        if self.active:
+            out = sos_get_command_output("%s images" % self.binary,
+                                         chroot=self.policy.sysroot)
+            if out['status'] == 0:
+                for ent in out['output'].splitlines():
+                    ent = ent.split()
+                    # takes the form (image_name, image_id)
+                    images.append((ent[0] + ':' + ent[1], ent[2]))
+        return images
+
+    def fmt_container_cmd(self, container, cmd, quotecmd):
+        """Format a command to run inside a container using the runtime
+
+        :param container: The name or ID of the container in which to run
+        :type container: ``str``
+
+        :param cmd: The command to run inside `container`
+        :type cmd: ``str``
+
+        :param quotecmd: Whether the cmd should be quoted.
+        :type quotecmd: ``bool``
+
+        :returns: Formatted string to run `cmd` inside `container`
+        :rtype: ``str``
+        """
+        if quotecmd:
+            quoted_cmd = quote(cmd)
+        else:
+            quoted_cmd = cmd
+        container_id = self.get_container_by_name(container)
+        return "%s %s %s" % (self.run_cmd, container_id,
+                             quoted_cmd) if container_id is not None else ''
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openshift_ovn.py
+++ b/sos/report/plugins/openshift_ovn.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2021 Nadia Pinaeva <npinaeva@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class OpenshiftOVN(Plugin, RedHatPlugin):
+    """This plugin is used to collect OCP 4.x OVN logs.
+    """
+    short_desc = 'Openshift OVN'
+    plugin_name = "openshift_ovn"
+    containers = ('ovnkube-master', 'ovn-ipsec')
+    profiles = ('openshift',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/var/lib/ovn/etc/ovnnb_db.db",
+            "/var/lib/ovn/etc/ovnsb_db.db",
+            "/var/lib/openvswitch/etc/keys",
+            "/var/log/openvswitch/libreswan.log",
+            "/var/log/openvswitch/ovs-monitor-ipsec.log"
+        ])
+
+        self.add_cmd_output([
+            'ovn-appctl -t /var/run/ovn/ovnnb_db.ctl ' +
+            'cluster/status OVN_Northbound',
+            'ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ' +
+            'cluster/status OVN_Southbound'],
+            container='ovnkube-master')
+        self.add_cmd_output([
+            'ovs-appctl -t ovs-monitor-ipsec tunnels/show',
+            'ipsec status',
+            'certutil -L -d sql:/etc/ipsec.d'],
+            container='ovn-ipsec')


### PR DESCRIPTION
`openshift_ovn` plugin collects logs from crio containers
Fix `get_container_by_name` function returning container_id and not name

Tested with new `--container-runtime` option, works well.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?