### PR TITLE
[logging] Safeguard against attempting to log non-UTF characters

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1296,6 +1296,8 @@ class SoSReport(SoSComponent):
             try:
                 fd = self.get_temp_file()
                 output = class_(report).unicode()
+                # safeguard against non-UTF characters
+                output = output.encode('utf-8', 'replace').decode()
                 fd.write(output)
                 fd.flush()
                 self.archive.add_file(fd, dest=os.path.join('sos_reports',

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -929,7 +929,10 @@ class Plugin():
         )
 
     def _format_msg(self, msg):
-        return "[plugin:%s] %s" % (self.name(), msg)
+        return "[plugin:%s] %s" % (self.name(),
+                                   # safeguard against non-UTF logging, see
+                                   # #2790 for reference
+                                   msg.encode('utf-8', 'replace').decode())
 
     def _log_error(self, msg):
         self.soslog.error(self._format_msg(msg))


### PR DESCRIPTION
The `logging` module does not support non UTF-8 characters, and as such
there was an exception being thrown when trying to log for example a
copied file that has such characters in the file name.

Safeguard against this by converting all messages logged via
`Plugin._format_msg()` to UTF-8, and replace any problematic characters
with `?`s to attempt to preserve context within the logs.

Closes: #2790

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?