### PR TITLE
[sos] Fix typo in po files

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/am.po
+++ b/po/am.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/ar.po
+++ b/po/ar.po
@@ -32,7 +32,7 @@ msgstr "الملحق %s غير سليم، تم تعطيله"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "لا يمكن تثبيت الملحق %s، تم تعطيله."
 
 #: ../sos/sosreport.py:985

--- a/po/as.po
+++ b/po/as.po
@@ -37,7 +37,7 @@ msgstr "প্লাগ-ইন %s অনুমোদন কৰা নাযা�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "প্লাগ-ইন %s ইনস্টল কৰা নাযায়, উপেক্ষা কৰা হৈছে "
 
 #: ../sos/sosreport.py:985

--- a/po/ast.po
+++ b/po/ast.po
@@ -37,7 +37,7 @@ msgstr "nun se validó'l plugin %s, inorándolu"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "nun s'instaló'l plugin %s, inorándolu"
 
 #: ../sos/sosreport.py:985

--- a/po/be.po
+++ b/po/be.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/bg.po
+++ b/po/bg.po
@@ -33,7 +33,7 @@ msgstr "плъгин %s не се валидира, прескачане"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "плъгин %s не се инсталира, прескачане"
 
 #: ../sos/sosreport.py:985

--- a/po/bn.po
+++ b/po/bn.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -37,7 +37,7 @@ msgstr "প্লাগ-ইন %s অনুমোদন করা যায়ন�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "প্লাগ-ইন %s ইনস্টল করা যায়নি, উপেক্ষা করা হচ্ছে "
 
 #: ../sos/sosreport.py:985

--- a/po/bs.po
+++ b/po/bs.po
@@ -33,7 +33,7 @@ msgstr "plugin %s se nije mogao potvrditi, preskace se"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "plugin %s se nije instalirao, preskace se "
 
 #: ../sos/sosreport.py:985

--- a/po/ca.po
+++ b/po/ca.po
@@ -46,7 +46,7 @@ msgstr "el connector %s no es valida, ometent"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "el connector %s no s'instal·la, ometent"
 
 #: ../sos/sosreport.py:985

--- a/po/cs.po
+++ b/po/cs.po
@@ -36,7 +36,7 @@ msgstr "plugin %s není validní, přeskakuji"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "plugin %s nejde nainstalovat, přeskakuji"
 
 #: ../sos/sosreport.py:985

--- a/po/cy.po
+++ b/po/cy.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/da.po
+++ b/po/da.po
@@ -35,7 +35,7 @@ msgstr "udvidelsesmodulet %s validerer ikke, springer over"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "udvidelsesmodulet %s installerer ikke, springer over"
 
 #: ../sos/sosreport.py:985

--- a/po/de.po
+++ b/po/de.po
@@ -41,7 +41,7 @@ msgstr "Plugin %s validiert nicht, wird ausgelassen"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "Plugin %s installiert sich nicht, wird ausgelassen"
 
 #: ../sos/sosreport.py:985

--- a/po/de_CH.po
+++ b/po/de_CH.po
@@ -38,7 +38,7 @@ msgstr "Plugin %s validiert nicht, wird ausgelassen"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "Plugin %s installiert sich nicht, wird ausgelassen"
 
 #: ../sos/sosreport.py:985

--- a/po/el.po
+++ b/po/el.po
@@ -34,7 +34,7 @@ msgstr "το πρόσθετο %s δεν είναι έγκυρο,η διαδικ�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "το πρόσθετο %s δεν μπορεί να εγκατασταθεί,η διαδικασία προσπερνάται"
 
 #: ../sos/sosreport.py:985

--- a/po/en.po
+++ b/po/en.po
@@ -34,7 +34,7 @@ msgstr "plugin %s does not validate, skipping"
 
 #: ../sos/sosreport.py:625
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "plugin %s does not install, skipping"
 
 #: ../sos/sosreport.py:627

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -34,7 +34,7 @@ msgstr "plugin %s does not validate, skipping"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "plugin %s does not install, skipping"
 
 #: ../sos/sosreport.py:985

--- a/po/es.po
+++ b/po/es.po
@@ -37,7 +37,7 @@ msgstr "no se puede validar"
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "el complemento %s necesita privilegios administrativos para ejecutarse; se ha omitido"
 
 #: ../sos/sosreport.py:985

--- a/po/et.po
+++ b/po/et.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/eu.po
+++ b/po/eu.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/fa.po
+++ b/po/fa.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/fi.po
+++ b/po/fi.po
@@ -32,7 +32,7 @@ msgstr "liitännäinen %s on virheellinen, ohitetaan"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "liitännäinen %s ei asennu, ohitetaan"
 
 #: ../sos/sosreport.py:985

--- a/po/fr.po
+++ b/po/fr.po
@@ -38,7 +38,7 @@ msgstr "le plugin %s n'a pas été validé, ignoré"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "le plugin %s ne s'installe pas, ignoré"
 
 #: ../sos/sosreport.py:985

