### PR TITLE
[policy] Update new debian versions

### DIFF
--- a/sos/policies/distros/debian.py
+++ b/sos/policies/distros/debian.py
@@ -23,6 +23,18 @@ class DebianPolicy(LinuxPolicy):
            + ":/usr/local/sbin:/usr/local/bin"
     sos_pkg_name = 'sosreport'
 
+    deb_versions = {
+        'squeeze':  6,
+        'wheezy':   7,
+        'jessie':   8,
+        'stretch':  9,
+        'buster':   10,
+        'bullseye': 11,
+        'bookworm': 12,
+        'trixie':   13,
+        'forky':    14,
+        }
+
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot, init=init,
@@ -50,12 +62,15 @@ class DebianPolicy(LinuxPolicy):
 
     def dist_version(self):
         try:
-            with open('/etc/lsb-release', 'r') as fp:
-                rel_string = fp.read()
-                if "wheezy/sid" in rel_string:
-                    return 6
-                elif "jessie/sid" in rel_string:
-                    return 7
+            with open('/etc/os-release', 'r') as fp:
+                rel_string = ""
+                lines = fp.readlines()
+                for line in lines:
+                    if "VERSION_CODENAME" in line:
+                        rel_string = line.split("=")[1].strip()
+                        break
+                if rel_string in self.deb_versions:
+                    return self.deb_versions[rel_string]
             return False
         except IOError:
             return False


### PR DESCRIPTION
Add all the new versions since 7, and update name/versions based on
https://wiki.debian.org/DebianReleases. Checked latest bookworm and
the release string was in /etc/debian_version, but
/etc/debian_version was inconsistent on other versions.
/etc/lsb-release didnt exist by default.

grab the codename from /etc/os-release and base the versions from
there

forky and trixie and not out yet, but added as per the releases page
for future proofing.

Closes: #2691

Signed-off-by: Arif Ali <arif.ali@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?