### PR TITLE
[collector] Improve sos collect for OCP

### DIFF
--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -123,6 +123,11 @@ class ocp(Cluster):
             if not ret['status'] == 0:
                 self.log_error("Error deleting temporary project: %s"
                                % ret['output'])
+            ret = self.exec_primary_cmd("oc wait namespace/%s --for=delete "
+                                        "--timeout=30s" % self.project)
+            if not ret['status'] == 0:
+                self.log_error("Error waiting for temporary project to be "
+                               "deleted: %s" % ret['output'])
             # don't leave the config on a non-existing project
             self.exec_primary_cmd("oc project default")
             self.project = None

--- a/sos/collector/transports/oc.py
+++ b/sos/collector/transports/oc.py
@@ -231,5 +231,9 @@ class OCTransport(RemoteTransport):
                 % (self.project, self.pod_name))
 
     def _retrieve_file(self, fname, dest):
-        cmd = self.run_oc("cp %s:%s %s" % (self.pod_name, fname, dest))
+        # check if --retries flag is available for given version of oc
+        result = self.run_oc("cp --retries", stderr=True)
+        flags = '' if "unknown flag" in result["output"] else '--retries=5'
+        cmd = self.run_oc("cp %s %s:%s %s"
+                          % (flags, self.pod_name, fname, dest))
         return cmd['status'] == 0


### PR DESCRIPTION
1. wait for sos tmp project to be deleted (just calling delete changes
project state to Terminating, and running a new sos collect is not
possible before this project is fully deleted)
2. use --retries flag to copy sos reports from the nodes more reliably.
The flag has been recently added to kubectl, and the most reliable way
to check if it's available or not is to check command error output for
"unknown flag" substring

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?