### PR TITLE
[options] Allow spaces in --keywords values in sos.conf

### DIFF
--- a/sos/options.py
+++ b/sos/options.py
@@ -200,7 +200,10 @@ class SoSOptions():
                         odict[rename_opts[key]] = odict.pop(key)
                 # set the values according to the config file
                 for key, val in odict.items():
-                    if isinstance(val, str):
+                    # most option values do not tolerate spaces, special
+                    # exception however for --keywords which we do want to
+                    # support phrases, and thus spaces, for
+                    if isinstance(val, str) and key != 'keywords':
                         val = val.replace(' ', '')
                     if key not in self.arg_defaults:
                         # read an option that is not loaded by the current


### PR DESCRIPTION
The `--keywords` option supports spaces to allow for obfuscated phrases,
not just words. This however breaks if a phrase is added to the config
file *before* a run with the phrase in the cmdline option, due to the
safeguards we have for all other values that do not support spaces.

Add a check in our flow for updating options from the config file to not
replace illegal spaces if we're checking the `keywords` option, for
which spaces are legal.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?