### PR TITLE
[md] Restrict data capture to raid members

### DIFF
--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -18,8 +18,13 @@ class Md(Plugin, IndependentPlugin):
 
     def setup(self):
         self.add_cmd_output("mdadm -D /dev/md*")
-        self.add_blockdev_cmd("mdadm -E %(dev)s",
-                              blacklist=['ram.*', 'zram.*'])
+        mdadm_members = self.exec_cmd("lsblk -o NAME,FSTYPE -r")
+        if mdadm_members['status'] == 0:
+            for line in mdadm_members['output'].splitlines():
+                if 'linux_raid_member' in line:
+                    dev = line.split()[0]
+                    self.add_cmd_output('mdadm -E /dev/%s' % dev)
+
         self.add_copy_spec([
             "/etc/mdadm.conf",
             "/dev/md/md-device-map",


### PR DESCRIPTION
When generating sos report, md-raid plugin won't capture the
metadata information from the actual RAID device. Also, it
tries to fetch metadata information for all block devices
available in the system.
Sometimes RAID is created using the disk partition,
but sos won't collect metadata from those devices.

This patch takes the list of raid members from lsblk,
and captures the output only for these devices.

Fixes: RHBZ#2062283
Fixes: #2881 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?