### PR TITLE
[report] Prevent obfuscating tmpDir path before tarbal move

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1619,12 +1619,12 @@ class SoSReport(SoSComponent):
 
                 # output filename is in the private tmpdir - move it to the
                 # containing directory.
-                final_name = os.path.join(self.sys_tmp,
-                                          os.path.basename(archive))
+                base_archive = os.path.basename(archive)
                 if do_clean:
-                    final_name = cleaner.obfuscate_string(
-                        final_name.replace('.tar', '-obfuscated.tar')
+                    base_archive = cleaner.obfuscate_string(
+                            base_archive.replace('.tar', '-obfuscated.tar')
                     )
+                final_name = os.path.join(self.sys_tmp, base_archive)
                 # Get stat on the archive
                 archivestat = os.stat(archive)
 


### PR DESCRIPTION
When moving sos tarball from a private directory to /var/tmp, apply filename obfuscation just to the file and not the tmpDir path itself.

Resolves: #3065

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?