### PR TITLE
Make cluster init failure more robust

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -443,7 +443,8 @@ class SoSCollector(SoSComponent):
 
     def exit(self, msg, error=1):
         """Used to safely terminate if sos-collector encounters an error"""
-        self.cluster.cleanup()
+        if self.cluster:
+            self.cluster.cleanup()
         self.log_error(msg)
         try:
             self.close_all_connections()

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -382,7 +382,8 @@ class SosNode():
         given ver. This means that if the installed version is greater than
         ver, this will still return True
         """
-        return LooseVersion(self.sos_info['version']) >= ver
+        return self.sos_info['version'] is not None and \
+            LooseVersion(self.sos_info['version']) >= ver
 
     def is_installed(self, pkg):
         """Checks if a given package is installed on the node"""


### PR DESCRIPTION
Reproducer: on a non-`ovirt` system, try to wrongly sos collect like it would be that cluster type:

    python3 bin/sos collect -vvv --case-id=666 --no-local --cluster-type ovirt --primary "127.0.0.1" --batch


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?