### PR TITLE
[clean] Ignore empty items for obfuscation better

### DIFF
--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -49,6 +49,8 @@ class SoSMap():
             :param item:        The plaintext object to obfuscate
         """
         with self.lock:
+            if not item:
+                return item
             self.dataset[item] = self.sanitize_item(item)
             return self.dataset[item]
 
@@ -67,7 +69,8 @@ class SoSMap():
         """Retrieve an item's obfuscated counterpart from the map. If the item
         does not yet exist in the map, add it by generating one on the fly
         """
-        if self.ignore_item(item) or self.item_in_dataset_values(item):
+        if (not item or self.ignore_item(item) or
+                self.item_in_dataset_values(item)):
             return item
         if item not in self.dataset:
             return self.add(item)

--- a/sos/cleaner/mappings/username_map.py
+++ b/sos/cleaner/mappings/username_map.py
@@ -24,7 +24,7 @@ class SoSUsernameMap(SoSMap):
 
     def load_names_from_options(self, opt_names):
         for name in opt_names:
-            if name not in self.dataset.keys():
+            if name and name not in self.dataset.keys():
                 self.add(name)
 
     def sanitize_item(self, username):

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -55,7 +55,7 @@ class SoSUsernameParser(SoSCleanerParser):
                 user = line.split()[0]
             except Exception:
                 continue
-            if user.lower() in self.skip_list:
+            if not user or user.lower() in self.skip_list:
                 continue
             users.add(user)
         for each in users:


### PR DESCRIPTION
This commit fixes a couple edge cases where an item empty (e.g. and
empty string '') was not being properly ignored, which in turned caused
failures in writing both obfuscations and replacement files.

This should no longer be possible.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?