### PR TITLE
[libvirt] Fix missing libvirt.all_logs option in libvirt plugin

### DIFF
--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 import glob
 
 
@@ -16,6 +16,15 @@ class Libvirt(Plugin, IndependentPlugin):
 
     plugin_name = 'libvirt'
     profiles = ('system', 'virt')
+
+    option_list = [
+        PluginOpt('all_logs', default=False,
+                  desc='collect all available libvirt log files',
+                  long_desc=(
+                    'Enable collection of libvirt log files such as '
+                    '/var/log/libvirt/qemu/*.log* and '
+                    '/var/log/libvirt/libvirtd.log')),
+    ]
 
     def setup(self):
         libvirt_keytab = "/etc/libvirt/krb5.tab"


### PR DESCRIPTION
Seems like there's use of 'all_logs' option in the code of the libvirt
plugin, but there's no definition of it as an available option in the
class. This change just adds it so that an external user can use it.

I tested it with:
```
sudo `which sos` report -o libvirt  -k libvirt.all_logs
```

and by checking:

```
sudo `which sos` report -l | grep "libvirt.all_logs
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?