### PR TITLE
[transport] Detect retrieval failures and automatically retry

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1221,8 +1221,9 @@ this utility or remote systems that it connects to.
     def close_all_connections(self):
         """Close all sessions for nodes"""
         for client in self.client_list:
-            self.log_debug('Closing connection to %s' % client.address)
-            client.disconnect()
+            if client.connected:
+                self.log_debug('Closing connection to %s' % client.address)
+                client.disconnect()
 
     def create_cluster_archive(self):
         """Calls for creation of tar archive then cleans up the temporary

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -92,6 +92,7 @@ class ocp(Cluster):
                                % ret['output'])
             # don't leave the config on a non-existing project
             self.exec_primary_cmd("oc project default")
+            self.project = None
         return True
 
     def _build_dict(self, nodelist):

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -751,12 +751,11 @@ class SosNode():
             if self.file_exists(path):
                 self.log_info("Copying remote %s to local %s" %
                               (path, destdir))
-                self._transport.retrieve_file(path, dest)
+                return self._transport.retrieve_file(path, dest)
             else:
                 self.log_debug("Attempting to copy remote file %s, but it "
                                "does not exist on filesystem" % path)
                 return False
-            return True
         except Exception as err:
             self.log_debug("Failed to retrieve %s: %s" % (path, err))
             return False
@@ -793,16 +792,20 @@ class SosNode():
                 except Exception:
                     self.log_error('Failed to make archive readable')
                     return False
-            self.soslog.info('Retrieving sos report from %s' % self.address)
+            self.log_info('Retrieving sos report from %s' % self.address)
             self.ui_msg('Retrieving sos report...')
-            ret = self.retrieve_file(self.sos_path)
+            try:
+                ret = self.retrieve_file(self.sos_path)
+            except Exception as err:
+                self.log_error(err)
+                return False
             if ret:
                 self.ui_msg('Successfully collected sos report')
                 self.file_list.append(self.sos_path.split('/')[-1])
+                return True
             else:
-                self.log_error('Failed to retrieve sos report')
-                raise SystemExit
-            return True
+                self.ui_msg('Failed to retrieve sos report')
+                return False
         else:
             # sos sometimes fails but still returns a 0 exit code
             if self.stderr.read():

--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -303,7 +303,20 @@ class RemoteTransport():
         :returns:   True if file was successfully copied from remote, or False
         :rtype:     ``bool``
         """
-        return self._retrieve_file(fname, dest)
+        attempts = 0
+        try:
+            while attempts < 5:
+                attempts += 1
+                ret = self._retrieve_file(fname, dest)
+                if ret:
+                    return True
+                self.log_info("File retrieval attempt %s failed" % attempts)
+            self.log_info("File retrieval failed after 5 attempts")
+            return False
+        except Exception as err:
+            self.log_error("Exception encountered during retrieval attempt %s "
+                           "for %s: %s" % (attempts, fname, err))
+            raise err
 
     def _retrieve_file(self, fname, dest):
         raise NotImplementedError("Transport %s does not support file copying"

--- a/sos/collector/transports/local.py
+++ b/sos/collector/transports/local.py
@@ -35,6 +35,7 @@ class LocalTransport(RemoteTransport):
     def _retrieve_file(self, fname, dest):
         self.log_debug("Moving %s to %s" % (fname, dest))
         shutil.copy(fname, dest)
+        return True
 
     def _format_cmd_for_exec(self, cmd):
         return cmd

--- a/sos/collector/transports/oc.py
+++ b/sos/collector/transports/oc.py
@@ -202,7 +202,8 @@ class OCTransport(RemoteTransport):
                                                     env, False)
 
     def _disconnect(self):
-        os.unlink(self.pod_tmp_conf)
+        if os.path.exists(self.pod_tmp_conf):
+            os.unlink(self.pod_tmp_conf)
         removed = self.run_oc("delete pod %s" % self.pod_name)
         if "deleted" not in removed['output']:
             self.log_debug("Calling delete on pod '%s' failed: %s"


### PR DESCRIPTION
If a paritcular attempt to retrieve a remote file fails, we should
automatically retry that collection up to a certain point. This provides
`sos collect` more resiliency for the collection of sos report archives.

This change necessitates a change in how we handle the SoSNode flow for
failed sos report retrievals, and as such contains minor fixes to
transports to ensure that we do not incorrectly hit exceptions in error
handling that were not previously possible with how we exited the
SoSNode retrieval flow.

Closes: #2777

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?