### PR TITLE
[ceph] add iSCSI gateway

### DIFF
--- a/sos/report/plugins/ceph_iscsi.py
+++ b/sos/report/plugins/ceph_iscsi.py
@@ -1,0 +1,36 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+
+
+class CephISCSI(Plugin, RedHatPlugin, UbuntuPlugin):
+
+    short_desc = "CEPH iSCSI"
+
+    plugin_name = "ceph_iscsi"
+    profiles = ("storage", "virt", "container")
+    packages = ("ceph-iscsi",)
+    services = ("rbd-target-api", "rbd-target-gw")
+    containers = ("rbd-target-api.*", "rbd-target-gw.*")
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/tcmu/tcmu.conf",
+            "/var/log/**/ceph-client.*.log",
+            "/var/log/**/rbd-target-api.log",
+            "/var/log/**/rbd-target-gw.log",
+            "/var/log/tcmu-runner.log"
+        ])
+
+        self.add_cmd_output([
+            "gwcli info",
+            "gwcli ls"
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Along with existing Ceph plugins, Ceph iSCSI gateway use case requires additional config and log files to be analyzed.
https://docs.ceph.com/en/latest/rbd/iscsi-overview/

Closes: #3098
Related-Bug: https://bugs.launchpad.net/ubuntu/+source/sosreport/+bug/2000672
Signed-off-by: Nobuto Murata <nobuto.murata@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?