### PR TITLE
[cirrus] Update GCE testing images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,27 +8,30 @@ env:
     FEDORA_NAME: "fedora-${FEDORA_VER}"
     FEDORA_PRIOR_NAME: "fedora-${FEDORA_PRIOR_VER}"
 
-    UBUNTU_NAME: "ubuntu-20.04"
-    UBUNTU_PRIOR_NAME: "ubuntu-18.04"
+    UBUNTU_NAME: "ubuntu-22.04"
+    UBUNTU_PRIOR_NAME: "ubuntu-20.04"
 
     CENTOS_9_NAME: "centos-stream-9"
     CENTOS_8_NAME: "centos-stream-8"
 
     CENTOS_PROJECT: "centos-cloud"
+    FEDORA_PROJECT: "fedora-cloud"
     SOS_PROJECT: "sos-devel-jobs"
     UBUNTU_PROJECT: "ubuntu-os-cloud"
 
     # These are generated images pushed to GCP from Red Hat
-    FEDORA_IMAGE_NAME: "f${FEDORA_VER}-server-sos-testing"
+    # FEDORA_PRIOR to be switched to "stock" images from the Fedora Project
+    # once the F36 image is pushed. 
     FEDORA_PRIOR_IMAGE_NAME: "f${FEDORA_PRIOR_VER}-server-sos-testing"
     FOREMAN_CENTOS_IMAGE_NAME: "foreman-25-centos-8-sos-testing"
     FOREMAN_DEBIAN_IMAGE_NAME: "foreman-25-debian-10-sos-testing"
 
     # Images exist on GCP already
-    CENTOS_9_IMAGE_NAME: "centos-stream-9-v20220317"
-    CENTOS_8_IMAGE_NAME: "centos-stream-8-v20220317"
-    UBUNTU_IMAGE_NAME: "ubuntu-2004-focal-v20201111"
-    UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-1804-bionic-v20201111"
+    CENTOS_9_IMAGE_NAME: "centos-stream-9-v20220621"
+    CENTOS_8_IMAGE_NAME: "centos-stream-8-v20220621"
+    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-${FEDORA_VER}-1-2-x86-64"
+    UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20220622"
+    UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2004-focal-v20220701"
 
 # Default task timeout
 timeout_in: 30m
@@ -96,7 +99,7 @@ report_stageone_task:
             BUILD_NAME: ${CENTOS_8_NAME}
             VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
         - env:
-            PROJECT: ${SOS_PROJECT}
+            PROJECT: ${FEDORA_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env:
@@ -148,7 +151,7 @@ report_stagetwo_task:
             BUILD_NAME: ${CENTOS_8_NAME}
             VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
         - env:
-            PROJECT: ${SOS_PROJECT}
+            PROJECT: ${FEDORA_PROJECT}
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env:


### PR DESCRIPTION
Updates the images for Fedora to use the stock images on GCE, the CentOS
Stream images to their latest release, and the Ubuntu images to test on
the latest 22.04 LTS release.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?