### PR TITLE
[mac_parser, plugins] Refine parser skipping, add kmods to plugins

### DIFF
--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -44,7 +44,7 @@ class SoSMacParser(SoSCleanerParser):
         '534f:53'
     )
     skip_files = [
-        'sos_commands/kernel/modinfo.*'
+        'sos_commands/.*/modinfo.*'
     ]
     map_file_key = 'mac_map'
     compile_regexes = False

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3305,7 +3305,8 @@ class Plugin():
                 self.add_service_status(service)
                 self.add_journal(service)
         for kmod in self.kernel_mods:
-            self.add_cmd_output(f"modinfo {kmod}")
+            if self.is_module_loaded(kmod):
+                self.add_cmd_output(f"modinfo {kmod}")
 
     def setup(self):
         """Collect the list of files declared by the plugin. This method

--- a/sos/report/plugins/firewall_tables.py
+++ b/sos/report/plugins/firewall_tables.py
@@ -10,11 +10,23 @@ from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate)
 
 
 class firewall_tables(Plugin, IndependentPlugin):
+    """Collects information about local firewall tables, such as iptables,
+    and nf_tables (via nft). Note that this plugin does _not_ collect firewalld
+    information, which is handled by a separate plugin.
+
+    Collections from this plugin are largely gated byt the presence of relevant
+    kernel modules - for example,  the plugin will not collect the nf_tables
+    ruleset if both the `nf_tables` and `nfnetlink` kernel modules are not
+    currently loaded (unless using the --allow-system-changes option).
+    """
 
     short_desc = 'firewall tables'
 
     plugin_name = "firewall_tables"
     profiles = ('network', 'system')
+    files = ('/etc/nftables',)
+    kernel_mods = ('ip_tables', 'ip6_tables', 'nf_tables', 'nfnetlink',
+                   'ebtables')
 
     def collect_iptable(self, tablename):
         """ Collecting iptables rules for a table loads either kernel module

--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -10,12 +10,20 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class Nvme(Plugin, IndependentPlugin):
+    """Collects nvme device configuration information for each nvme device that
+    is installed on the system.
 
-    short_desc = 'Collect config and system information about NVMe devices'
+    Basic information is collected via the `smartctl` utility, however detailed
+    information will be collected via the `nvme` CLI if the `nvme-cli` package
+    is installed.
+    """
+
+    short_desc = 'NVMe device information'
 
     plugin_name = "nvme"
     profiles = ('storage',)
     packages = ('nvme-cli',)
+    kernel_mods = ('nvme', 'nvme_core')
 
     def setup(self):
         self.add_copy_spec("/etc/nvme/*")

--- a/sos/report/plugins/xfs.py
+++ b/sos/report/plugins/xfs.py
@@ -10,11 +10,19 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class Xfs(Plugin, IndependentPlugin):
+    """This plugin collects information on mounted XFS filessystems on the
+    local system.
+
+    Users should expect `xfs_info` and `xfs_admin` collections by this plugin
+    for each XFS filesystem that is locally mounted.
+    """
 
     short_desc = 'XFS filesystem'
 
     plugin_name = 'xfs'
     profiles = ('storage',)
+    files = ('/sys/fs/xfs', '/proc/fs/xfs')
+    kernel_mods = ('xfs',)
 
     def setup(self):
         mounts = '/proc/mounts'


### PR DESCRIPTION
This patchset first refines the mac parser's file skipping to skip all `modinfo` commands, instead of just the one from the kernel plugin.

Second, it updates several plugins to define modules in their respective `kernel_mods` enablement trigger, which will also cause separate `modinfo` collections within those plugins per #3037 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?