### PR TITLE
[clean] Refactor handling of symlink obfuscation

### DIFF
--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -288,18 +288,31 @@ class SoSObfuscationArchive():
             path = _path_future.result()
             return path
 
-    def get_file_list(self):
-        """Return a list of all files within the archive"""
-        self.file_list = []
+    def get_symlinks(self):
+        """Iterator for a list of symlinks in the archive"""
         for dirname, dirs, files in os.walk(self.extracted_path):
             for _dir in dirs:
                 _dirpath = os.path.join(dirname, _dir)
-                # catch dir-level symlinks
-                if os.path.islink(_dirpath) and os.path.isdir(_dirpath):
-                    self.file_list.append(_dirpath)
+                if os.path.islink(_dirpath):
+                    yield _dirpath
             for filename in files:
-                self.file_list.append(os.path.join(dirname, filename))
-        return self.file_list
+                _fname = os.path.join(dirname, filename)
+                if os.path.islink(_fname):
+                    yield _fname
+
+    def get_file_list(self):
+        """Iterator for a list of files in the archive, to allow clean to
+        iterate over.
+
+        Will not include symlinks, as those are handled separately
+        """
+        for dirname, dirs, files in os.walk(self.extracted_path):
+            for filename in files:
+                _fname = os.path.join(dirname, filename.lstrip('/'))
+                if os.path.islink(_fname):
+                    continue
+                else:
+                    yield _fname
 
     def get_directory_list(self):
         """Return a list of all directories within the archive"""


### PR DESCRIPTION
Previously, there was a small but not impossible situation for a race
condition within `clean`'s handling of symlinks where a symlink name
could be obfuscated differently than what the link's target could be
obfuscated too.

Fix this by handling symlinks separately than the rest of the archive,
like what we do for directory names. When obfuscating files, archives
will now skip over symlinks and yield file names for iteration, rather
than generating and returning full file lists. Once the obfuscation of
"real" files is complete, then separately iterate over symlinks. Since
the file obfuscation also includes file names, this means that link
targets are already known to the mappings and we eliminate the potential
race condition.

Closes: #2852

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?