### PR TITLE
[sosnode] Fix removal warning when cleaning up on a local node

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -817,7 +817,9 @@ class SosNode():
     def remove_sos_archive(self):
         """Remove the sosreport archive from the node, since we have
         collected it and it would be wasted space otherwise"""
-        if self.sos_path is None:
+        if self.sos_path is None or self.local:
+            # local transport moves the archive rather than copies it, so there
+            # is no archive at the original location to remove
             return
         if 'sosreport' not in self.sos_path:
             self.log_debug("Node sos report path %s looks incorrect. Not "


### PR DESCRIPTION
When `cleanup()` is called for a local node, we were generating a false
warning that we couldn't remove the sos report. This removal attempt is
unnecessary since local nodes moves the sos archive during collector
archive creation, rather than copying it like we do for remote nodes.

Closes: #2769

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?