### PR TITLE
[ceph_mon] Replace an obsolete command

### DIFF
--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -79,10 +79,13 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
             # Extract the OSD ids from valid output lines
             for procs in out['output'].splitlines():
                 proc = procs.split()
-                if len(proc) < 6:
-                    continue
-                if proc[4] == '--id' and "ceph-mgr" in proc[0]:
-                    mgr_ids.append("mgr.%s" % proc[5])
+                # Locate the '--id' value
+                if proc and proc[0].endswith("ceph-mgr"):
+                    try:
+                        id_index = proc.index("--id")
+                        mgr_ids.append("mgr.%s" % proc[id_index+1])
+                    except (IndexError, ValueError):
+                        self.log_warn("could not find ceph-mgr id: %s", procs)
 
         # If containerized, run commands in containers
         try:

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -73,10 +73,13 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
             # Extract the OSD ids from valid output lines
             for procs in out['output'].splitlines():
                 proc = procs.split()
-                if len(proc) < 6:
-                    continue
-                if proc[4] == '--id' and proc[5].isdigit():
-                    osd_ids.append("osd.%s" % proc[5])
+                # Locate the '--id' value
+                if proc and proc[0].endswith("ceph-osd"):
+                    try:
+                        id_index = proc.index("--id")
+                        osd_ids.append("osd.%s" % proc[id_index+1])
+                    except (IndexError, ValueError):
+                        self.log_warn("could not find ceph-osd id: %s", procs)
 
         try:
             cname = self.get_all_containers_by_regex("ceph-osd*")[0][1]


### PR DESCRIPTION
mon_status command is no longer available since Octopus
release. Replaced it with its ceph tell equivalent that
works in both older as well as newer Ceph releases.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?