### PR TITLE
[ceph_mon] Add ceph log CLI commands

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -58,7 +58,9 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph mgr metadata",
             "ceph mgr module ls",
             "ceph mgr services",
-            "ceph mgr versions"
+            "ceph mgr versions",
+            "ceph log last 10000 debug cluster",
+            "ceph log last 10000 debug audit"
         ])
 
         ceph_cmds = [


### PR DESCRIPTION
Add following commands to ceph mon plugin:

- Collect ceph cluster log for 'cluster' channel
ceph log last 10000 debug cluster

- Collect ceph cluster log for 'audit' channel
ceph log last 10000 debug audit

NOTE: Here number 10000 is default value of mon_log_max
ceph config variable.

Signed-off-by: Prashant D <pdhange@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?