### PR TITLE
[policies] Remove deadcode around runlevels

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -116,15 +116,6 @@ class LinuxPolicy(Policy):
             '/etc/shadow'
         ]
 
-    def default_runlevel(self):
-        try:
-            with open("/etc/inittab") as fp:
-                pattern = r"id:(\d{1}):initdefault:"
-                text = fp.read()
-                return int(re.findall(pattern, text)[0])
-        except (IndexError, IOError):
-            return 3
-
     def kernel_version(self):
         return self.release
 

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -160,28 +160,6 @@ class RedHatPolicy(LinuxPolicy):
         else:
             return files
 
-    def runlevel_by_service(self, name):
-        from subprocess import Popen, PIPE
-        ret = []
-        p = Popen("LC_ALL=C /sbin/chkconfig --list %s" % name,
-                  shell=True,
-                  stdout=PIPE,
-                  stderr=PIPE,
-                  bufsize=-1,
-                  close_fds=True)
-        out, err = p.communicate()
-        if err:
-            return ret
-        for tabs in out.split()[1:]:
-            try:
-                (runlevel, onoff) = tabs.split(":", 1)
-            except IndexError:
-                pass
-            else:
-                if onoff == "on":
-                    ret.append(int(runlevel))
-        return ret
-
     def get_tmp_dir(self, opt_tmp_dir):
         if not opt_tmp_dir:
             return self._tmp_dir

--- a/sos/policies/distros/suse.py
+++ b/sos/policies/distros/suse.py
@@ -51,28 +51,6 @@ class SuSEPolicy(LinuxPolicy):
         OpenSuSE, SLES or other Suse distribution and False otherwise."""
         return False
 
-    def runlevel_by_service(self, name):
-        from subprocess import Popen, PIPE
-        ret = []
-        p = Popen("LC_ALL=C /sbin/chkconfig --list %s" % name,
-                  shell=True,
-                  stdout=PIPE,
-                  stderr=PIPE,
-                  bufsize=-1,
-                  close_fds=True)
-        out, err = p.communicate()
-        if err:
-            return ret
-        for tabs in out.split()[1:]:
-            try:
-                (runlevel, onoff) = tabs.split(":", 1)
-            except IndexError:
-                pass
-            else:
-                if onoff == "on":
-                    ret.append(int(runlevel))
-        return ret
-
     def get_tmp_dir(self, opt_tmp_dir):
         if not opt_tmp_dir:
             return self._tmp_dir


### PR DESCRIPTION
Removes the `runlevel_by_service()` methods from the redhat and suse
policies, as these methods are both outdated (by trying to leverage
`chkconfig`) and entirely unsued.

Further, removes the `LinuxPolicy.default_runlevel()` method as it is
similarly unused in sos.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?