### PR TITLE
[tests] Do not remove temp dirs from failed CI test runs

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1541,13 +1541,15 @@ class SoSReport(SoSComponent):
         except (OSError):
             if self.opts.debug:
                 raise
-            self.cleanup()
+            if not os.getenv('SOS_TEST_LOGS', None) == 'keep':
+                self.cleanup()
         except (KeyboardInterrupt):
             self.ui_log.error("\nExiting on user cancel")
             self.cleanup()
             self._exit(130)
         except (SystemExit) as e:
-            self.cleanup()
+            if not os.getenv('SOS_TEST_LOGS', None) == 'keep':
+                self.cleanup()
             sys.exit(e.code)
 
         self._exit(1)

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -121,7 +121,8 @@ class BaseSoSTest(Test):
         """
         exec_cmd = self._generate_sos_command()
         try:
-            self.cmd_output = process.run(exec_cmd, timeout=self.sos_timeout)
+            self.cmd_output = process.run(exec_cmd, timeout=self.sos_timeout,
+                                          env={'SOS_TEST_LOGS': 'keep'})
         except Exception as err:
             if not hasattr(err, 'result'):
                 # can't inspect the exception raised, just bail out


### PR DESCRIPTION
In the event a CI test execution fails before the archive is created,
for any reason, we want to preserve the temp directory as the logs there
are still useful.

As such, add a specific env var to our test runs via avocado. Then, when
we detect a failure check for that env var to determine if we should in
fact do our cleanup or not.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?