### PR TITLE
[clean] Don't re-create regex for parsers on every skip check

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -12,7 +12,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import shutil
 import tempfile
 
@@ -711,9 +710,9 @@ third party.
             tfile = tempfile.NamedTemporaryFile(mode='w', dir=self.tmpdir)
             _parsers = [
                 _p for _p in self.parsers if not
-                any([
-                    re.match(p, short_name) for p in _p.skip_files
-                ])
+                any(
+                    _skip.match(short_name) for _skip in _p.skip_patterns
+                )
             ]
             with open(filename, 'r') as fname:
                 for line in fname:

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -49,6 +49,16 @@ class SoSCleanerParser():
     def __init__(self, config={}):
         if self.map_file_key in config:
             self.mapping.conf_update(config[self.map_file_key])
+        self._generate_skip_regexes()
+
+    def _generate_skip_regexes(self):
+        """Generate the regexes for the parser's configured `skip_files`,
+        so that we don't regenerate them on every file being examined for if
+        the parser should skip a given file.
+        """
+        self.skip_patterns = []
+        for p in self.skip_files:
+            self.skip_patterns.append(re.compile(p))
 
     def generate_item_regexes(self):
         """Generate regexes for items the parser will be searching for


### PR DESCRIPTION
When determining if a parser should be skipped for a given file, we were
previously doing so ineffeciently by regenerating the regex object for
every file from the parser's `skip_files` class attr.

Instead, during parser initialization, use those string definitions to
create a list of regex objects to be used directly by the skip file
checks. This way, we only generate the regex objects once for each
parser for the entire run.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?