### PR TITLE
[vdsm] Set LVM option use_devicesfile=0

### DIFF
--- a/sos/report/plugins/vdsm.py
+++ b/sos/report/plugins/vdsm.py
@@ -29,7 +29,8 @@ import re
 # use_lvmetad is set to 0 in order not to show cached, old lvm metadata.
 # use_lvmetad=0
 #
-# preferred_names and filter config values are set to capture Vdsm devices.
+# preferred_names, use_devicesfile and filter config values are set to
+# capture Vdsm devices.
 # preferred_names=[ '^/dev/mapper/' ]
 # filter=[ 'a|^/dev/mapper/.*|', 'r|.*|' ]
 LVM_CONFIG = """
@@ -43,6 +44,7 @@ devices {
     ignore_suspended_devices=1
     write_cache_state=0
     disable_after_error_count=3
+    use_devicesfile=0
     filter=["a|^/dev/disk/by-id/dm-uuid-mpath-|", "r|.+|"]
 }
 """


### PR DESCRIPTION
Since RHV 4.4 SP1, vdsm configures LVM to use devicesfile, causing that
the LVM filter configuration used by sos is ignored.

This change disables the use of the devicesfile, so that the information
of the devices used for RHV storage domains can be collected.

Fixes: RHBZ#2093993

Signed-off-by: Juan Orti <jortialc@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?