### PR TITLE
[cirrus|foreman] Expand Foreman testing matrix, automate install

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,8 @@ env:
     FEDORA_NAME: "fedora-36"
     FEDORA_PRIOR_NAME: "fedora-35"
 
+    DEBIAN_NAME: "debian-11"
+
     UBUNTU_NAME: "ubuntu-22.04"
     UBUNTU_PRIOR_NAME: "ubuntu-20.04"
 
@@ -13,17 +15,15 @@ env:
     CENTOS_8_NAME: "centos-stream-8"
 
     CENTOS_PROJECT: "centos-cloud"
+    DEBIAN_PROJECT: "debian-cloud"
     FEDORA_PROJECT: "fedora-cloud"
     SOS_PROJECT: "sos-devel-jobs"
     UBUNTU_PROJECT: "ubuntu-os-cloud"
 
-    # These are generated images pushed to GCP from Red Hat
-    FOREMAN_CENTOS_IMAGE_NAME: "foreman-25-centos-8-sos-testing"
-    FOREMAN_DEBIAN_IMAGE_NAME: "foreman-25-debian-10-sos-testing"
-
     # Images exist on GCP already
     CENTOS_9_IMAGE_NAME: "centos-stream-9-v20220621"
     CENTOS_8_IMAGE_NAME: "centos-stream-8-v20220621"
+    DEBIAN_IMAGE_NAME: "debian-11-bullseye-v20220822"
     FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-36-20220506-n-0-x86-64"
     FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-35-1-2-x86-64"
     UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20220622"
@@ -205,24 +205,30 @@ report_stagetwo_task:
 
 report_foreman_task:
     skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py')"
+    timeout_in: 45m
     alias: "foreman_integration"
-    name: "Integration Test - Foreman ${FOREMAN_VER}"
+    name: "Integration Test - Foreman ${FOREMAN_VER} - ${BUILD_NAME}"
     depends_on: stageone_report
     gce_instance: &bigvm
         <<: *standardvm
         type: e2-standard-2
     matrix:
         - env:
-            PROJECT: ${SOS_PROJECT}
-            VM_IMAGE_NAME: ${FOREMAN_CENTOS_IMAGE_NAME}
-            # Use the CentOS 8 sos rpm for this task
-            BUILD_NAME: ${CENTOS_8_NAME}
-            FOREMAN_VER: "2.5 - CentOS Stream 8"
+            <<: *centos8
+            FOREMAN_VER: "2.5"
         - env:
-            PROJECT: ${SOS_PROJECT}
-            VM_IMAGE_NAME: ${FOREMAN_DEBIAN_IMAGE_NAME}
-            FOREMAN_VER: "2.5 - Debian 10"
+            <<: *centos8
+            FOREMAN_VER: "3.1"
+        - env:
+            <<: *centos8
+            FOREMAN_VER: "3.4"
+        - env:
+            PROJECT: ${DEBIAN_PROJECT}
+            VM_IMAGE_NAME: ${DEBIAN_IMAGE_NAME}
+            BUILD_NAME: ${DEBIAN_NAME}
+            FOREMAN_VER: "3.4"
     setup_script: *setup
+    foreman_setup_script: ./tests/test_data/foreman_setup.sh
     main_script: PYTHONPATH=tests/ avocado run -p TESTLOCAL=true --test-runner=runner -t foreman tests/product_tests/foreman/
     on_failure:
         fail_script: *faillogs

--- a/tests/test_data/foreman_setup.sh
+++ b/tests/test_data/foreman_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+SUCCESS=0
+
+if grep -iq centos /etc/os-release; then
+    if  [[ `echo | awk "{print ($FOREMAN_VER >= 3.4)}"` -eq 1 ]]; then
+        dnf -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
+        dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VER/el8/x86_64/foreman-release.rpm
+        dnf -y module enable foreman:el8
+    else
+        dnf -y install https://yum.puppet.com/puppet6-release-el-8.noarch.rpm
+        dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VER/el8/x86_64/foreman-release.rpm
+        dnf -y module enable ruby:2.7
+    fi
+    dnf -y install foreman-installer && SUCCESS=1
+elif grep -iq debian /etc/os-release; then
+    apt-get update
+    apt-get -y install ca-certificates locales
+    sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+    locale-gen
+    export LC_ALL=en_US.UTF-8
+    export LANG=en_US.UTF-8
+    curl https://apt.puppet.com/puppet7-release-bullseye.deb --output /root/puppet7-release-bullseye.deb
+    apt-get install /root/puppet7-release-bullseye.deb
+    curl https://deb.theforeman.org/foreman.asc --output /etc/apt/trusted.gpg.d/foreman.asc
+    echo "deb http://deb.theforeman.org/ bullseye $FOREMAN_VER" | tee /etc/apt/sources.list.d/foreman.list
+    echo "deb http://deb.theforeman.org/ plugins $FOREMAN_VER" | tee -a /etc/apt/sources.list.d/foreman.list
+    apt-get update
+    apt-get -y install foreman-installer && SUCCESS=1
+fi
+
+if [[ $SUCCESS == 1 ]]; then
+    foreman-installer --foreman-db-password='S0Sdb=p@ssw0rd!' --foreman-initial-admin-password='S0S@dmin\\p@ssw0rd!'
+else
+    echo "Setup failed"
+    exit 1
+fi


### PR DESCRIPTION
Foreman has made several releases since we initially added integration testing for it. Rebuilding the images is maintenance overhead we can reduce by automating the installation of foreman on images.

Provide this scripted installation, and expand our testing matrix to additional versions of Foreman. As of this commit, we will be testing versions 2.5 and 3.1 on CentOS Stream 8 to cover Red Hat Satellite features, as well as Foreman version 3.4 (the latest current upstream) for CentOS 8 and Debian 11.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?