### PR TITLE
[collect] Correct `self.primary` to NoneType default

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -140,7 +140,7 @@ class SoSCollector(SoSComponent):
         os.umask(0o77)
         self.client_list = []
         self.node_list = []
-        self.primary = False
+        self.primary = None
         self.retrieved = 0
         self.cluster = None
         self.cluster_type = None
@@ -1013,7 +1013,7 @@ class SoSCollector(SoSComponent):
                 self.node_list.remove(i)
         # remove the primary node from the list, since we already have
         # an open session to it.
-        if self.primary:
+        if self.primary is not None:
             for n in self.node_list:
                 if n == self.primary.hostname or n == self.opts.primary:
                     self.node_list.remove(n)


### PR DESCRIPTION
Corrects the initial assignment of `self.primary` to `None` instead of
`False`, so that quick scanning over the code is more inline with
`Cluster` instances.

Closes: #2892

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?