### PR TITLE
[cleaner] Update regex for finding IPv4/v6 addresses

### DIFF
--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -20,10 +20,10 @@ class SoSMacParser(SoSCleanerParser):
     name = 'MAC Parser'
     regex_patterns = [
         # IPv6
-        r'(([^:|-])([0-9a-fA-F]{2}(:|-)){7}[0-9a-fA-F]{2}(\s|$))',
+        r'(([^:|-])?([0-9a-fA-F]{2}(:|-)){7}[0-9a-fA-F]{2}(\s|$))',
         r'(([^:|-])([0-9a-fA-F]{4}(:|-)){3}[0-9a-fA-F]{4}(\s|$))',
         # IPv4, avoiding matching a substring within IPv6 addresses
-        r'(([^:|-])([0-9a-fA-F]{2}([:-])){5}([0-9a-fA-F]){2}(.)?(\s|$|\W))'
+        r'(([^:|-])?([0-9a-fA-F]{2}([:-])){5}([0-9a-fA-F]){2}(.)?(\s|$|\W))'
     ]
     obfuscated_patterns = (
         '53:4f:53',


### PR DESCRIPTION
The regex trys to match a single character not present
in the given list [^:|-]. The string which starts with
addresses are left out as there is
no character to match.

Adding ? to matches the previous token between zero and one time.

Resolves Issue: #2829

Signed-off-by: Nikhil Kakade <nikhilkaka5@outlook.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?