### PR TITLE
[component] Adjust loglevel setting to be more transparent

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -351,14 +351,13 @@ class SoSComponent():
         if not self.opts.quiet:
             console = logging.StreamHandler(sys.stdout)
             console.setFormatter(logging.Formatter('%(message)s'))
-            if self.opts.verbosity and self.opts.verbosity > 1:
-                console.setLevel(logging.DEBUG)
+            if self.opts.verbosity:
                 if flog:
                     flog.setLevel(logging.DEBUG)
-            elif self.opts.verbosity and self.opts.verbosity > 0:
-                console.setLevel(logging.WARNING)
-                if flog:
-                    flog.setLevel(logging.DEBUG)
+                if self.opts.verbosity > 1:
+                    console.setLevel(logging.DEBUG)
+                else:
+                    console.setLevel(logging.WARNING)
             else:
                 console.setLevel(logging.WARNING)
             self.soslog.addHandler(console)


### PR DESCRIPTION
Changed loglevel logic to be more transparent.
Setting file loglevel (flog) on DEBUG when any verbosity is
set.

If not leave flog to INFO.

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?