### PR TITLE
[composer] Update plugin for OSBuild Composer

### DIFF
--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -10,7 +10,7 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 class Composer(Plugin, IndependentPlugin):
 
-    short_desc = 'Lorax Composer'
+    short_desc = 'OSBuild Composer'
 
     plugin_name = 'composer'
     profiles = ('sysmgmt', 'virt', )

--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -55,4 +55,9 @@ class Composer(Plugin, IndependentPlugin):
                 "composer-cli compose log %s" % compose.split(" ")[0]
             )
 
+        self.add_journal(units=[
+            "osbuild-composer.service",
+            "osbuild-worker@*.service",
+        ])
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -15,7 +15,12 @@ class Composer(Plugin, IndependentPlugin):
     plugin_name = 'composer'
     profiles = ('sysmgmt', 'virt', )
 
-    packages = ('composer-cli',)
+    packages = (
+        'composer-cli',
+        'weldr-client',
+        'cockpit-composer',
+        'osbuild-composer',
+    )
 
     def _get_entries(self, cmd):
         entries = []

--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -48,4 +48,11 @@ class Composer(Plugin, IndependentPlugin):
         for src in sources:
             self.add_cmd_output("composer-cli sources info %s" % src)
 
+        composes = self._get_entries("composer-cli compose list")
+        for compose in composes:
+            # the first column contains the compose id
+            self.add_cmd_output(
+                "composer-cli compose log %s" % compose.split(" ")[0]
+            )
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -32,6 +32,8 @@ class Composer(Plugin, IndependentPlugin):
 
     def setup(self):
         self.add_copy_spec([
+            "/etc/osbuild-composer/osbuild-composer.toml",
+            "/etc/osbuild-worker/osbuild-worker.toml",
             "/etc/lorax/composer.conf",
             "/var/log/lorax-composer/composer.log",
             "/var/log/lorax-composer/dnf.log",


### PR DESCRIPTION
lorax was deprecated a while ago; [osbuild/osbuild-composer](https://github.com/osbuild/osbuild-composer) is the reimplemenation which is actively maintained.

I left lorax files in there just in case, happy to remove them if that's preferred. Also happy to squash in case the commits are too small.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?