### PR TITLE
[systemd] Collect systemctl list-units --all

### DIFF
--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -39,6 +39,7 @@ class Systemd(Plugin, IndependentPlugin):
             # status --all mostly seems to cover the others.
             "systemctl list-units",
             "systemctl list-units --failed",
+            "systemctl list-units --all",
             "systemctl list-unit-files",
             "systemctl list-jobs",
             "systemctl list-dependencies",


### PR DESCRIPTION
Systemd has a hard limit of units that it can keep, and the limit is 128K.

Once that limit is hit (which is usually happening due to various bugs),
systemd returns E2BIG ("Argument list too long") when trying to start a
new unit. Until recently, it was not possible to figure out what is
going on without looking at the "systemctl list-units --all" output.

That's why it's nice to have it in sos report.

Found while working on https://bugzilla.redhat.com/show_bug.cgi?id=2028153

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?