### PR TITLE
[cleaner] Prevent stripping '_' on no match in hostname parser

### DIFF
--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -147,7 +147,9 @@ class SoSHostnameMap(SoSMap):
         if item in self.dataset:
             return self.dataset[item]
         if not self.domain_name_in_loaded_domains(item.lower()):
-            return item
+            # no match => return the original string with optional
+            # leading/trailing '.' or '_' characters
+            return ''.join([prefix, item, suffix])
         if item.endswith(self.strip_exts):
             ext = '.' + item.split('.')[-1]
             item = item.replace(ext, '')

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -102,7 +102,8 @@ class CleanerParserTests(unittest.TestCase):
     def setUp(self):
         self.ip_parser = SoSIPParser(config={})
         self.mac_parser = SoSMacParser(config={})
-        self.host_parser = SoSHostnameParser(config={}, opt_domains='foobar.com')
+        self.host_parser = SoSHostnameParser(config={},
+                                             opt_domains=['foobar.com'])
         self.kw_parser = SoSKeywordParser(config={}, keywords=['foobar'])
         self.kw_parser_none = SoSKeywordParser(config={})
         self.kw_parser.generate_item_regexes()
@@ -170,6 +171,11 @@ class CleanerParserTests(unittest.TestCase):
         line = 'testing just myhost in a line'
         _test = self.host_parser.parse_line(line)[0]
         self.assertNotEqual(line, _test)
+
+    def test_hostname_no_obfuscate_underscore(self):
+        line = 'pam_env.so _why.not_'
+        _test = self.host_parser.parse_line(line)[0]
+        self.assertEqual(line, _test)
 
     def test_keyword_parser_valid_line(self):
         line = 'this is my foobar test line'


### PR DESCRIPTION
Hostname parser works with stripped leading/trailing '.' and '_' characters for a match. When no pattern match is found, we must return the original unstripped item.

Resolves: #3022

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?