### PR TITLE
[manifest,Plugin] Create a tag summary within a report's manifest

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -440,7 +440,8 @@ class SoSMetadata():
 
         Used to write manifest.json to the final archives.
         """
-        return json.dumps(self, default=lambda o: getattr(o, '_values', str(o)),
+        return json.dumps(self,
+                          default=lambda o: getattr(o, '_values', str(o)),
                           indent=indent)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/component.py
+++ b/sos/component.py
@@ -399,16 +399,32 @@ class SoSMetadata():
     metadata
     """
 
+    def __init__(self):
+        self._values = {}
+
+    def __iter__(self):
+        for item in self._values.items():
+            yield item[1]
+
+    def __getitem__(self, item):
+        return self._values[item]
+
+    def __getattr__(self, attr):
+        try:
+            return self._values[attr]
+        except Exception:
+            raise AttributeError(attr)
+
     def add_field(self, field_name, content):
         """Add a key, value entry to the current metadata instance
         """
-        setattr(self, field_name, content)
+        self._values[field_name] = content
 
     def add_section(self, section_name):
         """Adds a new instance of SoSMetadata to the current instance
         """
-        setattr(self, section_name, SoSMetadata())
-        return getattr(self, section_name)
+        self._values[section_name] = SoSMetadata()
+        return self._values[section_name]
 
     def add_list(self, list_name, content=[]):
         """Add a named list element to the current instance. If content is not
@@ -416,7 +432,7 @@ class SoSMetadata():
         """
         if not isinstance(content, list):
             raise TypeError('content added must be list')
-        setattr(self, list_name, content)
+        self._values[list_name] = content
 
     def get_json(self, indent=None):
         """Convert contents of this SoSMetdata instance, and all other nested
@@ -424,8 +440,7 @@ class SoSMetadata():
 
         Used to write manifest.json to the final archives.
         """
-        return json.dumps(self,
-                          default=lambda o: getattr(o, '__dict__', str(o)),
+        return json.dumps(self, default=lambda o: getattr(o, '_values', str(o)),
                           indent=indent)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -21,8 +21,8 @@ class Ssh(Plugin, IndependentPlugin):
     def setup(self):
 
         self.add_file_tags({
-            '/etc/ssh/sshd_config': 'sshd_config',
-            '/etc/ssh/ssh_config': 'ssh_config'
+            '/etc/ssh/sshd_config$': 'sshd_config',
+            '/etc/ssh/ssh_config$': 'ssh_config'
         })
 
         sshcfgs = [

--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -33,6 +33,15 @@ class NormalSoSReport(StageOneReportTest):
     def test_free_symlink_created(self):
         self.assertFileCollected('free')
 
+    def test_tag_summary_created(self):
+        self.assertTrue(
+            'tag_summary' in self.manifest['components']['report'],
+            "No tag summary generated in report"
+        )
+        self.assertTrue(
+            isinstance(self.manifest['components']['report']['tag_summary'], dict),
+            "Tag summary malformed"
+        )
 
 class LogLevelTest(StageOneReportTest):
     """

--- a/tests/report_tests/plugin_tests/collect_manual_tests.py
+++ b/tests/report_tests/plugin_tests/collect_manual_tests.py
@@ -32,6 +32,6 @@ class CollectManualTest(StageOneReportTest):
 
     def test_manifest_collections_correct(self):
         pkgman = self.get_plugin_manifest('unpackaged')
-        self.assertTrue(pkgman['collections']['unpackaged'])
+        self.assertTrue(any(c['name'] == 'unpackaged' for c in pkgman['collections']))
         pyman = self.get_plugin_manifest('python')
-        self.assertTrue(pyman['collections']['digests.json'])
+        self.assertTrue(any(c['name'] == 'digests.json' for c in pyman['collections']))


### PR DESCRIPTION
Red Hat Insights is looking to better leverage sos tags to satisfy their own specs for rules and such. Currently, tags are added directly to collections, which presents a scalability problem when iterating through a report's collection manifest for a large number of rules.

Mitigate this by compiling a "tag summary" within the report manifest, which collates a dict whose keys are all existing tags for collections existing within that report, and whose values are lists of every file (be it file copied or command output collection) in the report that has that tag.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?