### PR TITLE
[redhat policy] Use /etc/os-release instead of /etc/redhat-release 

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -40,7 +40,6 @@ class RedHatPolicy(LinuxPolicy):
         ('Distribution Website', 'https://www.redhat.com/'),
         ('Commercial Support', 'https://www.access.redhat.com/')
     ]
-    _redhat_release = '/etc/redhat-release'
     _tmp_dir = "/var/tmp"
     _in_container = False
     default_scl_prefix = '/opt/rh'
@@ -471,7 +470,7 @@ support representative.
         atomic = False
         if ENV_HOST_SYSROOT not in os.environ:
             return atomic
-        host_release = os.environ[ENV_HOST_SYSROOT] + cls._redhat_release
+        host_release = os.environ[ENV_HOST_SYSROOT] + OS_RELEASE
         if not os.path.exists(host_release):
             return False
         try:
@@ -558,7 +557,7 @@ support representative.
         coreos = False
         if ENV_HOST_SYSROOT not in os.environ:
             return coreos
-        host_release = os.environ[ENV_HOST_SYSROOT] + cls._redhat_release
+        host_release = os.environ[ENV_HOST_SYSROOT] + OS_RELEASE
         try:
             for line in open(host_release, 'r').read().splitlines():
                 coreos |= 'Red Hat Enterprise Linux CoreOS' in line


### PR DESCRIPTION
as the most compatible way to find host release

To be confirmed by Red Hat CoreOS team

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?