### PR TITLE
[tigervnc] Update collections for newer versions of TigerVNC

### DIFF
--- a/sos/report/plugins/tigervnc.py
+++ b/sos/report/plugins/tigervnc.py
@@ -12,17 +12,35 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class TigerVNC(Plugin, RedHatPlugin):
+    """
+    This plugin gathers information for VNC servers provided by the tigervnc
+    package. This is explicitly for server-side collections, not clients.
+
+    By default, this plugin will capture the contents of /etc/tigervnc, which
+    may include usernames. If usernames are sensitive information for end
+    users of sos, consider using the `--clean` option to obfuscate these
+    names.
+    """
 
     short_desc = 'TigerVNC server configuration'
     plugin_name = 'tigervnc'
     packages = ('tigervnc-server',)
 
     def setup(self):
-        self.add_copy_spec([
-            '/etc/tigervnc/vncserver-config-defaults',
-            '/etc/tigervnc/vncserver-config-mandatory',
-            '/etc/tigervnc/vncserver.users'
-        ])
+        self.add_copy_spec('/etc/tigervnc/')
+
+        # service names are 'vncserver@$port' where $port is :1,, :2, etc...
+        # however they are not reported via list-unit-files, only list-units
+        vncs = self.exec_cmd(
+            'systemctl list-units --type=service --no-legend vncserver*'
+        )
+        if vncs['status'] == 0:
+            for serv in vncs['output'].splitlines():
+                vnc = serv.split()
+                if not vnc:
+                    continue
+                self.add_service_status(vnc[0])
+                self.add_journal(vnc[0])
 
         self.add_cmd_output('vncserver -list')
 


### PR DESCRIPTION
First, relaxes the file specifications for collection by capturing the
entire `/etc/tigervnc/` directory.

Second, adds collection of service status and journal output for each
configured vnc server. Collection of `vncserver -list` is kept for
backwards compatibility.

Finally, add a short docstring for the plugin for --help output.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?