### PR TITLE
[ovn_central] Account for Red Hat ovn package naming

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -147,7 +147,7 @@ class OVNCentral(Plugin):
 
 class RedHatOVNCentral(OVNCentral, RedHatPlugin):
 
-    packages = ('openvswitch-ovn-central', 'ovn2.*-central', )
+    packages = ('openvswitch-ovn-central', 'ovn.*-central', )
     ovn_sbdb_sock_path = '/var/run/openvswitch/ovnsb_db.ctl'
 
 

--- a/sos/report/plugins/ovn_host.py
+++ b/sos/report/plugins/ovn_host.py
@@ -55,7 +55,7 @@ class OVNHost(Plugin):
 
 class RedHatOVNHost(OVNHost, RedHatPlugin):
 
-    packages = ('openvswitch-ovn-host', 'ovn2.*-host', )
+    packages = ('openvswitch-ovn-host', 'ovn.*-host', )
 
 
 class DebianOVNHost(OVNHost, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Previous ovn packages were 'ovn2xxx' and now they have
been renamed to 'ovn-2xxx'. This causes sos tool to not
recognize that the packages are installed and it won't
collect the relevant data.

This patch is changing the match expression to be compatible
with the previous and newer naming conventions.

Signed-off-by: Daniel Alvarez Sanchez <dalvarez@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?