### PR TITLE
[postgresql] Simplify val_type for dbport

### DIFF
--- a/sos/report/plugins/postgresql.py
+++ b/sos/report/plugins/postgresql.py
@@ -41,7 +41,7 @@ class PostgreSQL(Plugin):
                   desc='database name to dump with pg_dump'),
         PluginOpt('dbhost', default='', val_type=str,
                   desc='database hostname/IP address (no unix sockets)'),
-        PluginOpt('dbport', default=5432, val_type=[int, str],
+        PluginOpt('dbport', default=5432, val_type=int,
                   desc='database server listening port')
     ]
 


### PR DESCRIPTION
After the change introduced via PR #2935
(Allow 'str' PlugOpt type to accept any value)
the postgresql plugin was the only one specifying
both str and int as possible values. This patch
simplifies the val_type field to be in line
with the rest of plugins where str covers int as well.

Depends on: #2935 
Closes: #2936

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?