### PR TITLE
[utilities, Plugin] Improve binary file detection, don't tail binary files

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,8 @@ py_break_task:
             PY_VERSION: "latest"
         - env:
             PY_VERSION: "3.9"
-    setup_script: pip install -r requirements.txt
+    # This image has 2 py environments. Install to the one sos uses.
+    setup_script: pip3 install -t /usr/lib/python3/dist-packages -r requirements.txt
     main_script: ./bin/sos report --batch
 
 # Make sure a user can manually build an rpm from the checkout
@@ -120,7 +121,7 @@ report_stageone_task:
             dnf -y remove sos
             dnf -y install python3-pip ethtool
         fi
-    setup_script: &setup 'pip3 install avocado-framework==94.0'
+    setup_script: &setup 'pip3 install avocado-framework==94.0 python-magic'
     # run the unittests separately as they require a different PYTHONPATH in
     # order for the imports to work properly under avocado
     unittest_script: PYTHONPATH=. avocado run tests/unittests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycodestyle>=2.4.0
-nose>=1.3.7
 coverage>=4.0.3
 Sphinx>=1.3.5
 pexpect>=4.0.0
+python_magic>=0.4.20

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     ],
     cmdclass=cmdclass,
     command_options=command_options,
-    requires=['pexpect']
+    requires=['pexpect', 'python_magic']
     )
 
 

--- a/sos.spec
+++ b/sos.spec
@@ -16,6 +16,7 @@ Requires: python3-rpm
 Requires: tar
 Requires: xz
 Requires: python3-pexpect
+Requires: python3-magic
 Obsoletes: sos-collector <= 1.9
 
 %description

--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -16,6 +16,7 @@ import tarfile
 import re
 
 from concurrent.futures import ProcessPoolExecutor
+from sos.utilities import file_is_binary
 
 
 # python older than 3.8 will hit a pickling error when we go to spawn a new
@@ -351,14 +352,14 @@ class SoSObfuscationArchive():
         :rtype:     ``bool``
         """
         obvious_removes = [
-            r'.*\.gz',  # TODO: support flat gz/xz extraction
-            r'.*\.xz',
-            r'.*\.bzip2',
+            r'.*\.gz$',  # TODO: support flat gz/xz extraction
+            r'.*\.xz$',
+            r'.*\.bzip2$',
             r'.*\.tar\..*',  # TODO: support archive unpacking
             r'.*\.txz$',
             r'.*\.tgz$',
-            r'.*\.bin',
-            r'.*\.journal',
+            r'.*\.bin$',
+            r'.*\.journal$',
             r'.*\~$'
         ]
 
@@ -368,28 +369,10 @@ class SoSObfuscationArchive():
             if re.match(_arc_reg, fname):
                 return True
 
-        if os.path.isfile(self.get_file_path(fname)):
-            return self.file_is_binary(fname)
+        _full_path = self.get_file_path(fname)
+        if os.path.isfile(_full_path):
+            return file_is_binary(_full_path)
         # don't fail on dir-level symlinks
         return False
-
-    def file_is_binary(self, fname):
-        """Determine if the file is a binary file or not.
-
-
-        :param fname:          Filename relative to the extracted archive root
-        :type fname:           ``str``
-
-        :returns:   ``True`` if file is binary, else ``False``
-        :rtype:     ``bool``
-        """
-        with open(self.get_file_path(fname), 'tr') as tfile:
-            try:
-                # when opened as above (tr), reading binary content will raise
-                # an exception
-                tfile.read(1)
-                return False
-            except UnicodeDecodeError:
-                return True
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -13,7 +13,7 @@
 from sos.utilities import (sos_get_command_output, import_module, grep,
                            fileobj, tail, is_executable, TIMEOUT_DEFAULT,
                            path_exists, path_isdir, path_isfile, path_islink,
-                           listdir, path_join, bold)
+                           listdir, path_join, bold, file_is_binary)
 
 from sos.archive import P_FILE
 import os
@@ -64,16 +64,6 @@ def _node_type(st):
     for t in _types:
         if t[0](st.st_mode):
             return t[1]
-
-
-def _file_is_compressed(path):
-    """Check if a file appears to be compressed
-
-    Return True if the file specified by path appears to be compressed,
-    or False otherwise by testing the file name extension against a
-    list of known file compression extentions.
-    """
-    return path.endswith(('.gz', '.xz', '.bz', '.bz2'))
 
 
 _certmatch = re.compile("-*BEGIN.*?-*END", re.DOTALL)
@@ -1820,7 +1810,7 @@ class Plugin():
                 if sizelimit and current_size > sizelimit:
                     limit_reached = True
 
-                    if tailit and not _file_is_compressed(_file):
+                    if tailit and not file_is_binary(_file):
                         self._log_info("collecting tail of '%s' due to size "
                                        "limit" % _file)
                         file_name = _file

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -9,6 +9,7 @@ import unittest
 import os
 import tempfile
 import shutil
+import random
 
 from io import StringIO
 
@@ -16,6 +17,7 @@ from sos.report.plugins import Plugin, regex_findall, _mangle_command, PluginOpt
 from sos.archive import TarFileArchive
 from sos.policies.distros import LinuxPolicy
 from sos.policies.init_systems import InitSystem
+from string import ascii_lowercase
 
 PATH = os.path.dirname(__file__)
 
@@ -25,8 +27,10 @@ def j(filename):
 
 
 def create_file(size, dir=None):
-    f = tempfile.NamedTemporaryFile(delete=False, dir=dir)
-    f.write(b"*" * size * 1024 * 1024)
+    f = tempfile.NamedTemporaryFile(delete=False, dir=dir, mode='w')
+    fsize = size * 1024 * 1024
+    content = ''.join(random.choice(ascii_lowercase) for x in range(fsize))
+    f.write(content)
     f.flush()
     f.close()
     return f.name


### PR DESCRIPTION
First, implement better binary file detection for `sos clean` via the `python-magic` module. Which is the python bindings for `libmagic` - which among other things is the backend behind the `file` command.

Then add a check to `add_copy_spec()` so we don't tail binary files.

Closes: #2839
Closes: #2851


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?