### PR TITLE
[ceph] Update Ceph plugins for newer versions of Ceph

### DIFF
--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -17,7 +17,7 @@ class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'ceph_common'
     profiles = ('storage', 'virt', 'container')
 
-    containers = ('ceph-(mon|rgw|osd).*',)
+    containers = ('ceph-(.*-)?(mon|rgw|osd).*',)
     ceph_hostname = gethostname()
 
     packages = (

--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -7,17 +7,14 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
-import glob
 
 
 class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH mds'
     plugin_name = 'ceph_mds'
     profiles = ('storage', 'virt', 'container')
-    containers = ('ceph-fs.*',)
-
-    def check_enabled(self):
-        return True if glob.glob('/var/lib/ceph/mds/*/*') else False
+    containers = ('ceph-(.*-)?fs.*',)
+    files = ('/var/lib/ceph/mds/',)
 
     def setup(self):
         self.add_file_tags({

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -6,28 +6,67 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
+
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
+    """
+    This plugin is for capturing information from Ceph mgr nodes. While the
+    majority of this plugin should be version-agnostic, several collections are
+    dependent upon the version of Ceph installed. Versions that correlate to
+    RHCS 4 or RHCS 5 are explicitly handled for differences such as those
+    pertaining to log locations on the host filesystem.
+
+    Note that while this plugin will activate based on the presence of Ceph
+    containers, commands are run directly on the host as those containers are
+    often not configured to successfully run the `ceph` commands collected by
+    this plugin. These commands are majorily `ceph daemon` commands that will
+    reference discovered admin sockets under /var/run/ceph.
+    """
 
     short_desc = 'CEPH mgr'
 
     plugin_name = 'ceph_mgr'
     profiles = ('storage', 'virt', 'container')
-    files = ('/var/lib/ceph/mgr/',)
-    containers = ('ceph-(.*)?mgr.*',)
+    files = ('/var/lib/ceph/mgr/', '/var/lib/ceph/*/mgr*')
+    containers = ('ceph-(.*-)?mgr.*',)
 
     def setup(self):
+
+        self.ceph_version = self.get_ceph_version()
+
+        logdir = '/var/log/ceph'
+        libdir = '/var/lib/ceph'
+        rundir = '/run/ceph'
+
+        if self.ceph_version >= 16:
+            logdir += '/*'
+            libdir += '/*'
+            rundir += '/*'
+
         self.add_file_tags({
-            '/var/log/ceph/ceph-mgr.*.log': 'ceph_mgr_log',
+            f'{logdir}/ceph-mgr.*.log': 'ceph_mgr_log',
         })
 
+        self.add_forbidden_path([
+            "/etc/ceph/*keyring*",
+            f"{libdir}/*keyring*",
+            f"{libdir}/**/*keyring*",
+            f"{libdir}/osd*",
+            f"{libdir}/mon*",
+            # Excludes temporary ceph-osd mount location like
+            # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
+            f"{libdir}/tmp/*mnt*",
+            "/etc/ceph/*bindpass*",
+        ])
+
         self.add_copy_spec([
-            "/var/log/ceph/ceph-mgr*.log",
-            "/var/lib/ceph/mgr/",
-            "/var/lib/ceph/bootstrap-mgr/",
-            "/run/ceph/ceph-mgr*",
+            f"{logdir}/ceph-mgr*.log",
+            f"{libdir}/mgr*",
+            f"{libdir}/bootstrap-mgr/",
+            f"{rundir}/ceph-mgr*",
         ])
 
         # more commands to be added later
@@ -42,7 +81,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph log last cephadm"
         ])
 
-        ceph_cmds = [
+        cmds = [
             "config diff",
             "config show",
             "dump_cache",
@@ -61,44 +100,33 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
             "version"
         ]
 
-        self.add_forbidden_path([
-            "/etc/ceph/*keyring*",
-            "/var/lib/ceph/*keyring*",
-            "/var/lib/ceph/*/*keyring*",
-            "/var/lib/ceph/*/*/*keyring*",
-            "/var/lib/ceph/osd",
-            "/var/lib/ceph/mon",
-            # Excludes temporary ceph-osd mount location like
-            # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
-            "/var/lib/ceph/tmp/*mnt*",
-            "/etc/ceph/*bindpass*",
-        ])
-
-        mgr_ids = []
-        # Get the ceph user processes
-        out = self.exec_cmd('ps -u ceph -o args')
-
-        if out['status'] == 0:
-            # Extract the OSD ids from valid output lines
-            for procs in out['output'].splitlines():
-                proc = procs.split()
-                # Locate the '--id' value
-                if proc and proc[0].endswith("ceph-mgr"):
-                    try:
-                        id_index = proc.index("--id")
-                        mgr_ids.append("mgr.%s" % proc[id_index+1])
-                    except (IndexError, ValueError):
-                        self.log_warn("could not find ceph-mgr id: %s", procs)
-
-        # If containerized, run commands in containers
-        try:
-            cname = self.get_all_containers_by_regex("ceph-mgr*")[0][1]
-        except Exception:
-            cname = None
-
         self.add_cmd_output([
-            "ceph daemon %s %s"
-            % (mgrid, cmd) for mgrid in mgr_ids for cmd in ceph_cmds
-        ], container=cname)
+            f"ceph daemon {m} {cmd}" for m in self.get_socks() for cmd in cmds]
+        )
+
+    def get_ceph_version(self):
+        ver = self.exec_cmd('ceph --version')
+        if ver['status'] == 0:
+            try:
+                _ver = ver['output'].split()[2]
+                return int(_ver.split('.')[0])
+            except Exception as err:
+                self._log_debug(f"Could not determine ceph version: {err}")
+        self._log_error(
+            'Failed to find ceph version, command collection will be limited'
+        )
+        return 0
+
+    def get_socks(self):
+        """
+        Find any available admin sockets under /var/run/ceph (or subdirs for
+        later versions of Ceph) which can be used for ceph daemon commands
+        """
+        ceph_sockets = []
+        for rdir, dirs, files in os.walk('/var/run/ceph/'):
+            for file in files:
+                if file.startswith('ceph-mgr') and file.endswith('.asok'):
+                    ceph_sockets.append(self.path_join(rdir, file))
+        return ceph_sockets
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
-import glob
 
 
 class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -16,11 +15,8 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
 
     plugin_name = 'ceph_mgr'
     profiles = ('storage', 'virt', 'container')
