### PR TITLE
[virsh] Collect the node device info

### DIFF
--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -40,6 +40,7 @@ class LibvirtClient(Plugin, IndependentPlugin):
             'nodecpumap',
             'maxvcpus kvm',
             'sysinfo',
+            'nodedev-list --tree',
         ]
 
         for subcmd in subcmds:
@@ -73,4 +74,10 @@ class LibvirtClient(Plugin, IndependentPlugin):
                     self.add_cmd_output('%s %s %s' % (cmd, x, d),
                                         foreground=True)
 
+        nodedev_output = self.exec_cmd(
+            '{0} nodedev-list'.format(cmd), foreground=True)
+        if nodedev_output['status'] == 0:
+            for n in nodedev_output['output'].splitlines():
+                self.add_cmd_output(
+                    '{0} nodedev-dumpxml {1}'.format(cmd, n), foreground=True)
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Implement the virsh sub-command `nodedev-list --tree` and `nodedev-dumpxml` to virsh plugins.

Resolves: #3079

Signed-off-by: Han Han <hhan@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?