### PR TITLE
[cirrus] Increase stagetwo timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -191,6 +191,7 @@ report_stagetwo_task:
     alias: "stagetwo_report"
     name: "Report Stage Two - $BUILD_NAME"
     depends_on: stageone_report
+    timeout_in: 45m
     gce_instance: *standardvm
     matrix:
         - env: *centos9


### PR DESCRIPTION
The stagetwo tests are getting closer to consistent 30 minutes timeouts, with centos 8 generally hitting the timeout most often among the stagetwo tests. This is mostly due to the inefficient way in which we dump 100MB into the system journal in order to test journal size limiting.

As a stopgap measure until we can figure out a better/more reliable way to artificially increase the journal size, increase the timeout of these tests to avoid unnecessary re-runs which would otherwise pass.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?