### PR TITLE
[ceph] Accommodate both running on host and containers

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -44,34 +44,24 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.ceph_version = self.get_ceph_version()
 
-        logdir = '/var/log/ceph'
-        libdir = '/var/lib/ceph'
-        rundir = '/run/ceph'
-
-        if self.ceph_version >= 16:
-            logdir += '/*'
-            libdir += '/*'
-            rundir += '/*'
-
         self.add_file_tags({
             '.*/ceph.conf': 'ceph_conf',
-            f"{logdir}/ceph-.*mon.*.log": 'ceph_mon_log'
+            "/var/log/ceph/(.*/)?ceph-.*mon.*.log": 'ceph_mon_log'
         })
 
         self.add_forbidden_path([
             "/etc/ceph/*keyring*",
-            f"{libdir}/*keyring*",
-            f"{libdir}/**/*keyring*",
+            "/var/lib/ceph/**/*keyring*",
             # Excludes temporary ceph-osd mount location like
             # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
-            f"{libdir}/tmp/*mnt*",
+            "/var/lib/ceph/**/tmp/*mnt*",
             "/etc/ceph/*bindpass*"
         ])
 
         self.add_copy_spec([
-            f"{rundir}/ceph-mon*",
-            f"{libdir}/**/kv_backend",
-            f"{logdir}/*ceph-mon*.log"
+            "/run/ceph/**/ceph-mon*",
+            "/var/lib/ceph/**/kv_backend",
+            "/var/log/ceph/**/*ceph-mon*.log"
         ])
 
         self.add_cmd_output([

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -35,37 +35,25 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
 
     def setup(self):
 
-        self.ceph_version = self.get_ceph_version()
-
-        logdir = '/var/log/ceph'
-        libdir = '/var/lib/ceph'
-        rundir = '/run/ceph'
-
-        if self.ceph_version >= 16:
-            logdir += '/*'
-            libdir += '/*'
-            rundir += '/*'
-
         self.add_file_tags({
-            f"{logdir}/ceph-(.*-)?osd.*.log": 'ceph_osd_log',
+            "/var/log/ceph/(.*/)?ceph-(.*-)?osd.*.log": 'ceph_osd_log',
         })
 
         self.add_forbidden_path([
             "/etc/ceph/*keyring*",
-            f"{libdir}/*keyring*",
-            f"{libdir}/**/*keyring*",
+            "/var/lib/ceph/**/*keyring*",
             # Excludes temporary ceph-osd mount location like
             # /var/lib/ceph/tmp/mnt.XXXX from sos collection.
-            f"{libdir}/tmp/*mnt*",
+            "/var/lib/ceph/**/tmp/*mnt*",
             "/etc/ceph/*bindpass*"
         ])
 
         # Only collect OSD specific files
         self.add_copy_spec([
-            f"{rundir}/ceph-osd*",
-            f"{libdir}/**/kv_backend",
-            f"{logdir}/ceph-osd*.log",
-            f"{logdir}/ceph-volume*.log",
+            "/run/ceph/**/ceph-osd*",
+            "/var/lib/ceph/**/kv_backend",
+            "/var/log/ceph/**/ceph-osd*.log",
+            "/var/log/ceph/**/ceph-volume*.log",
         ])
 
         self.add_cmd_output([
@@ -111,18 +99,5 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
                 if file.endswith('.asok'):
                     ceph_sockets.append(self.path_join(rdir, file))
         return ceph_sockets
-
-    def get_ceph_version(self):
-        ver = self.exec_cmd('ceph --version')
-        if ver['status'] == 0:
-            try:
-                _ver = ver['output'].split()[2]
-                return int(_ver.split('.')[0])
-            except Exception as err:
-                self._log_debug(f"Could not determine ceph version: {err}")
-        self._log_error(
-            'Failed to find ceph version, command collection will be limited'
-        )
-        return 0
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This supersedes #3103.

Simplify the log collection condition by introducing a file glob. It can capture logs from both existing clusters such as package based deployments and container based deployments such as cephadm.

Closes: #3100

Co-authored-by: Samuel Walladge <samuel.walladge@canonical.com>
Signed-off-by: Nobuto Murata <nobuto.murata@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
---

Testing procedure:
```bash
./bin/sos report --batch --build -n fwupd --label "<LABEL e.g. 4.4>"

grep -c 'plugin:ceph.* collecting path ' /tmp/sosreport-*-LABEL-*/sos_logs/sos.log

grep -c 'plugin:ceph.* collecting output ' /tmp/sosreport-*-LABEL-*/sos_logs/sos.log
```

Testing output:
[Package based deployment]
- Ceph MON
  - \# of collecting path
    - 4.4 -> 14
    - main (31b991ef) -> 11
    - proposed patchset -> 17
  - \# of collecting output
    - 4.4 -> 92
    - main (31b991ef) -> 137
    - proposed patchset -> 137
- Ceph OSD
  - \# of collecting path
    - 4.4 -> 11
    - main (31b991ef) -> 11
    - proposed patchset -> 16
  - \# of collecting output
    - 4.4 -> 23
    - main (31b991ef) -> 98
    - proposed patchset -> 98

[cephadm]
- \# of collecting path
  - 4.4 -> 3
  - main (31b991ef) -> 5
  - proposed patchset -> 26
- \# of collecting output
  - 4.4 -> 1
  - main (31b991ef) -> 230
  - proposed patchset -> 230

