### PR TITLE
[rpmostree] Improvements at rpm-ostree plugin

### DIFF
--- a/sos/report/plugins/rpmostree.py
+++ b/sos/report/plugins/rpmostree.py
@@ -22,7 +22,8 @@ class Rpmostree(Plugin, RedHatPlugin):
         self.add_copy_spec('/etc/ostree/remotes.d/')
 
         subcmds = [
-            'status',
+            'status -v',
+            'kargs',
             'db list',
             'db diff',
             '--version'


### PR DESCRIPTION
- `rpm-ostree status` replaced with `rpm-ostree status -v`
- Added `rpm-ostree kargs` output

Signed-off-by: Pablo Alonso Rodriguez <palonsoro@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?