### PR TITLE
[ostree] Add services enablement trigger

### DIFF
--- a/sos/report/plugins/ostree.py
+++ b/sos/report/plugins/ostree.py
@@ -16,6 +16,7 @@ class OSTree(Plugin, IndependentPlugin):
     plugin_name = 'ostree'
     profiles = ('system', 'sysmgmt', 'packagemanager')
     files = ('/ostree',)
+    services = ('ostree-finalize-staged', 'ostree-boot-complete')
 
     def setup(self):
         self.add_copy_spec("/ostree/repo/config")


### PR DESCRIPTION
Adds two services to the `services` tuple for this plugin to both serve
as an enablement trigger, and to capture the status and journals of
these services automatically.

This is an update/replacement to #2919 originally proposed by Colin
Walters.

Closes: #2919

Co-authored-by: Colin Walters <walters@verbum.org>
Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?