### PR TITLE
[ceph_common] Update log patterns for multiple ceph versions

### DIFF
--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -48,7 +48,7 @@ class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.add_file_tags({
             '.*/ceph.conf': 'ceph_conf',
-            '/var/log/ceph/ceph.log.*': 'ceph_log',
+            '/var/log/ceph(.*)?/ceph.log.*': 'ceph_log',
         })
 
         if not all_logs:
@@ -57,8 +57,8 @@ class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin):
             self.add_copy_spec("/var/log/calamari",)
 
         self.add_copy_spec([
-            "/var/log/ceph/ceph.log",
-            "/var/log/ceph/ceph.audit.log*",
+            "/var/log/ceph/**/ceph.log",
+            "/var/log/ceph/**/ceph.audit.log*",
             "/var/log/calamari/*.log",
             "/etc/ceph/",
             "/etc/calamari/",


### PR DESCRIPTION
Updates the log patterns for `ceph_common` to handle Ceph versions that use or don't use fsid's as part of the logging paths.

Related: #3122

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?