### PR TITLE
[report] Prevent obfuscating tmpDir path also in --build mode

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1586,10 +1586,10 @@ class SoSReport(SoSComponent):
             # move the archive root out of the private tmp directory.
             directory = self.archive.get_archive_path()
             dir_name = os.path.basename(directory)
+            if do_clean:
+                dir_name = cleaner.obfuscate_string(dir_name)
             try:
                 final_dir = os.path.join(self.sys_tmp, dir_name)
-                if do_clean:
-                    final_dir = cleaner.obfuscate_string(final_dir)
                 os.rename(directory, final_dir)
                 directory = final_dir
             except (OSError, IOError):


### PR DESCRIPTION
Likewise #3065, we should not obfuscate path to directory when --build option is used.

Resolves: #3071
Relates: #3065

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?