### PR TITLE
[PackageManager] Make pkg_by_name() more predictable

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -62,7 +62,7 @@ class RedHatPolicy(LinuxPolicy):
 
         self.valid_subclasses += [RedHatPlugin]
 
-        self.pkgs = self.package_manager.all_pkgs()
+        self.pkgs = self.package_manager.packages
 
         # If rpm query failed, exit
         if not self.pkgs:

--- a/sos/policies/distros/suse.py
+++ b/sos/policies/distros/suse.py
@@ -32,10 +32,8 @@ class SuSEPolicy(LinuxPolicy):
         self.usrmove = False
         self.package_manager = RpmPackageManager()
 
-        pkgs = self.package_manager.all_pkgs()
-
         # If rpm query timed out after timeout duration exit
-        if not pkgs:
+        if not self.package_manager.packages:
             print("Could not obtain installed package list", file=sys.stderr)
             sys.exit(1)
 

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -987,7 +987,9 @@ class Plugin():
         :returns: ``True`` id the package is installed, else ``False``
         :rtype: ``bool``
         """
-        return self.policy.pkg_by_name(package_name) is not None
+        return (
+            len(self.policy.package_manager.all_pkgs_by_name(package_name)) > 0
+        )
 
     def is_service(self, name):
         """Does the service $name exist on the system?

--- a/sos/report/plugins/etcd.py
+++ b/sos/report/plugins/etcd.py
@@ -71,7 +71,7 @@ class etcd(Plugin, RedHatPlugin):
             # assume v3 is the default
             url = 'http://localhost:2379'
             try:
-                ver = self.policy.package_manager.get_pkg_list()['etcd']
+                ver = self.policy.package_manager.packages['etcd']
                 ver = ver['version'][0]
                 if ver == '2':
                     url = 'http://localhost:4001'

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -261,7 +261,7 @@ class RedHatNetworking(Networking, RedHatPlugin):
     def setup(self):
         # Handle change from -T to -W in Red Hat netstat 2.0 and greater.
         try:
-            netstat_pkg = self.policy.package_manager.all_pkgs()['net-tools']
+            netstat_pkg = self.policy.package_manager.packages['net-tools']
             # major version
             if int(netstat_pkg['version'][0]) < 2:
                 self.ns_wide = "-T"

--- a/tests/unittests/policy_tests.py
+++ b/tests/unittests/policy_tests.py
@@ -84,7 +84,7 @@ class PackageManagerTests(unittest.TestCase):
         self.pm = PackageManager()
 
     def test_default_all_pkgs(self):
-        self.assertEquals(self.pm.all_pkgs(), {})
+        self.assertEquals(self.pm.packages, {})
 
     def test_default_all_pkgs_by_name(self):
         self.assertEquals(self.pm.all_pkgs_by_name('doesntmatter'), [])


### PR DESCRIPTION
As highlighted in #1817, `pkg_by_name()` could provide unpredictable
results, when using wildcards. As such, limited this method to only
returning package info for exact package name matches. In turn, change
`Plugin.is_installed()` to leverage `PackageManager.all_pkgs_by_name()`
which does explicitly support wildcards and returns information on _all_
matching packages, not just the last one found.

In so doing, clean up the `PackageManager` design to use a new
`packages` property for these lookups, and update the former usage of
`all_pkgs()` accordingly. Similarly, signal `get_pkg_list()` should be
    private (in any sense that a python method can be) by renaming to
    `_get_pkg_list()` and update the single Plugin (`etcd`) referencing this
    method.

Closes: #1817

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?