### PR TITLE
[tests] Increase default timeout

### DIFF
--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -65,7 +65,7 @@ class BaseSoSTest(Test):
     _tmpdir = None
     _exception_expected = False
     sos_cmd = ''
-    sos_timeout = 300
+    sos_timeout = 600
     redhat_only = False
     ubuntu_only = False
     end_of_test_case = False


### PR DESCRIPTION
For our CI tests, CPU resources are not guaranteed which in turn can
cause longer-than-expected run times for test executions. In practice,
this is only seen occasionally but it requires manual intervention when
the timeouts are hit (and thus far it has been seen that the changes
these timeouts are hit on are not actually causing the timeouts).

Previous conversations have revolved around improving test efficiency,
however this seems unlikely given the nature of some of the test setup
and further, even with the most efficienct approach possible we would
still be at the whim of resource availability.

As such, increase the default timeout to account for this resource
consideration.

Closes: #2700

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?