### PR TITLE
[auditd] Capture log files when configured to a non default location

### DIFF
--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -33,9 +33,23 @@ class Auditd(Plugin, IndependentPlugin):
             "auditctl -l"
         ])
 
+        config_file = "/etc/audit/auditd.conf"
+        log_file = "/var/log/audit/audit.log"
+        try:
+            with open(config_file, 'r') as cf:
+                for line in cf.read().splitlines():
+                    if not line:
+                        continue
+                    words = line.split('=')
+                    if words[0].strip() == 'log_file':
+                        log_file = words[1].strip()
+        except IOError as error:
+            self._log_error('Could not open conf file %s: %s' %
+                            (config_file, error))
+
         if not self.get_option("all_logs"):
-            self.add_copy_spec("/var/log/audit/audit.log")
+            self.add_copy_spec(log_file)
         else:
-            self.add_copy_spec("/var/log/audit")
+            self.add_copy_spec(log_file+'*')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The location of the audit.log files can be changed
in the configuration file /etc/audit/audit.conf.
This change ensures that we capture the log files
when the user specifies a different location via
log_file.

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?