### PR TITLE
[dellrac] ensure the logpath directory exists

### DIFF
--- a/sos/report/plugins/dellrac.py
+++ b/sos/report/plugins/dellrac.py
@@ -34,7 +34,13 @@ class DellRAC(Plugin, IndependentPlugin):
             self.do_debug()
 
     def do_debug(self):
-        logpath = self.get_cmd_output_path(make=False)
+        # ensure the sos_commands/dellrac directory does exist in either case
+        # as we will need to run the command at that dir, and also ensure
+        # logpath is properly populated in either case as well
+        try:
+            logpath = self.get_cmd_output_path()
+        except FileExistsError:
+            logpath = self.get_cmd_output_path(make=False)
         subcmd = 'supportassist collect -f'
         self.add_cmd_output(
             '%s %s support.zip' % (self.racadm, subcmd),


### PR DESCRIPTION
Due to the runat=logpath argument, we must ensure the logpath directory
is created. Also catch properly the case when the directory has been
created before.

Resolves: #2845

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?