### PR TITLE
[Plugin] Collect `modinfo` output for `kernel_mods` enablement trigger

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3304,6 +3304,8 @@ class Plugin():
             if self.is_service(service):
                 self.add_service_status(service)
                 self.add_journal(service)
+        for kmod in self.kernel_mods:
+            self.add_cmd_output(f"modinfo {kmod}")
 
     def setup(self):
         """Collect the list of files declared by the plugin. This method


### PR DESCRIPTION
For any kernel modules specified as a plugin enablement trigger via `kernel_mods`, we should automatically collect `modinfo` output for those modules, much like we do with journals for units that are specified for the `services` plugin enablement trigger.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?