### PR TITLE
[Plugin] Add container parameter for add_cmd_output()

### DIFF
--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -85,16 +85,14 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
                     mgr_ids.append("mgr.%s" % proc[5])
 
         # If containerized, run commands in containers
-        containers_list = self.get_all_containers_by_regex("ceph-mgr*")
-        if containers_list:
-            self.add_cmd_output([
-                self.fmt_container_cmd(
-                    containers_list[0][1], "ceph daemon %s %s"
-                    % (mgrid, cmd)) for mgrid in mgr_ids for cmd in ceph_cmds
-            ])
-        else:
-            self.add_cmd_output([
-                "ceph daemon %s %s" % (
-                    mgrid, cmd) for mgrid in mgr_ids for cmd in ceph_cmds
-            ])
+        try:
+            cname = self.get_all_containers_by_regex("ceph-mgr*")[0][1]
+        except Exception:
+            cname = None
+
+        self.add_cmd_output([
+            "ceph daemon %s %s"
+            % (mgrid, cmd) for mgrid in mgr_ids for cmd in ceph_cmds
+        ], container=cname)
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -105,18 +105,14 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
         ])
 
         # If containerized, run commands in containers
-        containers_list = self.get_all_containers_by_regex("ceph-mon*")
-        if containers_list:
-            for container in containers_list:
-                self.add_cmd_output([
-                    self.fmt_container_cmd(container[1], "ceph %s" % s)
-                    for s in ceph_cmds
-                ])
-                break
-        # Not containerized but still mon node
-        else:
-            self.add_cmd_output([
-                "ceph %s" % s for s in ceph_cmds
-            ])
+        try:
+            cname = self.get_all_containers_by_regex("ceph-mon*")[0][1]
+        except Exception:
+            cname = None
+
+        self.add_cmd_output(
+            ["ceph %s" % cmd for cmd in ceph_cmds],
+            container=cname
+        )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -78,19 +78,15 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
                 if proc[4] == '--id' and proc[5].isdigit():
                     osd_ids.append("osd.%s" % proc[5])
 
-        containers_list = self.get_all_containers_by_regex("ceph-osd*")
+        try:
+            cname = self.get_all_containers_by_regex("ceph-osd*")[0][1]
+        except Exception:
+            cname = None
 
-        if containers_list:
-            self.add_cmd_output([
-                self.fmt_container_cmd(
-                    containers_list[0][1], "ceph daemon %s %s"
-                    % (osid, cmd)) for osid in osd_ids for cmd in ceph_cmds
-            ])
-        else:
-            self.add_cmd_output([
-                "ceph daemon %s %s" % (
-                    osid, cmd) for osid in osd_ids for cmd in ceph_cmds
-            ])
+        self.add_cmd_output(
+            ["ceph daemon %s %s" % (i, c) for i in osd_ids for c in ceph_cmds],
+            container=cname
+        )
 
         self.add_forbidden_path([
             "/etc/ceph/*keyring*",

--- a/sos/report/plugins/opencontrail.py
+++ b/sos/report/plugins/opencontrail.py
@@ -25,8 +25,7 @@ class OpenContrail(Plugin, IndependentPlugin):
             cnames = self.get_containers(get_all=True)
             cnames = [c[1] for c in cnames if 'opencontrail' in c[1]]
             for cntr in cnames:
-                _cmd = self.fmt_container_cmd(cntr, 'contrail-status')
-                self.add_cmd_output(_cmd)
+                self.add_cmd_output('contrail-status', container=cntr)
         else:
             self.add_cmd_output("contrail-status")
 

--- a/sos/report/plugins/openstack_designate.py
+++ b/sos/report/plugins/openstack_designate.py
@@ -20,12 +20,10 @@ class OpenStackDesignate(Plugin):
 
     def setup(self):
         # collect current pool config
-        pools_cmd = self.fmt_container_cmd(
-            self.get_container_by_name(".*designate_central"),
-            "designate-manage pool generate_file --file /dev/stdout")
 
         self.add_cmd_output(
-            pools_cmd,
+            "designate-manage pool generate_file --file /dev/stdout",
+            container=self.get_container_by_name(".*designate_central"),
             suggest_filename="openstack_designate_current_pools.yaml"
         )
 

--- a/sos/report/plugins/openstack_ironic.py
+++ b/sos/report/plugins/openstack_ironic.py
@@ -80,8 +80,7 @@ class OpenStackIronic(Plugin):
                                    'ironic_pxe_tftp', 'ironic_neutron_agent',
                                    'ironic_conductor', 'ironic_api']:
                 if self.container_exists('.*' + container_name):
-                    self.add_cmd_output(self.fmt_container_cmd(container_name,
-                                                               'rpm -qa'))
+                    self.add_cmd_output('rpm -qa', container=container_name)
 
         else:
             self.conf_list = [

--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -123,11 +123,10 @@ class OVNCentral(Plugin):
 
         # If OVN is containerized, we need to run the above commands inside
         # the container.
-        cmds = [
-            self.fmt_container_cmd(self._container_name, cmd) for cmd in cmds
-        ]
 
-        self.add_cmd_output(cmds, foreground=True)
+        self.add_cmd_output(
+            cmds, foreground=True, container=self._container_name
+        )
 
         self.add_copy_spec("/etc/sysconfig/ovn-northd")
 

--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -34,14 +34,15 @@ class RabbitMQ(Plugin, IndependentPlugin):
             for container in container_names:
                 self.add_container_logs(container)
                 self.add_cmd_output(
-                    self.fmt_container_cmd(container, 'rabbitmqctl report'),
+                    'rabbitmqctl report',
+                    container=container,
                     foreground=True
                 )
                 self.add_cmd_output(
-                    self.fmt_container_cmd(
-                        container, "rabbitmqctl eval "
-                        "'rabbit_diagnostics:maybe_stuck().'"),
-                    foreground=True, timeout=10
+                    "rabbitmqctl eval 'rabbit_diagnostics:maybe_stuck().'",
+                    container=container,
+                    foreground=True,
+                    timeout=10
                 )
         else:
             self.add_cmd_output("rabbitmqctl report")


### PR DESCRIPTION
Adds a new `container` parameter for `Plugin.add_cmd_output()`, which if
set will format all commands passed to that call for execution in the
specified container.

`Plugin.fmt_container_cmd()` is called for this purpose, and has been
modified so that if the given container does not exist, an empty string
is returned instead, thus preventing execution on the host.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?