### PR TITLE
[Plugin] Allow plugins to define default command environment vars

### DIFF
--- a/tests/report_tests/plugin_tests/plugin_environment.py
+++ b/tests/report_tests/plugin_tests/plugin_environment.py
@@ -1,0 +1,44 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+
+from sos_tests import StageTwoReportTest
+
+
+class PluginDefaultEnvironmentTest(StageTwoReportTest):
+    """
+    Ensure that being able to set a default set of environment variables is
+    working correctly and does not leave a lingering env var on the system
+
+    :avocado: tags=stageone
+    """
+
+    install_plugins = ['default_env_test']
+    sos_cmd = '-o default_env_test'
+
+    def test_environment_used_in_cmd(self):
+        self.assertFileHasContent(
+            'sos_commands/default_env_test/env_var_test',
+            'Does Linus play hockey?'
+        )
+
+    def test_environment_setting_logged(self):
+        self.assertSosLogContains(
+            'Default environment for all commands now set to'
+        )
+
+    def test_environment_not_set_on_host(self):
+        self.assertTrue('TORVALDS' not in os.environ)
+        self.assertTrue('GREATESTSPORT' not in os.environ)
+
+    def test_environment_not_captured(self):
+        # we should still have an empty environment file
+        self.assertFileCollected('environment')
+        self.assertFileNotHasContent('environment', 'TORVALDS')
+        self.assertFileNotHasContent('environment', 'GREATESTSPORT')

--- a/tests/test_data/fake_plugins/default_env_test.py
+++ b/tests/test_data/fake_plugins/default_env_test.py
@@ -1,0 +1,28 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class DefaultEnv(Plugin, IndependentPlugin):
+
+    plugin_name = 'default_env_test'
+    short_desc = 'Fake plugin to test default env var handling'
+
+    def setup(self):
+        self.set_default_cmd_environment({
+            'TORVALDS': 'Linus',
+            'GREATESTSPORT': 'hockey'
+        })
+
+        self.add_cmd_output(
+            "sh -c 'echo Does '$TORVALDS' play '$GREATESTSPORT'?'",
+            suggest_filename='env_var_test'
+        )
+
+        self.add_env_var(['TORVALDS', 'GREATESTSPORT'])

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -305,6 +305,21 @@ class PluginTests(unittest.TestCase):
         p.postproc()
         self.assertTrue(p.did_postproc)
 
+    def test_set_default_cmd_env(self):
+        p = MockPlugin({
+            'sysroot': self.sysroot,
+            'policy': LinuxPolicy(init=InitSystem(), probe_runtime=False),
+            'cmdlineopts': MockOptions(),
+            'devices': {}
+        })
+        e = {'TORVALDS': 'Linus'}
+        p.set_default_cmd_environment(e)
+        self.assertEquals(p.default_environment, e)
+        add_e = {'GREATESTSPORT': 'hockey'}
+        p.add_default_cmd_environment(add_e)
+        self.assertEquals(p.default_environment['GREATESTSPORT'], 'hockey')
+        self.assertEquals(p.default_environment['TORVALDS'], 'Linus')
+
 
 class AddCopySpecTests(unittest.TestCase):
 


### PR DESCRIPTION
Adds the ability for plugins to define a default set of environment vars
to pass to all commands executed by the plugin. This may be done either
via the new `set_default_cmd_environment()` or
`add_default_cmd_environment()` methods. The former will override any
previously set values, whereas the latter will add/update/modify any
existing values.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?