### PR TITLE
Sos pmoravec dont obfuscate tmpdir path

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -431,8 +431,9 @@ third party.
 
     def write_map_for_archive(self, _map):
         try:
-            map_path = self.obfuscate_string(
-                os.path.join(self.sys_tmp, "%s-private_map" % self.arc_name)
+            map_path = os.path.join(
+                self.sys_tmp,
+                self.obfuscate_string("%s-private_map" % self.arc_name)
             )
             return self.write_map_to_file(_map, map_path)
         except Exception as err:


### PR DESCRIPTION
Two commits preventing to apply cleaner obfuscation to the working directory path itself. Creating files or moving directories must happen within the (non-obfuscated) working dir.

The `archive` commit changes purpose of `self._name` variable from `/var/tmp/sos.oq9ae6gj/sosreport-pmoravec-rhel8-2022-03-16-qzazpxi` to just `sosreport-pmoravec-rhel8-2022-03-16-qzazpxi`. Since the full path is already captured in `_archive_root` variable.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?