### PR TITLE
[snap] Update base to core22

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,13 +117,13 @@ snap_build_task:
     name: "snap Build From Checkout"
     gce_instance:
         image_project: "${UBUNTU_PROJECT}"
-        image_name: "${UBUNTU_PRIOR_IMAGE_NAME}"
+        image_name: "${UBUNTU_IMAGE_NAME}"
         type: e2-medium
     setup_script: |
         apt update
         apt -y install snapd
         systemctl start snapd
-        sed -i 's/adopt-info.*/version: test/g' snap/snapcraft.yaml
+        sed -i -e 's/adopt-info.*/version: test/g' -e '/set version/d' snap/snapcraft.yaml
         snap install snapcraft --classic
     main_script: |
         snapcraft --destructive-mode

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   primarily aimed at Linux distributions and other UNIX-like operating
   systems.
 grade: stable
-base: core20
+base: core22
 confinement: classic
 adopt-info: sos
 
@@ -14,8 +14,8 @@ parts:
     plugin: python
     source: .
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --always)
+      craftctl default
+      craftctl set version="$(git describe --tags --always)"
     build-packages:
       - git
       - python3


### PR DESCRIPTION
core20 has python3-magic 0.4.15, and hence the binary detection will not work by default. Moving to core22 goes to 0.4.24-2 which would mean this would work nevertheless

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?