### PR TITLE
[policies] Directly use a Transport for remote commands

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -383,7 +383,7 @@ class SosNode():
             return self.commons['policy']
         host = load(cache={}, sysroot=self.opts.sysroot, init=InitSystem(),
                     probe_runtime=True,
-                    remote_exec=self._transport.remote_exec,
+                    remote_exec=self._transport.run_command,
                     remote_check=self.read_file('/etc/os-release'))
         if host:
             self.log_info("loaded policy %s for host" % host.distro)

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -68,6 +68,11 @@ class Policy():
     :param probe_runtime: Should the Policy try to load a ContainerRuntime
     :type probe_runtime: ``bool``
 
+    :param remote_exec:     If this policy is loaded for a remote node, use
+                            this to facilitate executing commands via the
+                            SoSTransport in use
+    :type remote_exec:      ``SoSTranport.run_command()``
+
     :cvar distro: The name of the distribution the Policy represents
     :vartype distro: ``str``
 


### PR DESCRIPTION
Previously, remote command executions handled by policies were done by moodifying the command string based on the `remote_exec` property of the given `SoSTransport` in use for the node that the policy was loaded for.

While this worked well for SSH connections, newer transports may need to do some manipulation of returned data in order for the rest of `sos collect` to function as intended.

As such, switch to directly using a transport's `run_command()` method, which will ideally handle any needed manipulations of either how the command is execute and/or how the returned data is presented to the calling component.

Related: #3087

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?