### PR TITLE
[arcconf]: Update arcconf plugin to collect UART logs

### DIFF
--- a/sos/report/plugins/arcconf.py
+++ b/sos/report/plugins/arcconf.py
@@ -23,6 +23,9 @@ class arcconf(Plugin, IndependentPlugin):
     def setup(self):
 
         # get list of adapters
-        self.add_cmd_output("arcconf getconfig 1")
-
+        self.add_cmd_output([
+            "arcconf getconfig 1",
+            "arcconf list",
+            "arcconf GETLOGS 1 UART"
+        ])
 # vim: et ts=4 sw=4


### PR DESCRIPTION
This patch is to update arcconf plugin to collect
UART logs

added following commands:
"arcconf list",
"arcconf GETLOGS 1 UART"

Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>
Reported-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>
Tested-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?