### PR TITLE
[cirrus] Update CentOS Stream 8 image, add Stream 9 testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,8 @@ env:
     UBUNTU_NAME: "ubuntu-20.04"
     UBUNTU_PRIOR_NAME: "ubuntu-18.04"
 
-    CENTOS_NAME: "centos-stream-8"
+    CENTOS_9_NAME: "centos-stream-9"
+    CENTOS_8_NAME: "centos-stream-8"
 
     CENTOS_PROJECT: "centos-cloud"
     SOS_PROJECT: "sos-devel-jobs"
@@ -24,7 +25,8 @@ env:
     FOREMAN_DEBIAN_IMAGE_NAME: "foreman-25-debian-10-sos-testing"
 
     # Images exist on GCP already
-    CENTOS_IMAGE_NAME: "centos-stream-8-v20210609"
+    CENTOS_9_IMAGE_NAME: "centos-stream-9-v20220317"
+    CENTOS_8_IMAGE_NAME: "centos-stream-8-v20220317"
     UBUNTU_IMAGE_NAME: "ubuntu-2004-focal-v20201111"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-1804-bionic-v20201111"
 
@@ -86,8 +88,12 @@ report_stageone_task:
     matrix:
         - env:
             PROJECT: ${CENTOS_PROJECT}
-            BUILD_NAME: ${CENTOS_NAME}
-            VM_IMAGE_NAME: ${CENTOS_IMAGE_NAME}
+            BUILD_NAME: ${CENTOS_9_NAME}
+            VM_IMAGE_NAME: ${CENTOS_9_IMAGE_NAME}
+        - env:
+            PROJECT: ${CENTOS_PROJECT}
+            BUILD_NAME: ${CENTOS_8_NAME}
+            VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
         - env:
             PROJECT: ${SOS_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
@@ -134,8 +140,12 @@ report_stagetwo_task:
     matrix:
         - env:
             PROJECT: ${CENTOS_PROJECT}
-            BUILD_NAME: ${CENTOS_NAME}
-            VM_IMAGE_NAME: ${CENTOS_IMAGE_NAME}
+            BUILD_NAME: ${CENTOS_9_NAME}
+            VM_IMAGE_NAME: ${CENTOS_9_IMAGE_NAME}
+        - env:
+            PROJECT: ${CENTOS_PROJECT}
+            BUILD_NAME: ${CENTOS_8_NAME}
+            VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
         - env:
             PROJECT: ${SOS_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}


### PR DESCRIPTION
Updates the CentOS Stream 8 image used to run the CI tests, and adds
testing on CentOS Stream 9 now that those images are available.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?