### PR TITLE
[logs] Drop catalog from `this` and `last` boot

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -64,9 +64,9 @@ class Logs(Plugin, IndependentPlugin):
                       for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
             self.add_journal(since=since, tags='journal_full', priority=100)
-            self.add_journal(boot="this", catalog=True, since=since,
+            self.add_journal(boot="this", since=since,
                              tags='journal_since_boot')
-            self.add_journal(boot="last", catalog=True, since=since,
+            self.add_journal(boot="last", since=since,
                              tags='journal_last_boot')
             if self.get_option("all_logs"):
                 self.add_copy_spec([

--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -24,7 +24,7 @@ class LogsPluginTest(StageOneReportTest):
 
     def test_journalctl_collections(self):
         self.assertFileCollected('sos_commands/logs/journalctl_--disk-usage')
-        self.assertFileCollected('sos_commands/logs/journalctl_--no-pager_--catalog_--boot')
+        self.assertFileCollected('sos_commands/logs/journalctl_--no-pager_--boot')
 
     def test_journal_runtime_collected(self):
         self.assertFileGlobInArchive('/var/log/journal/*')


### PR DESCRIPTION
Removes catalog entries from the journal collection for `this` and
`last` boot collections.

Closes: #2132

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?