### PR TITLE
[utilities] Switch locale to C.UTF-8

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -159,7 +159,7 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
 
     cmd_env = os.environ.copy()
     # ensure consistent locale for collected command output
-    cmd_env['LC_ALL'] = 'C'
+    cmd_env['LC_ALL'] = 'C.UTF-8'
     # optionally add an environment change for the command
     if env:
         for key, value in env.items():


### PR DESCRIPTION
Changes the `LC_ALL` locale env var used for all command collections
from `C` to `C.UTF-8` which should provide safer/more reliable output
from non-English localizations. This is backed up by PEP-538:

    https://peps.python.org/pep-0538/

Closes: #2946

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?