### PR TITLE
[mac_parser] Avoid substring matches with look-behinds

### DIFF
--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -13,17 +13,25 @@ from sos.cleaner.mappings.mac_map import SoSMacMap
 
 import re
 
+# aa:bb:cc:fe:ff:dd:ee:ff
+IPV6_REG_8HEX = (r'((?<!([0-9a-fA-F]:)|::)([^:|-])?([0-9a-fA-F]{2}(:|-)){7}'
+                 r'[0-9a-fA-F]{2}(\s|$))')
+# aabb:ccee:ddee:ffaa
+IPV6_REG_4HEX = (r'((?<!([0-9a-fA-F]:)|::)(([^:\-]?[0-9a-fA-F]{4}(:|-)){3}'
+                 r'[0-9a-fA-F]{4}(\s|$)))')
+# aa:bb:cc:dd:ee:ff avoiding ipv6 substring matches
+IPV4_REG = (r'((?<!([0-9a-fA-F]:)|::)(([^:\-])?([0-9a-fA-F]{2}([:-])){5}'
+            r'([0-9a-fA-F]){2}(\s|$)))')
+
 
 class SoSMacParser(SoSCleanerParser):
     """Handles parsing for MAC addresses"""
 
     name = 'MAC Parser'
     regex_patterns = [
-        # IPv6
-        r'(([^:|-])?([0-9a-fA-F]{2}(:|-)){7}[0-9a-fA-F]{2}(\s|$))',
-        r'(([^:|-])([0-9a-fA-F]{4}(:|-)){3}[0-9a-fA-F]{4}(\s|$))',
-        # IPv4, avoiding matching a substring within IPv6 addresses
-        r'(([^:|-])?([0-9a-fA-F]{2}([:-])){5}([0-9a-fA-F]){2}(.)?(\s|$|\W))'
+        IPV6_REG_8HEX,
+        IPV6_REG_4HEX,
+        IPV4_REG
     ]
     obfuscated_patterns = (
         '53:4f:53',


### PR DESCRIPTION
This commit adds a negative look-behind to the regex patterns for mac
addresses so we avoid matching substrings from both non-mac-address
strings, certain ipv6 address strings, and longer strings of hextets
that we could potentially match a substring of.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?