### PR TITLE
[vmware] collect vmware timesync status

### DIFF
--- a/sos/report/plugins/vmware.py
+++ b/sos/report/plugins/vmware.py
@@ -37,7 +37,8 @@ class VMWare(Plugin, RedHatPlugin):
         self.add_cmd_output([
             "vmware-checkvm",
             "vmware-toolbox-cmd device list",
-            "vmware-toolbox-cmd -v"
+            "vmware-toolbox-cmd -v",
+            "vmware-toolbox-cmd timesync status"
         ])
 
         stats = self.exec_cmd("vmware-toolbox-cmd stat raw")


### PR DESCRIPTION
It displays information whether VMware time sync is enabled, which
affects how ntpd/chronyd works.

Resolves: #2824

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?