### PR TITLE
[ocp] Skip project setup whenever oc transport is not used

### DIFF
--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -123,7 +123,9 @@ class ocp(Cluster):
         return nodes
 
     def set_transport_type(self):
-        if is_executable('oc') or self.opts.transport == 'oc':
+        if self.opts.transport != 'auto':
+            return self.opts.transport
+        if is_executable('oc'):
             return 'oc'
         self.log_info("Local installation of 'oc' not found or is not "
                       "correctly configured. Will use ControlPersist.")

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -79,10 +79,11 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin):
         pods = self._get_crio_list(pod_cmd)
 
         for container in containers:
-            self.add_cmd_output("crictl inspect %s" % container)
+            self.add_cmd_output("crictl inspect %s" % container,
+                                subdir="containers")
             if self.get_option('logs'):
                 self.add_cmd_output("crictl logs -t %s" % container,
-                                    subdir="containers", priority=100)
+                                    subdir="containers/logs", priority=100)
 
         for image in images:
             self.add_cmd_output("crictl inspecti %s" % image, subdir="images")


### PR DESCRIPTION
Fixes a corner case where we would still attempt to create a new project
within the OCP cluster even if we weren't using the `oc` transport.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?