### PR TITLE
[sos] Fix unhandled exception when concurrently removing temp dir

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1453,9 +1453,14 @@ class SoSReport(SoSComponent):
             if not archive:
                 print("Creating archive tarball failed.")
             else:
-                # compute and store the archive checksum
-                hash_name = self.policy.get_preferred_hash_name()
-                checksum = self._create_checksum(archive, hash_name)
+                try:
+                    # compute and store the archive checksum
+                    hash_name = self.policy.get_preferred_hash_name()
+                    checksum = self._create_checksum(archive, hash_name)
+                except Exception:
+                    print(_("Error generating archive checksum after "
+                            "archive creation.\n"))
+                    return False
                 try:
                     self._write_checksum(archive, hash_name, checksum)
                 except (OSError, IOError):


### PR DESCRIPTION
This patch tries to capture the exception when running
the sosreport at the same time the temp directory
specified as an option is deleted.

Resolves: #2806

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?