### PR TITLE
[skydive] Fix PlugOpts val_type=str to accept numeric values

### DIFF
--- a/sos/report/plugins/skydive.py
+++ b/sos/report/plugins/skydive.py
@@ -26,9 +26,9 @@ class Skydive(Plugin, RedHatPlugin):
     password_warn_text = " (password visible in process listings)"
 
     option_list = [
-        PluginOpt('username', default='', val_type=str,
+        PluginOpt('username', default='', val_type=[int, str],
                   desc='skydive username'),
-        PluginOpt('password', default='', val_type=str,
+        PluginOpt('password', default='', val_type=[int, str],
                   desc='skydive password' + password_warn_text),
         PluginOpt('analyzer', default='', val_type=str,
                   desc='skydive analyzer address')


### PR DESCRIPTION
This PR fixes the cases where either the username or the
password are numeric values, and avoid receiving error
messages like:

Plugin option 'skydive.password' takes string (no spaces),
not int

Resolves: #2922 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?