### PR TITLE
[seagate_ses] Add new plugin to get Seagate JBOD status

### DIFF
--- a/sos/report/plugins/seagate_ses.py
+++ b/sos/report/plugins/seagate_ses.py
@@ -1,0 +1,65 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class SeagateSES(Plugin, IndependentPlugin):
+    """The seagate_ses plugin collect information about all
+    connected seagate storage shelves.
+    It captures Controller status information, ID, controllers' VPD
+    information, Environmental zone, Drive, PHY details, Cooling Module
+    and PSU information.
+    """
+
+    short_desc = 'Seagate SES status'
+    plugin_name = 'seagate_ses'
+    plugin_timeout = 600
+    profiles = ('system', 'storage', 'hardware',)
+    packages = ('fwdownloader_megaraid',)
+
+    def setup(self):
+        res = self.collect_cmd_output('fwdownloader -ses')
+
+        # Finding actual SES devices and ignoring 0th element
+        # as it does not contain any device information
+        op_lst = []
+        if res['status'] == 0:
+            op_lst = res['output'].split("SES Device")[1:]
+        devices = [
+            i for i in range(len(op_lst))
+            if "Vendor ID: SEAGATE" in op_lst[i]
+        ]
+
+        cmd = 'getstatus -d'
+        subcmds = [
+            'ddump_canmgr',
+            'ddump_cblmgr',
+            'ddump_drvmgr',
+            'ddump_phycounters',
+            'ddump_pwrmgr',
+            'ddump_envctrl',
+            'envctrl_fan',
+            'envctrl_zone',
+            'fwstatus',
+            'getboardid',
+            'getvpd',
+            'report_faults',
+            'ver',
+          ]
+
+        for devid in devices:
+            self.add_cmd_output([
+                "%s %d -CLI %s" % (cmd, devid, subcmd) for subcmd in subcmds
+            ])
+
+            self.add_cmd_output([
+                "%s %d -cli %s" % (cmd, devid, subcmd) for subcmd in subcmds
+            ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adding a new plugin to get Seagate JBOD status
SES Monitoring tool "getstatus" is used to the information of Seagate storage products.

Signed-off-by: Nikhil Kakade <nikhilkaka1@gmail.com>
<img width="828" alt="Screenshot 2022-04-12 at 11 14 36 PM" src="https://user-images.githubusercontent.com/66179696/163115093-9579d3db-2d89-421d-b334-805c55f3a7c4.png">
<img width="1107" alt="Screenshot 2022-04-12 at 11 15 32 PM" src="https://user-images.githubusercontent.com/66179696/163115107-fd47b57e-323a-42d0-85c9-985d3598d659.png">

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?