### PR TITLE
[clean,username_parser] Handle usernames with domain prefixes

### DIFF
--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -94,7 +94,7 @@ class SoSMap():
         :returns:       A compiled regex pattern for the item
         :rtype:         ``re.Pattern``
         """
-        return re.compile(item, re.I)
+        return re.compile(re.escape(item), re.I)
 
     def sanitize_item(self, item):
         """Perform the obfuscation relevant to the item being added to the map.

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -55,9 +55,11 @@ class SoSUsernameParser(SoSCleanerParser):
                 continue
             if not user or user.lower() in self.skip_list:
                 continue
-            users.add(user)
-        for each in users:
+            users.add(user.lower())
+        for each in sorted(users, key=len, reverse=True):
             self.mapping.get(each)
+            if '\\' in each:
+                self.mapping.get(each.split('\\')[-1])
 
     def _parse_line(self, line):
         return line, 0


### PR DESCRIPTION
In some configurations, we can expect usernames to be written as `DOMAIN\user`, as well as the plain `user` form. Previously, the domain-prefixed format would throw an exception in our obfuscation if the letter after the `\` would cause the interpreter to regard that as a special character.

Fix this by escaping the values passed to `get_regex_result()` so that we can successfully compile a regex pattern object for domain-prefixed usernames as well.

Further, when we encounter one of these usernames, the username parser should automatically add an entry for the non-prefixed username as well. While this will result in a secondary obfuscation match (due to the current design of `sos clean`), this is preferable to potentially leaving non-prefixed usernames in plaintext, if they happen to appear in logs but not in any of our sourced files.

Related: RHBZ#2127977

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?