### PR TITLE
[ceph_mon/ceph_osd] Collect metata type used in the backend

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -28,9 +28,9 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
         })
 
         self.add_copy_spec([
-            "/var/log/ceph/ceph-mon*.log",
-            "/var/lib/ceph/mon/",
-            "/run/ceph/ceph-mon*"
+            "/run/ceph/ceph-mon*",
+            "/var/lib/ceph/mon/*/kv_backend",
+            "/var/log/ceph/ceph-mon*.log"
         ])
 
         self.add_cmd_output([
@@ -110,14 +110,11 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph tell mon.%s mon_status" % mon_id for mon_id in mon_ids
         ], subdir="json_output", tags="insights_ceph_health_detail")
 
-        # these can be cleaned up too but leaving them for safety for now
         self.add_forbidden_path([
             "/etc/ceph/*keyring*",
             "/var/lib/ceph/*keyring*",
             "/var/lib/ceph/*/*keyring*",
             "/var/lib/ceph/*/*/*keyring*",
-            "/var/lib/ceph/osd",
-            "/var/lib/ceph/mon",
             # Excludes temporary ceph-osd mount location like
             # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
             "/var/lib/ceph/tmp/*mnt*",

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -28,13 +28,10 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
 
         # Only collect OSD specific files
         self.add_copy_spec([
+            "/run/ceph/ceph-osd*",
+            "/var/lib/ceph/osd/*/kv_backend",
             "/var/log/ceph/ceph-osd*.log",
             "/var/log/ceph/ceph-volume*.log",
-
-            "/var/lib/ceph/osd/",
-            "/var/lib/ceph/bootstrap-osd/",
-
-            "/run/ceph/ceph-osd*"
         ])
 
         self.add_cmd_output([
@@ -96,8 +93,6 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
             "/var/lib/ceph/*keyring*",
             "/var/lib/ceph/*/*keyring*",
             "/var/lib/ceph/*/*/*keyring*",
-            "/var/lib/ceph/osd",
-            "/var/lib/ceph/mon",
             # Excludes temporary ceph-osd mount location like
             # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
             "/var/lib/ceph/tmp/*mnt*",


### PR DESCRIPTION
Ceph uses leveldb (old versions) or rocksdb (recent to current ones)
for metadata. The older filestore backend is deprecated since
Quincy (17.2.0) which uses leveldb. So it's useful to know
if, for example, ceph-mon is still using leveldb for metadata.
This can happen even after upgrading to newer Ceph versions
if the leveldb isn't migrated to leveldb.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?