### PR TITLE
[redhat] Simplify `dist_version()` logic

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -375,16 +375,10 @@ support representative.
         try:
             rr = self.package_manager.all_pkgs_by_name_regex("redhat-release*")
             pkgname = self.pkgs[rr[0]]["version"]
-            if pkgname[0] == "4":
-                return 4
-            elif pkgname[0] in ["5Server", "5Client"]:
-                return 5
-            elif pkgname[0] == "6":
-                return 6
-            elif pkgname[0] == "7":
-                return 7
-            elif pkgname[0] == "8":
-                return 8
+            # this should always map to the major version number. This will not
+            # be so on RHEL 5, but RHEL 5 does not support python3 and thus
+            # should never run a version of sos with this check
+            return pkgname[0]
         except Exception:
             pass
         return False


### PR DESCRIPTION
Simplifies the logic in `dist_version()` to just return the major
version of the `redhat-release` package. This will not only remove a
requirement to update this check for new major version releases, but
also makes the call meaningful on RH-family distros aside from RHEL,
such as Fedora.

Note that this may fail on RHEL 5, but that is not a valid concern as
RHEL 5 does not support python3 and thus should never be in a situation
where sos-4.x+ is installed on such a system.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?