### PR TITLE
[insights] Collect /var/lib/insights

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -170,6 +170,7 @@ any third party.
         override subclass-specific paths
         """
         return [
+            '*.egg',
             '*.pyc',
             '*.pyo',
             '*.swp'

--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -10,8 +10,18 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class RedHatInsights(Plugin, RedHatPlugin):
+    """Plugin to capture configuration and logging for the Red Hat Insights
+    client. Insights is used to provide ongoing analysis of systems for
+    proactive problem mitigation, with the client being one of the primary
+    sources of data for the service.
 
-    short_desc = 'Collect config and logs for Red Hat Insights'
+    This plugin will capture configuration information under
+    /etc/insighits-client, as well as logs from /var/log/insights-client. A
+    single connection test via the `insights-client` command is performed and
+    recorded as well for troubleshooting purposes.
+    """
+
+    short_desc = 'Red Hat Insights configuration and client'
     plugin_name = 'insights'
     packages = ('redhat-access-insights', 'insights-client')
     profiles = ('system', 'sysmgmt')
@@ -23,6 +33,7 @@ class RedHatInsights(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec(self.config)
+        self.add_copy_spec('/var/lib/insights')
 
         # Legacy log file location
         self.add_copy_spec("/var/log/redhat-access-insights/*.log")


### PR DESCRIPTION
Adds collection of `/var/lib/insights` to the `insights` plugin.

There is an `.egg` in this location but rather than individually
skipping it, add a global forbidden path on all eggs.

Related: RHBZ#2103233

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?