### PR TITLE
[tests] Allow testing from local installation, use PR-built packages in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,6 +33,13 @@ env:
     UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20220622"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2004-focal-v20220701"
 
+    # Curl-command prefix for downloading task artifacts, simply add the
+    # the url-encoded task name, artifact name, and path as a suffix.
+    # This approach originally seen in the podman project.
+    ARTCURL: >-
+        curl --fail --location -O
+        --url https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}
+
 # Default task timeout
 timeout_in: 30m
 
@@ -70,16 +77,43 @@ py_break_task:
 # Make sure a user can manually build an rpm from the checkout
 rpm_build_task:
     alias: "rpm_build"
-    name: "RPM Build From Checkout"
-    container:
-        image: "fedora"
-    setup_script: dnf -y install rpm-build rpmdevtools gettext python3-devel
+    name: "rpm Build From Checkout - ${BUILD_NAME}"
+    gce_instance: &standardvm
+        image_project: "${PROJECT}"
+        image_name: "${VM_IMAGE_NAME}"
+        type: e2-medium
+    matrix:
+        - env: &centos9
+            PROJECT: ${CENTOS_PROJECT}
+            BUILD_NAME: ${CENTOS_9_NAME}
+            VM_IMAGE_NAME: ${CENTOS_9_IMAGE_NAME}
+        - env: &centos8
+            PROJECT: ${CENTOS_PROJECT}
+            BUILD_NAME: ${CENTOS_8_NAME}
+            VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
+        - env: &fedora
+            PROJECT: ${FEDORA_PROJECT}
+            BUILD_NAME: ${FEDORA_NAME}
+            VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
+        - env: &fedoraprior
+            PROJECT: ${SOS_PROJECT}
+            BUILD_NAME: ${FEDORA_PRIOR_NAME}
+            VM_IMAGE_NAME: ${FEDORA_PRIOR_IMAGE_NAME}
+    setup_script: |
+        dnf clean all
+        dnf -y install rpm-build rpmdevtools gettext python3-devel
     main_script: |
-        rpmdev-setuptree
+        mkdir -p /rpmbuild/{BUILD,BUILDROOT,RPMS,SRPMS,SOURCES}
         python3 setup.py sdist
-        cp dist/sos*.tar.gz ~/rpmbuild/SOURCES
+        cp dist/sos*.tar.gz /rpmbuild/SOURCES/
         rpmbuild -bs sos.spec
         rpmbuild -bb sos.spec
+    # Retrieving the built rpm in later tasks requires knowing the exact name
+    # of the file. To avoid having to juggle version numbers here, rename it
+    prep_artifacts_script: mv /rpmbuild/RPMS/noarch/sos-*.rpm ./sos_${BUILD_NAME}.rpm
+    packages_artifacts:
+        path: ./sos_${BUILD_NAME}.rpm
+        type: application/octet-stream
 
 # Make sure a user can manually build a snap from the checkout
 snap_build_task:
@@ -97,61 +131,56 @@ snap_build_task:
         snap install snapcraft --classic
     main_script: |
         snapcraft --destructive-mode
-    snap_artifacts:
+    packages_artifacts:
         path: "*.snap"
 
 # Run the stage one (no mocking) tests across all distros on GCP
 report_stageone_task:
     alias: "stageone_report"
     name: "Report Stage One - $BUILD_NAME"
-    gce_instance: &standardvm
-        image_project: "${PROJECT}"
-        image_name: "${VM_IMAGE_NAME}"
-        type: e2-medium
+    depends_on:
+        - rpm_build
+        - snap_build
+    gce_instance: *standardvm
     matrix:
-        - env:
-            PROJECT: ${CENTOS_PROJECT}
-            BUILD_NAME: ${CENTOS_9_NAME}
-            VM_IMAGE_NAME: ${CENTOS_9_IMAGE_NAME}
-        - env:
-            PROJECT: ${CENTOS_PROJECT}
-            BUILD_NAME: ${CENTOS_8_NAME}
-            VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
-        - env:
-            PROJECT: ${FEDORA_PROJECT}
-            BUILD_NAME: ${FEDORA_NAME}
-            VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
-        - env:
-            PROJECT: ${SOS_PROJECT}
-            BUILD_NAME: ${FEDORA_PRIOR_NAME}
-            VM_IMAGE_NAME: ${FEDORA_PRIOR_IMAGE_NAME}
-        - env:
+        - env: *centos9
+        - env: *centos8
+        - env: *fedora
+        - env: *fedoraprior
+        - env: &ubuntu
             PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: ${UBUNTU_NAME}
             VM_IMAGE_NAME: ${UBUNTU_IMAGE_NAME}
