### PR TITLE
[utilities] Don't try to chroot to /

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -120,7 +120,7 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
     # closure are caught in the parent (chroot and chdir are bound from
     # the enclosing scope).
     def _child_prep_fn():
-        if (chroot):
+        if chroot and chroot != '/':
             os.chroot(chroot)
         if (chdir):
             os.chdir(chdir)


### PR DESCRIPTION
With the recent fix for sysroot being `None` to always being (correctly)
`/`, we should guard against situations where `sos_get_command_output()`
would now try to chroot to `/` before running any command. Incidentally,
this would also cause our unittests to fail if they were run by a
non-root user.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?