### PR TITLE
[COS] add-remote-exec-arg-to-COS-policy-and-COSPlugin-to-valid-subclass

### DIFF
--- a/sos/policies/distros/cos.py
+++ b/sos/policies/distros/cos.py
@@ -36,6 +36,13 @@ class CosPolicy(LinuxPolicy):
     valid_subclasses = [CosPlugin, IndependentPlugin]
     PATH = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 
+    def __init__(self, sysroot=None, init=None, probe_runtime=True,
+                 remote_exec=None):
+        super(CosPolicy, self).__init__(sysroot=sysroot, init=init,
+                                        probe_runtime=probe_runtime,
+                                        remote_exec=remote_exec)
+        self.valid_subclasses += [CosPolicy]
+
     @classmethod
     def check(cls, remote=''):
         if remote:


### PR DESCRIPTION
Policies when initialized it only contains independent plugin, adding
CosPlugin while initializing the CosPolicy

Signed-off-by: Varsha Teratipally <teratipally@google.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?