### PR TITLE
[fibrechannel] collect Cisco fnic statistics

### DIFF
--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -24,7 +24,8 @@ class Fibrechannel(Plugin, RedHatPlugin):
 
     # vendor specific debug paths
     debug_paths = [
-        '/sys/kernel/debug/qla2*/'
+        '/sys/kernel/debug/qla2*/',
+        '/sys/kernel/debug/fnic/',
     ]
 
     def setup(self):


### PR DESCRIPTION
Collect /sys/kernel/debug/fnic statistics about Cisco UCS fibre channel
fNIC connection.

Resolves: #2926

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?