### PR TITLE
[cgroups] not collect memory.kmem.slabinfo

### DIFF
--- a/sos/report/plugins/cgroups.py
+++ b/sos/report/plugins/cgroups.py
@@ -30,6 +30,9 @@ class Cgroups(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         ])
 
         self.add_cmd_output("systemd-cgls")
+        self.add_forbidden_path(
+            "/sys/fs/cgroup/memory/**/memory.kmem.slabinfo",
+            recursive=True)
 
         return
 


### PR DESCRIPTION
Forbid collection of memory.kmem.slabinfo
which in case of system with lot of
containers may cause stuck kworker.

Resolves: #2889

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?