### PR TITLE
[cleaner] Convert print()s to leveraging ui logging

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -139,7 +139,7 @@ class SoSCleaner(SoSComponent):
                 _loaded_name = _loaded.name.lower().split('parser')[0].strip()
                 if _parser.lower().strip() == _loaded_name:
                     self.log_info("Disabling parser: %s" % _loaded_name)
-                    self.ui_log.warn(
+                    self.ui_log.warning(
                         "Disabling the '%s' parser. Be aware that this may "
                         "leave sensitive plain-text data in the archive."
                         % _parser
@@ -406,16 +406,20 @@ third party.
         shutil.move(arc_path, final_path)
         arcstat = os.stat(final_path)
 
-        # logging will have been shutdown at this point
-        print("A mapping of obfuscated elements is available at\n\t%s"
-              % map_path)
+        # while these messages won't be included in the log file in the archive
+        # some facilities, such as our avocado test suite, will sometimes not
+        # capture print() output, so leverage the ui_log to print to console
+        self.ui_log.info(
+            f"A mapping of obfuscated elements is available at\n\t{map_path}"
+        )
+        self.ui_log.info(
+            f"\nThe obfuscated archive is available at\n\t{final_path}\n"
+        )
 
-        print("\nThe obfuscated archive is available at\n\t%s\n" % final_path)
-        print("\tSize\t%s" % get_human_readable(arcstat.st_size))
-        print("\tOwner\t%s\n" % getpwuid(arcstat.st_uid).pw_name)
-
-        print("Please send the obfuscated archive to your support "
-              "representative and keep the mapping file private")
+        self.ui_log.info(f"\tSize\t{get_human_readable(arcstat.st_size)}")
+        self.ui_log.info(f"\tOwner\t{getpwuid(arcstat.st_uid).pw_name}\n")
+        self.ui_log.info("Please send the obfuscated archive to your support "
+                         "representative and keep the mapping file private")
 
         self.cleanup()
 


### PR DESCRIPTION
It was recently found that some condition will cause Avocado to not capture trailing `print()` statements in our test suite, and it is reasonable to assume other automation may also have similar edge cases.

Resolve this by switching potentially problematic `print()`s to use the ui logging stream, which will still print to console even after the file handler has been closed.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?