### PR TITLE
[ovn_central] Add support to OVN DBs clustering and non-clustered

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -24,7 +24,7 @@ class OVNCentral(Plugin):
     short_desc = 'OVN Northd'
     plugin_name = "ovn_central"
     profiles = ('network', 'virt')
-    containers = ('ovn-dbs-bundle.*',)
+    containers = ('ovn-dbs-bundle.*', 'ovn_cluster_north_db_server')
 
     def get_tables_from_schema(self, filename, skip=[]):
         if self._container_name:
@@ -66,7 +66,13 @@ class OVNCentral(Plugin):
             cmds.append('%s list %s' % (ovn_cmd, table))
 
     def setup(self):
-        self._container_name = self.get_container_by_name(self.containers[0])
+        # check if env is a clustered or non-clustered one
+        if self.container_exists(self.containers[1]):
+            self._container_name = self.get_container_by_name(
+                self.containers[1])
+        else:
+            self._container_name = self.get_container_by_name(
+                self.containers[0])
 
         ovs_rundir = os.environ.get('OVS_RUNDIR')
         for pidfile in ['ovnnb_db.pid', 'ovnsb_db.pid', 'ovn-northd.pid']:


### PR DESCRIPTION
Most of the output we get from the ovn_central plugin is obtained by
executing ovn-nbctl or ovn-sbctl commands on specifc container on the
controller node.

Until now for non-clustered environments (active/backup mode) the
container used was ovn-dbs-bundle-* (its name includes a variable
numeric id), but this container disappears when OVN DB clustered
is deployed, adding specific containers for the OVN NB DB cluster
and the OVN SB DB cluster.

This patch adds logic to identify if we are in front of an OVN DB
server running in clustered mode or not, by checking for the
existence of specific containers, otherwise it works as before.

Signed-off-by: Fernando Royo <froyo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?