### PR TITLE
[teamd,tests] Add a test for teamd plugin and device enumeration

### DIFF
--- a/tests/report_tests/plugin_tests/teamd.py
+++ b/tests/report_tests/plugin_tests/teamd.py
@@ -1,0 +1,46 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from avocado.utils import process
+from sos_tests import StageTwoReportTest
+
+
+class TeamdPluginTest(StageTwoReportTest):
+    """Ensure that team device enumeration is working correctly, by creating
+    a 'fake' team device. This inherently also tests proper iteration of
+    add_device_cmd().
+
+    :avocado: tags=stagetwo
+    """
+
+    packages = {
+        'rhel': ['teamd', 'NetworkManager-team']
+    }
+
+    sos_cmd = '-o teamd'
+    redhat_only = True
+
+    def pre_sos_setup(self):
+        # restart NetworkManager to account for the new package
+        nmout = process.run('systemctl restart NetworkManager', timeout=30)
+        assert nmout.exit_status == 0, "NetworkManager failed to restart"
+        # create the team device
+        res = process.run('nmcli con add type team ifname sostesting',
+                          timeout=30)
+        assert res.exit_status == 0, "Failed creating team device: %s" % res.stdout_text
+
+    def post_test_tear_down(self):
+        res = process.run('nmcli con delete team-sostesting', timeout=30)
+        assert res.exit_status == 0, "Failed to delete temp team device: %s" % res.stdout_text
+
+    def test_teamd_plugin_executed(self):
+        self.assertPluginIncluded('teamd')
+
+    def test_team_dev_iteration(self):
+        self.assertFileGlobInArchive('sos_commands/teamd/*sostest*state')
+        self.assertFileGlobInArchive('sos_commands/teamd/*sostesting_ports')


### PR DESCRIPTION
Adds a new test case for the `teamd` plugin that also inherently acts to
test team device enumeration.

Included with this test case is an addition to the base test classes
that allows for tests to define a `post_test_tear_down()` method that
will be run at the end of each test execution to allow for manual
cleanup - in this case deleting a 'fake' team device created for the
test.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?