### PR TITLE
[stratis] Update plugin commands for stratis-3.x

### DIFF
--- a/sos/report/plugins/stratis.py
+++ b/sos/report/plugins/stratis.py
@@ -22,12 +22,14 @@ class Stratis(Plugin, RedHatPlugin):
     def setup(self):
         subcmds = [
             'pool list',
+            'pool list --stopped',
             'filesystem list',
             'blockdev list',
             'key list',
-            'daemon redundancy',
             'daemon version',
             'report engine_state_report',
+            'report managed_objects_report',
+            'report stopped_pools',
             '--version',
         ]
 


### PR DESCRIPTION
Update the stratis plugin commands to unclude stopped pools,
the stopped pools and managed object reports, and remove the
collection of the daemon redundancy command which is no longer
supported.

This implements the changes discussed in stratis-storage/project#499

Signed-off-by: Bryn M. Reeves <bmr@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?