### PR TITLE
[collector] Prevent appending local host in strict_node_list mode

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -914,7 +914,8 @@ class SoSCollector(SoSComponent):
 
         self.ui_log.info('The following is a list of nodes to collect from:')
         if self.primary.connected and self.primary.hostname is not None:
-            if not (self.primary.local and self.opts.no_local):
+            if not ((self.primary.local and self.opts.no_local)
+                    or self.cluster.strict_node_list):
                 self.ui_log.info('\t%-*s' % (self.commons['hostlen'],
                                              self.primary.hostname))
 
@@ -1022,12 +1023,13 @@ class SoSCollector(SoSComponent):
         if applicable"""
         if (self.hostname in self.node_list and self.opts.no_local):
             self.node_list.remove(self.hostname)
-        for i in self.ip_addrs:
-            if i in self.node_list:
-                self.node_list.remove(i)
+        if not self.cluster.strict_node_list:
+            for i in self.ip_addrs:
+                if i in self.node_list:
+                    self.node_list.remove(i)
         # remove the primary node from the list, since we already have
         # an open session to it.
-        if self.primary is not None:
+        if self.primary is not None and not self.cluster.strict_node_list:
             for n in self.node_list:
                 if n == self.primary.hostname or n == self.opts.primary:
                     self.node_list.remove(n)
@@ -1173,7 +1175,7 @@ this utility or remote systems that it connects to.
     def collect(self):
         """ For each node, start a collection thread and then tar all
         collected sosreports """
-        if self.primary.connected:
+        if self.primary.connected and not self.cluster.strict_node_list:
             self.client_list.append(self.primary)
 
         self.ui_log.info("\nConnecting to nodes...")


### PR DESCRIPTION
The changes in respecting strict_node_list are three-fold:

1) Don't add local hostname among "list of nodes to collect from:"
2) Skip explicit adding of the primary node to client_list
3) Don't reduce_node_list (as it can purge away local host e.g. in case   of IP address node)

Resolves: #3096

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?