### PR TITLE
[report,collect] Add env var and prompt options for encryption

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -33,6 +33,7 @@ sos report \- Collect and package diagnostic and support data
           [--skip-files files]\fR
           [--allow-system-changes]\fR
           [-z|--compression-type method]\fR
+          [--encrypt]\fR
           [--encrypt-key KEY]\fR
           [--encrypt-pass PASS]\fR
           [--upload] [--upload-url url] [--upload-user user]\fR
@@ -221,6 +222,26 @@ Run commands even if they can change the system (e.g. load kernel modules).
 .TP
 .B \-z, \--compression-type METHOD
 Override the default compression type specified by the active policy.
+.TP
+.B \-\-encrypt
+Encrypt the resulting archive, and determine the method by which that encryption
+is done by either a user prompt or environment variables.
+
+When run with \fB--batch\fR, using this option will cause sos to look for either the
+\fBSOSENCRYPTKEY\fR or \fBSOSENCRYPTPASS\fR environment variables. If set, this will
+implicitly enable the \fB--encrypt-key\fR or \fB--encrypt-pass\fR options, respectively,
+to the values set by the environment variable. This enables the use of these options
+without directly setting those options in a config file or command line string. Note that
+use of an encryption key has precedence over a passphrase.
+
+Otherwise, using this option will cause sos to prompt the user to choose the method
+of encryption to use. Choices will be [P]assphrase, [K]ey, [E]nv vars, or [N]o encryption.
+If passphrase or key the user will then be prompted for the respective value, env vars will
+cause sos to source the information in the manner stated above, and choosing no encryption
+will disable encryption.
+
+See the sections on \fB--encrypt-key\fR and \fB--encrypt-pass\fR below for more
+information.
 .TP
 .B \--encrypt-key KEY
 Encrypts the resulting archive that sosreport produces using GPG. KEY must be

--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -82,6 +82,26 @@ to be set across all components.
 .B \-\-batch
 Do not prompt interactively, user will not be prompted for any data
 .TP
+.B \-\-encrypt
+Encrypt the resulting archive, and determine the method by which that encryption
+is done by either a user prompt or environment variables.
+
+When run with \fB--batch\fR, using this option will cause sos to look for either the
+\fBSOSENCRYPTKEY\fR or \fBSOSENCRYPTPASS\fR environment variables. If set, this will
+implicitly enable the \fB--encrypt-key\fR or \fB--encrypt-pass\fR options, respectively,
+to the values set by the environment variable. This enables the use of these options
+without directly setting those options in a config file or command line string. Note that
+use of an encryption key has precedence over a passphrase.
+
+Otherwise, using this option will cause sos to prompt the user to choose the method
+of encryption to use. Choices will be [P]assphrase, [K]ey, [E]nv vars, or [N]o encryption.
+If passphrase or key the user will then be prompted for the respective value, env vars will
+cause sos to source the information in the manner stated above, and choosing no encryption
+will disable encryption.
+
+See the sections on \fB--encrypt-key\fR and \fB--encrypt-pass\fR below for more
+information.
+.TP
 .B \--encrypt-key KEY
 Encrypts the resulting archive that sosreport produces using GPG. KEY must be
 an existing key in the user's keyring as GPG does not allow for keyfiles.

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -159,6 +159,11 @@ class SoS():
 
         # Group to make tarball encryption (via GPG/password) exclusive
         encrypt_grp = global_grp.add_mutually_exclusive_group()
+        encrypt_grp.add_argument("--encrypt", default=False,
+                                 action="store_true",
+                                 help=("Encrypt the archive, either prompting "
+                                       "for a password/key or referencing "
+                                       "an environment variable"))
         encrypt_grp.add_argument("--encrypt-key",
                                  help="Encrypt the archive using a GPG "
                                       "key-pair")


### PR DESCRIPTION
Adds a new `--encrypt` option that may be used in place of the existing
encrypt-related options. If used alongside `--batch`, this new option
will cause sos to set encryption options based on the `SOSENCRYPTKEY` or
`SOSENCRYPTPASS` environment variables. This allows users to leverage
this functionality without potentially leaking the values into `ps`-like
output inside the archive.

If `--batch` is not used, then this option prompts the user to select
the type of method to use and then provide the value in-line, or to use
the env var option.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?