--- a/po/gl.po
+++ b/po/gl.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/gu.po
+++ b/po/gu.po
@@ -38,7 +38,7 @@ msgstr "પ્લગઈન %s માન્ય થઈ શક્યું નહ�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "પ્લગઈન %s સ્થાપિત થતું નથી, અવગણી રહ્યા છીએ"
 
 #: ../sos/sosreport.py:985

--- a/po/he.po
+++ b/po/he.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/hi.po
+++ b/po/hi.po
@@ -38,7 +38,7 @@ msgstr "प्लगिन %s वैध नहीं कर सकता है,
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "प्लगिन %s अधिष्ठापित नहीं कर रहा है, छोड़ रहा है"
 
 #: ../sos/sosreport.py:985

--- a/po/hr.po
+++ b/po/hr.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/hu.po
+++ b/po/hu.po
@@ -33,7 +33,7 @@ msgstr "%s dugasz érvénytelen, kihagyás"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "%s dugasz nem települ, kihagyás"
 
 #: ../sos/sosreport.py:985

--- a/po/hy.po
+++ b/po/hy.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/id.po
+++ b/po/id.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "laporan sos membutuhkan hak akses root untuk berjalan."
 
 #: ../sos/sosreport.py:985

--- a/po/ilo.po
+++ b/po/ilo.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/is.po
+++ b/po/is.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/it.po
+++ b/po/it.po
@@ -34,7 +34,7 @@ msgstr "il plugin %s non é valido e verrà ignorato"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "il plugin %s non si installa, ignorato"
 
 #: ../sos/sosreport.py:985

--- a/po/ja.po
+++ b/po/ja.po
@@ -37,7 +37,7 @@ msgstr "プラグイン %s は認証できません、スキップします"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "プラグイン %s は インストールできません。スキップします"
 
 #: ../sos/sosreport.py:985

--- a/po/ka.po
+++ b/po/ka.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/kn.po
+++ b/po/kn.po
@@ -37,7 +37,7 @@ msgstr "ಪ್ಲಗ್‌ಇನ್ %s ಮಾನ್ಯಗೊಂಡಿಲ್ಲ, 
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "ಪ್ಲಗ್‌ಇನ್ %s ಅನುಸ್ಥಾಪನೆಗೊಂಡಿಲ್ಲ, ಉಪೇಕ್ಷಿಸಲಾಗುತ್ತಿದೆ"
 
 #: ../sos/sosreport.py:985

--- a/po/ko.po
+++ b/po/ko.po
@@ -36,7 +36,7 @@ msgstr "%s 플러그인이 유효하지 않아 생략합니다."
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "%s 플러그인이 설치되지 않아 생략합니다."
 
 #: ../sos/sosreport.py:985

--- a/po/ku.po
+++ b/po/ku.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/lo.po
+++ b/po/lo.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/lt.po
+++ b/po/lt.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/lv.po
+++ b/po/lv.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/mk.po
+++ b/po/mk.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/ml.po
+++ b/po/ml.po
@@ -36,7 +36,7 @@ msgstr "%s എന്നത് ശരിയായ പ്ളഗ്ഗിന്‍ 
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "%s എന്ന പ്ളഗ്ഗിന്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുവാന്‍ സാധ്യമല്ല, ഉപേക്ഷിക്കുന്നു"
 
 #: ../sos/sosreport.py:985

--- a/po/mr.po
+++ b/po/mr.po
@@ -37,7 +37,7 @@ msgstr "प्लगइन %s तपासले गेले नाही, व�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "प्लगइन %s चे प्रतिष्ठापान अशक्य, वगळत आहे"
 
 #: ../sos/sosreport.py:985

--- a/po/ms.po
+++ b/po/ms.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/my.po
+++ b/po/my.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/nb.po
+++ b/po/nb.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/nds.po
+++ b/po/nds.po
@@ -38,7 +38,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/nl.po
+++ b/po/nl.po
@@ -35,7 +35,7 @@ msgstr "plug-in %s valideerde niet, wordt overgeslagen"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "plug-in %s laat zich niet installeren, wordt overgeslagen"
 
 #: ../sos/sosreport.py:985

--- a/po/nn.po
+++ b/po/nn.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/nso.po
+++ b/po/nso.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/or.po
+++ b/po/or.po
@@ -37,7 +37,7 @@ msgstr "ପ୍ଲଗଇନ %s କୁ ବୈଧିକୃତ କରେ ନାହ�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "ପ୍ଲଗଇନ %s ସ୍ଥାପନ କରେନାହିଁ, ଏଡ଼ାଇ ଦେଉଛି"
 
 #: ../sos/sosreport.py:985

--- a/po/pa.po
+++ b/po/pa.po
@@ -37,7 +37,7 @@ msgstr "ਪਲੱਗਇਨ %s ਪ੍ਰਮਾਣਿਤ ਨਹੀਂ ਹੈ, ਛ�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "ਪਲੱਗਇਨ %s ਇੰਸਟਾਲ ਨਹੀਂ ਹੋਇਆ, ਛੱਡ ਰਿਹਾ ਹੈ"
 
 #: ../sos/sosreport.py:985

