### PR TITLE
[report] Fix setting of all options via `-a`

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -660,7 +660,7 @@ class SoSReport(SoSComponent):
     def _set_all_options(self):
         if self.opts.alloptions:
             for plugname, plug in self.loaded_plugins:
-                for opt in plug.options:
+                for opt in plug.options.values():
                     if bool in opt.val_type:
                         opt.value = True
 


### PR DESCRIPTION
Fixes an issue where the use of `-a` would fail due to trying to
iterate over the key of the plugin's options dict rather than the actual
`PluginOpt` value.

Closes: #2786

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?