### PR TITLE
[openstack] Ensure memcache_secret_key is masked

### DIFF
--- a/sos/report/plugins/gnocchi.py
+++ b/sos/report/plugins/gnocchi.py
@@ -67,6 +67,11 @@ class Gnocchi(Plugin):
             r"password\s?=(.*)",
             r"password=*****",
         )
+        self.do_file_sub(
+            "/etc/gnocchi/gnocchi.conf",
+            r"memcache_secret_key\s?=(.*)",
+            r"memcache_secret_key=*****",
+        )
 
 
 class RedHatGnocchi(Gnocchi, RedHatPlugin):

--- a/sos/report/plugins/openstack_barbican.py
+++ b/sos/report/plugins/openstack_barbican.py
@@ -37,9 +37,12 @@ class OpenStackBarbican(Plugin, DebianPlugin, UbuntuPlugin):
         self.add_forbidden_path("/etc/barbican/alias/*")
 
     def postproc(self):
+        protect_keys = [
+            "password", "rabbit_password", "memcache_secret_key"
+        ]
         self.do_file_sub(
             "/etc/barbican/barbican.conf",
-            r"(password|rabbit_password[\t\ ]*=[\t\ ]*)(.+)",
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
             r"\1********"
         )
 

--- a/sos/report/plugins/openstack_glance.py
+++ b/sos/report/plugins/openstack_glance.py
@@ -83,7 +83,8 @@ class OpenStackGlance(Plugin):
         protect_keys = [
             "admin_password", "password", "qpid_password", "rabbit_password",
             "s3_store_secret_key", "ssl_key_password",
-            "vmware_server_password", "transport_url"
+            "vmware_server_password", "transport_url",
+            "memcache_secret_key"
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_manila.py
+++ b/sos/report/plugins/openstack_manila.py
@@ -55,7 +55,8 @@ class OpenStackManila(Plugin):
 
     def postproc(self):
         protect_keys = [".*password.*", "transport_url",
-                        "hdfs_ssh_pw", "maprfs_ssh_pw"]
+                        "hdfs_ssh_pw", "maprfs_ssh_pw",
+                        "memcache_secret_key"]
         connection_keys = ["connection", "sql_connection"]
 
         self.apply_regex_sub(

--- a/sos/report/plugins/openstack_neutron.py
+++ b/sos/report/plugins/openstack_neutron.py
@@ -78,7 +78,8 @@ class OpenStackNeutron(Plugin):
             "crd_password", "primary_l3_host_password", "serverauth",
             "ucsm_password", "ha_vrrp_auth_password", "ssl_key_password",
             "nsx_password", "vcenter_password", "edge_appliance_password",
-            "tenant_admin_password", "apic_password", "transport_url"
+            "tenant_admin_password", "apic_password", "transport_url",
+            "memcache_secret_key"
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_novajoin.py
+++ b/sos/report/plugins/openstack_novajoin.py
@@ -28,6 +28,9 @@ class OpenStackNovajoin(Plugin):
         regexp = (r"(?i)password=(.*)")
         self.do_file_sub("/etc/novajoin/join.conf", regexp,
                          r"password=*********")
+        regexp = (r"(?i)memcache_secret_key=(.*)")
+        self.do_file_sub("/etc/novajoin/join.conf", regexp,
+                         r"password=*********")
 
 
 class RedHatNovajoin(OpenStackNovajoin, RedHatPlugin):

--- a/sos/report/plugins/openstack_octavia.py
+++ b/sos/report/plugins/openstack_octavia.py
@@ -110,7 +110,8 @@ class OpenStackOctavia(Plugin):
     def postproc(self):
         protect_keys = [
             "ca_private_key_passphrase", "heartbeat_key", "password",
-            "connection", "transport_url", "server_certs_key_passphrase"
+            "connection", "transport_url", "server_certs_key_passphrase",
+            "memcache_secret_key"
         ]
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
 

--- a/sos/report/plugins/openstack_placement.py
+++ b/sos/report/plugins/openstack_placement.py
@@ -69,7 +69,7 @@ class OpenStackPlacement(Plugin):
         )
 
     def postproc(self):
-        protect_keys = ["password"]
+        protect_keys = ["password", "memcache_secret_key"]
         connection_keys = ["database_connection", "slave_connection"]
 
         self.apply_regex_sub(

--- a/sos/report/plugins/openstack_trove.py
+++ b/sos/report/plugins/openstack_trove.py
@@ -46,7 +46,7 @@ class OpenStackTrove(Plugin):
         protect_keys = [
             "default_password_length", "notifier_queue_password",
             "rabbit_password", "replication_password", "admin_password",
-            "dns_passkey", "transport_url"
+            "dns_passkey", "transport_url", "memcache_secret_key"
         ]
         connection_keys = ["connection"]
 


### PR DESCRIPTION
The memcache_secret_key parameter from the keystonemiddleware library
takes the secret key used to encrypt data stored in memcache, so it is
considered as sensitive information.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?