### PR TITLE
[systemtap] Correct enable trigger to `commands`

### DIFF
--- a/sos/report/plugins/systemtap.py
+++ b/sos/report/plugins/systemtap.py
@@ -18,7 +18,7 @@ class SystemTap(Plugin, IndependentPlugin):
     plugin_name = 'systemtap'
     profiles = ('debug', 'performance')
 
-    files = ('stap',)
+    commands = ('stap',)
     packages = ('systemtap', 'systemtap-runtime')
 
     def setup(self):


### PR DESCRIPTION
The enablement trigger of `files` in this plugin was incorrect, and
should have been `commands` given we're checking for an executable.

Fix that, so that this plugin can properly enable on more than just the
package names.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?