### PR TITLE
[hostname] Fix edge case for new hosts in a known subdomain

### DIFF
--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -129,7 +129,7 @@ class SoSHostnameMap(SoSMap):
             item = item[0:-1]
         if not self.domain_name_in_loaded_domains(item.lower()):
             return item
-        if item.endswith(('.yaml', '.yml', '.crt', '.key', '.pem')):
+        if item.endswith(('.yaml', '.yml', '.crt', '.key', '.pem', '.log')):
             ext = '.' + item.split('.')[-1]
             item = item.replace(ext, '')
             suffix += ext
@@ -148,7 +148,8 @@ class SoSHostnameMap(SoSMap):
                 if len(_test) == 1 or not _test[0]:
                     # does not match existing obfuscation
                     continue
-                elif _test[0].endswith('.') and not _host_substr:
+                elif not _host_substr and (_test[0].endswith('.') or
+                                           item.endswith(_existing)):
                     # new hostname in known domain
                     final = super(SoSHostnameMap, self).get(item)
                     break
@@ -219,8 +220,8 @@ class SoSHostnameMap(SoSMap):
             # don't obfuscate vendor domains
             if re.match(_skip, '.'.join(domain)):
                 return '.'.join(domain)
-        top_domain = domain[-1]
-        dname = '.'.join(domain[0:-1])
+        top_domain = domain[-1].lower()
+        dname = '.'.join(domain[0:-1]).lower()
         ob_domain = self._new_obfuscated_domain(dname)
         ob_domain = '.'.join([ob_domain, top_domain])
         self.dataset['.'.join(domain)] = ob_domain


### PR DESCRIPTION
Fixes an edge case that would cause us to at first not recognize that a
given hostname string is a new host in a known subdomain, but then on
the obfuscation attempt properly recognize it as such and result in an
incomplete obfuscation.

This was mostly triggered by specific patterns for build hosts within
`sos_commands/rpm/package-data`. With this refined check, these types of
matches are properly obfuscated.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?