### PR TITLE
[cleaner] Fix long domain handling/detection, parser handling, and known skips

### DIFF
--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -43,6 +43,7 @@ class SoSObfuscationArchive():
     type_name = 'undetermined'
     description = 'undetermined'
     is_nested = False
+    skip_files = []
     prep_files = {}
 
     def __init__(self, archive_path, tmpdir):
@@ -111,6 +112,7 @@ class SoSObfuscationArchive():
         Returns: list of files and file regexes
         """
         return [
+            'proc/kallsyms',
             'sosreport-',
             'sys/firmware',
             'sys/fs',

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -37,7 +37,8 @@ class SoSIPParser(SoSCleanerParser):
         'sos_commands/snappy/snap_list_--all',
         'sos_commands/snappy/snap_--version',
         'sos_commands/vulkan/vulkaninfo',
-        'var/log/.*dnf.*'
+        'var/log/.*dnf.*',
+        'var/log/.*packag.*'  # get 'packages' and 'packaging' logs
     ]
 
     map_file_key = 'ip_map'

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -32,6 +32,7 @@ class SoSUsernameParser(SoSCleanerParser):
         'nobody',
         'nfsnobody',
         'shutdown',
+        'stack',
         'reboot',
         'root',
         'ubuntu',


### PR DESCRIPTION
This patchset includes an alternative fix to #2811 which also carries some fixes for other issues found while investigating the CI failures from that change.

We should now properly account for long `--domains` values, and better handle parser file skips. Additionally, some well-known files/strings are added to skip lists that were discovered in tandem with this work.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?