### PR TITLE
[elastic] Add the command output for /_cat/indices

### DIFF
--- a/sos/report/plugins/elastic.py
+++ b/sos/report/plugins/elastic.py
@@ -56,6 +56,7 @@ class Elastic(Plugin, IndependentPlugin):
                 "curl -X GET '%s/_cluster/health?pretty'" % endpoint,
                 "curl -X GET '%s/_cluster/stats?pretty'" % endpoint,
                 "curl -X GET '%s/_cat/nodes?v'" % endpoint,
-            ])
+                "curl -X GET '%s/_cat/indices'" % endpoint,
+        ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Signed-off-by: Trevor Benson <trevor.benson@scality.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?

I'm marking all as "compliant". In the past I left it empty when there was no related issues to resolve with the PR. However thinking it over it seems this would then mean both:

- No existing Issue to resolve from this PR
- I did not relate the existing issue to this PR

So in hindsight I presume all boxes should be marked even when no related issues exist, confirming it should be good for review/merge.