### PR TITLE
[sosnode] Properly pass `--namespaces` to nodes

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -634,6 +634,10 @@ class SosNode():
                 sos_opts.append(
                     "--container-runtime=%s" % self.opts.container_runtime
                 )
+            if self.opts.namespaces:
+                sos_opts.append(
+                    "--namespaces=%s" % self.opts.namespaces
+                )
 
         self.update_cmd_from_cluster()
 


### PR DESCRIPTION
The `namespaces` option was presented to `sos collect`, but was not
actually being passed to nodes.

Fix this, and gate the usage of the option to version 4.3, or the
relevant RHEL backport version like we do for `--container-runtime`.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?