### PR TITLE
[scsi] Add collection of SCSI persistent reserve commands

### DIFF
--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -11,6 +11,17 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class Scsi(Plugin, IndependentPlugin):
+    """
+    Collects various information about the SCSI devices install on the host
+    system.
+
+    This plugin will capture a large amount of data from the /sys filesystem,
+    as well as several different invocations of the `lsscsi` command.
+
+    Additionally, several `sg_persist` commands will be collected for each
+    SCSI device identified by sos. Note that in most cases these commands are
+    provided by the `sg3_utils` package which may not be present by default.
+    """
 
     short_desc = 'SCSI devices'
 
@@ -45,5 +56,12 @@ class Scsi(Plugin, IndependentPlugin):
         scsi_hosts = glob("/sys/class/scsi_host/*")
         self.add_blockdev_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,
                               prepend_path='/sys/class/scsi_host')
+
+        self.add_blockdev_cmd([
+            "sg_persist --in -k -d %(dev)s",
+            "sg_persist --in -r -d %(dev)s",
+            "sg_persist --in -s -d %(dev)s",
+            "sg_inq %(dev)s"
+        ], whitelist=['sd.*'])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds collection of various `sq_persist` and `sg_inq` commands to the
`scsi` plugin for scsi block devices on the host system.

Also adds a docstring description to the plugin to assist with `sos
help` output.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?