### PR TITLE
cmd fwdownloader may never end sometimes, add timeout for it

### DIFF
--- a/bin/sos
+++ b/bin/sos
@@ -20,5 +20,6 @@ except KeyboardInterrupt:
 if __name__ == '__main__':
     sos = SoS(sys.argv[1:])
     sos.execute()
+    os._exit(0)
 
 # vim:ts=4 et sw=4

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -176,7 +176,7 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
             os.chdir(chdir)
 
     def _check_poller(proc):
-        if poller():
+        if poller() or proc.poll() == 124:
             proc.terminate()
             raise SoSTimeoutError
         time.sleep(0.01)
@@ -240,6 +240,7 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
                     _output.close()
                 # until we separate timeouts from the `timeout` command
                 # handle per-cmd timeouts via Plugin status checks
+                reader.running = False
                 return {'status': 124, 'output': reader.get_contents(),
                         'truncated': reader.is_full}
         if to_file:


### PR DESCRIPTION
[seagate_ses] Add timeout for fwdownloader in seagate_ses plugin.

Recently, I found the **fwdownloader -ses**  command would never finish sometime when run sos report .
It will cause sos report hang.  
I have manual test in my environment , The parameter plugin_timeout can't restrict plugin execution time if the inside command execution time over plugin_timeout.

Here is invoke stack when hang problem occurred.
![image](https://user-images.githubusercontent.com/19721523/198181834-2c5c131a-5c65-4664-a518-68e699b8e1fd.png)
