### PR TITLE
[build] Require the sos alias

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,9 +20,10 @@ jobs:
     - run: |
         sudo apt -y remove sosreport
         sudo snap install --classic --dangerous ${{ steps.build-snap.outputs.snap }}
+        sudo snap alias sosreport.sos sos
     # Do some testing with the snap
     - run: |
-        /snap/bin/sos help
+        sudo sos help
     - uses: snapcore/action-publish@v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}


### PR DESCRIPTION
When installing via --danegerous, the aliases are not done automatically, so create he sos alias, so that we can run via "sos report"

Signed-off-by: Arif Ali <arif.ali@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?