### PR TITLE
Replace deprecated Logger.warn by Logger.warning

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -598,7 +598,7 @@ class SoSCollector(SoSComponent):
 
     def log_warn(self, msg):
         """Log warn messages to both console and log file"""
-        self.soslog.warn(msg)
+        self.soslog.warning(msg)
 
     def log_error(self, msg):
         """Log error messages to both console and log file"""

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -220,7 +220,7 @@ class Cluster():
 
     def log_warn(self, msg):
         """Used to print warning messages"""
-        self.soslog.warn(self._fmt_msg(msg))
+        self.soslog.warning(self._fmt_msg(msg))
 
     def get_option(self, option):
         """

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -86,7 +86,7 @@ class ocp(Cluster):
                         _oc_path['output'].strip().lstrip('/')
                     )
                 else:
-                    self.log_warn(
+                    self.log_warning(
                         "Unable to to determine PATH for 'oc' command, "
                         "node enumeration may fail."
                     )

--- a/sos/component.py
+++ b/sos/component.py
@@ -300,7 +300,7 @@ class SoSComponent():
                 self.opts.encrypt_pass = None
                 self.soslog.info("User specified --encrypt, but chose no "
                                  "encryption when prompted.")
-                self.ui_log.warn("Archive will not be encrypted")
+                self.ui_log.warning("Archive will not be encrypted")
         else:
             self._set_encrypt_from_env_vars()
 

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -460,7 +460,7 @@ class SoSReport(SoSComponent):
             elif not self.policy.runtimes:
                 msg = ("WARNING: No container runtimes are active, ignoring "
                        "option to set default runtime to '%s'\n" % crun)
-                self.soslog.warn(msg)
+                self.soslog.warning(msg)
             elif crun not in self.policy.runtimes.keys():
                 valid = ', '.join(p for p in self.policy.runtimes.keys()
                                   if p != 'default')
@@ -552,7 +552,7 @@ class SoSReport(SoSComponent):
                 _devs.update(self._get_eth_devs())
                 _devs['bridge'] = self._get_bridge_devs()
         except Exception as err:
-            self.soslog.warn("Could not enumerate network devices: %s" % err)
+            self.soslog.warning(f"Could not enumerate network devices: {err}")
         return _devs
 
     def _get_network_namespace_devices(self):
@@ -618,7 +618,7 @@ class SoSReport(SoSComponent):
                         if _nseth not in filt_devs:
                             _eth_devs.append(_nseth)
             except Exception as err:
-                self.soslog.warn(
+                self.soslog.warning(
                     "Could not determine network namespace '%s' devices: %s"
                     % (namespace, err)
                 )
@@ -639,7 +639,7 @@ class SoSReport(SoSComponent):
         try:
             _bout = sos_get_command_output('brctl show', timeout=15)
         except Exception as err:
-            self.soslog.warn("Unable to enumerate bridge devices: %s" % err)
+            self.soslog.warning("Unable to enumerate bridge devices: %s" % err)
         if _bout['status'] == 0:
             for _bline in _bout['output'].splitlines()[1:]:
                 try:
@@ -1586,8 +1586,9 @@ class SoSReport(SoSComponent):
                 os.umask(old_umask)
         else:
             if self.opts.encrypt_pass or self.opts.encrypt_key:
-                self.ui_log.warn("\nUnable to encrypt when using --build. "
-                                 "Encryption is only available for archives.")
+                self.ui_log.warning("\nUnable to encrypt when using --build. "
+                                    "Encryption is only available for "
+                                    "archives.")
             # move the archive root out of the private tmp directory.
             directory = self.archive.get_archive_path()
             dir_name = os.path.basename(directory)

--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -104,8 +104,8 @@ class Gluster(Plugin, RedHatPlugin):
                     self.soslog.info("could not send SIGUSR1 to glusterfs/"
                                      "glusterd processes")
             else:
-                self.soslog.warn("Unable to generate statedumps, no such "
-                                 "directory: %s" % self.statedump_dir)
+                self.soslog.warning("Unable to generate statedumps, no such "
+                                    "directory: %s" % self.statedump_dir)
             state = self.exec_cmd("gluster get-state")
             if state['status'] == 0:
                 state_file = state['output'].split()[-1]

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -36,7 +36,7 @@ WARNING: Failed to load 'magic' module version >= 0.4.20 which sos aims to \
 use for detecting binary files. A less effective method will be used. It is \
 recommended to install proper python3-magic package with the module.
 """)
-    log.warn('\n' + fill(msg, 72, replace_whitespace=False) + '\n')
+    log.warning('\n' + fill(msg, 72, replace_whitespace=False) + '\n')
 
 
 TIMEOUT_DEFAULT = 300

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -349,7 +349,7 @@ class BaseSoSReportTest(BaseSoSTest):
                 self._manifest = json.loads(content)
             except Exception:
                 self._manifest = ''
-                self.warn('Could not load manifest for test')
+                self.warning('Could not load manifest for test')
         return self._manifest
 
     @property


### PR DESCRIPTION
One such change is already done in https://github.com/sosreport/sos/pull/3106 .

Resolves: #3109

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?