### PR TITLE
[utilities] Close file only when storing to file

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -212,7 +212,8 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
                 p.wait(timeout if timeout else None)
             except Exception:
                 p.terminate()
-                _output.close()
+                if to_file:
+                    _output.close()
                 # until we separate timeouts from the `timeout` command
                 # handle per-cmd timeouts via Plugin status checks
                 return {'status': 124, 'output': reader.get_contents(),


### PR DESCRIPTION
Call _output.close() only when to_file=true.

Closes: #2925

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?