### PR TITLE
[GenericPolicy] Fix execution when GenericPolicy is loaded

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import random
 import string
+import sys
 
 from pwd import getpwuid
 from sos.presets import (NO_PRESET, GENERIC_PRESETS, PRESETS_PATH,
@@ -40,8 +41,11 @@ def load(cache={}, sysroot=None, init=None, probe_runtime=True,
                                          probe_runtime=probe_runtime,
                                          remote_exec=remote_exec)
 
+    if sys.platform != 'linux':
+        raise Exception("SoS is not supported on this platform")
+
     if 'policy' not in cache:
-        cache['policy'] = GenericPolicy()
+        cache['policy'] = sos.policies.distros.GenericLinuxPolicy()
 
     return cache['policy']
 
@@ -598,14 +602,6 @@ any third party.
 
         preset.delete(self.presets_path)
         self.presets.pop(name)
-
-
-class GenericPolicy(Policy):
-    """This Policy will be returned if no other policy can be loaded. This
-    should allow for IndependentPlugins to be executed on any system"""
-
-    def get_msg(self):
-        return self.msg % {'distro': self.system}
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -791,3 +791,19 @@ class LinuxPolicy(Policy):
                                       cmd)
         else:
             return cmd
+
+
+class GenericLinuxPolicy(LinuxPolicy):
+    """This Policy will be returned if no other policy can be loaded. This
+    should allow for IndependentPlugins to be executed on any system"""
+
+    vendor_urls = [('Upstream Project', 'https://github.com/sosreport/sos')]
+    vendor = 'SoS'
+    vendor_text = ('SoS was unable to determine that the distribution of this '
+                   'system is supported, and has loaded a generic '
+                   'configuration. This may not provide desired behavior, and '
+                   'users are encouraged to request a new distribution-specifc'
+                   ' policy at the GitHub project above.\n')
+
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Over time a lot has changed with `Policy()` implementation. Along with
that, the functionality of `GenericPolicy` broke at some point, thus
preventing any form of execution of SoS on distributions without
explicit policies.

Fix this by changing `GenericPolicy` to `GenericLinuxPolicy` (to be more
explicit in case we re-add non-Linux support in the future) and having
it subclass `LinuxPolicy` instead of the top-level `Policy`.

Further, add a platform check to ensure we are not inadvertently loading
a Linux-based policy on a non-Linux platform which would likely result
in failure to do anything useful.

The `GenericLinuxPolicy` will only load `IndependentPlugin`-tagged
plugins, does not leverage an init system, and does not provide any
default upload functionality.

Related: #2928

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?