### PR TITLE
[flake8] Fix new style alerts

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -664,7 +664,7 @@ class TarFileArchive(FileCacheArchive):
             return tarinfo
         if self._with_selinux_context:
             context = self.get_selinux_context(orig_path)
-            if(context):
+            if context:
                 tarinfo.pax_headers['RHT.security.selinux'] = context
         self.set_tarinfo_from_stat(tarinfo, fstat)
         return tarinfo

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -57,7 +57,7 @@ class OpenStackKeystone(Plugin):
                 "identity domain_config_dir")
         self.domain_config_dir = exec_out['output']
         if exec_out['status'] != 0 or \
-                not(self.path_isdir(self.domain_config_dir)):
+                not (self.path_isdir(self.domain_config_dir)):
             self.domain_config_dir = "/etc/keystone/domains"
         self.add_copy_spec(self.domain_config_dir)
 


### PR DESCRIPTION
Fix two new alerts from `flake8` that appear to have gone unnoticed
until a recent update.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?