### PR TITLE
ostree: Collect logs from ostree-finalize-staged in particular

### DIFF
--- a/sos/report/plugins/ostree.py
+++ b/sos/report/plugins/ostree.py
@@ -27,4 +27,11 @@ class OSTree(Plugin, IndependentPlugin):
         if self.get_option("verify"):
             self.add_cmd_output("ostree fsck")
 
+        units = [
+            'ostree-finalize-staged',
+            'ostree-boot-complete',
+        ]
+        for unit in units:
+            self.add_journal(unit)
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
See https://github.com/ostreedev/ostree/pull/2589 for rationale;
this is a key systemd unit and we always want its full logs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?