### PR TITLE
[virsh]: Collect more info from host

### DIFF
--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -33,9 +33,13 @@ class LibvirtClient(Plugin, IndependentPlugin):
             'domcapabilities',
             'capabilities',
             'nodeinfo',
-            'freecell',
+            'freecell --all',
             'node-memory-tune',
-            'version'
+            'version',
+            'pool-capabilities',
+            'nodecpumap',
+            'maxvcpus kvm',
+            'sysinfo',
         ]
 
         for subcmd in subcmds:


### PR DESCRIPTION
Implement sub-command to collect the info from host, including the free memory of all numa nodes(freecell --all), the storage pool capabilities(pool-capabilities), the number of CPUs and the online CPUs(nodecpumap), the max number of vcpus supported by kvm(maxvcpus kvm), and the hypervisor sysinfo(sysinfo)

Signed-off-by: Han Han <hhan@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?