### PR TITLE
[policies] Set fallback to None sysroot

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -78,7 +78,7 @@ class LinuxPolicy(Policy):
         if sysroot:
             self.sysroot = sysroot
         else:
-            self.sysroot = self._container_init()
+            self.sysroot = self._container_init() or '/'
 
         self.init_kernel_modules()
 


### PR DESCRIPTION
9596473 commit added a regression allowing to set sysroot to None
when running sos report on a regular system (outside a container). In
such a case, we need to fallback to '/' sysroot.

Resolves: #2846

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?