### PR TITLE
[libvirt] Collect swtpm logs from host/container

### DIFF
--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -51,9 +51,11 @@ class Libvirt(Plugin, IndependentPlugin):
                 "/var/log/libvirt/qemu/*.log*",
                 "/var/log/libvirt/lxc/*.log",
                 "/var/log/libvirt/uml/*.log",
+                "/var/log/swtpm/libvirt/qemu/*.log",
                 "/var/log/containers/libvirt/libvirtd.log",
                 "/var/log/containers/libvirt/qemu/*.log*",
                 "/var/log/containers/libvirt/lxc/*.log",
+                "/var/log/containers/libvirt/swtpm/libvirt/qemu/*.log",
                 "/var/log/containers/libvirt/uml/*.log",
             ])
         else:


### PR DESCRIPTION
Update the libvirt plugin to collect swtpm logs from hosts,
and certain containerized environments, like OpenStack TripleO

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?