### PR TITLE
[redhat] Honour credential-less --upload-url on RedHat distro properly

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -377,7 +377,8 @@ support representative.
         from RHCP failures to the public RH dropbox
         """
         try:
-            if not self.get_upload_user() or not self.get_upload_password():
+            if self.upload_url.startswith(RH_API_HOST) and \
+              (not self.get_upload_user() or not self.get_upload_password()):
                 self.upload_url = RH_SFTP_HOST
             uploaded = super(RHELPolicy, self).upload_archive(archive)
         except Exception:


### PR DESCRIPTION
When missing some credentials, do overwrite upload_url to the Red Hat
SFTP server *only* when upload-url points to the Customer Portal API
server.

Resolves: #2869
Closes: #2870

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?