### PR TITLE
[logs] grab journalctl logs if not --all-logs

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -63,12 +63,14 @@ class Logs(Plugin, IndependentPlugin):
         journal = any([self.path_exists(self.path_join(p, "log/journal/"))
                        for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
-            self.add_journal(since=since, tags='journal_full', priority=100)
-            self.add_journal(boot="this", since=since,
-                             tags='journal_since_boot')
-            self.add_journal(boot="last", since=since,
-                             tags='journal_last_boot')
-            if self.get_option("all_logs"):
+            if not self.get_option("all_logs"):
+                self.add_journal(since=since, tags='journal_full',
+                                 priority=100)
+                self.add_journal(boot="this", since=since,
+                                 tags='journal_since_boot')
+                self.add_journal(boot="last", since=since,
+                                 tags='journal_last_boot')
+            else:
                 self.add_copy_spec([
                     "/var/log/journal/*",
                     "/run/log/journal/*"


### PR DESCRIPTION
If we are using --all-logs, we are collecting /var/log/journal, so we don't need to collect the journalctl output of the logs, when these can easily be grabbed from the files in /var/log/journal

Signed-off-by: Arif Ali <arif.ali@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?