### PR TITLE
[Plugin] Allow plugins to perform manual collections

### DIFF
--- a/sos/policies/package_managers/__init__.py
+++ b/sos/policies/package_managers/__init__.py
@@ -50,12 +50,13 @@ class PackageManager():
     verify_command = None
     verify_filter = None
     files_command = None
+    query_path_command = None
     chroot = None
     files = None
 
-    def __init__(self, chroot=None, query_command=None,
-                 verify_command=None, verify_filter=None,
-                 files_command=None, remote_exec=None):
+    def __init__(self, chroot=None, query_command=None, verify_command=None,
+                 verify_filter=None, files_command=None,
+                 query_path_command=None, remote_exec=None):
         self._packages = {}
         self.files = []
 
@@ -63,6 +64,7 @@ class PackageManager():
         self.verify_command = verify_command or self.verify_command
         self.verify_filter = verify_filter or self.verify_filter
         self.files_command = files_command or self.files_command
+        self.query_path_command = query_path_command or self.query_path_command
 
         # if needed, append the remote command to these so that this returns
         # the remote package details, not local
@@ -191,6 +193,24 @@ class PackageManager():
             files = shell_out(cmd, timeout=0, chroot=self.chroot)
             self.files = files.splitlines()
         return self.files
+
+    def pkg_by_path(self, path):
+        """Given a path, return the package that owns that path.
+
+        :param path:    The filepath to check for package ownership
+        :type path:     ``str``
+
+        :returns:       The package name or 'unknown'
+        :rtype:         ``str``
+        """
+        if not self.query_path_command:
+            return 'unknown'
+        try:
+            cmd = f"{self.query_path_command} {path}"
+            pkg = shell_out(cmd, timeout=5, chroot=self.chroot)
+            return pkg.splitlines() or 'unknown'
+        except Exception:
+            return 'unknown'
 
     def build_verify_command(self, packages):
         """build_verify_command(self, packages) -> str

--- a/sos/policies/package_managers/dpkg.py
+++ b/sos/policies/package_managers/dpkg.py
@@ -16,6 +16,7 @@ class DpkgPackageManager(PackageManager):
     """
 
     query_command = "dpkg-query -W -f='${Package}|${Version}\\n'"
+    query_path_command = "dpkg -S"
     verify_command = "dpkg --verify"
     verify_filter = ""
 

--- a/sos/policies/package_managers/rpm.py
+++ b/sos/policies/package_managers/rpm.py
@@ -16,6 +16,7 @@ class RpmPackageManager(PackageManager):
     """
 
     query_command = 'rpm -qa --queryformat "%{NAME}|%{VERSION}|%{RELEASE}\\n"'
+    query_path_command = 'rpm -qf'
     files_command = 'rpm -qal'
     verify_command = 'rpm -V'
     verify_filter = ["debuginfo", "-devel"]

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1328,7 +1328,7 @@ class SoSReport(SoSComponent):
         )
         self.ui_progress(status_line)
         try:
-            plug.collect()
+            plug.collect_plugin()
             # certain exceptions can cause either of these lists to no
             # longer contain the plugin, which will result in sos hanging
             # so we can't blindly call remove() on these two.

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3164,7 +3164,7 @@ class Plugin():
             self._log_info(f"manual collection '{fname}' finished in {run}")
             if isinstance(tags, str):
                 tags = [tags]
-            self.manifest.collections[fname.split('.')[0]] = {
+            self.manifest.collections[fname] = {
                 'filepath': _pfname,
                 'tags': tags
             }

--- a/sos/report/plugins/unpackaged.py
+++ b/sos/report/plugins/unpackaged.py
@@ -19,7 +19,7 @@ class Unpackaged(Plugin, RedHatPlugin):
                   'package manager')
     plugin_name = 'unpackaged'
 
-    def setup(self):
+    def collect(self):
 
         def get_env_path_list():
             """Return a list of directories in $PATH.
@@ -69,19 +69,20 @@ class Unpackaged(Plugin, RedHatPlugin):
         if not self.test_predicate(cmd=True):
             return
 
-        paths = get_env_path_list()
-        all_fsystem = []
-        all_frpm = set(
-            os.path.realpath(x) for x in self.policy.mangle_package_path(
-                self.policy.package_manager.all_files()
-            ) if any([x.startswith(p) for p in paths])
-        )
+        with self.collection_file('unpackaged') as ufile:
+            paths = get_env_path_list()
+            all_fsystem = []
+            all_frpm = set(
+                os.path.realpath(x) for x in self.policy.mangle_package_path(
+                    self.policy.package_manager.all_files()
+                ) if any([x.startswith(p) for p in paths])
+            )
 
-        for d in paths:
-            all_fsystem += all_files_system(d)
-        not_packaged = [x for x in all_fsystem if x not in all_frpm]
-        not_packaged_expanded = format_output(not_packaged)
-        self.add_string_as_file('\n'.join(not_packaged_expanded), 'unpackaged',
-                                plug_dir=True)
+            for d in paths:
+                all_fsystem += all_files_system(d)
+            not_packaged = [x for x in all_fsystem if x not in all_frpm]
+            not_packaged_expanded = format_output(not_packaged)
+
+            ufile.write('\n'.join(not_packaged_expanded))
 
 # vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/collect_manual_tests.py
