### PR TITLE
[policies] Add Rocky Linux policy

### DIFF
--- a/sos/policies/distros/rocky.py
+++ b/sos/policies/distros/rocky.py
@@ -1,0 +1,52 @@
+# Copyright (C) Louis Abel <label@rockylinux.org>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.policies.distros.redhat import RedHatPolicy, OS_RELEASE
+import os
+
+
+class RockyPolicy(RedHatPolicy):
+    distro = "Rocky Linux"
+    vendor = "Rocky Enterprise Software Foundation"
+    vendor_urls = [
+            ('Distribution Website', 'https://rockylinux.org'),
+            ('Vendor Website', 'https://resf.org')
+    ]
+
+    def __init__(self, sysroot=None, init=None, probe_runtime=True,
+                 remote_exec=None):
+        super(RockyPolicy, self).__init__(sysroot=sysroot, init=init,
+                                          probe_runtime=probe_runtime,
+                                          remote_exec=remote_exec)
+
+    @classmethod
+    def check(cls, remote=''):
+        if remote:
+            return cls.distro in remote
+
+        # Return False if /etc/os-release is missing
+        if not os.path.exists(OS_RELEASE):
+            return False
+
+        # Return False if /etc/rocky-release is missing
+        if not os.path.isfile('/etc/rocky-release'):
+            return False
+
+        # If we've gotten this far, check for Rocky in
+        # /etc/os-release
+        with open(OS_RELEASE, 'r') as f:
+            for line in f:
+                if line.startswith('NAME'):
+                    if 'Rocky Linux' in line:
+                        return True
+
+        return False
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Rocky Linux is an enterprise Linux distribution based on RHEL. This adds
a Rocky Linux policy, which inherits the RedHatPolicy base and uses the
RedHatPlugin tagging class.

Signed-off-by: Louis Abel <label@rockylinux.org>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?