### PR TITLE
[mac_parser] Match quoted mac addresses, fix duplication check

### DIFF
--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -14,14 +14,20 @@ from sos.cleaner.mappings.mac_map import SoSMacMap
 import re
 
 # aa:bb:cc:fe:ff:dd:ee:ff
-IPV6_REG_8HEX = (r'((?<!([0-9a-fA-F]:)|::)([^:|-])?([0-9a-fA-F]{2}(:|-)){7}'
-                 r'[0-9a-fA-F]{2}(\s|$))')
+IPV6_REG_8HEX = (
+    r'((?<!([0-9a-fA-F\'\"]:)|::)([^:|-])?([0-9a-fA-F]{2}(:|-)){7}'
+    r'[0-9a-fA-F]{2}(\'|\")?(\s|$))'
+)
 # aabb:ccee:ddee:ffaa
-IPV6_REG_4HEX = (r'((?<!([0-9a-fA-F]:)|::)(([^:\-]?[0-9a-fA-F]{4}(:|-)){3}'
-                 r'[0-9a-fA-F]{4}(\s|$)))')
+IPV6_REG_4HEX = (
+    r'((?<!([0-9a-fA-F\'\"]:)|::)(([^:\-]?[0-9a-fA-F]{4}(:|-)){3}'
+    r'[0-9a-fA-F]{4}(\'|\")?(\s|$)))'
+)
 # aa:bb:cc:dd:ee:ff avoiding ipv6 substring matches
-IPV4_REG = (r'((?<!([0-9a-fA-F]:)|::)(([^:\-])?([0-9a-fA-F]{2}([:-])){5}'
-            r'([0-9a-fA-F]){2}(\s|$)))')
+IPV4_REG = (
+    r'((?<!([0-9a-fA-F\'\"]:)|::)(([^:\-])?([0-9a-fA-F]{2}([:-])){5}'
+    r'([0-9a-fA-F]){2}(\'|\")?(\s|$)))'
+)
 
 
 class SoSMacParser(SoSCleanerParser):
@@ -65,10 +71,10 @@ class SoSMacParser(SoSCleanerParser):
             if matches:
                 count += len(matches)
                 for match in matches:
-                    if match.startswith(self.obfuscated_patterns):
+                    stripped_match = self.reduce_mac_match(match)
+                    if stripped_match.startswith(self.obfuscated_patterns):
                         # avoid double scrubbing
                         continue
-                    stripped_match = self.reduce_mac_match(match)
                     new_match = self.mapping.get(stripped_match)
                     line = line.replace(stripped_match, new_match)
         return line, count

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -131,6 +131,30 @@ class CleanerParserTests(unittest.TestCase):
         _test = self.mac_parser.parse_line(line)[0]
         self.assertNotEqual(line, _test)
 
+    def test_mac_parser_with_quotes(self):
+        line = "foobar foo '12:34:56:78:90:AA' bar barfoo"
+        _test = self.mac_parser.parse_line(line)[0]
+        self.assertNotEqual(line, _test)
+        dline = 'foobar foo "aa:12:bb:34:cc:56" bar barfoo'
+        _dtest = self.mac_parser.parse_line(dline)[0]
+        self.assertNotEqual(dline, _dtest)
+
+    def test_mac_parser_with_quotes_ipv6(self):
+        line = "foobar foo 'FF:EE:DD:FF:FE:CC:BB:AA' bar barfoo"
+        _test = self.mac_parser.parse_line(line)[0]
+        self.assertNotEqual(line, _test)
+        dline = 'foobar foo "DD:EE:FF:FF:FE:BB:CC:AA" bar barfoo'
+        _dtest = self.mac_parser.parse_line(dline)[0]
+        self.assertNotEqual(dline, _dtest)
+
+    def test_mac_parser_with_quotes_ipv6_quad(self):
+        line = "foobar foo 'AABB:CCDD:EEFF:FFAA' bar barfoo"
+        _test = self.mac_parser.parse_line(line)[0]
+        self.assertNotEqual(line, _test)
+        dline = 'foobar foo "AAFF:FFEE:DDCC:BBAA" bar barfoo'
+        _dtest = self.mac_parser.parse_line(dline)[0]
+        self.assertNotEqual(dline, _dtest)
+
     def test_hostname_load_hostname_string(self):
         fqdn = 'myhost.subnet.example.com'
         self.host_parser.load_hostname_into_map(fqdn)


### PR DESCRIPTION
First, update the regexes to account for possible quotes wrapping the
mac address to match.

Second, fix an edge case with these quoted mac addresses in our check
for avoiding duplicating obfuscations of already obfuscated addresses by
checking the stripped mac address instead of the raw one.

Closes: #2873

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?