### PR TITLE
[runtimes] Allow container IDs to be used with `container_exists()`

### DIFF
--- a/sos/policies/runtimes/__init__.py
+++ b/sos/policies/runtimes/__init__.py
@@ -147,6 +147,23 @@ class ContainerRuntime():
                     vols.append(ent[-1])
         return vols
 
+    def container_exists(self, container):
+        """Check if a given container ID or name exists on the system from the
+        perspective of the container runtime.
+
+        Note that this will only check _running_ containers
+
+        :param container:       The name or ID of the container
+        :type container:        ``str``
+
+        :returns:               True if the container exists, else False
+        :rtype:                 ``bool``
+        """
+        for _contup in self.containers:
+            if container in _contup:
+                return True
+        return False
+
     def fmt_container_cmd(self, container, cmd, quotecmd):
         """Format a command to run inside a container using the runtime
 

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2593,7 +2593,7 @@ class Plugin():
         """If a container runtime is present, check to see if a container with
         a given name is currently running
 
-        :param name:    The name of the container to check presence of
+        :param name:    The name or ID of the container to check presence of
         :type name: ``str``
 
         :returns: ``True`` if `name` exists, else ``False``
@@ -2601,8 +2601,8 @@ class Plugin():
         """
         _runtime = self._get_container_runtime()
         if _runtime is not None:
-            con = _runtime.get_container_by_name(name)
-            return con is not None
+            return (_runtime.container_exists(name) or
+                    _runtime.get_container_by_name(name) is not None)
         return False
 
     def get_all_containers_by_regex(self, regex, get_all=False):


### PR DESCRIPTION
As container runtimes can interchange container names and container IDs,
sos should also allow the use of container IDs when checking for the
presence of a given container.

In particular, this change unblocks the use of `Plugin.exec_cmd()` when
used in conjunction with `Plugin.get_container_by_name()` to pick a
container based on a provided regex that the container name may match.

Related: #2856

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?