### PR TITLE
[Plugin] Refactor add_blockdev_cmd into add_device_cmd

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -434,8 +434,10 @@ class SoSReport(SoSComponent):
 
     def _get_hardware_devices(self):
         self.devices = {
-            'block': self.get_block_devs(),
-            'fibre': self.get_fibre_devs()
+            'storage': {
+                'block': self.get_block_devs(),
+                'fibre': self.get_fibre_devs()
+            }
         }
         # TODO: enumerate network devices, preferably with devtype info
 
@@ -474,7 +476,7 @@ class SoSReport(SoSComponent):
         """Enumerate a list of fibrechannel devices on this system so that
         plugins can iterate over them
 
-        These devices are used by add_fibredev_cmd() in the Plugin class.
+        These devices are used by add_device_cmd() in the Plugin class.
         """
         try:
             devs = []
@@ -496,16 +498,15 @@ class SoSReport(SoSComponent):
         """Enumerate a list of block devices on this system so that plugins
         can iterate over them
 
-        These devices are used by add_blockdev_cmd() in the Plugin class.
+        These devices are used by add_device_cmd() in the Plugin class.
         """
         try:
-            device_list = os.listdir('/sys/block')
+            device_list = ["/dev/%s" % d for d in os.listdir('/sys/block')]
             loop_devices = sos_get_command_output('losetup --all --noheadings')
             real_loop_devices = []
             if loop_devices['status'] == 0:
                 for loop_dev in loop_devices['output'].splitlines():
                     loop_device = loop_dev.split()[0].replace(':', '')
-                    loop_device = loop_device.replace('/dev/', '')
                     real_loop_devices.append(loop_device)
             ghost_loop_devs = [dev for dev in device_list
                                if dev.startswith("loop")
@@ -1566,7 +1567,7 @@ class SoSReport(SoSComponent):
         self.report_md.add_list('profiles', self.opts.profiles)
         self.report_md.add_section('devices')
         for key, value in self.devices.items():
-            self.report_md.devices.add_list(key, value)
+            self.report_md.devices.add_field(key, value)
         self.report_md.add_list('enabled_plugins', self.opts.enable_plugins)
         self.report_md.add_list('disabled_plugins', self.opts.skip_plugins)
         self.report_md.add_section('plugins')

--- a/sos/report/plugins/ata.py
+++ b/sos/report/plugins/ata.py
@@ -27,7 +27,8 @@ class Ata(Plugin, IndependentPlugin):
             "smartctl -l scterc %(dev)s",
             "smartctl -l scterc %(dev)s -j"
         ]
-        self.add_blockdev_cmd(cmd_list, whitelist=['sd.*', 'hd.*'])
+        self.add_device_cmd(cmd_list, devices='block',
+                            whitelist=['sd.*', 'hd.*'])
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -56,7 +56,7 @@ class Block(Plugin, IndependentPlugin):
             "udevadm info %(dev)s",
             "udevadm info -a %(dev)s"
         ]
-        self.add_blockdev_cmd(cmds, blacklist='ram.*')
+        self.add_device_cmd(cmds, devices='block', blacklist='ram.*')
 
         lsblk = self.collect_cmd_output("lsblk -f -a -l")
         # for LUKS devices, collect cryptsetup luksDump

--- a/sos/report/plugins/fibrechannel.py
+++ b/sos/report/plugins/fibrechannel.py
@@ -29,7 +29,7 @@ class Fibrechannel(Plugin, RedHatPlugin):
     ]
 
     def setup(self):
-        self.add_blockdev_cmd("udevadm info -a %(dev)s", devices='fibre')
+        self.add_device_cmd("udevadm info -a %(dev)s", devices='fibre')
         if self.get_option('debug'):
             self.add_copy_spec(self.debug_paths)
 

--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -36,6 +36,6 @@ class Nvme(Plugin, IndependentPlugin):
             "nvme error-log %(dev)s",
             "nvme show-regs %(dev)s"
         ]
-        self.add_blockdev_cmd(cmds, whitelist='nvme.*')
+        self.add_device_cmd(cmds, devices='block', whitelist='nvme.*')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -61,14 +61,13 @@ class Scsi(Plugin, IndependentPlugin):
         ])
 
         scsi_hosts = glob("/sys/class/scsi_host/*")
-        self.add_blockdev_cmd("udevadm info -a %(dev)s", devices=scsi_hosts,
-                              prepend_path='/sys/class/scsi_host')
+        self.add_device_cmd("udevadm info -a %(dev)s", devices=scsi_hosts)
 
-        self.add_blockdev_cmd([
+        self.add_device_cmd([
             "sg_persist --in -k -d %(dev)s",
             "sg_persist --in -r -d %(dev)s",
             "sg_persist --in -s -d %(dev)s",
             "sg_inq %(dev)s"
-        ], whitelist=['sd.*'])
+        ], devices='block', whitelist=['sd.*'])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Initially, the design behind `add_blockdev_cmd()` made the assumption
that there would (eventually) be separate methods for different kinds of
devices. On review, this is less practical and less maintainable than a
single method, `add_device_cmd()` paired with improved functionality for
handling device lists.

As such, rework `add_blockdev_cmd()` into `add_device_cmd()` and with
it, change the logic on how device lists are sourced. The `devices` dict
handed to plugins now has a top-level separation between device types,
in this revision putting `block` and `fibre` devices under `storage` in
the `devices` dict.

In using `add_device_cmd()`, plugins may now specify either `block`,
`fibre`, or `storage` for both. In addition, any devices passed via the
`devices` parameter that aren't keys in the devices dict are returned,
meaning a plugin may specify a list of devices and add `storage` to
include all storage devices for command iteration.

This change should allow easier addition of network device iteration.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?