### PR TITLE
[tests] Add a test for non-default plugin_timeout compliance

### DIFF
--- a/tests/test_data/fake_plugins/timeout_test.py
+++ b/tests/test_data/fake_plugins/timeout_test.py
@@ -13,6 +13,7 @@ class TimeoutTest(Plugin, IndependentPlugin):
 
     plugin_name = 'timeout_test'
     short_desc = 'Tests timeout functionality in test suite'
+    plugin_timeout = 100
 
 
     def setup(self):


### PR DESCRIPTION
There was a gap in our testing that allowed #2863 to escape our notice -
that a `Plugin()`'s `plugin_timeout` attribute would be ignored if it
wasn't set to `TIMEOUT_DEFAULT`.

As that was resolved by #2864, add a test to ensure it remains working
as expected. The expected resolution order for a plugin's whole timeout
is as follows:

 1. The value set by `-k plugin.timeout`
 2. The value set by `--plugin-timeout`
 3. The value hardcoded in the plugin via the `plugin_timeout` attr
 4. `TIMEOUT_DEFAULT`

Related: #2863
Related: #2864

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?