--- a/po/pl.po
+++ b/po/pl.po
@@ -34,7 +34,7 @@ msgstr "nieprawidłowa"
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "wtyczka %s do wykonania wymaga uprawnień roota, pomijanie"
 
 #: ../sos/sosreport.py:985

--- a/po/pt.po
+++ b/po/pt.po
@@ -36,7 +36,7 @@ msgstr "plugin %s não valida. A passar ao seguinte"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "plugin %s não instala. A passar ao seguinte"
 
 #: ../sos/sosreport.py:985

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -33,7 +33,7 @@ msgstr "o plugin %s não validou, ignorando"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "o plugin %s não instala, ignorando"
 
 #: ../sos/sosreport.py:985

--- a/po/ro.po
+++ b/po/ro.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/ru.po
+++ b/po/ru.po
@@ -38,7 +38,7 @@ msgstr "модуль %s не прошёл проверку. Пропускает
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "модуль %s не устанавливается. Пропускается."
 
 #: ../sos/sosreport.py:985

--- a/po/si.po
+++ b/po/si.po
@@ -37,7 +37,7 @@ msgstr "%s ප්ලගීනය සත්‍යාපනය වන්නේ න
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "%s ප්ලගීනය ස්ථාපනය වන්නේ නැත, මගහරි"
 
 #: ../sos/sosreport.py:985

--- a/po/sk.po
+++ b/po/sk.po
@@ -35,7 +35,7 @@ msgstr "nie je možné overiť modul %s, preskakujem"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "nie je možné nainštalovať modul %s, preskakujem"
 
 #: ../sos/sosreport.py:985

--- a/po/sl.po
+++ b/po/sl.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/sos.pot
+++ b/po/sos.pot
@@ -33,7 +33,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/sq.po
+++ b/po/sq.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/sr.po
+++ b/po/sr.po
@@ -35,7 +35,7 @@ msgstr "додатак %s се није оверио, прескачем"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "додатак %s се није инсталирао, прескачем"
 
 #: ../sos/sosreport.py:985

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -35,7 +35,7 @@ msgstr "dodatak %s se nije overio, preskačem"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "dodatak %s se nije instalirao, preskačem"
 
 #: ../sos/sosreport.py:985

--- a/po/sv.po
+++ b/po/sv.po
@@ -35,7 +35,7 @@ msgstr "insticksmodul %s validerar inte, hoppar över"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "insticksmodul %s installerar inte, hoppar över"
 
 #: ../sos/sosreport.py:985

--- a/po/ta.po
+++ b/po/ta.po
@@ -37,7 +37,7 @@ msgstr "கூடுதல் இணைப்பு %s தவறாக உள்
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "கூடுதல் இணைப்பு %s நிறுவப்படவில்லை, தவிர்க்கப்படுகிறது"
 
 #: ../sos/sosreport.py:985

--- a/po/te.po
+++ b/po/te.po
@@ -38,7 +38,7 @@ msgstr "ప్లగ్‌యిన్ %s నిర్ధారించబడ�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "ప్లగిన్ %s సంస్థాపించబడలేదు, వదిలివేయుచున్నది"
 
 #: ../sos/sosreport.py:985

--- a/po/th.po
+++ b/po/th.po
@@ -35,7 +35,7 @@ msgstr "ส่วนขยาย %s ไม่ถูกต้อง จะข้�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "ส่วนขยาย %s ติดตั้งไม่ได้ จะข้ามไป"
 
 #: ../sos/sosreport.py:985

--- a/po/tr.po
+++ b/po/tr.po
@@ -37,7 +37,7 @@ msgstr "%s eklentisi doğrulanamadı, atlanıyor"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "%s eklentisi kurulamıyor, atlanıyor"
 
 #: ../sos/sosreport.py:985

--- a/po/uk.po
+++ b/po/uk.po
@@ -36,7 +36,7 @@ msgstr "модуль %s не пройшов перевірку автентич�
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "модуль %s не встановлюється. Пропускається."
 
 #: ../sos/sosreport.py:985

--- a/po/ur.po
+++ b/po/ur.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/vi.po
+++ b/po/vi.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -37,7 +37,7 @@ msgstr "插件 %s 无效，跳过"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "未安装插件 %s，跳过"
 
 #: ../sos/sosreport.py:985

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -35,7 +35,7 @@ msgstr "外掛程式 %s 無法驗證，因此跳過"
 
 #: ../sos/sosreport.py:983
 #, fuzzy, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr "未安裝外掛程式 %s，故而跳過"
 
 #: ../sos/sosreport.py:985

--- a/po/zu.po
+++ b/po/zu.po
@@ -32,7 +32,7 @@ msgstr ""
 
 #: ../sos/sosreport.py:983
 #, python-format
-msgid "plugin %s requires root permissionsto execute, skipping"
+msgid "plugin %s requires root permissions to execute, skipping"
 msgstr ""
 
 #: ../sos/sosreport.py:985


### PR DESCRIPTION
This patch adds a missing space between two words
in one of the strings in all po files.

Resolves: #2932 

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?