### PR TITLE
[report] Handle exceptionally old pexpect versions

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -1129,7 +1129,13 @@ class LinuxPolicy(Policy):
         # need to strip the protocol prefix here
         sftp_url = self.get_upload_url().replace('sftp://', '')
         sftp_cmd = "sftp -oStrictHostKeyChecking=no %s@%s" % (user, sftp_url)
-        ret = pexpect.spawn(sftp_cmd, encoding='utf-8')
+
+        if int(pexpect.__version__[0]) >= 4:
+            # newer expect requires decoding from subprocess
+            ret = pexpect.spawn(sftp_cmd, encoding='utf-8')
+        else:
+            # older pexpect does not
+            ret = pexpect.spawn(sftp_cmd)
 
         sftp_expects = [
             u'sftp>',


### PR DESCRIPTION
Depending on configuration, certain downstreams may provide pexpect 2.3
or 4.6 (or later). The backport for SFTP upload support assumed a 4.x
version pexpect, however 2.x does not support the `encoding` parameter
to `pexpect.spawn()`.

Add a version check to determine if that parameter needs to be used or
not. Note that this does not need to be implemented against `main`, as
all supported downstreams for `main` support a minimum version of 4.x.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?