### PR TITLE
[storcli] Fix show events command

### DIFF
--- a/sos/report/plugins/storcli.py
+++ b/sos/report/plugins/storcli.py
@@ -27,7 +27,6 @@ class StorCLI(Plugin, IndependentPlugin):
             'show ctrlcount',
             '/call show AliLog',
             '/call show all',
-            '/call show events',
             '/call show termlog',
             '/call/bbu show all',
             '/call/cv show all',
@@ -47,5 +46,13 @@ class StorCLI(Plugin, IndependentPlugin):
                 "%s %s%s" % (cmd, subcmd, json),
                 suggest_filename="storcli64_%s%s" % (subcmd, json),
                 runat=logpath)
+
+        # /call show events need 'file=' option to get adapter info like below
+        # "Adapter: # - Number of Events: xxx".
+        subcmd = '/call show events'
+        self.add_cmd_output(
+             "%s %s file=/dev/stdout%s" % (cmd, subcmd, json),
+             suggest_filename="storcli64_%s%s" % (subcmd, json),
+             runat=logpath)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adapter information is not showing in
/call show events command because it
requires file=<filename> as a parameter

e.g.
/opt/MegaRAID/storcli/storcli64 /call show events file=storcli64_.call_show_events

Signed-off-by: Mahesh Potkar <maheshpotkar@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?