### PR TITLE
[collect] Remove --sos-cmd option

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -41,7 +41,6 @@ sos collect \- Collect sosreports from multiple (cluster) nodes
     [\-\-skip-files FILES]
     [\-s|\-\-sysroot SYSROOT]
     [\-\-ssh\-user SSH_USER]
-    [\-\-sos-cmd SOS_CMD]
     [\-t|\-\-threads THREADS]
     [\-\-timeout TIMEOUT]
     [\-\-transport TRANSPORT]
@@ -338,15 +337,6 @@ sos collect will prompt for a sudo password for non-root users.
 .TP
 \fB\-s\fR SYSROOT, \fB\-\-sysroot\fR SYSROOT
 Sosreport option. Specify an alternate root file system path.
-.TP
-\fB\-\-sos-cmd\fR SOS_CMD
-Define all options that sosreport should be run with on the nodes. This will
-override any other commandline options as well as any options specified by a 
-cluster profile.
-
-The sosreport command will execute as 'sosreport --batch SOS_CMD'. The BATCH 
-option cannot be removed from the sosreport command as it is required to run 
-sosreport non-interactively for sos collect to function.
 .TP
 \fB\-t\fR THREADS \fB\-\-threads\fR THREADS
 Report option. Specify the number of collection threads to run.

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -118,7 +118,6 @@ class SoSCollector(SoSComponent):
         'skip_commands': [],
         'skip_files': [],
         'skip_plugins': [],
-        'sos_opt_line': '',
         'ssh_key': '',
         'ssh_port': 22,
         'ssh_user': 'root',
@@ -404,9 +403,6 @@ class SoSCollector(SoSComponent):
                                  help='Prompt for password for each node')
         collect_grp.add_argument('--preset', default='', required=False,
                                  help='Specify a sos preset to use')
-        collect_grp.add_argument('--sos-cmd', dest='sos_opt_line',
-                                 help=('Manually specify the commandline '
-                                       'for sos report on nodes'))
         collect_grp.add_argument('--ssh-user',
                                  help='Specify an SSH user. Default root')
         collect_grp.add_argument('--timeout', type=int, required=False,
@@ -939,18 +935,6 @@ class SoSCollector(SoSComponent):
     def configure_sos_cmd(self):
         """Configures the sosreport command that is run on the nodes"""
         self.sos_cmd = 'sosreport --batch '
-        if self.opts.sos_opt_line:
-            filt = ['&', '|', '>', '<', ';']
-            if any(f in self.opts.sos_opt_line for f in filt):
-                self.log_warn('Possible shell script found in provided sos '
-                              'command. Ignoring --sos-opt-line entirely.')
-                self.opts.sos_opt_line = None
-            else:
-                self.sos_cmd = '%s %s' % (
-                    self.sos_cmd, quote(self.opts.sos_opt_line))
-                self.log_debug("User specified manual sosreport command. "
-                               "Command set to %s" % self.sos_cmd)
-                return True
 
         sos_opts = []
 

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -584,9 +584,6 @@ class SosNode():
         if label:
             sos_cmd = '%s %s ' % (sos_cmd, quote(label))
 
-        if self.opts.sos_opt_line:
-            return '%s %s' % (sos_cmd, self.opts.sos_opt_line)
-
         sos_opts = []
 
         # sos-3.6 added --threads


### PR DESCRIPTION
Removes the `--sos-cmd` option for `sos collect`. Allowing passthru options in this manner is inherently flawed, and any attempts at sanitizing potentially malicious/dangerous values will always be a losing battle. Instead, `sos collect` should leverage available `report` options that are vetted and handled via the existing per-node capabilities checks that is well-defined for explicit passthru options.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?