### PR TITLE
[InitSystem] Allow toggle of default `is_running` result

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -414,7 +414,7 @@ support representative.
     def probe_preset(self):
         # Emergency or rescue mode?
         for target in ["rescue", "emergency"]:
-            if self.init_system.is_running("%s.target" % target):
+            if self.init_system.is_running("%s.target" % target, False):
                 return self.find_preset(CB)
         # Package based checks
         if self.pkg_by_name("satellite-common") is not None:

--- a/sos/policies/init_systems/__init__.py
+++ b/sos/policies/init_systems/__init__.py
@@ -83,7 +83,7 @@ class InitSystem():
         """
         return name in self.services
 
-    def is_running(self, name):
+    def is_running(self, name, default=True):
         """Checks if the given service name is in a running state.
 
         This should be overridden by initsystems that subclass InitSystem
@@ -91,14 +91,17 @@ class InitSystem():
         :param name: The name of the service
         :type name: ``str``
 
-        :returns: ``True`` if the service is running, else ``False``
+        :param default: The default response in case the check fails
+        :type default:  ``bool`
+
+        :returns: ``True`` if the service is running, else ``default``
         :rtype: ``bool``
         """
         # This is going to be primarily used in gating if service related
         # commands are going to be run or not. Default to always returning
         # True when an actual init system is not specified by policy so that
         # we don't inadvertantly restrict sosreports on those systems
-        return True
+        return default
 
     def load_all_services(self):
         """This loads all services known to the init system into a dict.

--- a/sos/policies/init_systems/systemd.py
+++ b/sos/policies/init_systems/systemd.py
@@ -43,8 +43,11 @@ class SystemdInit(InitSystem):
             except IndexError:
                 pass
 
-    def is_running(self, name):
-        svc = self.get_service_status(name)
-        return svc['status'] == 'active'
+    def is_running(self, name, default=False):
+        try:
+            svc = self.get_service_status(name)
+            return svc['status'] == 'active'
+        except Exception:
+            return default
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The base `InitSystem` used when systemd is not present (or at least
functional), defaults to returning `True` for all probes, in an effort
to not inadvertantly block service queries.

This works well for most scenarios, however it backfires when checking
for runlevel-analogous systemd targets for items such as the `cantboot`
preset - in that the base `InitSystem` will always enable that preset.

Fix that by allowing calls to `InitSystem.is_running()` to specify a
default value to return, instead of blindly always returning `True`.
Similarly, update the preset check to default to `False` to avoid
improperly enabling that preset when systemd is unavailable.

Closes: #2913

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?