### PR TITLE
[build] add concurrency to workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -3,11 +3,13 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: snap-build
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3
       with:
@@ -16,6 +18,7 @@ jobs:
       id: build-snap
     # Make sure the snap is installable
     - run: |
+        sudo apt -y remove sosreport
         sudo snap install --classic --dangerous ${{ steps.build-snap.outputs.snap }}
     # Do some testing with the snap
     - run: |


### PR DESCRIPTION
Add concutrrency to the job, so that if there is one already running, then that would be cancelled

Remove the deb package, and that takes precedance with the path do the test doesn't quite work

Signed-off-by: Arif Ali <arif.ali@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?