### PR TITLE
[ovn_central] Add ovsdb directory for Ubuntu

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -150,7 +150,8 @@ class OVNCentral(Plugin):
                 self.path_join('/usr/local/etc/openvswitch', dbfile),
                 self.path_join('/etc/openvswitch', dbfile),
                 self.path_join('/var/lib/openvswitch', dbfile),
-                self.path_join('/var/lib/ovn/etc', dbfile)
+                self.path_join('/var/lib/ovn/etc', dbfile),
+                self.path_join('/var/lib/ovn', dbfile)
             ])
             if ovs_dbdir:
                 self.add_copy_spec(self.path_join(ovs_dbdir, dbfile))


### PR DESCRIPTION
Debian & Ubuntu OVN packages store the ovsdb files in /var/lib/ovn

Signed-off-by: Trent Lloyd <trent.lloyd@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?