-        - env:
+        - env: &ubuntuprior
             PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: ${UBUNTU_PRIOR_NAME}
             VM_IMAGE_NAME: ${UBUNTU_PRIOR_IMAGE_NAME}
-    remove_sos_script: &remove_sos |
+    setup_script: &setup |
         if [ $(command -v apt) ]; then
+            echo "$ARTCURL/snap%20Build%20From%20Checkout/packages/sosreport_test_amd64.snap"
+            $ARTCURL/snap%20Build%20From%20Checkout/packages/sosreport_test_amd64.snap
             apt -y purge sosreport
             apt update --allow-releaseinfo-change
-            apt -y install python3-pip
+            apt -y install python3-pip snapd python3-magic
+            systemctl start snapd
+            snap install ./sosreport_test_amd64.snap --classic --dangerous
         fi
         if [ $(command -v dnf) ]; then
+            echo "$ARTCURL/rpm%20Build%20From%20Checkout%20-%20${BUILD_NAME}/packages/sos_${BUILD_NAME}.rpm"
+            $ARTCURL/rpm%20Build%20From%20Checkout%20-%20${BUILD_NAME}/packages/sos_${BUILD_NAME}.rpm
             dnf -y remove sos
             dnf -y install python3-pip ethtool
+            dnf -y install ./sos_${BUILD_NAME}.rpm
         fi
-    setup_script: &setup 'pip3 install avocado-framework==94.0 python-magic pyyaml'
+        pip3 install avocado-framework==94.0
     # run the unittests separately as they require a different PYTHONPATH in
     # order for the imports to work properly under avocado
     unittest_script: PYTHONPATH=. avocado run tests/unittests/
-    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run -p TESTLOCAL=true --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
     on_failure:
         fail_script: &faillogs |
             ls -d /var/tmp/avocado* /root/avocado* 2> /dev/null | xargs tar cf sos-fail-logs.tar
-        log_artifacts:
+        log_artifacts: &logs
             path: "sos-fail-logs.tar"
 
 # IFF the stage one tests all pass, then run stage two for latest distros
@@ -161,23 +190,11 @@ report_stagetwo_task:
     depends_on: stageone_report
     gce_instance: *standardvm
     matrix:
-        - env:
-            PROJECT: ${CENTOS_PROJECT}
-            BUILD_NAME: ${CENTOS_9_NAME}
-            VM_IMAGE_NAME: ${CENTOS_9_IMAGE_NAME}
-        - env:
-            PROJECT: ${CENTOS_PROJECT}
-            BUILD_NAME: ${CENTOS_8_NAME}
-            VM_IMAGE_NAME: ${CENTOS_8_IMAGE_NAME}
-        - env:
-            PROJECT: ${FEDORA_PROJECT}
-            BUILD_NAME: ${FEDORA_NAME}
-            VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
-        - env:
-            PROJECT: ${UBUNTU_PROJECT}
-            BUILD_NAME: ${UBUNTU_NAME}
-            VM_IMAGE_NAME: ${UBUNTU_IMAGE_NAME}
-    remove_sos_script: *remove_sos
+        - env: *centos9
+        - env: *centos8
+        - env: *fedora
+        - env: *ubuntu
+    setup_script: *setup
     install_pexpect_script: |
         if [ $(command -v apt) ]; then
             apt -y install python3-pexpect
@@ -185,12 +202,10 @@ report_stagetwo_task:
         if [ $(command -v dnf) ]; then
             dnf -y install python3-pexpect
         fi
-    setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t stagetwo tests/{cleaner,collect,report,vendor}_tests
+    main_script: PYTHONPATH=tests/ avocado run -p TESTLOCAL=true --test-runner=runner -t stagetwo tests/{cleaner,collect,report,vendor}_tests
     on_failure:
         fail_script: *faillogs
-        log_artifacts:
-            path: "sos-fail-logs.tar"
+        log_artifacts: *logs
 
 report_foreman_task:
     skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py')"
@@ -204,15 +219,15 @@ report_foreman_task:
         - env:
             PROJECT: ${SOS_PROJECT}
             VM_IMAGE_NAME: ${FOREMAN_CENTOS_IMAGE_NAME}
+            # Use the CentOS 8 sos rpm for this task
+            BUILD_NAME: ${CENTOS_8_NAME}
             FOREMAN_VER: "2.5 - CentOS Stream 8"
         - env:
             PROJECT: ${SOS_PROJECT}
             VM_IMAGE_NAME: ${FOREMAN_DEBIAN_IMAGE_NAME}
             FOREMAN_VER: "2.5 - Debian 10"
