### PR TITLE
[report] Provide better warning about estimate-mode

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -343,9 +343,13 @@ is available at the end.
 
 Plugins will be collected sequentially, size of collected files and commands outputs
 will be calculated and the plugin files will be immediatelly deleted prior execution
-of the next plugin. This still can consume whole free disk space, though. Please note,
-size estimations may not be accurate for highly utilized systems due to changes between
-an estimate and a real execution.
+of the next plugin. This still can consume whole free disk space, though.
+
+Please note, size estimations may not be accurate for highly utilized systems due to
+changes between an estimate and a real execution. Also some difference between
+estimation (using `stat` command) and other commands used (i.e. `du`).
+
+A rule of thumb is to reserve at least double the estimation.
 .TP
 .B \--upload
 If specified, attempt to upload the resulting archive to a vendor defined location.

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1330,7 +1330,8 @@ class SoSReport(SoSComponent):
             self.ui_log.info("Please note the estimation is relevant to the "
                              "current options.")
             self.ui_log.info("Be aware that the real disk space requirements "
-                             "might be different.")
+                             "might be different. A rule of thumb is to "
+                             "reserve at least double the estimation.")
             self.ui_log.info("")
 
         # package up and compress the results


### PR DESCRIPTION
As --estimate-only calculates disk usage based on `stat` data that
differs from outputs of other commands like `du`, enhance the warning
about reliability of the calculated estimation.

Also add a rule-of-thumb recommendation of real disk space requirements.

Resolves: #2815

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?