### PR TITLE
[networkmanager] filter out more passwords from NetworkManager keyfiles

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -111,6 +111,10 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
             for net_conf in files:
                 self.do_file_sub(
                     "/etc/NetworkManager/system-connections/"+net_conf,
-                    r"(psk|password)=(.*)", r"\1=***")
+                    r"(password|psk|mka-cak|password-raw|pin|preshared-key"
+                    r"|private-key|secrets|wep-key[0-9])=(.*)",
+                    r"\1=***",
+                )
+
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
NetworkManager's keyfiles (`*.nmconnection`) can contain secrets in plain
text. Let's try harder to filter them out.

The files are in `GKeyFile` format ([1]), so a naive regex doesn't really
cut it, because the meaning of the key also depends on the group
(keyfile section) it is in. But this probably still helps in many cases.

The current list (1.39.2) of NetworkManager secret properties in the
various keyfile groups is:
```
  mka-cak
  password-raw
  pin
  private-key
  psk
  secrets
  wep-key0
  wep-key1
  wep-key2
  wep-key3
```
plus several ending in /password/:
```
  ca-cert-password
  client-cert-password
  leap-password
  password
  phase2-ca-cert-password
  phase2-client-cert-password
  phase2-private-key-password
  private-key-password
```
Additionally, and what this patch does not cover, vpn secrets are in a
`[vpn-secrets]` groups, but those keys have their name depending on the
VPN plugin. In the future, we would filter out the entire `[vpn-secrets]`
group.

[1] https://developer-old.gnome.org/glib/unstable/glib-Key-value-file-parser.html

Signed-off-by: Thomas Haller <thaller(at)redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?