### PR TITLE
[tests] Improve performance of writing data for logs test

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -694,7 +694,7 @@ class TarFileArchive(FileCacheArchive):
         if method == 'gzip':
             kwargs = {'compresslevel': 6}
         else:
-            kwargs = {'preset': 3}
+            kwargs = {'preset': 6}
         tar = tarfile.open(self._archive_name, mode="w:%s" % _comp_mode,
                            **kwargs)
         # we need to pass the absolute path to the archive root but we


### PR DESCRIPTION
The stagetwo logs test that verifies our journal size limiting is functional has long suffered from performance issues. This was due to an inefficient method of generating random data to write to the journal, in addition to compression algorithms generally having a difficult time with large amounts of random data.

Address this primarily by improving the method used to generate the random data in the first place. Rather than rebuilding a long string from via the `random.choice()` method against a list of alphanumeric characters, generate the random strings via the `random.getrandbits()` method for a fixed size, then convert that to a hex string.

Further, write the data in a more efficient manner by not exceeding the journal's default log threshold for limiting/throttling, instead regenerating and writing the random data in fixed-sized chunks. Additionally, only write enough data to surpass our size threshold.

As a side effect of this change, our standard compression approach for LZMA (.xz) was struggling due to the more random nature of the written data. Our preset override of 3, which typically would reduce system strain, was actually hindering the ability to compress the final archive in a reasonable amount of time. Increasing this preset to 6 alleviates this issue, while keeping the resource consumption of compressing the archive similar to that of an end user manually running the `xz` command.

Related: #2700

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?