### PR TITLE
[python] Update version-dependent command for installed version

### DIFF
--- a/sos/report/plugins/python.py
+++ b/sos/report/plugins/python.py
@@ -16,14 +16,17 @@ import json
 import hashlib
 
 
-class Python(Plugin, DebianPlugin, UbuntuPlugin):
+class Python(Plugin):
+    """Captures information on the installed python runtime(s), as well as
+    python modules installed via pip.
+    """
 
     short_desc = 'Python runtime'
 
     plugin_name = 'python'
     profiles = ('system',)
 
-    packages = ('python', 'python3')
+    packages = ('python',)
 
     python_version = "python -V"
 
@@ -40,7 +43,18 @@ class Python(Plugin, DebianPlugin, UbuntuPlugin):
                 self.add_cmd_output("%s list installed" % pip)
 
 
+class UbuntuPython(Python, DebianPlugin, UbuntuPlugin):
+
+    python_version = "python3 -V"
+    packages = ('python3',)
+
+
 class RedHatPython(Python, RedHatPlugin):
+    """In addition to the base information, on Red Hat family distributions the
+    python plugin also supports the 'hashes' option. If enabled, this plugin
+    will generate a json-formatted listing of all pyfiles within the
+    distribution-standard python package installation locations.
+    """
 
     packages = ('python', 'python36', 'python2', 'python3', 'platform-python')
     option_list = [
@@ -51,7 +65,7 @@ class RedHatPython(Python, RedHatPlugin):
     def setup(self):
         self.add_cmd_output(['python2 -V', 'python3 -V'])
         if isinstance(self.policy, RHELPolicy) and \
-                self.policy.dist_version() > 7:
+                self.policy.dist_version() == 8:
             self.python_version = "/usr/libexec/platform-python -V"
         super(RedHatPython, self).setup()
 


### PR DESCRIPTION
Updates the python plugin to use `python3` for Ubuntu and Debian
distributions, and locks the use of `platform-python` to RHEL 8 as RHEL
9 does not continue to use of this interpreter executable.

Closes: #2502

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?