### PR TITLE
[pulpcore] obfuscate PASSWORD in non-greedy manner

### DIFF
--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -146,14 +146,16 @@ class PulpCore(Plugin, IndependentPlugin):
         # TODO obfuscate from /etc/pulp/settings.py :
         # SECRET_KEY = "eKfeDkTnvss7p5WFqYdGPWxXfHnsbDBx"
         # 'PASSWORD': 'tGrag2DmtLqKLTWTQ6U68f6MAhbqZVQj',
+        # the PASSWORD can be also in an one-liner list, so detect its value
+        # in non-greedy manner till first ',' or '}'
         self.do_path_regex_sub(
             "/etc/pulp/settings.py",
             r"(SECRET_KEY\s*=\s*)(.*)",
             r"\1********")
         self.do_path_regex_sub(
             "/etc/pulp/settings.py",
-            r"(PASSWORD\S*\s*:\s*)(.*)",
-            r"\1********")
+            r"(PASSWORD\S*\s*:\s*)(.*?)(,|\})",
+            r"\1********\3")
         # apply the same for "dynaconf list" output that prints settings.py
         # in a pythonic format
         self.do_cmd_output_sub(


### PR DESCRIPTION
Since PASSWORD can be in a one-liner list, we must mark the password value in a non-greedy manner until first ',' or '}' is found.

This works well also for multi-line lists where any line terminates by a comma.

Resolves: #3058

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?