+++ b/tests/report_tests/plugin_tests/collect_manual_tests.py
@@ -34,4 +34,4 @@ class CollectManualTest(StageOneReportTest):
         pkgman = self.get_plugin_manifest('unpackaged')
         self.assertTrue(pkgman['collections']['unpackaged'])
         pyman = self.get_plugin_manifest('python')
-        self.assertTrue(pyman['collections']['digests'])
+        self.assertTrue(pyman['collections']['digests.json'])

--- a/tests/report_tests/plugin_tests/collet_manual_tests.py
+++ b/tests/report_tests/plugin_tests/collet_manual_tests.py
@@ -10,8 +10,8 @@
 from sos_tests import StageOneReportTest
 
 
-class CollectStringTest(StageOneReportTest):
-    """Test to ensure that add_string_as_file() is working for plugins that
+class CollectManualTest(StageOneReportTest):
+    """Test to ensure that collect() is working for plugins that
     directly call it as part of their collections
 
     :avocado: tags=stageone
@@ -30,8 +30,8 @@ class CollectStringTest(StageOneReportTest):
     def test_no_strings_dir(self):
         self.assertFileNotCollected('sos_strings/')
 
-    def test_manifest_strings_correct(self):
+    def test_manifest_collections_correct(self):
         pkgman = self.get_plugin_manifest('unpackaged')
-        self.assertTrue(pkgman['strings']['unpackaged'])
+        self.assertTrue(pkgman['collections']['unpackaged'])
         pyman = self.get_plugin_manifest('python')
-        self.assertTrue(pyman['strings']['digests_json'])
+        self.assertTrue(pyman['collections']['digests'])

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -296,7 +296,7 @@ class PluginTests(unittest.TestCase):
         })
         p.archive = MockArchive()
         p.setup()
-        p.collect()
+        p.collect_plugin()
         self.assertEquals(p.archive.m, {})
 
     def test_postproc_default_on(self):
@@ -358,10 +358,10 @@ class AddCopySpecTests(unittest.TestCase):
         self.mp.sysroot = '/'
         fn = create_file(2)  # create 2MB file, consider a context manager
         self.mp.add_copy_spec(fn, 1)
-        content, fname, _tags = self.mp.copy_strings[0]
-        self.assertTrue("tailed" in fname)
+        fname, _size = self.mp._tail_files_list[0]
+        self.assertTrue(fname == fn)
         self.assertTrue("tmp" in fname)
-        self.assertEquals(1024 * 1024, len(content))
+        self.assertEquals(1024 * 1024, _size)
         os.unlink(fn)
 
     def test_bad_filename(self):
@@ -388,10 +388,9 @@ class AddCopySpecTests(unittest.TestCase):
         create_file(2, dir=tmpdir)
         create_file(2, dir=tmpdir)
         self.mp.add_copy_spec(tmpdir + "/*", 1)
-        self.assertEquals(len(self.mp.copy_strings), 1)
-        content, fname, _tags = self.mp.copy_strings[0]
-        self.assertTrue("tailed" in fname)
-        self.assertEquals(1024 * 1024, len(content))
+        self.assertEquals(len(self.mp._tail_files_list), 1)
+        fname, _size = self.mp._tail_files_list[0]
+        self.assertEquals(1024 * 1024, _size)
         shutil.rmtree(tmpdir)
 
     def test_multiple_files_no_limit(self):
@@ -450,7 +449,7 @@ class RegexSubTests(unittest.TestCase):
     def test_no_replacements(self):
         self.mp.sysroot = '/'
         self.mp.add_copy_spec(j("tail_test.txt"))
-        self.mp.collect()
+        self.mp.collect_plugin()
         replacements = self.mp.do_file_sub(
             j("tail_test.txt"), r"wont_match", "foobar")
         self.assertEquals(0, replacements)
@@ -459,7 +458,7 @@ class RegexSubTests(unittest.TestCase):
         # test uses absolute paths
         self.mp.sysroot = '/'
         self.mp.add_copy_spec(j("tail_test.txt"))
-        self.mp.collect()
+        self.mp.collect_plugin()
         replacements = self.mp.do_file_sub(
             j("tail_test.txt"), r"(tail)", "foobar")
         self.assertEquals(1, replacements)


### PR DESCRIPTION
This patchset implements changes that allow plugins to perform manual data collections/compilations that will get saved in the archive alongside normal command output collections.

First, adjust the behavior of collecting `tail`s of file specs that exceed the given log size so that it is no longer performed during `setup()`, but instead the actual collection takes place during the collection phase.

Second, renamed the `collect()` method to `collect_plugin()`, and implement `collect()` as a new entry point for plugin authors to define their manual collections.

The patches following the first two adjust existing plugins to use this new functionality. Additionally, the `process` plugin has been updated to collect a pid->package mapping, as has been long requested in #1350. This includes an update to `PackageManager` to facility these kinds of look ups. 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?