### PR TITLE
[ovirt] answer files: Filter out all password keys

### DIFF
--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -241,19 +241,22 @@ class Ovirt(Plugin, RedHatPlugin):
                 r'{key}=********'.format(key=key)
             )
 
-        # Answer files contain passwords
-        for key in (
-            'OVESETUP_CONFIG/adminPassword',
-            'OVESETUP_CONFIG/remoteEngineHostRootPassword',
-            'OVESETUP_DWH_DB/password',
-            'OVESETUP_DB/password',
-            'OVESETUP_REPORTS_CONFIG/adminPassword',
-            'OVESETUP_REPORTS_DB/password',
+        # Answer files contain passwords.
+        # Replace all keys that have 'password' in them, instead of hard-coding
+        # here the list of keys, which changes between versions.
+        # Sadly, the engine admin password prompt name does not contain
+        # 'password'... so neither does the env key.
+        for item in (
+            'password',
+            'OVESETUP_CONFIG_ADMIN_SETUP',
         ):
             self.do_path_regex_sub(
                 r'/var/lib/ovirt-engine/setup/answers/.*',
-                r'{key}=(.*)'.format(key=key),
-                r'{key}=********'.format(key=key)
+                re.compile(
+                    r'(?P<key>[^=]*{item}[^=]*)=.*'.format(item=item),
+                    flags=re.IGNORECASE
+                ),
+                r'\g<key>=********'
             )
 
         # aaa profiles contain passwords


### PR DESCRIPTION
Instead of hard-coding specific keys and having to maintain them over
time, replace the values of all keys that have 'password' in their name.
I think this covers all our current and hopefully future keys. It might
add "false positives" - keys that are not passwords but have 'password'
in their name - and I think that's a risk worth taking.

A partial list of keys added since the replaced code was written:
- grafana-related stuff
- keycloak-related stuff
- otopi-style answer files

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?