### PR TITLE
[avocado] Pin avocado test suite to version 94

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,7 +114,7 @@ report_stageone_task:
             dnf -y remove sos
             dnf -y install python3-pip ethtool
         fi
-    setup_script: &setup 'pip3 install avocado-framework'
+    setup_script: &setup 'pip3 install avocado-framework==94.0'
     # run the unittests separately as they require a different PYTHONPATH in
     # order for the imports to work properly under avocado
     unittest_script: PYTHONPATH=. avocado run tests/unittests/


### PR DESCRIPTION
The latest release of avocado-framework, 95.0, makes several changes
that will require us to investigate moving to the newer nrunner
test-runner.

For the moment, pin our CI tests to a previous version so that the
changes in newer avocado versions don't block current development.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?