### PR TITLE
[ovn_central] Rename container responsable of Red Hat ovn_central plugin

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -24,7 +24,7 @@ class OVNCentral(Plugin):
     short_desc = 'OVN Northd'
     plugin_name = "ovn_central"
     profiles = ('network', 'virt')
-    containers = ('ovs-db-bundle.*',)
+    containers = ('ovn-dbs-bundle.*',)
 
     def get_tables_from_schema(self, filename, skip=[]):
         if self._container_name:
@@ -66,7 +66,7 @@ class OVNCentral(Plugin):
             cmds.append('%s list %s' % (ovn_cmd, table))
 
     def setup(self):
-        self._container_name = self.get_container_by_name('ovs-dbs-bundle.*')
+        self._container_name = self.get_container_by_name(self.containers[0])
 
         ovs_rundir = os.environ.get('OVS_RUNDIR')
         for pidfile in ['ovnnb_db.pid', 'ovnsb_db.pid', 'ovn-northd.pid']:
@@ -110,12 +110,11 @@ class OVNCentral(Plugin):
             'ovn-sbctl get-connection',
         ]
 
-        schema_dir = '/usr/share/openvswitch'
-
-        nb_tables = self.get_tables_from_schema(self.path_join(
-            schema_dir, 'ovn-nb.ovsschema'))
-
-        self.add_database_output(nb_tables, nbctl_cmds, 'ovn-nbctl')
+        # backward compatibility
+        for path in ['/usr/share/openvswitch', '/usr/share/ovn']:
+            nb_tables = self.get_tables_from_schema(self.path_join(
+                path, 'ovn-nb.ovsschema'))
+            self.add_database_output(nb_tables, nbctl_cmds, 'ovn-nbctl')
 
         cmds = ovsdb_cmds
         cmds += nbctl_cmds
@@ -125,9 +124,11 @@ class OVNCentral(Plugin):
               format(self.ovn_sbdb_sock_path),
               "output": "Leader: self"}
         if self.test_predicate(self, pred=SoSPredicate(self, cmd_outputs=co)):
-            sb_tables = self.get_tables_from_schema(self.path_join(
-                schema_dir, 'ovn-sb.ovsschema'), ['Logical_Flow'])
-            self.add_database_output(sb_tables, sbctl_cmds, 'ovn-sbctl')
+            # backward compatibility
+            for path in ['/usr/share/openvswitch', '/usr/share/ovn']:
+                sb_tables = self.get_tables_from_schema(self.path_join(
+                    path, 'ovn-sb.ovsschema'), ['Logical_Flow'])
+                self.add_database_output(sb_tables, sbctl_cmds, 'ovn-sbctl')
             cmds += sbctl_cmds
 
         # If OVN is containerized, we need to run the above commands inside


### PR DESCRIPTION
ovn_central plugin is running by container with
name 'ovn-dbs-bundle*', a typo has been identified and
this cause plugin ovn_central not enabled by default as it
does not recognize any container responsible of this.

This patch fix this container name match.
Signed-off-by: Fernando Royo  <froyo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?