### PR TITLE
[report] --list-plugins should report used, not default, option values

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -868,24 +868,32 @@ class SoSReport(SoSComponent):
             _defaults = self.loaded_plugins[0][1].get_default_plugin_opts()
             for _opt in _defaults:
                 opt = _defaults[_opt]
-                val = opt.default
-                if opt.default == -1:
-                    val = TIMEOUT_DEFAULT
+                val = opt.value
+                if opt.value == -1:
+                    if _opt == 'timeout':
+                        val = self.opts.plugin_timeout or TIMEOUT_DEFAULT
+                    elif _opt == 'cmd-timeout':
+                        val = self.opts.cmd_timeout or TIMEOUT_DEFAULT
+                    else:
+                        val = TIMEOUT_DEFAULT
+                if opt.name == 'postproc':
+                    val = not self.opts.no_postproc
                 self.ui_log.info(" %-25s %-15s %s" % (opt.name, val, opt.desc))
             self.ui_log.info("")
 
             self.ui_log.info(_("The following plugin options are available:"))
             for opt in self.all_options:
                 if opt.name in ('timeout', 'postproc', 'cmd-timeout'):
-                    continue
+                    if opt.value == opt.default:
+                        continue
                 # format option value based on its type (int or bool)
-                if isinstance(opt.default, bool):
-                    if opt.default is True:
+                if isinstance(opt.value, bool):
+                    if opt.value is True:
                         tmpopt = "on"
                     else:
                         tmpopt = "off"
                 else:
-                    tmpopt = opt.default
+                    tmpopt = opt.value
 
                 if tmpopt is None:
                     tmpopt = 0


### PR DESCRIPTION
When using `--list-plugins`, sos should report the values that will be
used in a given command, or with a given config file, not what the
default values are.

By reporting the set value, users can be sure their configuration or
commandline settings are being honored correctly before executing a
report collection.

Closes: #2921

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?