### PR TITLE
[utilities] WIP do we really need glob expansion for commands?

### DIFF
--- a/sos/report/plugins/pam.py
+++ b/sos/report/plugins/pam.py
@@ -37,7 +37,7 @@ class Pam(Plugin):
 
 
 class RedHatPam(Pam, RedHatPlugin):
-    security_libs = "/lib*/security"
+    security_libs = "/lib64/security"
 
     def setup(self):
         super(RedHatPam, self).setup()

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -143,16 +143,8 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
         )
 
     args = shlex.split(command)
-    # Expand arguments that are wildcard paths.
-    expanded_args = []
-    for arg in args:
-        expanded_arg = glob.glob(arg)
-        if expanded_arg:
-            expanded_args.extend(expanded_arg)
-        else:
-            expanded_args.append(arg)
     try:
-        p = Popen(expanded_args, shell=False, stdout=PIPE,
+        p = Popen(args, shell=False, stdout=PIPE,
                   stderr=STDOUT if stderr else PIPE,
                   bufsize=-1, env=cmd_env, close_fds=True,
                   preexec_fn=_child_prep_fn)


### PR DESCRIPTION
I think being more precise might be important.

Checking next... (not complete list)
sos/report/plugins/apport.py:        self.add_cmd_output("bash -c 'grep -B 50 -m 1 ProcMaps /var/crash/*'")
sos/report/plugins/candlepin.py:        self.add_cmd_output("du -sh /var/lib/candlepin/*/*")
sos/report/plugins/ds.py:        self.add_cmd_output("ls -l /var/lib/dirsrv/slapd-*/db/*")
sos/report/plugins/foreman.py:        self.add_cmd_output('systemctl list-units dynflow*',
sos/report/plugins/krb5.py:        self.add_cmd_output("klist -ket %s/.k5*" % self.kdcdir)
sos/report/plugins/ldap.py:        self.add_cmd_output("ldapsearch -x -b '' -s base 'objectclass=*'")
sos/report/plugins/md.py:        self.add_cmd_output("mdadm -D /dev/md*")
sos/report/plugins/mysql.py:        self.add_cmd_output("du -s /var/lib/mysql/*")
sos/report/plugins/mysql.py:        self.add_cmd_output("du -s /var/lib/percona-xtradb-cluster/*")
sos/report/plugins/ipa.py:            "ls -la /etc/dirsrv/slapd-*/schema/",
sos/report/plugins/juju.py:            "ls -alRh /var/log/juju*",
sos/report/plugins/juju.py:            "ls -alRh /var/lib/juju*"
sos/report/plugins/smartcard.py:            "ls -nl /usr/lib*/pam_pkcs11/",

Signed-off-by: Bryan Quigley <code@bryanquigley.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?