### PR TITLE
[ovn-central] collect NB/SB ovsdb-server cluster status

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -84,6 +84,14 @@ class OVNCentral(Plugin):
         else:
             self.add_copy_spec("/var/log/ovn/*.log")
 
+        # ovsdb nb/sb cluster status commands
+        ovsdb_cmds = [
+            'ovs-appctl -t {} cluster/status OVN_Northbound'.format(
+                self.ovn_nbdb_sock_path),
+            'ovs-appctl -t {} cluster/status OVN_Southbound'.format(
+                self.ovn_sbdb_sock_path),
+        ]
+
         # Some user-friendly versions of DB output
         nbctl_cmds = [
             'ovn-nbctl show',
@@ -109,7 +117,8 @@ class OVNCentral(Plugin):
 
         self.add_database_output(nb_tables, nbctl_cmds, 'ovn-nbctl')
 
-        cmds = nbctl_cmds
+        cmds = ovsdb_cmds
+        cmds += nbctl_cmds
 
         # Can only run sbdb commands if we are the leader
         co = {'cmd': "ovs-appctl -t {} cluster/status OVN_Southbound".
@@ -148,10 +157,12 @@ class OVNCentral(Plugin):
 class RedHatOVNCentral(OVNCentral, RedHatPlugin):
 
     packages = ('openvswitch-ovn-central', 'ovn.*-central', )
+    ovn_nbdb_sock_path = '/var/run/openvswitch/ovnnb_db.ctl'
     ovn_sbdb_sock_path = '/var/run/openvswitch/ovnsb_db.ctl'
 
 
 class DebianOVNCentral(OVNCentral, DebianPlugin, UbuntuPlugin):
 
     packages = ('ovn-central', )
+    ovn_nbdb_sock_path = '/var/run/ovn/ovnnb_db.ctl'
     ovn_sbdb_sock_path = '/var/run/ovn/ovnsb_db.ctl'


### PR DESCRIPTION
Add commands to collect cluster status of Northbound and
Southbound ovsdb servers.

Resolves: #2840

Signed-off-by: Hemanth Nakkina hemanth.nakkina@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?