### PR TITLE
[build] Convert to setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ venv
 MANIFEST
 build/
 dist/
+*sos.egg*
 docs/_build
 
 # Pycharm

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ coverage>=4.0.3
 Sphinx>=1.3.5
 pexpect>=4.0.0
 pyyaml
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Sphinx>=1.3.5
 pexpect>=4.0.0
 pyyaml
 setuptools
+

--- a/setup.py
+++ b/setup.py
@@ -1,84 +1,16 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
-from distutils.command.build import build
-from distutils.command.install_data import install_data
-from distutils.dep_util import newer
-from distutils.log import error
-
-import glob
-import os
-import re
-import subprocess
-import sys
-
+from setuptools import setup, find_packages
 from sos import __version__ as VERSION
 
-PO_DIR = 'po'
-MO_DIR = os.path.join('build', 'mo')
-
-class BuildData(build):
-  def run(self):
-    build.run(self)
-    for po in glob.glob(os.path.join(PO_DIR, '*.po')):
-      lang = os.path.basename(po[:-3])
-      mo = os.path.join(MO_DIR, lang, 'sos.mo')
-
-      directory = os.path.dirname(mo)
-      if not os.path.exists(directory):
-        os.makedirs(directory)
-
-      if newer(po, mo):
-        try:
-          rc = subprocess.call(['msgfmt', '-o', mo, po])
-          if rc != 0:
-            raise Warning("msgfmt returned %d" % (rc,))
-        except Exception as e:
-          error("Failed gettext.")
-          sys.exit(1)
-
-class InstallData(install_data):
-  def run(self):
-    self.data_files.extend(self._find_mo_files())
-    install_data.run(self)
-
-  def _find_mo_files(self):
-    data_files = []
-    for mo in glob.glob(os.path.join(MO_DIR, '*', 'sos.mo')):
-      lang = os.path.basename(os.path.dirname(mo))
-      dest = os.path.join('share', 'locale', lang, 'LC_MESSAGES')
-      data_files.append((dest, [mo]))
-    return data_files
-
-  # Workaround https://bugs.python.org/issue644744
-  def copy_file (self, filename, dirname):
-    (out, _) = install_data.copy_file(self, filename, dirname)
-    # match for man pages
-    if re.search(r'/man/man\d/.+\.\d$', out):
-      return (out+".gz", _)
-    return (out, _)
-
-cmdclass = {'build': BuildData, 'install_data': InstallData}
-command_options = {}
-try:
-    from sphinx.setup_command import BuildDoc
-    cmdclass['build_sphinx'] = BuildDoc
-    command_options={
-        'build_sphinx': {
-            'project': ('setup.py', 'sos'),
-            'version': ('setup.py', VERSION),
-            'source_dir': ('setup.py', 'docs')
-        }
-    }
-except Exception:
-    print("Unable to build sphinx docs - module not present. Install sphinx "
-          "to enable documentation generation")
 
 setup(
     name='sos',
     version=VERSION,
-    description=("""A set of tools to gather troubleshooting"""
-                 """ information from a system."""),
+    install_requires=['pexpect', 'pyyaml'],
+    description=(
+        'A set of tools to gather troubleshooting information from a system'
+    ),
     author='Bryn M. Reeves',
     author_email='bmr@redhat.com',
     maintainer='Jake Hunsaker',
@@ -96,19 +28,7 @@ setup(
         ('share/doc/sos', ['AUTHORS', 'README.md']),
         ('config', ['sos.conf'])
     ],
-    packages=[
-        'sos', 'sos.presets', 'sos.presets.redhat', 'sos.policies',
-        'sos.policies.distros', 'sos.policies.runtimes',
-        'sos.policies.package_managers', 'sos.policies.init_systems',
-        'sos.report', 'sos.report.plugins', 'sos.collector',
-        'sos.collector.clusters', 'sos.collector.transports', 'sos.cleaner',
-        'sos.cleaner.mappings', 'sos.cleaner.parsers', 'sos.cleaner.archives',
-        'sos.help'
-    ],
-    cmdclass=cmdclass,
-    command_options=command_options,
-    requires=['pexpect', 'pyyaml']
-    )
-
+    packages=find_packages(include=['sos', 'sos.*'])
+)
 
 # vim: set et ts=4 sw=4 :

--- a/sos.spec
+++ b/sos.spec
@@ -1,5 +1,3 @@
-%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
-
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
 Version: 4.4
@@ -11,6 +9,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildArch: noarch
 Url: https://github.com/sosreport/sos/
 BuildRequires: python3-devel
+BuildRequires: python3-setuptools
 BuildRequires: gettext
 Requires: python3-rpm
 Requires: tar
@@ -46,7 +45,9 @@ rm -rf ${RPM_BUILD_ROOT}/usr/config/
 
 %find_lang %{name} || echo 0
 
-%files -f %{name}.lang
+# internationalization is currently broken. Uncomment this line once fixed.
+# %%files -f %%{name}.lang
+%files
 %{_sbindir}/sos
 %{_sbindir}/sosreport
 %{_sbindir}/sos-collector

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 from pipes import quote
 from sos.policies import load
 from sos.policies.init_systems import InitSystem
@@ -295,7 +295,7 @@ class SosNode():
         if ver:
             if len(ver.split('.')) == 2:
                 # safeguard against maintenance releases throwing off the
-                # comparison by LooseVersion
+                # comparison by parse_version
                 ver += '.0'
             try:
                 ver += '-%s' % rel.split('.')[0]
@@ -420,8 +420,8 @@ class SosNode():
         _ver = _format_version(ver)
 
         try:
-            _node_ver = LooseVersion(self.sos_info['version'])
-            _test_ver = LooseVersion(_ver)
+            _node_ver = parse_version(self.sos_info['version'])
+            _test_ver = parse_version(_ver)
             return _node_ver >= _test_ver
         except Exception as err:
             self.log_error("Error checking sos version: %s" % err)


### PR DESCRIPTION
2-patch set that first updates `setup.py` to use setuptools, and second replaces the usage of `LooseVersion` with `parse_version` for the purposes of comparing sos versions for option compatibility with `collect`.

As noted in the commit message, and specified in #3093, this conversion will stop compiling `.mo` translation files for packaged releases. However, this is currently seen as acceptable as the compiled translations have been found to be currently broken anyways.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?