### PR TITLE
[hostname] Reduce false positive matches

### DIFF
--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -40,6 +40,9 @@ class SoSHostnameMap(SoSMap):
         'api'
     ]
 
+    strip_exts = ('.yaml', '.yml', '.crt', '.key', '.pem', '.log', '.repo',
+                  '.rules')
+
     host_count = 0
     domain_count = 0
     _domains = {}
@@ -105,18 +108,16 @@ class SoSHostnameMap(SoSMap):
         """Check if a potential domain is in one of the domains we've loaded
         and should be obfuscated
         """
+        if domain in self._domains:
+            return True
         host = domain.split('.')
         no_tld = '.'.join(domain.split('.')[0:-1])
         if len(host) == 1:
             # don't block on host's shortname
-            return host[0] in self.hosts.keys()
+            return host[0] in self.hosts
         elif any([no_tld.endswith(_d) for _d in self._domains]):
             return True
-        else:
-            domain = host[0:-1]
-            for known_domain in self._domains:
-                if known_domain in domain:
-                    return True
+
         return False
 
     def get(self, item):
@@ -136,7 +137,7 @@ class SoSHostnameMap(SoSMap):
             item = item[0:-1]
         if not self.domain_name_in_loaded_domains(item.lower()):
             return item
-        if item.endswith(('.yaml', '.yml', '.crt', '.key', '.pem', '.log')):
+        if item.endswith(self.strip_exts):
             ext = '.' + item.split('.')[-1]
             item = item.replace(ext, '')
             suffix += ext


### PR DESCRIPTION
This commit aims to reduce false-positive matches by the hostname
parser/map. Do this by first removing a too-broad substring check that
is better covered by a simpler check in the `_domains` internal dict,
made possible by the previous change which explicitly checks without the
tld as part of the domain string.

Second, improve the set of extensions to strip from potential matches
that would otherwise be regarded as TLDs, but are in fact not TLDs.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?