### PR TITLE
[tests] Minor fixes for avocado and unittests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,7 +118,7 @@ report_stageone_task:
     # run the unittests separately as they require a different PYTHONPATH in
     # order for the imports to work properly under avocado
     unittest_script: PYTHONPATH=. avocado run tests/unittests/
-    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run --nrunner-max-parallel-tasks 1 -t stageone tests/{cleaner,collect,report,vendor}_tests
     on_failure:
         fail_script: &faillogs |
             ls -d /var/tmp/avocado* /root/avocado* 2> /dev/null | xargs tar cf sos-fail-logs.tar
@@ -153,7 +153,7 @@ report_stagetwo_task:
             dnf -y install python3-pexpect
         fi
     setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stagetwo tests/{cleaner,collect,report,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run --nrunner-max-parallel-tasks 1 -t stagetwo tests/{cleaner,collect,report,vendor}_tests
     on_failure:
         fail_script: *faillogs
         log_artifacts:
@@ -178,7 +178,7 @@ report_foreman_task:
             FOREMAN_VER: "2.5 - Debian 10"
     remove_sos_script: *remove_sos
     setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t foreman tests/product_tests/foreman/
+    main_script: PYTHONPATH=tests/ avocado run --nrunner-max-parallel-tasks 1 -t foreman tests/product_tests/foreman/
     on_failure:
         fail_script: *faillogs
         log_artifacts:

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -120,7 +120,7 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
     # closure are caught in the parent (chroot and chdir are bound from
     # the enclosing scope).
     def _child_prep_fn():
-        if (chroot):
+        if chroot and chroot != '/':
             os.chroot(chroot)
         if (chdir):
             os.chdir(chdir)

--- a/tests/collect_tests/help_output_tests.py
+++ b/tests/collect_tests/help_output_tests.py
@@ -14,7 +14,7 @@ from avocado.utils import software_manager
 from sos_tests import StageOneOutputTest, SOS_REPO_ROOT, skipIf
 
 installer = software_manager
-sm = installer.SoftwareManager()
+sm = installer.manager.SoftwareManager()
 
 PEXPECT_PRESENT = sm.check_installed('python3-pexpect')
 

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -10,7 +10,8 @@
 from avocado.core.exceptions import TestSkipError
 from avocado.core.output import LOG_UI
 from avocado import Test
-from avocado.utils import archive, process, distro, software_manager
+from avocado.utils import archive, process, distro
+from avocado.utils.software_manager import distro_packages, manager
 from fnmatch import fnmatch
 
 import glob
@@ -734,8 +735,7 @@ class StageTwoReportTest(BaseSoSReportTest):
         self.end_of_test_case = False
         # seems awkward, but check_installed() and remove() are not exposed
         # together with install_distro_packages()
-        self.installer = software_manager
-        self.sm = self.installer.SoftwareManager()
+        self.sm = manager.SoftwareManager()
 
         for dist in self.packages:
             if isinstance(self.packages[dist], str):
@@ -805,7 +805,7 @@ class StageTwoReportTest(BaseSoSReportTest):
             self._strip_installed_packages()
             if not self.packages[self.local_distro]:
                 return
-            installed = self.installer.install_distro_packages(self.packages)
+            installed = distro_packages.install_distro_packages(self.packages)
             if not installed:
                 raise("Unable to install requested packages %s"
                       % ', '.join(pkg for pkg in self.packages[self.local_distro]))


### PR DESCRIPTION
`SoftwareManager()` from the avocado test suite is now under a different
module, so we need to update the help output test accordingly.

Additionally, the legacy runner is being dismantled in avocado in favor
of the nrunner test runner. Upstream indicates it will be fully removed
sooner rather than later, so we should get ahead of it and switch to
nrunner. To do so successfully, since our tests are designed to have a
single `sos` execution per test case (Test() superclass), we need to
disable parallel execution of tests for this runner.

As part of local testing, it was found that the previous sysroot fix had
an unintentional side-effect of causing our unittests to fail if they
were run by a non-root user. This is because of a call to `os.chroot()`
in `_child_prep_fn()`. This has the edge case possibility of also
throwing an exception in certain invocations of `sos collect`, so add a
second conditional that we aren't trying to chroot to `/`. As a knock-on
effect, this will mean we are not constantly calling `os.chroot()` for
every command executed during report collections.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?