### PR TITLE
[build] use full path for snap check

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -22,7 +22,7 @@ jobs:
         sudo snap install --classic --dangerous ${{ steps.build-snap.outputs.snap }}
     # Do some testing with the snap
     - run: |
-        sos help
+        /snap/bin/sos help
     - uses: snapcore/action-publish@v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}


### PR DESCRIPTION
The environment for the build doesn't seem to be refreshing between runs, and hence sos from the snab binary location is not working. Having the full path ensures that this doesn't fail

Signed-off-by: Arif Ali <arif.ali@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?