### PR TITLE
[cleaner] Use compiled regex lists for parsers by default

### DIFF
--- a/sos/cleaner/mappings/ip_map.py
+++ b/sos/cleaner/mappings/ip_map.py
@@ -44,6 +44,7 @@ class SoSIPMap(SoSMap):
     _networks = {}
     network_first_octet = 100
     skip_network_octets = ['127', '169', '172', '192']
+    compile_regexes = False
 
     def ip_in_dataset(self, ipaddr):
         """There are multiple ways in which an ip address could be handed to us

--- a/sos/cleaner/mappings/mac_map.py
+++ b/sos/cleaner/mappings/mac_map.py
@@ -48,6 +48,7 @@ class SoSMacMap(SoSMap):
     mac_template = '53:4f:53:%s:%s:%s'
     mac6_template = '53:4f:53:ff:fe:%s:%s:%s'
     mac6_quad_template = '534f:53ff:fe%s:%s%s'
+    compile_regexes = False
 
     def add(self, item):
         item = item.replace('-', ':').lower().strip('=.,').strip()

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -42,6 +42,7 @@ class SoSIPParser(SoSCleanerParser):
     ]
 
     map_file_key = 'ip_map'
+    compile_regexes = False
 
     def __init__(self, config):
         self.mapping = SoSIPMap()

--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -9,7 +9,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 import os
-import re
 
 from sos.cleaner.parsers import SoSCleanerParser
 from sos.cleaner.mappings.keyword_map import SoSKeywordMap
@@ -40,14 +39,5 @@ class SoSKeywordParser(SoSCleanerParser):
             with open(keyword_file, 'r') as kwf:
                 self.user_keywords.extend(kwf.read().splitlines())
 
-    def generate_item_regexes(self):
-        for kw in self.user_keywords:
-            self.regexes[kw] = re.compile(kw, re.I)
-
-    def parse_line(self, line):
-        count = 0
-        for kwrd, reg in sorted(self.regexes.items(), key=len, reverse=True):
-            if reg.search(line):
-                line, _count = reg.subn(self.mapping.get(kwrd.lower()), line)
-                count += _count
-        return line, count
+    def _parse_line(self, line):
+        return line, 0

--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -41,6 +41,7 @@ class SoSMacParser(SoSCleanerParser):
         'sos_commands/kernel/modinfo.*'
     ]
     map_file_key = 'mac_map'
+    compile_regexes = False
 
     def __init__(self, config):
         self.mapping = SoSMacMap()
@@ -57,11 +58,8 @@ class SoSMacParser(SoSCleanerParser):
         # just to be safe, call strip() to remove any padding
         return match.strip()
 
-    def parse_line(self, line):
+    def _parse_line(self, line):
         count = 0
-        for skip_pattern in self.skip_line_patterns:
-            if re.match(skip_pattern, line, re.I):
-                return line, count
         for pattern in self.regex_patterns:
             matches = [m[0] for m in re.findall(pattern, line, re.I)]
             if matches:

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -8,8 +8,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import re
-
 from sos.cleaner.parsers import SoSCleanerParser
 from sos.cleaner.mappings.username_map import SoSUsernameMap
 
@@ -61,14 +59,5 @@ class SoSUsernameParser(SoSCleanerParser):
         for each in users:
             self.mapping.get(each)
 
-    def generate_item_regexes(self):
-        for user in self.mapping.dataset:
-            self.regexes[user] = re.compile(user, re.I)
-
-    def parse_line(self, line):
-        count = 0
-        for user, reg in sorted(self.regexes.items(), key=len, reverse=True):
-            if reg.search(line):
-                line, _count = reg.subn(self.mapping.get(user.lower()), line)
-                count += _count
-        return line, count
+    def _parse_line(self, line):
+        return line, 0


### PR DESCRIPTION
This commit follows the initial change made to the username and keyword
parsers in #2823 and applies it to all parsers by default.

When a new match is found, a new `regex.Pattern()` object will now be
compiled and saved in the parser's map, and this object will be used for
ongoing obfuscations from that point forward, rather than rebuilding
regexes for every line we iterate over with that parser.

This is now built into the base `SoSMap` and leveraged by parsers,
rather than being handled directly by parsers. Further, this will be
enabled by default for all existing and new parsers. This shows decent
improvements to hostname parser performance in local testing. Note that
this functionality is explicitly disabled for the mac and ip parsers.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?