### PR TITLE
[hpssm] array and controller show detail subcommands per slot.

### DIFF
--- a/sos/report/plugins/hpssm.py
+++ b/sos/report/plugins/hpssm.py
@@ -34,10 +34,12 @@ class Hpssm(Plugin, IndependentPlugin):
             'ctrl all show status'
         ]
         slot_subcmds = [
+            'array all show detail',
             'ld all show',
             'ld all show detail',
             'pd all show',
-            'pd all show detail'
+            'pd all show detail',
+            'show detail'
         ]
         self.add_cmd_output(
             ["%s %s" % (cmd, subcmd) for subcmd in subcmds]


### PR DESCRIPTION
Signed-off-by: Trevor Benson <trevor.benson@scality.com>

Command output for both subcommands are included in the output from the `ssacli ctrl all show config detail`, but not of the command output per controller slot. This resolves that discrepancy.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?