### PR TITLE
[report,Plugin] Enumerate network devices for plugins

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1871,7 +1871,7 @@ class Plugin():
     def add_device_cmd(self, cmds, devices, timeout=None, sizelimit=None,
                        chroot=True, runat=None, env=None, binary=False,
                        prepend_path=None, whitelist=[], blacklist=[], tags=[],
-                       priority=10):
+                       priority=10, subdir=None):
         """Run a command or list of commands against devices discovered during
         sos initialization.
 
@@ -1915,6 +1915,10 @@ class Plugin():
         :param blacklist: Do not run `cmds` against devices matching these
                           item(s)
         :type blacklist: ``list`` of ``str``
+
+        :param subdir:  Write the command output to this subdir within the
+                        Plugin directory
+        :type subdir:   ``str``
         """
 
         _dev_tags = []
@@ -1943,11 +1947,11 @@ class Plugin():
         self._add_device_cmd(cmds, _devs, timeout=timeout,
                              sizelimit=sizelimit, chroot=chroot, runat=runat,
                              env=env, binary=binary, prepend_path=prepend_path,
-                             tags=_dev_tags, priority=priority)
+                             tags=_dev_tags, priority=priority, subdir=subdir)
 
     def _add_device_cmd(self, cmds, devices, timeout=None, sizelimit=None,
                         chroot=True, runat=None, env=None, binary=False,
-                        prepend_path=None, tags=[], priority=10):
+                        prepend_path=None, tags=[], priority=10, subdir=None):
         """Run a command against all specified devices on the system.
         """
         if isinstance(cmds, str):
@@ -1965,7 +1969,8 @@ class Plugin():
                 self._add_cmd_output(cmd=_cmd, timeout=timeout,
                                      sizelimit=sizelimit, chroot=chroot,
                                      runat=runat, env=env, binary=binary,
-                                     tags=_dev_tags, priority=priority)
+                                     tags=_dev_tags, priority=priority,
+                                     subdir=subdir)
 
     def _add_cmd_output(self, **kwargs):
         """Internal helper to add a single command to the collection list."""

--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -94,16 +94,10 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
                     self.add_cmd_output('%s "%s"' %
                                         (nmcli_con_details_cmd, con))
 
-            nmcli_dev_status_result = self.exec_cmd(
-                "nmcli --terse --fields DEVICE dev"
+            self.add_device_cmd(
+                nmcli_dev_details_cmd + ' "%(dev)s"',
+                devices='ethernet'
             )
-            if nmcli_dev_status_result['status'] == 0:
-                for dev in nmcli_dev_status_result['output'].splitlines():
-                    if dev[0:7] == 'Warning':
-                        continue
-                    # See above comment describing quoting conventions.
-                    self.add_cmd_output('%s "%s"' %
-                                        (nmcli_dev_details_cmd, dev))
 
     def postproc(self):
         for root, dirs, files in os.walk(

--- a/sos/report/plugins/teamd.py
+++ b/sos/report/plugins/teamd.py
@@ -18,30 +18,18 @@ class Teamd(Plugin, IndependentPlugin):
 
     packages = ('teamd',)
 
-    def _get_team_interfaces(self):
-        teams = []
-        ip_result = self.exec_cmd("ip -o link")
-        if ip_result['status'] != 0:
-            return teams
-        for line in ip_result['output'].splitlines():
-            fields = line.split()
-            if fields[1][0:4] == 'team':
-                teams.append(fields[1][:-1])
-        return teams
-
     def setup(self):
         self.add_copy_spec([
             "/etc/dbus-1/system.d/teamd.conf",
             "/usr/lib/systemd/system/teamd@.service"
         ])
-        teams = self._get_team_interfaces()
-        for team in teams:
-            self.add_cmd_output([
-                "teamdctl %s state" % team,
-                "teamdctl %s state dump" % team,
-                "teamdctl %s config dump" % team,
-                "teamnl %s option" % team,
-                "teamnl %s ports" % team
-            ])
+
+        self.add_device_cmd([
+            "teamdctl %(dev)s state",
+            "teamdctl %(dev)s state dump",
+            "teamdctl %(dev)s config dump",
+            "teamnl %(dev)s option",
+            "teamnl %(dev)s ports"
+        ], devices='team')
 
 # vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/networking.py
+++ b/tests/report_tests/plugin_tests/networking.py
@@ -6,6 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
 
 from sos_tests import StageOneReportTest
 
@@ -29,3 +30,9 @@ class NetworkingPluginTest(StageOneReportTest):
     def test_forbidden_globs_skipped(self):
         self.assertFileGlobNotInArchive('/proc/net/rpc/*/channel')
         self.assertFileGlobNotInArchive('/proc/net/rpc/*/flush')
+
+    def test_netdevs_properly_iterated(self):
+        for dev in os.listdir('/sys/class/net'):
+            self.assertFileGlobInArchive(
+                "sos_commands/networking/ethtool_*_%s" % dev
+            )


### PR DESCRIPTION

This patchset first adds enumeration of network devices to the `devices` dict handed to plugins for device iteration. Second, it updates `add_device_cmd()` to allow handling of the `subdir` parameter, and finally it updates various network-related plugins to use `add_device_cmd()` instead of enumerating devices themselves.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?