### PR TITLE
[openstack_mistral] Collect mistral content itself

### DIFF
--- a/sos/report/plugins/openstack_instack.py
+++ b/sos/report/plugins/openstack_instack.py
@@ -44,12 +44,10 @@ class OpenStackInstack(Plugin):
 
         if self.get_option("all_logs"):
             self.add_copy_spec([
-                "/var/log/mistral/",
                 "/var/log/zaqar/",
             ])
         else:
             self.add_copy_spec([
-                "/var/log/mistral/*.log",
                 "/var/log/zaqar/*.log",
             ])
 

--- a/sos/report/plugins/openstack_mistral.py
+++ b/sos/report/plugins/openstack_mistral.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2022 Red Hat, Inc.
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+MISTRAL_DIRECTORIES = [
+        '/var/log/mistral/',
+        '/var/lib/mistral/',
+        ]
+MISTRAL_LOGS = [
+        '/var/log/mistral/*.log',
+        '/var/lib/mistral/*/*.log',
+        ]
+
+
+class OpenStackMistral(Plugin, RedHatPlugin):
+    '''Gather Mistral directories content, both data from /var/lib/mistral
+    and its log from /var/log/mistral if it exists (older OSP).
+    The data also embed logs for the ansible runs launched via the service,
+    meaning we'll be able to properly debug failures therein. The rest of the
+    data are the generated environment files, also really useful in order
+    to debug an issue at deploy or day-2 operations.
+    We filter out on the presence of any "mistral" related container on the
+    host - usually the Undercloud presents mistral_engine, mistral_executor
+    and mistral_api.
+    '''
+
+    short_desc = 'OpenStack Mistral'
+
+    plugin_name = "openstack_mistral"
+    profiles = ('openstack', 'openstack_undercloud')
+    containers = ('.*mistral_engine',)
+
+    def setup(self):
+        if self.get_option('all_log'):
+            self.add_copy_spec(MISTRAL_DIRECTORIES)
+        else:
+            self.add_copy_spec(MISTRAL_LOGS)
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Logs as well as deploy information are located in /var/lib/mistral as well. Until now, this location was overlooked, and important information about the deploy state, configuration and potential errors were missing from the initial SOS-Report, leading to time loss for both Customer and Support.

This patch intends to correct this situation, by ensuring the content is taken from the Undercloud.

Notes:
- this is especially important for OSP<17.0
- the location may content multiple subdirectories
- the location will contain the history of the different actions done by the operator

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?