### PR TITLE
[ceph_mon] Obfuscate sensitive config keys

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -134,4 +134,17 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             container=cname
         )
 
+    def postproc(self):
+        keys = [
+            'API_PASSWORD',
+            'API_USER.*',
+            'API_.*_KEY',
+            'key',
+            '_secret',
+            'rbd/mirror/peer/.*'
+        ]
+
+        creg = r"((\".*(%s)\":) \")(.*)(\".*)" % "|".join(keys)
+        self.do_cmd_output_sub('ceph config-key dump', creg, r'\1*******\5')
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a `postproc()` to the `ceph_mon` plugin to obfuscate sensitive
configuration keys printed by the `ceph config-key dump` command.

Closes: #2885

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?