### PR TITLE
[presets] Adjust OCP preset options

### DIFF
--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -36,10 +36,15 @@ RHOSP_OPTS = SoSOptions(plugopts=[
 
 RHOCP = "ocp"
 RHOCP_DESC = "OpenShift Container Platform by Red Hat"
-RHOCP_OPTS = SoSOptions(all_logs=True, verify=True, plugopts=[
-                             'networking.timeout=600',
-                             'networking.ethtool_namespaces=False',
-                             'networking.namespaces=200'])
+RHOCP_OPTS = SoSOptions(
+    verify=True, skip_plugins=['cgroups'], container_runtime='crio',
+    no_report=True, log_size=100,
+    plugopts=[
+        'crio.timeout=600',
+        'networking.timeout=600',
+        'networking.ethtool_namespaces=False',
+        'networking.namespaces=200'
+    ])
 
 RH_CFME = "cfme"
 RH_CFME_DESC = "Red Hat CloudForms"


### PR DESCRIPTION
Adjust the options used by the 'ocp' preset to better reflect the
current collection needs and approach.

This includes disabling the `cgroups` plugin due to the large amount of
mostly irrelevant data captured due to the high number of containers
present on OCP nodes, ensuring the `--container-runtime` option is set
to `crio` to align container-based collections, disabling HTML report
generation and increasing the base log size rather than blindly enabling
all-logs.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?