### PR TITLE
[cleaner] Check --domains values for validity

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -111,6 +111,8 @@ class SoSCleaner(SoSComponent):
             # when obfuscating a SoSCollector run during archive extraction
             os.makedirs(os.path.join(self.tmpdir, 'cleaner'), exist_ok=True)
 
+        self.validate_parser_values()
+
         self.cleaner_mapping = self.load_map_file()
         os.umask(0o77)
         self.in_place = in_place
@@ -315,6 +317,18 @@ third party.
             self.nested_archive = _arc
         if self.nested_archive:
             self.nested_archive.ui_name = self.nested_archive.description
+
+    def validate_parser_values(self):
+        """Check any values passed to the parsers via the commandline, e.g.
+        the --domains option, to ensure that they are valid for the parser in
+        question.
+        """
+        for _dom in self.opts.domains:
+            if len(_dom.split('.')) < 2:
+                raise Exception(
+                    f"Invalid value '{_dom}' given: --domains values must be "
+                    "actual domains"
+                )
 
     def execute(self):
         """SoSCleaner will begin by inspecting the TARGET option to determine


### PR DESCRIPTION
The domain parser is built to understand actual names, e.g.
'example.com', and not operate off of just 'example' despite the fact
that the parser handles TLDs separately.

To safeguard against potential errors when trying to parse the latter
example above as an actual domain, validate any values passed to
`--domains` during cleaner initialization.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?