### PR TITLE
[clean,IP Parser] Skip obvious version files for the IP parser

### DIFF
--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -35,10 +35,10 @@ class SoSIPParser(SoSCleanerParser):
         'sos_commands/rpm',
         'sos_commands/yum/.*list.*',
         'sos_commands/snappy/snap_list_--all',
-        'sos_commands/snappy/snap_--version',
         'sos_commands/vulkan/vulkaninfo',
         'var/log/.*dnf.*',
-        'var/log/.*packag.*'  # get 'packages' and 'packaging' logs
+        'var/log/.*packag.*',  # get 'packages' and 'packaging' logs
+        '.*(version|release)(\\.txt)?$',  # obvious version files
     ]
 
     map_file_key = 'ip_map'

--- a/tests/cleaner_tests/skip_version_ip_parser.py
+++ b/tests/cleaner_tests/skip_version_ip_parser.py
@@ -1,0 +1,33 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+DO_SKIP = '/tmp/sos-test-version.txt'
+NO_SKIP = '/tmp/sos-test-version-noskip'
+
+class SkipVersionIPParser(StageTwoReportTest):
+    """Ensures that we _skip_ files ending in 'version' (or 'version.txt') to
+    avoid incorrectly obfuscating version numbers.
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [DO_SKIP, NO_SKIP]
+    install_plugins = ['skip_versions']
+    sos_cmd = '--clean -o skip_versions'
+
+    def test_version_file_skipped(self):
+        self.assertFileCollected(DO_SKIP)
+        self.assertFileHasContent(DO_SKIP, '10.11.12.13')
+        self.assertFileHasContent(DO_SKIP, '6.0.0.1')
+
+    def test_incorrect_version_file_not_skipped(self):
+        self.assertFileCollected(NO_SKIP)
+        self.assertFileNotHasContent(NO_SKIP, '10.11.12.13')
+        self.assertFileNotHasContent(NO_SKIP, '6.0.0.1')

--- a/tests/test_data/fake_plugins/skip_versions.py
+++ b/tests/test_data/fake_plugins/skip_versions.py
@@ -1,0 +1,24 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class SkipVersions(Plugin, IndependentPlugin):
+    """Collect the fake version files from the test suite, to ensure proper
+    skipping of version files
+    """
+
+    plugin_name = 'skip_versions'
+    short_desc = 'fake plugin to test skipping version files via the IP parser'
+
+    def setup(self):
+        self.add_copy_spec([
+            '/tmp/sos-test-version.txt',
+            '/tmp/sos-test-version-noskip'
+        ])

--- a/tests/test_data/tmp/sos-test-version-noskip
+++ b/tests/test_data/tmp/sos-test-version-noskip
@@ -1,0 +1,6 @@
+This is a test file for skipping version files with the IP parser.
+
+All dotted-quad strings SHOULD be changed in this file.
+
+10.11.12.13
+6.0.0.1

--- a/tests/test_data/tmp/sos-test-version.txt
+++ b/tests/test_data/tmp/sos-test-version.txt
@@ -1,0 +1,6 @@
+This is a test file for skipping version files with the IP parser.
+
+No dotted-quad strings should be changed in this file.
+
+10.11.12.13
+6.0.0.1


### PR DESCRIPTION
For files that can be considered obvious version files - those that end
specifically with either `version` or `version.txt` - skip processing
via the IP parser, as this may lead to improper obfuscation of certain
version strings.

Closes: #2962

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?