### PR TITLE
[snap] Fix python env

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,17 +23,18 @@ parts:
       - gettext
     stage-packages:
       - python3-magic
+      - python3-venv
 
 apps:
   sos:
     environment:
-      PYTHONPATH: ${PYTHONPATH}:${SNAP}/lib/python3.8/site-packages:${SNAP}/usr/lib/python3/dist-packages
+      PYTHONPATH: ${PYTHONPATH}:${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages
     command: bin/sos
   sosreport:
     environment:
-      PYTHONPATH: ${PYTHONPATH}:${SNAP}/lib/python3.8/site-packages:${SNAP}/usr/lib/python3/dist-packages
+      PYTHONPATH: ${PYTHONPATH}:${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages
     command: bin/sos report
   sos-collector:
     environment:
-      PYTHONPATH: ${PYTHONPATH}:${SNAP}/lib/python3.8/site-packages:${SNAP}/usr/lib/python3/dist-packages
+      PYTHONPATH: ${PYTHONPATH}:${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages
     command: bin/sos collector


### PR DESCRIPTION
The python environment for core22 is python3.10. The environment needed changing accordingly.
core20 and core22 snapcraft doc suggests that python3-venv needs to be added for the python
plugin to work effectively

Signed-off-by: Arif Ali <arif.ali@canonical.com>

Partial fix for #3044 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?