### PR TITLE
[report] Remove useless inclusion of tempfile_util in commons

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -532,8 +532,7 @@ class SoSReport(SoSComponent):
             'verbosity': self.opts.verbosity,
             'cmdlineopts': self.opts,
             'devices': self.devices,
-            'namespaces': self.namespaces,
-            'tempfile_util': self.tempfile_util
+            'namespaces': self.namespaces
         }
 
     def get_temp_file(self):


### PR DESCRIPTION
An early implementation of #2729 included expanding `TempFileUtil` and
passing it as a means to create temp files to write command output
directly to. That approach was abandoned in favor of a more robust
implementation, but the cleanup of the previous design was apparently
not complete.

Fix this by removing the inclusion of tempfile_util in our `commons`
dict.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?