### PR TITLE
Sos pmoravec pulpcore candlepin psql tablesizes

### DIFF
--- a/sos/report/plugins/candlepin.py
+++ b/sos/report/plugins/candlepin.py
@@ -82,20 +82,21 @@ class Candlepin(Plugin, RedHatPlugin):
 
         self.add_cmd_output("du -sh /var/lib/candlepin/*/*")
         # collect tables sizes, ordered
-        _cmd = self.build_query_cmd("\
-            SELECT schema_name, relname, \
-                   pg_size_pretty(table_size) AS size, table_size \
-            FROM ( \
-              SELECT \
-                pg_catalog.pg_namespace.nspname AS schema_name, \
-                relname, \
-                pg_relation_size(pg_catalog.pg_class.oid) AS table_size \
-              FROM pg_catalog.pg_class \
-              JOIN pg_catalog.pg_namespace \
-                ON relnamespace = pg_catalog.pg_namespace.oid \
-            ) t \
-            WHERE schema_name NOT LIKE 'pg_%' \
-            ORDER BY table_size DESC;")
+        _cmd = self.build_query_cmd(
+            "SELECT table_name, pg_size_pretty(total_bytes) AS total, "
+            "pg_size_pretty(index_bytes) AS INDEX , "
+            "pg_size_pretty(toast_bytes) AS toast, pg_size_pretty(table_bytes)"
+            " AS TABLE FROM ( SELECT *, "
+            "total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes "
+            "FROM (SELECT c.oid,nspname AS table_schema, relname AS "
+            "TABLE_NAME, c.reltuples AS row_estimate, "
+            "pg_total_relation_size(c.oid) AS total_bytes, "
+            "pg_indexes_size(c.oid) AS index_bytes, "
+            "pg_total_relation_size(reltoastrelid) AS toast_bytes "
+            "FROM pg_class c LEFT JOIN pg_namespace n ON "
+            "n.oid = c.relnamespace WHERE relkind = 'r') a) a order by "
+            "total_bytes DESC"
+        )
         self.add_cmd_output(_cmd, suggest_filename='candlepin_db_tables_sizes',
                             env=self.env)
 


### PR DESCRIPTION
Collect `db_tables_sizes` also for `pulpcore` and unify/extend the format of the same psql stats in `candlepin`.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?