### PR TITLE
[report] Honor plugins' hardcoded plugin_timeout

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -636,7 +636,10 @@ class Plugin():
             if opt_timeout is None:
                 _timeout = own_timeout
             elif opt_timeout is not None and own_timeout == -1:
-                _timeout = int(opt_timeout)
+                if opt_timeout == TIMEOUT_DEFAULT:
+                    _timeout = default_timeout
+                else:
+                    _timeout = int(opt_timeout)
             elif opt_timeout is not None and own_timeout > -1:
                 _timeout = own_timeout
             else:


### PR DESCRIPTION
Currently, plugin's plugin_timeout hardcoded default is superseded by
whatever --plugin-timeout value, even when this option is not used and
we eval it to TIMEOUT_DEFAULT.

In this case of not setting --plugin-timeout, honour plugin's
plugin_timeout instead.

Resolves: #2863
Closes: #2864

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?