### PR TITLE
[fibrechannel]: Update fibrechannel plugin to collect HBA logs

### DIFF
--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -33,4 +33,20 @@ class Fibrechannel(Plugin, RedHatPlugin):
         if self.get_option('debug'):
             self.add_copy_spec(self.debug_paths)
 
+        self.add_cmd_output([
+            "hbacmd listhbas",
+            "hbacmd ServerAttributes"
+        ])
+
+        # collect Hbaattributes and Portattributes of WWN
+        listhbas = self.collect_cmd_output("hbacmd listhbas")
+        if listhbas['status'] == 0:
+            for line in listhbas['output'].splitlines():
+                if 'Port WWN' in line:
+                    dev = line.split()[3]
+                    self.add_cmd_output([
+                        "hbacmd HbaAttributes %s" % dev,
+                        "hbacmd PortAttributes %s" % dev,
+                        "hbacmd GetXcvrData %s" % dev
+                    ])
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This patch is to update fibrechannel plugin to collect
HBA device logs

following commands are added
hbacmd listhbas
hbacmd HbaAttributes <WWPN | MAC>
hbacmd PortAttributes <WWPN | MAC>
hbacmd ServerAttributes

Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>
Reported-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>
Reported-by: Toni Gibson <cajun1@us.ibm.com>
Tested-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [x ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?