### PR TITLE
[ipmitool] Collect data for IPMI channel number 1

### DIFF
--- a/sos/report/plugins/ipmitool.py
+++ b/sos/report/plugins/ipmitool.py
@@ -26,12 +26,14 @@ class IpmiTool(Plugin, RedHatPlugin, DebianPlugin):
         if result['status'] == 0:
             cmd += " -I usb"
 
+        for subcmd in ['channel info', 'channel getaccess', 'lan print']:
+            for channel in [1, 3]:
+                self.add_cmd_output("%s %s %d" % (cmd, subcmd, channel))
+
         # raw 0x30 0x65: Get HDD drive Fault LED State
         # raw 0x30 0xb0: Get LED Status
 
         self.add_cmd_output([
-            "%s channel info 3" % cmd,
-            "%s channel getaccess 3" % cmd,
             "%s raw 0x30 0x65" % cmd,
             "%s raw 0x30 0xb0" % cmd,
             "%s sel info" % cmd,
@@ -40,7 +42,6 @@ class IpmiTool(Plugin, RedHatPlugin, DebianPlugin):
             "%s sensor list" % cmd,
             "%s chassis status" % cmd,
             "%s lan print" % cmd,
-            "%s lan print 3" % cmd,
             "%s fru print" % cmd,
             "%s mc info" % cmd,
             "%s sdr info" % cmd


### PR DESCRIPTION
Hardware vendors choose an IPMI channel number for BMC LAN.
The current IPMI plugin is collecting data for channel 3.
Dell is using channel number 1. The number is not reserved for
a specific hardware vendor. It can be used by others too.

Signed-off-by: Vikas Goel <vikas.goel@gmail.com>

Add data collection for IPMI channel number 1.
https://www.dell.com/support/manuals/en-us/virtual-edge-platform-4600-4c/vep4600_bmc_user_guide_pub/configurations?guid=guid-7e10db8f-114e-475b-808a-3254f2dac46e&lang=en-us

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?