### PR TITLE
[plugins] Allow 'str' PlugOpt type to accept any value

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -452,6 +452,10 @@ class PluginOpt():
         return self.__str__()
 
     def set_value(self, val):
+        # 'str' type accepts any value, incl. numbers
+        if type('') in self.val_type:
+            self.value = str(val)
+            return
         if not any([type(val) == _t for _t in self.val_type]):
             valid = []
             for t in self.val_type:


### PR DESCRIPTION
For PlugOpt type 'str', we should allow any content including e.g.
numbers, and interpret it as a string.

Resolves: #2922
Closes: #2935

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?