-
-    containers = ('ceph-mgr.*',)
-
-    def check_enabled(self):
-        return True if glob.glob('/var/lib/ceph/mgr/*/*') else False
+    files = ('/var/lib/ceph/mgr/',)
+    containers = ('ceph-(.*)?mgr.*',)
 
     def setup(self):
         self.add_file_tags({

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
-import glob
 
 
 class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -16,10 +15,8 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
 
     plugin_name = 'ceph_mon'
     profiles = ('storage', 'virt', 'container')
-    containers = ('ceph-mon.*',)
-
-    def check_enabled(self):
-        return True if glob.glob('/var/lib/ceph/mon/*/*') else False
+    containers = ('ceph-(.*)?mon.*',)
+    files = ('/var/lib/ceph/mon/',)
 
     def setup(self):
         self.add_file_tags({

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -6,29 +6,66 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
+
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
 class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
+    """
+    This plugin is for capturing information from Ceph OSD nodes. While the
+    majority of this plugin should be version agnotics, several collections are
+    dependent upon the version of Ceph installed. Versions that correlate to
+    RHCS 4 or RHCS 5 are explicitly handled for differences such as those
+    pertaining to log locations on the host filesystem.
+
+    Note that while this plugin will activate based on the presence of Ceph
+    containers, commands are run directly on the host as those containers are
+    often not configured to successfully run the `ceph` commands collected by
+    this plugin. These commands are majorily `ceph daemon` commands that will
+    reference discovered admin sockets under /var/run/ceph.
+    """
 
     short_desc = 'CEPH osd'
 
     plugin_name = 'ceph_osd'
     profiles = ('storage', 'virt', 'container')
-    containers = ('ceph-(.*)?osd.*',)
-    files = ('/var/lib/ceph/osd/',)
+    containers = ('ceph-(.*-)?osd.*',)
+    files = ('/var/lib/ceph/osd/', '/var/lib/ceph/*/osd*')
 
     def setup(self):
+
+        self.ceph_version = self.get_ceph_version()
+
+        logdir = '/var/log/ceph'
+        libdir = '/var/lib/ceph'
+        rundir = '/run/ceph'
+
+        if self.ceph_version >= 16:
+            logdir += '/*'
+            libdir += '/*'
+            rundir += '/*'
+
         self.add_file_tags({
-            '/var/log/ceph/ceph-osd.*.log': 'ceph_osd_log',
+            f"{logdir}/ceph-(.*-)?osd.*.log": 'ceph_osd_log',
         })
+
+        self.add_forbidden_path([
+            "/etc/ceph/*keyring*",
+            f"{libdir}/*keyring*",
+            f"{libdir}/**/*keyring*",
+            # Excludes temporary ceph-osd mount location like
+            # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
+            f"{libdir}/tmp/*mnt*",
+            "/etc/ceph/*bindpass*"
+        ])
 
         # Only collect OSD specific files
         self.add_copy_spec([
-            "/run/ceph/ceph-osd*",
-            "/var/lib/ceph/osd/*/kv_backend",
-            "/var/log/ceph/ceph-osd*.log",
-            "/var/log/ceph/ceph-volume*.log",
+            f"{rundir}/ceph-osd*",
+            f"{libdir}/**/kv_backend",
+            f"{logdir}/ceph-osd*.log",
+            f"{logdir}/ceph-volume*.log",
         ])
 
         self.add_cmd_output([
@@ -36,7 +73,7 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph-volume lvm list"
         ])
 
-        ceph_cmds = [
+        cmds = [
            "bluestore bluefs available",
            "config diff",
            "config show",
@@ -59,41 +96,33 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
            "version",
         ]
 
-        osd_ids = []
-        # Get the ceph user processes
-        out = self.exec_cmd('ps -u ceph -o args')
-
-        if out['status'] == 0:
-            # Extract the OSD ids from valid output lines
-            for procs in out['output'].splitlines():
-                proc = procs.split()
-                # Locate the '--id' value
-                if proc and proc[0].endswith("ceph-osd"):
-                    try:
-                        id_index = proc.index("--id")
-                        osd_ids.append("osd.%s" % proc[id_index+1])
-                    except (IndexError, ValueError):
-                        self.log_warn("could not find ceph-osd id: %s", procs)
-
-        try:
-            cname = self.get_all_containers_by_regex("ceph-osd*")[0][1]
-        except Exception:
-            cname = None
-
         self.add_cmd_output(
-            ["ceph daemon %s %s" % (i, c) for i in osd_ids for c in ceph_cmds],
-            container=cname
+            [f"ceph daemon {i} {c}" for i in self.get_socks() for c in cmds]
         )
 
-        self.add_forbidden_path([
-            "/etc/ceph/*keyring*",
-            "/var/lib/ceph/*keyring*",
-            "/var/lib/ceph/*/*keyring*",
-            "/var/lib/ceph/*/*/*keyring*",
-            # Excludes temporary ceph-osd mount location like
-            # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
-            "/var/lib/ceph/tmp/*mnt*",
-            "/etc/ceph/*bindpass*"
-        ])
+    def get_socks(self):
+        """
+        Find any available admin sockets under /var/run/ceph (or subdirs for
+        later versions of Ceph) which can be used for ceph daemon commands
+        """
+        ceph_sockets = []
+        for rdir, dirs, files in os.walk('/var/run/ceph/'):
+            for file in files:
+                if file.endswith('.asok'):
+                    ceph_sockets.append(self.path_join(rdir, file))
+        return ceph_sockets
+
+    def get_ceph_version(self):
+        ver = self.exec_cmd('ceph --version')
+        if ver['status'] == 0:
+            try:
+                _ver = ver['output'].split()[2]
+                return int(_ver.split('.')[0])
+            except Exception as err:
+                self._log_debug(f"Could not determine ceph version: {err}")
+        self._log_error(
+            'Failed to find ceph version, command collection will be limited'
+        )
+        return 0
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
-import glob
 
 
 class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -16,10 +15,8 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
 
     plugin_name = 'ceph_osd'
     profiles = ('storage', 'virt', 'container')
-    containers = ('ceph-osd.*',)
-
-    def check_enabled(self):
-        return True if glob.glob('/var/lib/ceph/osd/*/*') else False
+    containers = ('ceph-(.*)?osd.*',)
+    files = ('/var/lib/ceph/osd/',)
 
     def setup(self):
         self.add_file_tags({

--- a/sos/report/plugins/ceph_rgw.py
+++ b/sos/report/plugins/ceph_rgw.py
@@ -7,7 +7,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
-import glob
 
 
 class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin):
@@ -16,10 +15,8 @@ class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin):
 
     plugin_name = 'ceph_rgw'
     profiles = ('storage', 'virt', 'container', 'webserver')
-    containers = ('ceph-rgw.*',)
-
-    def check_enabled(self):
-        return True if glob.glob('/var/lib/ceph/radosgw/*/*') else False
+    containers = ('ceph-(.*)?rgw.*',)
+    files = ('/var/lib/ceph/radosgw',)
 
     def setup(self):
         self.add_copy_spec('/var/log/ceph/ceph-client.rgw*.log',


### PR DESCRIPTION
This patchset first corrects an overall issue with the enablement of the ceph plugins for newer versions of Ceph, and then delves into updating the individual plugins to ensure collections remain consistent with expectations across those ceph versions.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?