### PR TITLE
[utilities] Restrict when commands are checked for wildcards

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -143,12 +143,15 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
         )
 
     args = shlex.split(command)
-    # Expand arguments that are wildcard paths.
+    # Expand arguments that are wildcard root paths.
     expanded_args = []
     for arg in args:
-        expanded_arg = glob.glob(arg)
-        if expanded_arg:
-            expanded_args.extend(expanded_arg)
+        if arg.startswith("/") and "*" in arg:
+            expanded_arg = glob.glob(arg)
+            if expanded_arg:
+                expanded_args.extend(expanded_arg)
+            else:
+                expanded_args.append(arg)
         else:
             expanded_args.append(arg)
     try:


### PR DESCRIPTION
Arguments that start with / and must contain a * are
the only ones that get checked if they can be expanded.

Signed-off-by: Bryan Quigley <code@bryanquigley.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?