### PR TITLE
[autofs] Scrub autofs_ldap_auth secrets

### DIFF
--- a/sos/report/plugins/autofs.py
+++ b/sos/report/plugins/autofs.py
@@ -54,6 +54,25 @@ class Autofs(Plugin):
             r"(password=)[^,\s]*",
             r"\1********"
         )
+        # Hide secrets in the LDAP authentication config
+        #
+        # Example of scrubbing of the secret:
+        #
+        #     secret="abc"
+        #   or
+        #     encoded_secret = 'abc'
+        #
+        # to:
+        #
+        #     secret="********"
+        #   or
+        #     encoded_secret = '********'
+        #
+        self.do_file_sub(
+            "/etc/autofs_ldap_auth.conf",
+            r"(secret[\s]*[=]+[\s]*)(\'|\").*(\'|\")",
+            r"\1\2********\3"
+        )
         self.do_cmd_output_sub(
             "automount -m",
             r"(password=)[^,\s]*",


### PR DESCRIPTION
The XML configuration file /etc/autofs_ldap_auth.conf may contain
an authentication secret in the <autofs_ldap_sasl_conf/> tag.

This patch makes sure the secret gets scrubbed.

Example of scrubbing of the secret:


  `secret="hackme"`
or
  `secret='hackme'`

to:

  `secret="********"`
or
  `secret='********'`

Signed-off-by: Stepan Broz <sbroz@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?