### PR TITLE
[mac_parser] Skip parsing of modinfo output

### DIFF
--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -29,6 +29,9 @@ class SoSMacParser(SoSCleanerParser):
         '53:4f:53',
         '534f:53'
     )
+    skip_files = [
+        'sos_commands/kernel/modinfo.*'
+    ]
     map_file_key = 'mac_map'
 
     def __init__(self, config):


### PR DESCRIPTION
Skip parsing of modinfo output by the mac parser, as this can lead to
numerous false positive matches and unhelpfully obfuscate the signature
of modules.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?