### PR TITLE
[virsh] Catch parsing exception

### DIFF
--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -48,7 +48,11 @@ class LibvirtClient(Plugin, IndependentPlugin):
             if k_list['status'] == 0:
                 k_lines = k_list['output'].splitlines()
                 # the 'Name' column position changes between virsh cmds
-                pos = k_lines[0].split().index('Name')
+                # catch the rare exceptions when 'Name' is not found
+                try:
+                    pos = k_lines[0].split().index('Name')
+                except Exception:
+                    continue
                 for j in filter(lambda x: x, k_lines[2:]):
                     n = j.split()[pos]
                     self.add_cmd_output('%s %s-dumpxml %s' % (cmd, k, n),


### PR DESCRIPTION
In case virsh output is malformed or missing 'Name' otherwise,
catch parsing exception and continue in next for loop iteration.

Resolves: #2836

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?