### PR TITLE
[Plugin] Make forbidden path checks more efficient

### DIFF
--- a/sos/report/plugins/cgroups.py
+++ b/sos/report/plugins/cgroups.py
@@ -31,10 +31,8 @@ class Cgroups(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
 
         self.add_cmd_output("systemd-cgls")
         self.add_forbidden_path(
-            "/sys/fs/cgroup/memory/**/memory.kmem.slabinfo",
-            recursive=True)
-
-        return
+            "/sys/fs/cgroup/memory/**/memory.kmem.slabinfo"
+        )
 
 
 class RedHatCgroups(Cgroups, RedHatPlugin):

--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -89,7 +89,7 @@ class PulpCore(Plugin, IndependentPlugin):
             "/etc/pki/pulp/*"
         ])
         # skip collecting certificate keys
-        self.add_forbidden_path("/etc/pki/pulp/**/*.key", recursive=True)
+        self.add_forbidden_path("/etc/pki/pulp/**/*.key")
 
         self.add_cmd_output("curl -ks https://localhost/pulp/api/v3/status/",
                             suggest_filename="pulp_status")

--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -30,7 +30,7 @@ class Rhui(Plugin, RedHatPlugin):
             "/var/log/rhui/*",
         ])
         # skip collecting certificate keys
-        self.add_forbidden_path("/etc/pki/rhui/**/*.key", recursive=True)
+        self.add_forbidden_path("/etc/pki/rhui/**/*.key")
 
         # call rhui-manager commands with 1m timeout and
         # with an env. variable ensuring that "RHUI Username:"


### PR DESCRIPTION
Forbidden path checks have up until now worked by taking a given file
path (potentially with globs), expanding that against all discovered
files that actually exist on the system, and then comparing a potential
collection path against that list.

While this works, and works reasonably fast for most scenarios, it isn't
very efficient and causes significant slow downs when a non-standard
configuration is in play - e.g. thousands of block devices which sos
would individually have to compare against tens of thousands of paths
for every path the `block` plugin wants to collect.

Improve this by first not expanding the forbidden path globs, but taking
them as distinct patterns, translating from shell-style (to maintain
historical precedent of using globs to specify paths to be skipped) to
python regex patterns as needed. Second, use `re` to handle our pattern
matching for comparison against the distinct patterns provided by a
plugin to skip.

Closes: #2938

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?