### PR TITLE
[fwupd] Guard commands by fwupd.service predicate

### DIFF
--- a/sos/report/plugins/fwupd.py
+++ b/sos/report/plugins/fwupd.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
 class Fwupd(Plugin, IndependentPlugin):
@@ -27,7 +27,7 @@ class Fwupd(Plugin, IndependentPlugin):
             # collect json format using fwupdagent
             "/usr/libexec/fwupd/fwupdagent get-devices",
             "/usr/libexec/fwupd/fwupdagent get-updates",
-        ])
+        ], pred=SoSPredicate(self, services=["fwupd"]))
 
         self.add_copy_spec("/etc/fwupd")
 


### PR DESCRIPTION
Execution of any command collected the plugin enables wfupd.service, hence their collection must be guarded by the relevant predicate.

Resolves: #3107
Relevant: rhbz#2145263

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?