### PR TITLE
[ceph_mgr] Add orchestrator CLI commands

### DIFF
--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -37,6 +37,13 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
         # more commands to be added later
         self.add_cmd_output([
             "ceph balancer status",
+            "ceph orch host ls",
+            "ceph orch device ls",
+            "ceph orch ls --export",
+            "ceph orch ps",
+            "ceph orch status --detail",
+            "ceph orch upgrade status",
+            "ceph log last cephadm"
         ])
 
         ceph_cmds = [


### PR DESCRIPTION
This patch adds the following commands to
the Ceph Manager plugin:

- To list hosts:
 ceph orch host ls

- To list devices on a host:
 ceph orch device ls

- To check the curent specification file/List
services known to orchestrator:
 ceph orch ls --export

- To list daemons known to orchestrator:
 ceph orch ps

- To check the configured backend and its status:
 ceph orch status --detail

- To check service versions vs available and
target containers:
 ceph orch upgrade status

- To see the recent activities/log from cephadm:
 ceph log last cephadm

Resolves: RHBZ#2116602

Signed-off-by: Jose Castillo <jcastillo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?