### PR TITLE
[distros] Pass --upload-directory to SFTP uploads

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -577,7 +577,10 @@ class LinuxPolicy(Policy):
         :returns:       Filename as it will exist on the SFTP server
         :rtype:         ``str``
         """
-        return self.upload_archive_name.split('/')[-1]
+        fname = self.upload_archive_name.split('/')[-1]
+        if self.upload_directory:
+            fname = os.path.join(self.upload_directory, fname)
+        return fname
 
     def _upload_https_put(self, archive, verify=True):
         """If upload_https() needs to use requests.put(), use this method.

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -324,7 +324,9 @@ support representative.
         """
         fname = self.upload_archive_name.split('/')[-1]
         if self.case_id:
-            return "%s_%s" % (self.case_id, fname)
+            fname = "%s_%s" % (self.case_id, fname)
+        if self.upload_directory:
+            fname = os.path.join(self.upload_directory, fname)
         return fname
 
     def upload_sftp(self):


### PR DESCRIPTION
Apart of that, print a heads up message during SFTP upload when --upload-directory
was set.

Resolves: #2880

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?