### PR TITLE
[cleaner] detect longer known domain names properly

### DIFF
--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -106,7 +106,6 @@ class SoSHostnameMap(SoSMap):
             # don't block on host's shortname
             return host[0] in self.hosts.keys()
         else:
-            domain = host[0:-1]
             for known_domain in self._domains:
                 if known_domain in domain:
                     return True


### PR DESCRIPTION
For domains consisting of >2 names (foo.bar.com or longer), detection
of them in input data does not currently work. Since we grep for a
string inside a list (split by '.') instead of the domainname (separated
from its top-level domain).

Resolves: #2811

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?