### PR TITLE
[packit] Update packit configuration for Copr srpm builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,18 +1,25 @@
-downstream_package_name: sos
-jobs:
-- job: copr_build
-  metadata:
-    targets:
-    - fedora-development-x86_64
-    - fedora-development-aarch64
-    - fedora-development-ppc64le
-    - fedora-development-s390x
-  trigger: pull_request
+upstream_project_url: https://github.com/sosreport/sos
 specfile_path: sos.spec
-synced_files:
-- sos.spec
-- .packit.yaml
+downstream_package_name: sos
 upstream_package_name: sos
+
+files_to_sync:
+  - sos.spec
+  - .packit.yaml
+
+srpm_build_deps:
+  - python3-devel
+  - gettext
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-development-ppc64le
+      - fedora-development-s390x
+
 notifications:
   pull_request:
     successful_build: true


### PR DESCRIPTION
Packit is moving srpm builds from sandbox to copr, which means we need to specify the build dependencies for packit to know how to create the build environment.

As part of this change, re-organize the config file to be easier to read, and update some of the deprecated keys or nesting per docs.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?