### PR TITLE
[cleaner] Implement generate_item_regexes for hostname_parser

### DIFF
--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -42,12 +42,13 @@ class SoSKeywordParser(SoSCleanerParser):
 
     def generate_item_regexes(self):
         for kw in self.user_keywords:
-            self.regexes[kw] = re.compile(kw, re.I)
+            self.regexes[kw.lower()] = re.compile(kw, re.I)
+        self.regexes = sorted(self.regexes.items(), key=len, reverse=True)
 
     def parse_line(self, line):
         count = 0
-        for kwrd, reg in sorted(self.regexes.items(), key=len, reverse=True):
+        for kwrd, reg in self.regexes:
             if reg.search(line):
-                line, _count = reg.subn(self.mapping.get(kwrd.lower()), line)
+                line, _count = reg.subn(self.mapping.get(kwrd), line)
                 count += _count
         return line, count

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -63,12 +63,13 @@ class SoSUsernameParser(SoSCleanerParser):
 
     def generate_item_regexes(self):
         for user in self.mapping.dataset:
-            self.regexes[user] = re.compile(user, re.I)
+            self.regexes[user.lower()] = re.compile(user, re.I)
+        self.regexes = sorted(self.regexes.items(), key=len, reverse=True)
 
     def parse_line(self, line):
         count = 0
-        for user, reg in sorted(self.regexes.items(), key=len, reverse=True):
+        for user, reg in self.regexes:
             if reg.search(line):
-                line, _count = reg.subn(self.mapping.get(user.lower()), line)
+                line, _count = reg.subn(self.mapping.get(user), line)
                 count += _count
         return line, count


### PR DESCRIPTION
Two commits patchset. `generate_item_regexes` for `hostname_parser` is the key one. It contains an improvement in pre-computation of sorting that is applicable to other instances of the method - which covers the second commit.

Some preliminary results show 30-40% performance gain of cleaner.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?