### PR TITLE
[docs] Fix cross-referencing in sphinx config, doc fixups in Plugin and Policy

### DIFF
--- a/docs/archive.rst
+++ b/docs/archive.rst
@@ -6,3 +6,11 @@
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autoclass:: sos.archive.Archive
+    :members:
+    :undoc-members:
+
+.. autoclass:: sos.archive.FileCacheArchive
+    :members:
+    :undoc-members:

--- a/docs/clusters.rst
+++ b/docs/clusters.rst
@@ -2,6 +2,6 @@
 =================================================
 
 .. automodule:: sos.collector.clusters
-    :noindex:
     :members:
+    :undoc-members:
     :show-inheritance:

--- a/docs/parsers.rst
+++ b/docs/parsers.rst
@@ -2,6 +2,6 @@
 =============================================
 
 .. automodule:: sos.cleaner.parsers
-    :noindex:
     :members:
+    :undoc-members:
     :show-inheritance:

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -2,6 +2,6 @@
 ===========================================
 
 .. automodule:: sos.report.plugins
-    :noindex:
     :members:
+    :undoc-members:
     :show-inheritance:

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -2,6 +2,6 @@
 =====================================
 
 .. automodule:: sos.policies
-    :noindex:
     :members:
+    :undoc-members:
     :show-inheritance:

--- a/docs/reporting.rst
+++ b/docs/reporting.rst
@@ -2,7 +2,6 @@
 ================================================
 
 .. automodule:: sos.report.reporting
-    :noindex:
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -2,7 +2,6 @@
 ========================================
 
 .. automodule:: sos.utilities
-    :noindex:
     :members:
     :undoc-members:
     :show-inheritance:

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -270,9 +270,9 @@ any third party.
         :param plugin_classes: The classes that the Plugin subclasses
         :type plugin_classes: ``list``
 
-        :returns: The first subclass that matches one of the Policy's
+        :returns: The first tagging class that matches one of the Policy's
                   `valid_subclasses`
-        :rtype: A tagging class for Plugins
+        :rtype: ``PluginDistroTag``
         """
         if len(plugin_classes) > 1:
             for p in plugin_classes:
@@ -288,7 +288,7 @@ any third party.
         Verifies that the plugin_class should execute under this policy
 
         :param plugin_class: The tagging class being checked
-        :type plugin_class: A Plugin() tagging class
+        :type plugin_class: ``PluginDistroTag``
 
         :returns: ``True`` if the `plugin_class` is allowed by the policy
         :rtype: ``bool``

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -662,9 +662,27 @@ class Plugin():
         return _env
 
     def timeout_from_options(self, optname, plugoptname, default_timeout):
-        """Returns either the default [plugin|cmd] timeout value, the value as
-        provided on the commandline via -k plugin.[|cmd-]timeout=value, or the
-        value of the global --[plugin|cmd]-timeout option.
+        """
+        Get the timeout value for either the plugin or a command, as
+        determined by either the value provided via the
+        plugin.timeout or plugin.cmd-timeout option, the global timeout or
+        cmd-timeout options, or the default value set by the plugin or the
+        collection, in that order of precendence.
+
+        :param optname: The name of the cmdline option being checked, either
+                        'plugin_timeout' or 'timeout'
+        :type optname:  ``str``
+
+        :param plugoptname: The name of the plugin option name being checked,
+                            either 'timeout' or 'cmd-timeout'
+        :type plugoptname: ``str``
+
+        :param default_timeout: The timeout to default to if determination is
+                                inconclusive or hits an error
+        :type default_timeout:  ``int``
+
+        :returns: The timeout value in seconds
+        :rtype:   ``int``
         """
         _timeout = None
         try:
@@ -2211,7 +2229,7 @@ class Plugin():
 
         :param plug_dir: Should the string be saved under the plugin's dir in
                          sos_commands/? If false, save to sos_strings/
-        :type plug_dir: ``bool`
+        :type plug_dir: ``bool``
 
         :param tags: A tag or set of tags to add to the manifest entry for this
                      collection
@@ -2752,7 +2770,7 @@ class Plugin():
 
         :param containers:   The name of the container to retrieve logs from,
                              may be a single name or a regex
-        :type containers:    ``str`` or ``list` of strs
+        :type containers:    ``str`` or ``list`` of strs
 
         :param get_all:     Should non-running containers also be queried?
                             Default: False
@@ -3389,8 +3407,52 @@ class Plugin():
         return out_ns
 
 
-class RedHatPlugin(object):
+class PluginDistroTag():
+    """The base tagging class for distro-specific classes used to signify that
+    a Plugin is written for that distro.
+
+    Use IndependentPlugin for plugins that are distribution agnostic
+    """
+    pass
+
+
+class RedHatPlugin(PluginDistroTag):
     """Tagging class for Red Hat's Linux distributions"""
+    pass
+
+
+class UbuntuPlugin(PluginDistroTag):
+    """Tagging class for Ubuntu Linux"""
+    pass
+
+
+class DebianPlugin(PluginDistroTag):
+    """Tagging class for Debian Linux"""
+    pass
+
+
+class SuSEPlugin(PluginDistroTag):
+    """Tagging class for SuSE Linux distributions"""
+    pass
+
+
+class OpenEulerPlugin(PluginDistroTag):
+    """Tagging class for openEuler linux distributions"""
+    pass
+
+
+class CosPlugin(PluginDistroTag):
+    """Tagging class for Container-Optimized OS"""
+    pass
+
+
+class IndependentPlugin(PluginDistroTag):
+    """Tagging class for plugins that can run on any platform"""
+    pass
+
+
+class ExperimentalPlugin(PluginDistroTag):
+    """Tagging class that indicates that this plugin is experimental"""
     pass
 
 
@@ -3472,41 +3534,6 @@ class SCLPlugin(RedHatPlugin):
         for copyspec in copyspecs:
             scl_copyspecs.append(self.convert_copyspec_scl(scl, copyspec))
         self.add_copy_spec(scl_copyspecs)
-
-
-class UbuntuPlugin(object):
-    """Tagging class for Ubuntu Linux"""
-    pass
-
-
-class DebianPlugin(object):
-    """Tagging class for Debian Linux"""
-    pass
-
-
-class SuSEPlugin(object):
-    """Tagging class for SuSE Linux distributions"""
-    pass
-
-
-class OpenEulerPlugin(object):
-    """Tagging class for openEuler linux distributions"""
-    pass
-
-
-class CosPlugin(object):
-    """Tagging class for Container-Optimized OS"""
-    pass
-
-
-class IndependentPlugin(object):
-    """Tagging class for plugins that can run on any platform"""
-    pass
-
-
-class ExperimentalPlugin(object):
-    """Tagging class that indicates that this plugin is experimental"""
-    pass
 
 
 def import_plugin(name, superclasses=None):


### PR DESCRIPTION
First commit fixes the sphinx doc configuration to remove `:noindex:` which was throwing off cross-referencing via `automodule`.

Second, minor fixes to docstrings (and filling out the docstring) in a few places in `Policy` and `Plugin`. Additionally make tagging classes have an actual base class of `PluginDistroTag`. Re-organize the declaration of supported tagging classes so they are all in one spot.

Closes: #2917

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?