-    remove_sos_script: *remove_sos
     setup_script: *setup
-    main_script: PYTHONPATH=tests/ avocado run --test-runner=runner -t foreman tests/product_tests/foreman/
+    main_script: PYTHONPATH=tests/ avocado run -p TESTLOCAL=true --test-runner=runner -t foreman tests/product_tests/foreman/
     on_failure:
         fail_script: *faillogs
-        log_artifacts:
-            path: "sos-fail-logs.tar"
+        log_artifacts: *logs

--- a/tests/report_tests/smoke_tests.py
+++ b/tests/report_tests/smoke_tests.py
@@ -10,7 +10,7 @@ import re
 
 
 from avocado.utils import process
-from sos_tests import StageOneReportTest, SOS_BIN, redhat_only, ubuntu_only
+from sos_tests import StageOneReportTest, redhat_only, ubuntu_only
 
 
 # These are the header strings in --list-plugins output
@@ -27,7 +27,7 @@ class AllPluginSmokeTest(StageOneReportTest):
     """
 
     def pre_sos_setup(self):
-        _cmd = '%s report --list-plugins' % SOS_BIN
+        _cmd = '%s report --list-plugins' % self.sos_bin
         out = process.run(_cmd, timeout=300).stdout.decode()
         reg = DISABLED + '(.*?)' + OPTIONS
         self.plugs = []

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -25,7 +25,7 @@ SOS_TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 SOS_REPO_ROOT = os.path.realpath(os.path.join(SOS_TEST_DIR, '../'))
 SOS_PLUGIN_DIR = os.path.realpath(os.path.join(SOS_REPO_ROOT, 'sos/report/plugins'))
 SOS_TEST_DATA_DIR = os.path.realpath(os.path.join(SOS_TEST_DIR, 'test_data'))
-SOS_BIN = os.path.realpath(os.path.join(SOS_TEST_DIR, '../bin/sos'))
+SOS_TEST_BIN = os.path.realpath(os.path.join(SOS_TEST_DIR, '../bin/sos'))
 
 RH_DIST = ['rhel', 'centos', 'fedora']
 UBUNTU_DIST = ['Ubuntu', 'debian']
@@ -64,6 +64,7 @@ class BaseSoSTest(Test):
     _klass_name = None
     _tmpdir = None
     _exception_expected = False
+    _local_sos_bin = shutil.which('sos') or SOS_TEST_BIN
     sos_cmd = ''
     sos_timeout = 600
     redhat_only = False
@@ -81,6 +82,10 @@ class BaseSoSTest(Test):
         if not self._tmpdir:
             self._tmpdir = os.getenv('AVOCADO_TESTS_COMMON_TMPDIR') + self.klass_name
         return self._tmpdir
+
+    @property
+    def sos_bin(self):
+        return self._local_sos_bin if self.params.get('TESTLOCAL') == 'true' else SOS_TEST_BIN
 
     def generate_sysinfo(self):
         """Collects some basic information about the system for later reference
@@ -417,7 +422,7 @@ class BaseSoSReportTest(BaseSoSTest):
         return os.path.join(self.tmpdir, "sosreport-%s" % self.__class__.__name__)
         
     def _generate_sos_command(self):
-        return "%s %s -v --batch --tmp-dir %s %s" % (SOS_BIN, self.sos_component, self.tmpdir, self.sos_cmd)
+        return "%s %s -v --batch --tmp-dir %s %s" % (self.sos_bin, self.sos_component, self.tmpdir, self.sos_cmd)
 
     def _execute_sos_cmd(self):
         super(BaseSoSReportTest, self)._execute_sos_cmd()
@@ -949,7 +954,7 @@ class StageOneOutputTest(BaseSoSTest):
     sos_cmd = ''
 
     def _generate_sos_command(self):
-        return "%s %s" % (SOS_BIN, self.sos_cmd)
+        return "%s %s" % (self.sos_bin, self.sos_cmd)
 
     @skipIf(lambda x: x._exception_expected, "Non-zero exit code expected")
     def test_help_output_successful(self):


### PR DESCRIPTION
We've built RPMs of each PR in Cirrus for some time, and recently added snaps as well.

We should use these built artifacts for more complete testing than what can be gained from running
from a git checkout of the PR.

This patchset allows the test suite to use a locally installed version of sos instead of forcing the use of the git checkout. This can be leveraged by adding `-p TESTLOCAL=true` to a given `avocado run` command. This is then brought forward in to the tasks run by Cirrus CI, using the rpm and snap built for each PR.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?