### PR TITLE
[mysql] Capture mysqlrouter config and logs

### DIFF
--- a/sos/report/plugins/mysql.py
+++ b/sos/report/plugins/mysql.py
@@ -34,10 +34,7 @@ class Mysql(Plugin):
 
         self.add_copy_spec([
             self.mysql_cnf,
-            # Required for MariaDB under pacemaker (MariaDB-Galera)
-            "/var/log/mysqld.log",
-            "/var/log/mysql/mysqld.log",
-            "/var/log/mariadb/mariadb.log",
+            "/etc/mysqlrouter/",
             "/var/lib/mysql/grastate.dat",
             "/var/lib/mysql/gvwstate.dat"
         ])
@@ -45,7 +42,16 @@ class Mysql(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/mysql*",
-                "/var/log/mariadb*"
+                "/var/log/mariadb*",
+                "/var/log/mysqlrouter/*"
+            ])
+        else:
+            self.add_copy_spec([
+                # Required for MariaDB under pacemaker (MariaDB-Galera)
+                "/var/log/mysqld.log",
+                "/var/log/mysql/mysqld.log",
+                "/var/log/mysqlrouter/mysqlrouter.log",
+                "/var/log/mariadb/mariadb.log"
             ])
 
         if self.get_option("dbdump"):


### PR DESCRIPTION
Adds collection of mysqlrouter config and log files to the `mysql`
plugin.

Closes: #2987

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?