### PR TITLE
[policies] Simplify flow in _container_init()

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -218,13 +218,15 @@ class LinuxPolicy(Policy):
         if ENV_CONTAINER in os.environ:
             if os.environ[ENV_CONTAINER] in ['docker', 'oci', 'podman']:
                 self._in_container = True
-        if ENV_HOST_SYSROOT in os.environ:
-            _host_sysroot = os.environ[ENV_HOST_SYSROOT]
-        use_sysroot = self._in_container and _host_sysroot is not None
-        if use_sysroot:
-            host_tmp_dir = os.path.abspath(_host_sysroot + self._tmp_dir)
-            self._tmp_dir = host_tmp_dir
-        return _host_sysroot if use_sysroot else None
+                if ENV_HOST_SYSROOT in os.environ:
+                    if not os.environ[ENV_HOST_SYSROOT]:
+                        # guard against blank/improperly unset values
+                        return None
+                    self._tmp_dir = os.path.abspath(
+                        os.environ[ENV_HOST_SYSROOT] + self._tmp_dir
+                    )
+                    return os.environ[ENV_HOST_SYSROOT]
+        return None
 
     def init_kernel_modules(self):
         """Obtain a list of loaded kernel modules to reference later for plugin


### PR DESCRIPTION
Simplifies the logic and flow of `LinuxPolicy._container_init()` so that
it is both easier to follow and less prone to edge cases that could
break in-container collections that are not setup to capture from the
host system.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?