### PR TITLE
[cleaner] Improve separating host from IPv6 address

### DIFF
--- a/sos/cleaner/mappings/ipv6_map.py
+++ b/sos/cleaner/mappings/ipv6_map.py
@@ -263,12 +263,9 @@ class ObfuscatedIPv6Network():
             ])
 
         if addr.compressed not in self.hosts:
-            try:
-                _, _host = addr.compressed.split(self.network_addr.rstrip(':'))
-            except ValueError:
-                # network addr is simply '::'
-                _n, _host = addr.compressed.split(self.network_addr)
-            _host = _host.lstrip(':')
+            # separate host from the address by removing its network prefix
+            _n = self.network_addr.rstrip(':')
+            _host = addr.compressed[len(_n):].lstrip(':')
             _ob_host = _generate_address()
             while _ob_host in self.hosts.values():
                 _ob_host = _generate_address()


### PR DESCRIPTION
Fix a corner case in separating host address from an IPv6 address when the host string is (substring of) the network address string.

Resolves: #3121
Relevant: #3120

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?