### PR TITLE
[Policy,collect] Prevent remote node policies from setting local PATH

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -45,7 +45,7 @@ def load(cache={}, sysroot=None, init=None, probe_runtime=True,
     return cache['policy']
 
 
-class Policy(object):
+class Policy():
     """Policies represent distributions that sos supports, and define the way
     in which sos behaves on those distributions. A policy should define at
     minimum a way to identify the distribution, and a package manager to allow
@@ -111,7 +111,7 @@ any third party.
     presets_path = PRESETS_PATH
     _in_container = False
 
-    def __init__(self, sysroot=None, probe_runtime=True):
+    def __init__(self, sysroot=None, probe_runtime=True, remote_exec=None):
         """Subclasses that choose to override this initializer should call
         super() to ensure that they get the required platform bits attached.
         super(SubClass, self).__init__(). Policies that require runtime
@@ -122,7 +122,9 @@ any third party.
         self.probe_runtime = probe_runtime
         self.package_manager = PackageManager()
         self.valid_subclasses = [IndependentPlugin]
-        self.set_exec_path()
+        self.remote_exec = remote_exec
+        if not self.remote_exec:
+            self.set_exec_path()
         self.sysroot = sysroot
         self.register_presets(GENERIC_PRESETS)
 

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -68,9 +68,11 @@ class LinuxPolicy(Policy):
     container_version_command = None
     container_authfile = None
 
-    def __init__(self, sysroot=None, init=None, probe_runtime=True):
+    def __init__(self, sysroot=None, init=None, probe_runtime=True,
+                 remote_exec=None):
         super(LinuxPolicy, self).__init__(sysroot=sysroot,
-                                          probe_runtime=probe_runtime)
+                                          probe_runtime=probe_runtime,
+                                          remote_exec=remote_exec)
 
         if sysroot:
             self.sysroot = sysroot

--- a/sos/policies/distros/debian.py
+++ b/sos/policies/distros/debian.py
@@ -26,7 +26,8 @@ class DebianPolicy(LinuxPolicy):
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot, init=init,
-                                           probe_runtime=probe_runtime)
+                                           probe_runtime=probe_runtime,
+                                           remote_exec=remote_exec)
         self.package_manager = DpkgPackageManager(chroot=self.sysroot,
                                                   remote_exec=remote_exec)
         self.valid_subclasses += [DebianPlugin]

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -53,7 +53,8 @@ class RedHatPolicy(LinuxPolicy):
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
         super(RedHatPolicy, self).__init__(sysroot=sysroot, init=init,
-                                           probe_runtime=probe_runtime)
+                                           probe_runtime=probe_runtime,
+                                           remote_exec=remote_exec)
         self.usrmove = False
 
         self.package_manager = RpmPackageManager(chroot=self.sysroot,
@@ -76,7 +77,8 @@ class RedHatPolicy(LinuxPolicy):
             self.PATH = "/sbin:/bin:/usr/sbin:/usr/bin:/root/bin"
         self.PATH += os.pathsep + "/usr/local/bin"
         self.PATH += os.pathsep + "/usr/local/sbin"
-        self.set_exec_path()
+        if not self.remote_exec:
+            self.set_exec_path()
         self.load_presets()
 
     @classmethod

--- a/sos/policies/distros/suse.py
+++ b/sos/policies/distros/suse.py
@@ -25,7 +25,8 @@ class SuSEPolicy(LinuxPolicy):
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
         super(SuSEPolicy, self).__init__(sysroot=sysroot, init=init,
-                                         probe_runtime=probe_runtime)
+                                         probe_runtime=probe_runtime,
+                                         remote_exec=remote_exec)
         self.valid_subclasses += [SuSEPlugin, RedHatPlugin]
 
         self.usrmove = False


### PR DESCRIPTION
This commit fixes an issue where policies loaded for remote nodes when
using `sos collect` would override the PATH setting for the local
policy, which in turn could prevent successful execution of cluster
profile operations.

Related: #2777

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?