### PR TITLE
[ovn_central] Add commands to get OVN DBs file information

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -145,15 +145,20 @@ class OVNCentral(Plugin):
         self.add_copy_spec("/etc/sysconfig/ovn-northd")
 
         ovs_dbdir = os.environ.get('OVS_DBDIR')
-        for dbfile in ['ovnnb_db.db', 'ovnsb_db.db']:
-            self.add_copy_spec([
-                self.path_join('/var/lib/openvswitch/ovn', dbfile),
-                self.path_join('/usr/local/etc/openvswitch', dbfile),
-                self.path_join('/etc/openvswitch', dbfile),
-                self.path_join('/var/lib/openvswitch', dbfile),
-                self.path_join('/var/lib/ovn/etc', dbfile),
-                self.path_join('/var/lib/ovn', dbfile)
-            ])
+        for dbfile in ["ovnnb_db.db", "ovnsb_db.db"]:
+            for path in [
+                "/var/lib/openvswitch/ovn",
+                "/usr/local/etc/openvswitch",
+                "/etc/openvswitch",
+                "/var/lib/openvswitch",
+                "/var/lib/ovn/etc",
+                "/var/lib/ovn",
+            ]:
+                dbfilepath = self.path_join(path, dbfile)
+                if os.path.exists(dbfilepath):
+                    self.add_copy_spec(dbfilepath)
+                    self.add_cmd_output(
+                        "ls -lan %s" % dbfilepath, foreground=True)
             if ovs_dbdir:
                 self.add_copy_spec(self.path_join(ovs_dbdir, dbfile))
 


### PR DESCRIPTION
In order to automate the parsing of the plugin output files, by systems could only read file contentit, seems useful to add an output cmd file where data, such as the size or permissions, of the OVN DBs is directly available.

This patch modifies the current behaviour to copy the db files of each OVN DB to create a file containing the ls -lan output of the files. The list of possible locations of these *.db files is maintained for backwards compatibility but it has been necessary to iterate over them to only obtain the information file of those that really exist.

Signed-off-by: Fernando Royo <froyo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?