### PR TITLE
[dnf] Scrub passwords from dnf.conf

### DIFF
--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -125,9 +125,28 @@ class DNFPlugin(Plugin, RedHatPlugin):
         self.get_modules_info(modules['output'])
 
     def postproc(self):
+        # Scrub passwords in repositories and yum/dnf variables
+        # Example of scrubbing:
+        #
+        #   password=hackme
+        # To:
+        #   password=********
+        #
+        # Whitespace around '=' is allowed.
         regexp = r"(password(\s)*=(\s)*)(\S+)\n"
         repl = r"\1********\n"
         for f in ["/etc/yum.repos.d/*", "/etc/dnf/vars/*"]:
             self.do_path_regex_sub(f, regexp, repl)
+
+        # Scrub password and proxy_password from /etc/dnf/dnf.conf.
+        # This uses the same regex patterns as above.
+        #
+        # Example of scrubbing:
+        #
+        #   proxy_password = hackme
+        # To:
+        #   proxy_password = ********
+        #
+        self.do_file_sub("/etc/dnf/dnf.conf", regexp, repl)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Currently the dnf plugin scrubs passwords from the repository files and DNF variables, however "password" and "proxy_password" can be defined in "/etc/dnf/dnf.conf".

This patch ensures that passwords are scrubbed from dnf.conf too.

Example of scrubbing:

Before:
  proxy_password = hackme
After:
  proxy_password = ********

Resolves: #3072

Signed-off-by: Stepan Broz <sbroz@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?