### PR TITLE
[pulpcore] Stop collecting commands relevant to old taskig system

### DIFF
--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -91,9 +91,6 @@ class PulpCore(Plugin, IndependentPlugin):
         # skip collecting certificate keys
         self.add_forbidden_path("/etc/pki/pulp/**/*.key", recursive=True)
 
-        self.add_cmd_output("rq info -u redis://localhost:6379/8",
-                            env={"LC_ALL": "en_US.UTF-8"},
-                            suggest_filename="rq_info")
         self.add_cmd_output("curl -ks https://localhost/pulp/api/v3/status/",
                             suggest_filename="pulp_status")
         dynaconf_env = {"LC_ALL": "en_US.UTF-8",
@@ -105,8 +102,6 @@ class PulpCore(Plugin, IndependentPlugin):
 
         task_days = self.get_option('task-days')
         for table in ['core_task', 'core_taskgroup',
-                      'core_reservedresourcerecord',
-                      'core_taskreservedresourcerecord',
                       'core_groupprogressreport', 'core_progressreport']:
             _query = "select * from %s where pulp_last_updated > NOW() - " \
                      "interval '%s days' order by pulp_last_updated" % \


### PR DESCRIPTION
The reserved resource approach was used by pulp-3 for a sporadic time
in early pulp-3 development only. It is abandoned and should not be
productised anywhere. So it is safe to remove the commands (together
with rq broker status that was in charge of reserved resources).

Resolves: #2865

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?