### PR TITLE
[host] Add collection of "top-level" symlinks and their targets

### DIFF
--- a/sos/report/plugins/host.py
+++ b/sos/report/plugins/host.py
@@ -12,6 +12,14 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class Host(Plugin, IndependentPlugin):
+    """This plugin primarily collects hostname related information, as well
+    as a few collections that do not fit well in other plugins. For example,
+    uptime information and SoS configuration data from /etc/sos.
+
+    This plugin is not intended to be a catch-all "general" plugin however for
+    these types of collections that do not have a specific component/package
+    or pre-existing plugin.
+    """
 
     short_desc = 'Host information'
 
@@ -24,6 +32,9 @@ class Host(Plugin, IndependentPlugin):
 
         self.add_cmd_output('hostname', root_symlink='hostname')
         self.add_cmd_output('uptime', root_symlink='uptime')
+
+        self.add_cmd_output('find / -maxdepth 2 -type l -ls',
+                            root_symlink='root-symlinks')
 
         self.add_cmd_output([
             'hostname -f',


### PR DESCRIPTION
Adds collection of a `find` command that shows symlinks from /, or one
subdirectory below, that lists all symlinks and their targets in `ls`
output format. This is by request from a RH support team for situations
where problematic systems have directories underneathe / that are solely
symlinks, and this information is relevant to problem investigation.

While the `host` plugin may not be the most intuitive place for this
collection, there are no other existing plugins that would be "more
correct", and adding a new "symlinks" plugin would likely only serve to
confuse authors and maintainers going forward.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?