### PR TITLE
[cirrus,tests] Update testing matrix to Fedora 35

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@
 # Main environment vars to set for all tasks
 env:
 
-    FEDORA_VER: "34"
-    FEDORA_PRIOR_VER: "33"
+    FEDORA_VER: "35"
+    FEDORA_PRIOR_VER: "34"
     FEDORA_NAME: "fedora-${FEDORA_VER}"
     FEDORA_PRIOR_NAME: "fedora-${FEDORA_PRIOR_VER}"
 
@@ -112,6 +112,7 @@ report_stageone_task:
         fi
         if [ $(command -v dnf) ]; then
             dnf -y remove sos
+            dnf -y install python3-pip ethtool
         fi
     setup_script: &setup 'pip3 install avocado-framework'
     # run the unittests separately as they require a different PYTHONPATH in


### PR DESCRIPTION
F35 has been out for a bit, we should update our testing matrix
accordingly.

New images have been pushed to GCP, so this change updates Cirrus to use
those new images.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?