### PR TITLE
[python] proper test for RHEL 8 dist_version

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -378,7 +378,7 @@ support representative.
             # this should always map to the major version number. This will not
             # be so on RHEL 5, but RHEL 5 does not support python3 and thus
             # should never run a version of sos with this check
-            return pkgname[0]
+            return int(pkgname[0])
         except Exception:
             pass
         return False

--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -55,9 +55,9 @@ class UbuntuPolicy(DebianPolicy):
                 lines = fp.readlines()
                 for line in lines:
                     if "DISTRIB_RELEASE" in line:
-                        return line.split("=")[1].strip()
+                        return int(line.split("=")[1].strip())
             return False
-        except IOError:
+        except (IOError, ValueError):
             return False
 
     def get_upload_https_auth(self):


### PR DESCRIPTION
This currently breaks `python` plugin that does not collect `/usr/libexec/platform-python` on RHEL8.

Resolves: #2997

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?