### PR TITLE
[cleaner] Apply compile_regexes after a regular parse line

### DIFF
--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -172,6 +172,13 @@ class CleanerParserTests(unittest.TestCase):
         _test = self.host_parser.parse_line(line)[0]
         self.assertNotEqual(line, _test)
 
+    def test_obfuscate_whole_fqdn_for_given_domainname(self):
+        self.host_parser.load_hostname_into_map('sostestdomain.domain')
+        line = 'let obfuscate soshost.sostestdomain.domain'
+        _test = self.host_parser.parse_line(line)[0]
+        self.assertFalse('soshost' in _test)
+        self.assertFalse('sostestdomain' in _test)
+
     def test_hostname_no_obfuscate_underscore(self):
         line = 'pam_env.so _why.not_'
         _test = self.host_parser.parse_line(line)[0]


### PR DESCRIPTION
Hostname parser treats strings like 'host.domain.com' with precompiled domain 'domain.com' in a wrong way. It first obfuscates the domain while subsequent _parse_line skips host obfuscation.
    
Calling _parse_line before _parse_line_with_compiled_regexes does clean both the host name and the domain name well.
    
Adding a unittest with a reproducer.
    
Resolves: #3054
    
Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?