### PR TITLE
[networking] Enhance ss_pred by xsk_diag kmod

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -134,7 +134,7 @@ class Networking(Plugin):
         ss_cmd = "ss -peaonmi"
         ss_pred = SoSPredicate(self, kmods=[
             'tcp_diag', 'udp_diag', 'inet_diag', 'unix_diag', 'netlink_diag',
-            'af_packet_diag'
+            'af_packet_diag', 'xsk_diag'
         ], required={'kmods': 'all'})
         self.add_cmd_output(ss_cmd, pred=ss_pred, changes=True)
 


### PR DESCRIPTION
'ss -peaonmi' does require also xsk_diag kmod that must be
added to the list of kmod predicates of the ss command.

Resolves: #2818
Related: #2816

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?