### PR TITLE
[krb5] Enable on Ubuntu/Debian, expand package tuple

### DIFF
--- a/sos/report/plugins/krb5.py
+++ b/sos/report/plugins/krb5.py
@@ -8,37 +8,44 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Krb5(Plugin):
+    """This plugin handles the collection of kerberos authentication config
+    files and logging. Users should expect to see their krb5 config(s) in the
+    final archive, along with krb5 logging and `klist` output.
+
+    kdc configs and acls will also be collected from the distribution-spcecific
+    kdc directory.
+    """
 
     short_desc = 'Kerberos authentication'
     plugin_name = 'krb5'
     profiles = ('identity', 'system')
-    packages = ('krb5-libs', 'krb5-user')
-
-    # This is Debian's default, which is closest to upstream's
-    kdcdir = "/var/lib/krb5kdc"
 
     def setup(self):
         self.add_copy_spec([
             "/etc/krb5.conf",
             "/etc/krb5.conf.d/*",
-            "%s/kadm5.acl" % self.kdcdir,
-            "%s/kdc.conf" % self.kdcdir,
+            f"{self.kdcdir}/kadm5.acl",
+            f"{self.kdcdir}/kdc.conf",
             "/var/log/krb5kdc.log",
             "/var/log/kadmind.log"
         ])
-        self.add_cmd_output("klist -ket %s/.k5*" % self.kdcdir)
+        self.add_cmd_output(f"klist -ket {self.kdcdir}/.k5*")
         self.add_cmd_output("klist -ket /etc/krb5.keytab")
 
 
 class RedHatKrb5(Krb5, RedHatPlugin):
 
-    def setup(self):
-        self.kdcdir = "/var/kerberos/krb5kdc"
-        super(RedHatKrb5, self).setup()
+    packages = ('krb5-libs', 'krb5-server')
+    kdcdir = "/var/kerberos/krb5kdc"
 
+
+class UbuntuKrb5(Krb5, DebianPlugin, UbuntuPlugin):
+
+    packages = ('krb5-kdc', 'krb5-config', 'krb5-user')
+    kdcdir = "/var/lib/krb5kdc"
 
 # vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/krb5.py
+++ b/tests/report_tests/plugin_tests/krb5.py
@@ -1,0 +1,39 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos_tests import StageTwoReportTest, redhat_only, ubuntu_only
+
+class Krb5PluginTest(StageTwoReportTest):
+    """Ensure that the krb5 plugin activates for the distros that we support it
+    on.
+
+    See https://github.com/sosreport/sos/issues/3041
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o krb5'
+    packages = {
+        'rhel': ['krb5-libs', 'krb5-server'],
+        'Ubuntu': ['krb5-user', 'krb5-kdc']
+    }
+
+    def test_plugin_ran(self):
+        self.assertPluginIncluded('krb5')
+
+    def test_conf_collected(self):
+        self.assertFileCollected('/etc/krb5.conf')
+
+    @ubuntu_only
+    def test_ubuntu_kdcdir_collected(self):
+        self.assertFileGlobInArchive('/var/lib/krb5kdc/*')
+
+    @redhat_only
+    def test_redhat_kdcdir_collected(self):
+        self.assertFileGlobInArchive('/var/kerberos/krb5kdc/*')


### PR DESCRIPTION
It was found that the `krb5` plugin was not executing on Ubuntu/Debian systems due to a legacy change that inadvertently removed support for those distributions.

Re-enable support by defining a new plugin class for those distros, setting the kdc directory appropriately. Additionally, expand the package tuple to include newer package names.

Closes: #3041

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?