### PR TITLE
[policies] set case_id before prompting for upload credentials

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -286,6 +286,7 @@ class LinuxPolicy(Policy):
         self.upload_password = cmdline_opts.upload_pass
         self.upload_archive_name = ''
 
+        # set or query for case id
         if not cmdline_opts.batch and not \
                 cmdline_opts.quiet:
             try:
@@ -296,6 +297,16 @@ class LinuxPolicy(Policy):
                         _("Optionally, please enter the case id that you are "
                           "generating this report for [%s]: ") % caseid
                     )
+            except KeyboardInterrupt:
+                raise
+        if cmdline_opts.case_id:
+            self.case_id = cmdline_opts.case_id
+
+        # set or query for upload credentials; this needs to be done after
+        # setting case id, as below methods might rely on detection of it
+        if not cmdline_opts.batch and not \
+                cmdline_opts.quiet:
+            try:
                 # Policies will need to handle the prompts for user information
                 if cmdline_opts.upload and self.get_upload_url():
                     self.prompt_for_upload_user()
@@ -303,9 +314,6 @@ class LinuxPolicy(Policy):
                 self.ui_log.info('')
             except KeyboardInterrupt:
                 raise
-
-        if cmdline_opts.case_id:
-            self.case_id = cmdline_opts.case_id
 
         return
 

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -266,11 +266,19 @@ support representative.
         if self.commons['cmdlineopts'].upload_url:
             super(RHELPolicy, self).prompt_for_upload_user()
             return
-        if self.case_id and not self.get_upload_user():
-            self.upload_user = input(_(
-                "Enter your Red Hat Customer Portal username for uploading ["
-                "empty for anonymous SFTP]: ")
-            )
+        if not self.get_upload_user():
+            if self.case_id:
+                self.upload_user = input(_(
+                    "Enter your Red Hat Customer Portal username for "
+                    "uploading [empty for anonymous SFTP]: ")
+                )
+            else:   # no case id provided => failover to SFTP
+                self.upload_url = RH_SFTP_HOST
+                self.ui_log.info("No case id provided, uploading to SFTP")
+                self.upload_user = input(_(
+                    "Enter your Red Hat Customer Portal username for "
+                    "uploading to SFTP [empty for anonymous]: ")
+                )
 
     def get_upload_url(self):
         if self.upload_url:


### PR DESCRIPTION
Since prompting for upload username/password relies on case_id for some policies, let fully set case_id before that.

Resolves: #3117

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?