### PR TITLE
[cirrus] Update Fedora images used in CI tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,8 @@
 # Main environment vars to set for all tasks
 env:
 
-    FEDORA_VER: "35"
-    FEDORA_PRIOR_VER: "34"
-    FEDORA_NAME: "fedora-${FEDORA_VER}"
-    FEDORA_PRIOR_NAME: "fedora-${FEDORA_PRIOR_VER}"
+    FEDORA_NAME: "fedora-36"
+    FEDORA_PRIOR_NAME: "fedora-35"
 
     UBUNTU_NAME: "ubuntu-22.04"
     UBUNTU_PRIOR_NAME: "ubuntu-20.04"
@@ -20,16 +18,14 @@ env:
     UBUNTU_PROJECT: "ubuntu-os-cloud"
 
     # These are generated images pushed to GCP from Red Hat
-    # FEDORA_PRIOR to be switched to "stock" images from the Fedora Project
-    # once the F36 image is pushed. 
-    FEDORA_PRIOR_IMAGE_NAME: "f${FEDORA_PRIOR_VER}-server-sos-testing"
     FOREMAN_CENTOS_IMAGE_NAME: "foreman-25-centos-8-sos-testing"
     FOREMAN_DEBIAN_IMAGE_NAME: "foreman-25-debian-10-sos-testing"
 
     # Images exist on GCP already
     CENTOS_9_IMAGE_NAME: "centos-stream-9-v20220621"
     CENTOS_8_IMAGE_NAME: "centos-stream-8-v20220621"
-    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-${FEDORA_VER}-1-2-x86-64"
+    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-36-20220506-n-0-x86-64"
+    FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-35-1-2-x86-64"
     UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20220622"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2004-focal-v20220701"
 
@@ -96,7 +92,7 @@ rpm_build_task:
             BUILD_NAME: ${FEDORA_NAME}
             VM_IMAGE_NAME: ${FEDORA_IMAGE_NAME}
         - env: &fedoraprior
-            PROJECT: ${SOS_PROJECT}
+            PROJECT: ${FEDORA_PROJECT}
             BUILD_NAME: ${FEDORA_PRIOR_NAME}
             VM_IMAGE_NAME: ${FEDORA_PRIOR_IMAGE_NAME}
     setup_script: |

--- a/tests/cleaner_tests/report_disabled_parsers.py
+++ b/tests/cleaner_tests/report_disabled_parsers.py
@@ -33,7 +33,7 @@ class ReportDisabledParsersTest(StageOneReportTest):
 
     # make sure that the other parsers remain functional
     def test_localhost_was_obfuscated(self):
-        self.assertFileHasContent('/etc/hostname', 'host0')
+        self.assertFileHasContent('hostname', 'host0')
 
     def test_mac_addrs_were_obfuscated(self):
         content = self.get_file_content('sos_commands/networking/ip_maddr_show')
@@ -54,7 +54,7 @@ class NativeCleanDisabledParsersTest(StageTwoReportTest):
     sos_component = 'clean'
 
     def test_localhost_not_obfuscated(self):
-        self.assertFileNotHasContent('/etc/hostname', self.sysinfo['pre']['networking']['hostname'])
+        self.assertFileNotHasContent('hostname', self.sysinfo['pre']['networking']['hostname'])
         self.assertFileNotHasContent('uname', self.sysinfo['pre']['networking']['hostname'])
 
     def test_local_ip_was_obfuscated(self):

--- a/tests/cleaner_tests/report_with_mask.py
+++ b/tests/cleaner_tests/report_with_mask.py
@@ -35,7 +35,7 @@ class ReportWithMask(StageOneReportTest):
         self.assertSosLogContains('Loaded .* as type sos report directory')
 
     def test_localhost_was_obfuscated(self):
-        self.assertFileHasContent('/etc/hostname', 'host0')
+        self.assertFileHasContent('hostname', 'host0')
 
     def test_ip_address_was_obfuscated(self):
         # Note: do not test for starting with the 100.* block here, as test

--- a/tests/report_tests/encryption_tests.py
+++ b/tests/report_tests/encryption_tests.py
@@ -42,7 +42,7 @@ class EncryptedCleanedReportTest(EncryptedReportTest):
     sos_cmd = "-o host,networking --clean --encrypt-pass %s" % encrypt_pass
 
     def test_hostname_obfuscated(self):
-        self.assertFileHasContent('/etc/hostname', 'host0')
+        self.assertFileHasContent('hostname', 'host0')
 
     def test_tarball_named_obfuscated(self):
         self.assertTrue('obfuscated' in self.archive)


### PR DESCRIPTION
The Fedora 36 image is now available on GCP, so update our testing
matrix to use it. Accordingly, this means we no longer need to build or
maintain our own Fedora images going forward.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?