### PR TITLE
[collector] use --image option for oc-based sos collect

### DIFF
--- a/sos/collector/transports/oc.py
+++ b/sos/collector/transports/oc.py
@@ -109,7 +109,8 @@ class OCTransport(RemoteTransport):
                 "containers": [
                     {
                         "name": "sos-collector-tmp",
-                        "image": "registry.redhat.io/rhel8/support-tools",
+                        "image": "registry.redhat.io/rhel8/support-tools"
+                                if not self.opts.image else self.opts.image,
                         "command": [
                             "/bin/bash"
                         ],


### PR DESCRIPTION
This option should be useful both for testing and real-life usage to be able to control version of support-tools container.

Description looks correct - https://github.com/sosreport/sos/blob/main/sos/collector/__init__.py#L357-L359, but please let me know if it was meant for something else or if I can update it.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?