### PR TITLE
[vdsm] Exclude /var/lib/vdsm/storage/transient_disks

### DIFF
--- a/sos/report/plugins/vdsm.py
+++ b/sos/report/plugins/vdsm.py
@@ -63,6 +63,7 @@ class Vdsm(Plugin, RedHatPlugin):
         self.add_forbidden_path('/etc/pki/vdsm/keys')
         self.add_forbidden_path('/etc/pki/vdsm/*/*-key.*')
         self.add_forbidden_path('/etc/pki/libvirt/private')
+        self.add_forbidden_path('/var/lib/vdsm/storage/transient_disks')
 
         self.add_service_status(['vdsmd', 'supervdsmd'])
 


### PR DESCRIPTION
This patch adds the directory /var/lib/vdsm/storage/transient_disks
to the list of forbidden paths, because it contains sensitive data
(cloud-init disks) or big files.

Resolves: RHBZ#2029154

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?