### PR TITLE
[ceph] Add new collect cluster profile for RHCS5

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -934,30 +934,34 @@ class SoSCollector(SoSComponent):
 
     def configure_sos_cmd(self):
         """Configures the sosreport command that is run on the nodes"""
-        self.sos_cmd = 'sosreport --batch '
+        sos_cmd = 'sosreport --batch '
 
-        sos_opts = []
+        sos_options = {}
 
         if self.opts.case_id:
-            sos_opts.append('--case-id=%s' % (quote(self.opts.case_id)))
+            sos_options['case-id'] = quote(self.opts.case_id)
         if self.opts.alloptions:
-            sos_opts.append('--alloptions')
+            sos_options['alloptions'] = ''
         if self.opts.all_logs:
-            sos_opts.append('--all-logs')
+            sos_options['all-logs'] = ''
         if self.opts.verify:
-            sos_opts.append('--verify')
+            sos_options['verify'] = ''
         if self.opts.log_size:
-            sos_opts.append(('--log-size=%s' % quote(str(self.opts.log_size))))
+            sos_options['log-size'] = quote(str(self.opts.log_size))
         if self.opts.sysroot:
-            sos_opts.append('-s %s' % quote(self.opts.sysroot))
+            sos_options['sysroot'] = quote(self.opts.sysroot)
         if self.opts.chroot:
-            sos_opts.append('-c %s' % quote(self.opts.chroot))
+            sos_options['chroot'] = quote(self.opts.chroot)
         if self.opts.compression_type != 'auto':
-            sos_opts.append('-z %s' % (quote(self.opts.compression_type)))
-        self.sos_cmd = self.sos_cmd + ' '.join(sos_opts)
-        self.log_debug("Initial sos cmd set to %s" % self.sos_cmd)
-        self.commons['sos_cmd'] = self.sos_cmd
-        self.collect_md.add_field('initial_sos_cmd', self.sos_cmd)
+            sos_options['compression-type'] = quote(self.opts.compression_type)
+
+        for k, v in sos_options.items():
+            sos_cmd += f"--{k} {v} "
+        sos_cmd = sos_cmd.rstrip()
+        self.log_debug(f"Initial sos cmd set to {sos_cmd}")
+        self.commons['sos_cmd'] = 'sosreport --batch '
+        self.commons['sos_options'] = sos_options
+        self.collect_md.add_field('initial_sos_cmd', sos_cmd)
 
     def connect_to_primary(self):
         """If run with --primary, we will run cluster checks again that

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -41,6 +41,9 @@ class Cluster():
     :cvar sos_plugins: Which plugins to forcibly enable for node reports
     :vartype sos_plugins: ``list``
 
+    :cvar sos_options: Options to pass to report on every node
+    :vartype sos_options: ``dict``
+
     :cvar sos_plugin_options: Plugin options to forcibly set for nodes
     :vartype sos_plugin_options: ``dict``
 
@@ -54,6 +57,7 @@ class Cluster():
     option_list = []
     packages = ('',)
     sos_plugins = []
+    sos_options = {}
     sos_plugin_options = {}
     sos_preset = ''
     cluster_name = None
@@ -115,6 +119,10 @@ class Cluster():
                 "Uses the following sos preset: %s" % cls.sos_preset,
                 newline=False
             )
+
+        if cls.sos_options:
+            _opts = ', '.join(f'--{k} {v}' for k, v in cls.sos_options.items())
+            section.add_text(f"Sets the following sos options: {_opts}")
 
         if cls.sos_plugins:
             section.add_text(

--- a/sos/collector/clusters/ceph.py
+++ b/sos/collector/clusters/ceph.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2022 Red Hat Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import json
+
+from sos.collector.clusters import Cluster
+
+
+class ceph(Cluster):
+    """
+    This cluster profile is for Ceph Storage clusters, and is primarily
+    built around Red Hat Ceph Storage 5. Nodes are enumerated via `cephadm`; if
+    your Ceph deployment uses cephadm but is not RHCS 5, this profile may work
+    as intended, but it is not currently guaranteed to do so. If you are using
+    such an environment and this profile does not work for you, please file a
+    bug report detailing what is failing.
+
+    By default, all nodes in the cluster will be returned for collection. This
+    may not be desirable, so users are encouraged to use the `labels` option
+    to specify a colon-delimited set of ceph node labels to restrict the list
+    of nodes to.
+
+    For example, using `-c ceph.labels=osd:mgr` will return only nodes labeled
+    with *either* `osd` or `mgr`.
+    """
+
+    cluster_name = 'Ceph Storage Cluster'
+    sos_plugins = [
+        'ceph_common',
+    ]
+    sos_options = {'log-size': 50}
+    packages = ('cephadm',)
+    option_list = [
+        ('labels', '', 'Colon delimited list of labels to select nodes with')
+    ]
+
+    def get_nodes(self):
+        self.nodes = []
+        ceph_out = self.exec_primary_cmd(
+            'cephadm shell -- ceph orch host ls --format json',
+            need_root=True
+        )
+
+        if not ceph_out['status'] == 0:
+            self.log_error(
+                f"Could not enumerate nodes via cephadm: {ceph_out['output']}"
+            )
+            return self.nodes
+
+        nodes = json.loads(ceph_out['output'].splitlines()[-1])
+        _labels = [lab for lab in self.get_option('labels').split(':') if lab]
+        for node in nodes:
+            if _labels and not any(_l in node['labels'] for _l in _labels):
+                self.log_debug(f"{node} filtered from list due to labels")
+                continue
+            self.nodes.append(node['hostname'])
+
+        return self.nodes
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -44,6 +44,7 @@ class SosNode():
         self.tmpdir = commons['tmpdir']
         self.hostlen = commons['hostlen']
         self.need_sudo = commons['need_sudo']
+        self.sos_options = commons['sos_options']
         self.local = False
         self.host = None
         self.cluster = None
@@ -550,6 +551,12 @@ class SosNode():
                 if plug not in self.enable_plugins:
                     self.enable_plugins.append(plug)
 
+        if self.cluster.sos_options:
+            for opt in self.cluster.sos_options:
+                # take the user specification over any cluster defaults
+                if opt not in self.sos_options:
+                    self.sos_options[opt] = self.cluster.sos_options[opt]
+
         if self.cluster.sos_plugin_options:
             for opt in self.cluster.sos_plugin_options:
                 if not any(opt in o for o in self.plugopts):
@@ -642,6 +649,10 @@ class SosNode():
             'sosreport',
             os.path.join(self.host.sos_bin_path, self.sos_bin)
         )
+
+        for opt in self.sos_options:
+            _val = self.sos_options[opt]
+            sos_opts.append(f"--{opt} {_val if _val else ''}")
 
         if self.plugopts:
             opts = [o for o in self.plugopts


### PR DESCRIPTION
Adds a new cluster profile for RHCS 5 for `sos collect`. This profile depends upon the use of `cephadm` which is used to both deploy and manage the cluster. Users may optionally restrict the list of nodes to collect from by using the `-c ceph.labels` option to specify a set of label(s) to filter node results with.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?