### PR TITLE
[tags] Add insights specific tags

### DIFF
--- a/sos/report/plugins/abrt.py
+++ b/sos/report/plugins/abrt.py
@@ -27,7 +27,7 @@ class Abrt(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_cmd_output("abrt-cli status",
-                            tags=["abrt_status", "insights_abrt_status_bare"])
+                            tags=["abrt_status", "abrt_status_bare"])
         abrt_list = self.collect_cmd_output("abrt-cli list")
         if self.get_option("detailed") and abrt_list['status'] == 0:
             for line in abrt_list["output"].splitlines():

--- a/sos/report/plugins/alternatives.py
+++ b/sos/report/plugins/alternatives.py
@@ -21,7 +21,9 @@ class Alternatives(Plugin, RedHatPlugin):
     def setup(self):
 
         self.add_cmd_tags({
-            "alternatives --display java.*": 'insights_display_java'
+            "alternatives --display java.*": 'display_java',
+            "alternatives --display python.*":
+                'alternatives_display_python'
         })
 
         self.add_cmd_output('alternatives --version')

--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -38,10 +38,10 @@ class Apache(Plugin):
     def setup(self):
         # collect list of installed modules and verify config syntax.
         self.add_cmd_output([
-            "apachectl -M",
             "apachectl -S",
             "apachectl -t"
         ], cmd_as_tag=True)
+        self.add_cmd_output("apachectl -M", tags="httpd_M")
 
         # Other plugins collect these files;
         # do not collect them here to avoid collisions in the archive paths.
@@ -81,10 +81,10 @@ class RedHatApache(Apache, RedHatPlugin):
     def setup(self):
 
         self.add_file_tags({
-            ".*/access_log": 'httpd_access_log',
-            ".*/error_log": 'httpd_error_log',
-            ".*/ssl_access_log": 'httpd_ssl_access_log',
-            ".*/ssl_error_log": 'httpd_ssl_error_log'
+            "/var/log/httpd/access_log": 'httpd_access_log',
+            "/var/log/httpd/error_log": 'httpd_error_log',
+            "/var/log/httpd/ssl_access_log": 'httpd_ssl_access_log',
+            "/var/log/httpd/ssl_error_log": 'httpd_ssl_error_log'
         })
 
         super(RedHatApache, self).setup()

--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -27,11 +27,12 @@ class Auditd(Plugin, IndependentPlugin):
             "/etc/audit/plugins.d/",
             "/etc/audisp/",
         ])
-        self.add_cmd_output([
-            "ausearch --input-logs -m avc,user_avc,fanotify -ts today",
-            "auditctl -s",
-            "auditctl -l"
-        ])
+
+        self.add_cmd_output(
+            "ausearch --input-logs -m avc,user_avc,fanotify -ts today"
+        )
+        self.add_cmd_output("auditctl -l", tags="auditctl_rules")
+        self.add_cmd_output("auditctl -s", tags="auditctl_status")
 
         config_file = "/etc/audit/auditd.conf"
         log_file = "/var/log/audit/audit.log"

--- a/sos/report/plugins/autofs.py
+++ b/sos/report/plugins/autofs.py
@@ -43,6 +43,7 @@ class Autofs(Plugin):
 
     def setup(self):
         self.add_copy_spec("/etc/auto*")
+        self.add_file_tags({"/etc/autofs.conf": "autofs_conf"})
         self.add_service_status("autofs")
         self.add_cmd_output("automount -m")
         if self.checkdebug():

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -25,15 +25,15 @@ class Block(Plugin, IndependentPlugin):
             '/sys/block/.*/queue/scheduler': 'scheduler'
         })
 
+        self.add_cmd_output("blkid -c /dev/null", tags="blkid")
+        self.add_cmd_output("ls -lanR /dev", tags="ls_dev")
+        self.add_cmd_output("lsblk", tags="lsblk")
+        self.add_cmd_output("lsblk -O -P", tags="lsblk_pairs")
         self.add_cmd_output([
-            "lsblk",
             "lsblk -t",
             "lsblk -D",
-            "blkid -c /dev/null",
             "blockdev --report",
-            "ls -lanR /dev",
             "ls -lanR /sys/block",
-            "lsblk -O -P",
             "losetup -a",
         ])
 
@@ -52,11 +52,12 @@ class Block(Plugin, IndependentPlugin):
 
         cmds = [
             "parted -s %(dev)s unit s print",
-            "fdisk -l %(dev)s",
             "udevadm info %(dev)s",
             "udevadm info -a %(dev)s"
         ]
         self.add_device_cmd(cmds, devices='block', blacklist='ram.*')
+        self.add_device_cmd("fdisk -l %(dev)s", blacklist="ram.*",
+                            devices="block", tags="fdisk_l_sos")
 
         lsblk = self.collect_cmd_output("lsblk -f -a -l")
         # for LUKS devices, collect cryptsetup luksDump

--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -33,19 +33,18 @@ class Boot(Plugin, IndependentPlugin):
             "/boot/yaboot.conf"
         ])
 
-        self.add_cmd_output("ls -lanR /boot", tags="insights_ls_boot")
-        self.add_cmd_output("ls -l /initrd.img /boot/initrd.img")
-
-        self.add_cmd_output([
-            "lsinitrd",
-            "lsinitramfs -l /initrd.img",
-            "lsinitramfs -l /boot/initrd.img",
-            "ls -lanR /sys/firmware",
-        ])
+        self.add_cmd_output("ls -lanR /boot", tags="ls_boot")
+        self.add_cmd_output("ls -lanR /sys/firmware",
+                            tags="ls_sys_firmware")
+        self.add_cmd_output("lsinitrd", tags="lsinitrd")
+        self.add_cmd_output("mokutil --sb-state",
+                            tags="mokutil_sbstate")
 
         self.add_cmd_output([
             "efibootmgr -v",
-            "mokutil --sb-state"
+            "ls -l /initrd.img /boot/initrd.img",
+            "lsinitramfs -l /initrd.img",
+            "lsinitramfs -l /boot/initrd.img"
         ])
 
         if self.get_option("all-images"):

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -64,13 +64,13 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "/var/log/ceph/**/*ceph-mon*.log"
         ])
 
+        self.add_cmd_output("ceph report", tags="ceph_report")
         self.add_cmd_output([
             # The ceph_mon plugin will collect all the "ceph ..." commands
             # which typically require the keyring.
 
             "ceph mon stat",
             "ceph quorum_status",
-            "ceph report",
             "ceph-disk list",
             "ceph versions",
             "ceph features",
@@ -103,7 +103,6 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
         ceph_cmds = [
             "mon dump",
             "status",
-            "health detail",
             "device ls",
             "df",
             "df detail",
@@ -112,7 +111,6 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "pg dump",
             "pg stat",
             "time-sync-status",
-            "osd tree",
             "osd stat",
             "osd df tree",
             "osd dump",
@@ -125,9 +123,15 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "osd numa-status"
         ]
 
+        self.add_cmd_output("ceph health detail --format json-pretty",
+                            subdir="json_output",
+                            tags="ceph_health_detail")
+        self.add_cmd_output("ceph osd tree --format json-pretty",
+                            subdir="json_output",
+                            tags="ceph_osd_tree")
         self.add_cmd_output(
             [f"ceph tell mon.{mid} mon_status" for mid in self.get_ceph_ids()],
-            subdir="json_output", tags="insights_ceph_health_detail"
+            subdir="json_output",
         )
 
         self.add_cmd_output([f"ceph {cmd}" for cmd in ceph_cmds])
@@ -135,7 +139,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
         # get ceph_cmds again as json for easier automation parsing
         self.add_cmd_output(
             [f"ceph {cmd} --format json-pretty" for cmd in ceph_cmds],
-            subdir="json_output", tags="insights_ceph_health_detail"
+            subdir="json_output",
         )
 
     def get_ceph_version(self):

--- a/sos/report/plugins/cgroups.py
+++ b/sos/report/plugins/cgroups.py
@@ -21,7 +21,7 @@ class Cgroups(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
     def setup(self):
 
         self.add_file_tags({
-            '/proc/1/cgroups': 'insights_init_process_cgroup'
+            '/proc/1/cgroups': 'init_process_cgroup'
         })
 
         self.add_copy_spec([

--- a/sos/report/plugins/chrony.py
+++ b/sos/report/plugins/chrony.py
@@ -22,12 +22,12 @@ class Chrony(Plugin):
         self.add_cmd_output([
             "chronyc activity",
             "chronyc tracking",
-            "chronyc -n sources",
             "chronyc sourcestats",
             "chronyc serverstats",
             "chronyc ntpdata",
             "chronyc -n clients"
         ])
+        self.add_cmd_output("chronyc -n sources", tags="chronyc_sources")
 
 
 class RedHatChrony(Chrony, RedHatPlugin):

--- a/sos/report/plugins/cloud_init.py
+++ b/sos/report/plugins/cloud_init.py
@@ -33,4 +33,8 @@ class CloudInit(Plugin, IndependentPlugin):
             '/var/log/cloud-init*'
         ])
 
+        self.add_file_tags({
+            "/etc/cloud/cloud.cfg": "cloud_cfg_filtered"
+        })
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/cobbler.py
+++ b/sos/report/plugins/cobbler.py
@@ -26,6 +26,10 @@ class RedHatCobbler(Cobbler, RedHatPlugin):
             "/var/lib/rhn/kickstarts",
             "/var/lib/cobbler"
         ])
+        self.add_file_tags({
+            "/etc/clobber/modules.conf": "cobbler_modules_conf",
+            "/etc/cobbler/settings": "cobbler_settings"
+        })
 
 
 class DebianCobbler(Cobbler, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -31,6 +31,10 @@ class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
             '/etc/subgid',
         ])
 
+        self.add_file_tags({
+            "/etc/containers/policy.json": "containers_policy"
+        })
+
         users_opt = self.get_option('rootlessusers')
         users_list = []
         if users_opt:

--- a/sos/report/plugins/corosync.py
+++ b/sos/report/plugins/corosync.py
@@ -31,9 +31,10 @@ class Corosync(Plugin):
             "corosync-cfgtool -s",
             "corosync-blackbox",
             "corosync-objctl -a",
-            "corosync-cmapctl",
             "corosync-cmapctl -m stats"
         ])
+        self.add_cmd_output("corosync-cmapctl",
+                            tags="corosync_cmapctl")
         self.exec_cmd("killall -USR2 corosync")
 
         corosync_conf = "/etc/corosync/corosync.conf"

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -85,7 +85,8 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
                                 subdir="containers")
             if self.get_option('logs'):
                 self.add_cmd_output("crictl logs -t %s" % container,
-                                    subdir="containers/logs", priority=100)
+                                    subdir="containers/logs", priority=100,
+                                    tags="crictl_logs")
 
         for image in images:
             self.add_cmd_output("crictl inspecti %s" % image, subdir="images")

--- a/sos/report/plugins/cs.py
+++ b/sos/report/plugins/cs.py
@@ -88,6 +88,9 @@ class CertificateSystem(Plugin, RedHatPlugin):
                 "/var/log/dirsrv/slapd-*/access",
                 "/var/log/dirsrv/slapd-*/errors"
             ])
+            self.add_file_tags({
+                "/var/log/dirsrv/*/access": "dirsrv_access"
+            })
         if csversion == 8:
             self.add_copy_spec([
                 "/etc/pki-*/CS.cfg",

--- a/sos/report/plugins/date.py
+++ b/sos/report/plugins/date.py
@@ -23,7 +23,7 @@ class Date(Plugin, IndependentPlugin):
             'date',
             'date --utc',
             'hwclock'
-        ])
+        ], cmd_as_tag=True)
 
         self.add_copy_spec([
             '/etc/localtime',

--- a/sos/report/plugins/devicemapper.py
+++ b/sos/report/plugins/devicemapper.py
@@ -31,4 +31,9 @@ class DeviceMapper(Plugin, IndependentPlugin):
             "dmstats print --allregions"
         ], pred=SoSPredicate(self, kmods=['dm_mod']))
 
+        self.add_cmd_tags({
+            "dmsetup info -c": "dmsetup_info",
+            "dmsetup status": "dmsetup_status"
+        })
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -49,10 +49,7 @@ class Docker(Plugin, CosPlugin):
 
         subcmds = [
             'events --since 24h --until 1s',
-            'info',
-            'images',
             'ps',
-            'ps -a',
             'stats --no-stream',
             'version',
             'volume ls'
@@ -60,6 +57,13 @@ class Docker(Plugin, CosPlugin):
 
         for subcmd in subcmds:
             self.add_cmd_output("docker %s" % subcmd)
+
+        self.add_cmd_output("docker info",
+                            tags="docker_info")
+        self.add_cmd_output("docker images",
+                            tags="docker_images")
+        self.add_cmd_output("docker ps -a",
+                            tags="docker_list_containers")
 
         # separately grab these separately as they can take a *very* long time
         if self.get_option('size'):
@@ -90,7 +94,8 @@ class Docker(Plugin, CosPlugin):
         for img in images:
             name, img_id = img
             insp = name if 'none' not in name else img_id
-            self.add_cmd_output("docker inspect %s" % insp, subdir='images')
+            self.add_cmd_output("docker inspect %s" % insp, subdir='images',
+                                tags="docker_image_inspect")
 
         for vol in volumes:
             self.add_cmd_output("docker volume inspect %s" % vol,

--- a/sos/report/plugins/ds.py
+++ b/sos/report/plugins/ds.py
@@ -65,6 +65,9 @@ class DirectoryServer(Plugin, RedHatPlugin):
                 "/etc/dirsrv/admin-serv",
                 "/var/log/dirsrv/*"
             ])
+            self.add_file_tags({
+                "/var/log/dirsrv/*/access": "dirsrv_access"
+            })
         elif "ds7" in self.check_version():
             self.add_copy_spec([
                 "/opt/redhat-ds/slapd-*/config",

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -46,9 +46,10 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "/etc/mtab",
             "/etc/fstab"
         ])
-        self.add_cmd_output("mount -l", root_symlink="mount")
+        self.add_cmd_output("mount -l", root_symlink="mount",
+                            tags="mount")
         self.add_cmd_output("df -al -x autofs", root_symlink="df",
-                            tags='insights_df__al')
+                            tags='df__al')
         self.add_cmd_output([
             "df -ali -x autofs",
             "findmnt",
@@ -67,7 +68,8 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         mounts = '/proc/mounts'
         ext_fs_regex = r"^(/dev/\S+).+ext[234]\s+"
         for dev in self.do_regex_find_all(ext_fs_regex, mounts):
-            self.add_cmd_output("dumpe2fs %s %s" % (dumpe2fs_opts, dev))
+            self.add_cmd_output("dumpe2fs %s %s" % (dumpe2fs_opts, dev),
+                                tags="dumpe2fs_h")
 
             if self.get_option('frag'):
                 self.add_cmd_output("e2freefrag %s" % (dev), priority=100)

--- a/sos/report/plugins/firewalld.py
+++ b/sos/report/plugins/firewalld.py
@@ -38,16 +38,16 @@ class FirewallD(Plugin, RedHatPlugin):
         # use a 10s timeout to workaround dbus problems in
         # docker containers.
         self.add_cmd_output([
-            "firewall-cmd --list-all-zones",
             "firewall-cmd --direct --get-all-chains",
             "firewall-cmd --direct --get-all-rules",
             "firewall-cmd --direct --get-all-passthroughs",
+            "firewall-cmd --get-log-denied",
+            "firewall-cmd --list-all-zones",
             "firewall-cmd --permanent --list-all-zones",
             "firewall-cmd --permanent --direct --get-all-chains",
             "firewall-cmd --permanent --direct --get-all-rules",
             "firewall-cmd --permanent --direct --get-all-passthroughs",
-            "firewall-cmd --state",
-            "firewall-cmd --get-log-denied"
+            "firewall-cmd --state"
         ], timeout=10, cmd_as_tag=True)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -72,7 +72,9 @@ class Foreman(Plugin):
         self.add_file_tags({
             '/var/log/foreman/production.log.*': 'foreman_production_log',
             '/etc/sysconfig/foreman-tasks': 'foreman_tasks_config',
-            '/etc/sysconfig/dynflowd': 'foreman_tasks_config'
+            '/etc/sysconfig/dynflowd': 'foreman_tasks_config',
+            '/var/log/httpd/foreman-ssl_access_ssl.log':
+                'foreman_ssl_access_ssl_log'
         })
 
         self.add_forbidden_path([
@@ -118,7 +120,6 @@ class Foreman(Plugin):
         ])
 
         self.add_cmd_output([
-            'hammer ping',
             'foreman-selinux-relabel -nv',
             'passenger-status --show pool',
             'passenger-status --show requests',
@@ -130,6 +131,7 @@ class Foreman(Plugin):
             'ping -c1 -W1 %s' % _host_f,
             'ping -c1 -W1 localhost'
         ])
+        self.add_cmd_output("hammer ping", tags="hammer_ping")
 
         # Dynflow Sidekiq
         self.add_cmd_output('systemctl list-units dynflow*',

--- a/sos/report/plugins/foreman_installer.py
+++ b/sos/report/plugins/foreman_installer.py
@@ -88,10 +88,10 @@ class RedHatForemanInstaller(ForemanInstaller, RedHatPlugin):
     def setup(self):
 
         self.add_file_tags({
-            '/var/log/foreman-installer/satellite.log.*':
-                ['insights_satellite_log' 'satellite_installer_log'],
-            '/var/log/foreman-installer/capsule.log.*':
-                ['insights_capsule_log' 'capsule_installer_log'],
+            '/var/log/foreman-installer/satellite.log':
+                ['foreman_satellite_log' 'satellite_installer_log'],
+            '/var/log/foreman-installer/capsule.log':
+                ['capsule_log' 'capsule_installer_log'],
         })
 
         super(RedHatForemanInstaller, self).setup()

--- a/sos/report/plugins/foreman_proxy.py
+++ b/sos/report/plugins/foreman_proxy.py
@@ -22,7 +22,7 @@ class ForemanProxy(Plugin):
 
     def setup(self):
         self.add_file_tags({
-            '/var/log/foreman-proxy/proxy.log.*': 'foreman_proxy_log',
+            '/var/log/foreman-proxy/proxy.log': 'foreman_proxy_log',
             '/etc/foreman-proxy/settings.yml': 'foreman_proxy_conf'
         })
 

--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -61,11 +61,10 @@ class Gluster(Plugin, RedHatPlugin):
             "/var/lib/glusterd/glusterfind/glusterfind_*_secret.pem"
         )
 
-        self.add_cmd_output([
-            "gluster peer status",
-            "gluster pool list",
-            "gluster volume status"
-        ])
+        self.add_cmd_output("gluster peer status", tags="gluster_peer_status")
+        self.add_cmd_output("gluster pool list")
+        self.add_cmd_output("gluster volume status",
+                            tags="gluster_v_status")
 
         self.add_copy_spec([
             "/etc/redhat-storage-release",
@@ -111,7 +110,8 @@ class Gluster(Plugin, RedHatPlugin):
                 state_file = state['output'].split()[-1]
                 self.add_copy_spec(state_file)
 
-        volume_cmd = self.collect_cmd_output("gluster volume info")
+        volume_cmd = self.collect_cmd_output("gluster volume info",
+                                             tags="gluster_v_info")
         if volume_cmd['status'] == 0:
             for line in volume_cmd['output'].splitlines():
                 if not line.startswith("Volume Name:"):

--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -21,7 +21,8 @@ class Grub2(Plugin, IndependentPlugin):
 
         self.add_file_tags({
             '/boot/grub2/grub.cfg': 'grub2_cfg',
-            '/boot/efi/.*/grub.cfg': 'grub2_efi_cfg'
+            '/boot/efi/.*/grub.cfg': 'grub2_efi_cfg',
+            '/boot/grub2/grubenv': 'grubenv'
         })
 
         self.add_copy_spec([

--- a/sos/report/plugins/hardware.py
+++ b/sos/report/plugins/hardware.py
@@ -30,7 +30,8 @@ class Hardware(Plugin, IndependentPlugin):
             "/sys/class/drm/*/edid"
         ])
 
-        self.add_cmd_output("dmidecode", root_symlink="dmidecode")
+        self.add_cmd_output("dmidecode", root_symlink="dmidecode",
+                            tags="dmidecode")
         self.add_cmd_output("lshw")
 
 

--- a/sos/report/plugins/host.py
+++ b/sos/report/plugins/host.py
@@ -30,14 +30,14 @@ class Host(Plugin, IndependentPlugin):
 
         self.add_forbidden_path('/etc/sos/cleaner')
 
-        self.add_cmd_output('hostname', root_symlink='hostname')
-        self.add_cmd_output('uptime', root_symlink='uptime')
-
+        self.add_cmd_output('hostname', root_symlink='hostname',
+                            tags=['hostname_default', 'hostname_short'])
+        self.add_cmd_output('hostname -f', tags='hostname')
+        self.add_cmd_output('uptime', root_symlink='uptime', tags="uptime")
         self.add_cmd_output('find / -maxdepth 2 -type l -ls',
                             root_symlink='root-symlinks')
 
         self.add_cmd_output([
-            'hostname -f',
             'hostid',
             'hostnamectl status'
         ])

--- a/sos/report/plugins/i18n.py
+++ b/sos/report/plugins/i18n.py
@@ -21,6 +21,6 @@ class I18n(Plugin, IndependentPlugin):
             "/etc/X11/xinit/xinput.d/*",
             "/etc/locale.conf"
         ])
-        self.add_cmd_output("locale", env={'LC_ALL': None})
+        self.add_cmd_output("locale", env={'LC_ALL': None}, tags="locale")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -162,10 +162,17 @@ class Ipa(Plugin, RedHatPlugin):
         getcert_pred = SoSPredicate(self,
                                     services=['certmonger'])
 
-        self.add_cmd_output("getcert list", pred=getcert_pred)
+        self.add_cmd_output("getcert list", pred=getcert_pred,
+                            tags="getcert_list")
 
         for certdb_directory in glob("/etc/dirsrv/slapd-*/"):
             self.add_cmd_output("certutil -L -d %s" % certdb_directory)
+
+        self.add_file_tags({
+            "/var/log/ipa/healthcheck/healthcheck.log":
+                "freeipa_healthcheck_log"
+        })
+
         return
 
     def postproc(self):

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -30,9 +30,11 @@ class KDump(Plugin):
             "/sys/kernel/fadump_registered",
             "/sys/kernel/fadump/registered",
             "/sys/kernel/fadump/mem_reserved",
-            "/sys/kernel/kexec_crash_loaded",
             "/sys/kernel/kexec_crash_size"
         ])
+
+        self.add_copy_spec("/sys/kernel/kexec_crash_loaded",
+                           tags="kexec_crash_loaded")
 
 
 class RedHatKDump(KDump, RedHatPlugin):
@@ -71,10 +73,11 @@ class RedHatKDump(KDump, RedHatPlugin):
         self.add_copy_spec([
             "/etc/kdump.conf",
             "/etc/udev/rules.d/*kexec.rules",
-            "/var/crash/*/vmcore-dmesg.txt",
             "/var/crash/*/kexec-dmesg.log",
             "/var/log/kdump.log"
         ])
+        self.add_copy_spec("/var/crash/*/vmcore-dmesg.txt",
+                           tags="vmcore_dmesg")
         try:
             path = self.read_kdump_conffile()
         except Exception:

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -43,8 +43,8 @@ class Kernel(Plugin, IndependentPlugin):
 
     def setup(self):
         # compat
-        self.add_cmd_output("uname -a", root_symlink="uname")
-        self.add_cmd_output("lsmod", root_symlink="lsmod")
+        self.add_cmd_output("uname -a", root_symlink="uname", tags="uname")
+        self.add_cmd_output("lsmod", root_symlink="lsmod", tags="lsmod")
         self.add_cmd_output("ls -lt /sys/kernel/slab")
 
         try:
@@ -70,9 +70,9 @@ class Kernel(Plugin, IndependentPlugin):
 
         self.add_cmd_output([
             "dmesg",
-            "sysctl -a",
             "dkms status"
         ], cmd_as_tag=True)
+        self.add_cmd_output("sysctl -a", tags="sysctl")
 
         clocksource_path = "/sys/devices/system/clocksource/clocksource0/"
 

--- a/sos/report/plugins/krb5.py
+++ b/sos/report/plugins/krb5.py
@@ -30,9 +30,9 @@ class Krb5(Plugin):
             "/etc/krb5.conf.d/*",
             f"{self.kdcdir}/kadm5.acl",
             f"{self.kdcdir}/kdc.conf",
-            "/var/log/krb5kdc.log",
             "/var/log/kadmind.log"
         ])
+        self.add_copy_spec("/var/log/krb5kdc.log", tags="kerberos_kdc_log")
         self.add_cmd_output(f"klist -ket {self.kdcdir}/.k5*")
         self.add_cmd_output("klist -ket /etc/krb5.keytab")
 

--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -73,6 +73,11 @@ class Libvirt(Plugin, IndependentPlugin):
             for pf in ["environ", "cgroup", "maps", "numa_maps", "limits"]:
                 self.add_copy_spec("/proc/%s/%s" % (pid, pf))
 
+        self.add_file_tags({
+            "/run/libvirt/qemu/*.xml": "var_qemu_xml",
+            "/var/log/libvirt/qemu/*.log": "libvirtd_qemu_log"
+        })
+
     def postproc(self):
         match_exp = r"(\s*passwd=\s*')([^']*)('.*)"
         libvirt_path_exps = [

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -63,7 +63,8 @@ class Logs(Plugin, IndependentPlugin):
         journal = any([self.path_exists(self.path_join(p, "log/journal/"))
                        for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
-            self.add_journal(since=since, tags='journal_full', priority=100)
+            self.add_journal(since=since, tags=['journal_full', 'journal_all'],
+                             priority=100)
             self.add_journal(boot="this", since=since,
                              tags='journal_since_boot')
             self.add_journal(boot="last", since=since,

--- a/sos/report/plugins/lvm2.py
+++ b/sos/report/plugins/lvm2.py
@@ -63,7 +63,7 @@ class Lvm2(Plugin, IndependentPlugin):
 
         self.add_cmd_output(
             "vgdisplay -vv %s" % lvm_opts_foreign,
-            root_symlink="vgdisplay"
+            root_symlink="vgdisplay", tags="vgdisplay"
         )
 
         pvs_cols = 'pv_mda_free,pv_mda_size,pv_mda_count,pv_mda_used_count'
@@ -72,12 +72,16 @@ class Lvm2(Plugin, IndependentPlugin):
         vgs_cols = vgs_cols + ',' + 'vg_tags,systemid'
         lvs_cols = ('lv_tags,devices,lv_kernel_read_ahead,lv_read_ahead,'
                     'stripes,stripesize')
-        self.add_cmd_output([
-            "vgscan -vvv %s" % lvm_opts,
-            "pvscan -v %s" % lvm_opts,
+        self.add_cmd_output("lvs -a -o +%s %s" % (lvs_cols, lvm_opts_foreign),
+                            tags="lvs_headings")
+        self.add_cmd_output(
             "pvs -a -v -o +%s %s" % (pvs_cols, lvm_opts_foreign),
-            "vgs -v -o +%s %s" % (vgs_cols, lvm_opts_foreign),
-            "lvs -a -o +%s %s" % (lvs_cols, lvm_opts_foreign)
+            tags="pvs_headings")
+        self.add_cmd_output("vgs -v -o +%s %s" % (vgs_cols, lvm_opts_foreign),
+                            tags="vgs_headings")
+        self.add_cmd_output([
+            "pvscan -v %s" % lvm_opts,
+            "vgscan -vvv %s" % lvm_opts
         ])
 
         self.add_copy_spec("/etc/lvm")

--- a/sos/report/plugins/md.py
+++ b/sos/report/plugins/md.py
@@ -23,7 +23,8 @@ class Md(Plugin, IndependentPlugin):
             for line in mdadm_members['output'].splitlines():
                 if 'linux_raid_member' in line:
                     dev = line.split()[0]
-                    self.add_cmd_output('mdadm -E /dev/%s' % dev)
+                    self.add_cmd_output('mdadm -E /dev/%s' % dev,
+                                        tags="mdadm_E")
 
         self.add_copy_spec([
             "/etc/mdadm.conf",

--- a/sos/report/plugins/memcached.py
+++ b/sos/report/plugins/memcached.py
@@ -26,7 +26,8 @@ class RedHatMemcached(Memcached, RedHatPlugin):
 
     def setup(self):
         super(RedHatMemcached, self).setup()
-        self.add_copy_spec("/etc/sysconfig/memcached")
+        self.add_copy_spec("/etc/sysconfig/memcached",
+                           tags="sysconfig_memcached")
 
 
 class DebianMemcached(Memcached, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/multipath.py
+++ b/sos/report/plugins/multipath.py
@@ -19,7 +19,7 @@ class Multipath(Plugin, IndependentPlugin):
     def setup(self):
 
         self.add_cmd_tags({
-            'multipath -v4 -ll': 'insights_multipath__v4__ll'
+            'multipath -v4 -ll': 'multipath__v4__ll'
         })
 
         self.add_copy_spec("/etc/multipath.conf", tags='multipath_conf')

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -242,6 +242,24 @@ class Networking(Plugin):
                         ns_cmd_prefix + "ethtool -S %(dev)s"
                     ], devices=_devs['ethernet'], priority=50, subdir=_subdir)
 
+        self.add_cmd_tags({
+            "ethtool [^-].*": "ethtool",
+            "ethtool -S.*": "ethtool_S",
+            "ethtool -T.*": "ethtool_T",
+            "ethtool -a.*": "ethtool_a",
+            "ethtool -c.*": "ethtool_c",
+            "ethtool -g.*": "ethtool_g",
+            "ethtool -i.*": "ethtool_i",
+            "ethtool -k.*": "ethtool_k",
+            "ip -d address": "ip_addr",
+            "ip -s -s neigh show": "ip_neigh_show",
+            "ip route show table all": "iproute_show_table_all",
+            "ip -s -d link": "ip_s_link",
+            "netstat.*-neopa": "netstat",
+            "netstat.*-agn": "netstat_agn",
+            "netstat -s": "netstat_s"
+        })
+
 
 class RedHatNetworking(Networking, RedHatPlugin):
     trace_host = "rhn.redhat.com"

--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -99,6 +99,11 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
                 devices='ethernet'
             )
 
+        self.add_cmd_tags({
+            "nmcli dev show": "nmcli_dev_show",
+            "nmcli dev show .*": "nmcli_dev_show_sos"
+        })
+
     def postproc(self):
         for root, dirs, files in os.walk(
                 "/etc/NetworkManager/system-connections"):

--- a/sos/report/plugins/openstack_ceilometer.py
+++ b/sos/report/plugins/openstack_ceilometer.py
@@ -37,6 +37,11 @@ class OpenStackCeilometer(Plugin):
             self.var_puppet_gen + "/etc/ceilometer/*"
         ])
 
+        self.add_file_tags({
+            "/var/log/ceilometer/central.log":
+                "ceilometer_central_log"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/ceilometer/*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/report/plugins/openstack_glance.py
+++ b/sos/report/plugins/openstack_glance.py
@@ -72,6 +72,13 @@ class OpenStackGlance(Plugin):
             else:
                 self.add_cmd_output("openstack image list --long")
 
+        self.add_file_tags({
+            "/etc/glance/glance-api.conf": "glance_api_conf",
+            "/etc/glance/glance-cache.conf": "glance_cache_conf",
+            "/etc/glance/glance-registry.conf": "glance_registry_conf",
+            "/var/log/glance/api.log": "glance_api_log"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/glance/*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/report/plugins/openstack_heat.py
+++ b/sos/report/plugins/openstack_heat.py
@@ -79,6 +79,10 @@ class OpenStackHeat(Plugin):
             self.var_puppet_gen + "_api_cfn/var/spool/cron/heat",
         ])
 
+        self.add_file_tags({
+            "/var/log/heat/heat-engine.log": "heat_engine_log"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub(
             "/etc/heat/*",

--- a/sos/report/plugins/openstack_instack.py
+++ b/sos/report/plugins/openstack_instack.py
@@ -51,6 +51,10 @@ class OpenStackInstack(Plugin):
                 "/var/log/zaqar/*.log",
             ])
 
+        self.add_file_tags({
+            "/var/log/mistral/executor.log": "mistral_executor_log"
+        })
+
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]
 

--- a/sos/report/plugins/openstack_ironic.py
+++ b/sos/report/plugins/openstack_ironic.py
@@ -110,6 +110,10 @@ class OpenStackIronic(Plugin):
             for path in ['/var/lib/ironic', '/httpboot', '/tftpboot']:
                 self.add_cmd_output('ls -laRt %s' % path)
 
+        self.add_file_tags({
+            ".*/etc/ironic/ironic.conf": "ironic_conf"
+        })
+
         vars_all = [p in os.environ for p in [
                     'OS_USERNAME', 'OS_PASSWORD']]
 

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -75,6 +75,11 @@ class OpenStackKeystone(Plugin):
             self.add_cmd_output("openstack endpoint list")
             self.add_cmd_output("openstack catalog list")
 
+        self.add_file_tags({
+            ".*/etc/keystone/keystone.conf": "keystone_conf",
+            "/var/log/keystone/keystone.log": "keystone_log"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/keystone/*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/report/plugins/openstack_manila.py
+++ b/sos/report/plugins/openstack_manila.py
@@ -46,6 +46,10 @@ class OpenStackManila(Plugin):
                 "/var/log/manila/*.log",
             ])
 
+        self.add_file_tags({
+            ".*/etc/manila/manila.conf": "manila_conf"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/manila/*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/report/plugins/openstack_neutron.py
+++ b/sos/report/plugins/openstack_neutron.py
@@ -63,6 +63,11 @@ class OpenStackNeutron(Plugin):
             self.add_cmd_output("openstack floating ip list")
             self.add_cmd_output("openstack security group list")
 
+        self.add_file_tags({
+            ".*/etc/neutron/plugins/ml2/ml2_conf.ini": "neutronml2_conf",
+            "/var/log/neutron/server.log": "neutron_server_log"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub("/etc/neutron/*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/report/plugins/openstack_octavia.py
+++ b/sos/report/plugins/openstack_octavia.py
@@ -46,6 +46,10 @@ class OpenStackOctavia(Plugin):
             self.var_puppet_gen + "/etc/my.cnf.d/tripleo.cnf",
         ])
 
+        self.add_file_tags({
+            ".*/etc/octavia/octavia.conf": "octavia_conf"
+        })
+
         # don't collect certificates
         self.add_forbidden_path("/etc/octavia/certs")
         self.add_forbidden_path(self.var_config_data + "/etc/octavia/certs")

--- a/sos/report/plugins/openstack_swift.py
+++ b/sos/report/plugins/openstack_swift.py
@@ -40,6 +40,11 @@ class OpenStackSwift(Plugin):
             self.var_puppet_gen + "/memcached/etc/sysconfig/memcached"
         ])
 
+        self.add_file_tags({
+            "/etc/swift/swift.conf": "swift_conf",
+            "/var/log/swift/swift.log": "swift_log"
+        })
+
     def apply_regex_sub(self, regexp, subst):
         self.do_path_regex_sub(r"/etc/swift/.*\.conf.*", regexp, subst)
         self.do_path_regex_sub(

--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -85,10 +85,14 @@ class OpenVSwitch(Plugin):
         if ovs_dbdir:
             self.add_copy_spec(self.path_join(ovs_dbdir, 'conf.db'))
 
+        self.add_file_tags({
+            "/var/log/openvswitch/ovs-vswitchd.log":
+                "openvswitch_daemon_log",
+            "/var/log/openvswitch/ovsdb-server.log":
+                "openvswitch_server_log"
+        })
+
         self.add_cmd_output([
-            # The '-t 5' adds an upper bound on how long to wait to connect
-            # to the Open vSwitch server, avoiding hangs when running sos.
-            "ovs-vsctl -t 5 show",
             # List the contents of important runtime directories
             "ls -laZ /run/openvswitch",
             "ls -laZ /dev/hugepages/",
@@ -116,8 +120,6 @@ class OpenVSwitch(Plugin):
             "ovs-appctl tnl/ports/show -v",
             # Capture upcall information
             "ovs-appctl upcall/show",
-            # Capture DPDK and other parameters
-            "ovs-vsctl -t 5 get Open_vSwitch . other_config",
             # Capture OVS list
             "ovs-vsctl -t 5 list Open_vSwitch",
             # Capture OVS interface list
@@ -149,6 +151,13 @@ class OpenVSwitch(Plugin):
             # Capture miniflow extract implementations
             "ovs-appctl dpif-netdev/miniflow-parser-get"
         ])
+        # Capture DPDK and other parameters
+        self.add_cmd_output("ovs-vsctl -t 5 get Open_vSwitch . other_config",
+                            tags="openvswitch_other_config")
+        # The '-t 5' adds an upper bound on how long to wait to connect
+        # to the Open vSwitch server, avoiding hangs when running sos.
+        self.add_cmd_output("ovs-vsctl -t 5 show",
+                            tags="ovs_vsctl_show")
 
         # Gather systemd services logs
         self.add_journal(units="openvswitch")

--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -165,6 +165,15 @@ class Ovirt(Plugin, RedHatPlugin):
             "/var/lib/ovirt-engine-reports/jboss_runtime/config"
         ])
 
+        self.add_file_tags({
+            "/etc/ovirt-engine/engine.conf.d/.*":
+                "ovirt_engine_confd",
+            "/var/log/ovirt-engine/boot.log":
+                "ovirt_engine_boot_log",
+            "/var/log/ovirt-engine/console.log":
+                "ovirt_engine_console_log"
+        })
+
         # Copying host certs; extra copy the hidden .truststore file
         self.add_forbidden_path([
             "/etc/pki/ovirt-engine/keys",

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -44,14 +44,14 @@ class Pacemaker(Plugin):
     def setup_pcs(self):
         self.add_copy_spec("/var/log/pcsd/pcsd.log")
         self.add_cmd_output([
-            "pcs config",
-            "pcs status --full",
             "pcs stonith sbd status --full",
             "pcs stonith sbd watchdog list",
             "pcs stonith history show",
-            "pcs quorum status",
             "pcs property list --all"
         ])
+        self.add_cmd_output("pcs config", tags="pcs_config")
+        self.add_cmd_output("pcs quorum status", tags="pcs_quorum_status")
+        self.add_cmd_output("pcs status --full", tags="pcs_status")
 
     def postproc_crm_shell(self):
         self.do_cmd_output_sub(

--- a/sos/report/plugins/pci.py
+++ b/sos/report/plugins/pci.py
@@ -34,7 +34,8 @@ class Pci(Plugin, IndependentPlugin):
         ])
 
         if self.check_for_bus_devices():
-            self.add_cmd_output("lspci -nnvv", root_symlink="lspci")
+            self.add_cmd_output("lspci -nnvv", root_symlink="lspci",
+                                tags="lspci")
             self.add_cmd_output("lspci -tv")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -57,7 +57,7 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.add_cmd_tags({
             'podman images': 'podman_list_images',
-            'podman ps.*': 'podman_list_containers'
+            'podman ps': 'podman_list_containers'
         })
 
         subcmds = [

--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -60,13 +60,13 @@ class Process(Plugin, IndependentPlugin):
 
         self.add_cmd_output("ps auxwwwm", root_symlink="ps",
                             tags=['ps_aux', 'ps_auxww', 'ps_auxwww',
-                                  'ps_auxwwwm', 'insights_ps_auxcww'],
+                                  'ps_auxwwwm', 'ps_auxcww'],
                             priority=1)
 
         self.add_cmd_output("pstree -lp", root_symlink="pstree")
         if self.get_option("lsof"):
             self.add_cmd_output("lsof +M -n -l -c ''", root_symlink="lsof",
-                                timeout=15, priority=50)
+                                timeout=15, priority=50, tags="lsof")
 
         if self.get_option("lsof-threads"):
             self.add_cmd_output("lsof +M -n -l", timeout=15, priority=50)

--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -28,7 +28,9 @@ class Processor(Plugin, IndependentPlugin):
             "%s/vulnerabilities/.*" % cpupath: 'cpu_vulns',
             "%s/vulnerabilities/spectre_v2" % cpupath: 'cpu_vulns_spectre_v2',
             "%s/vulnerabilities/meltdown" % cpupath: 'cpu_vulns_meltdown',
-            "%s/cpu.*/online" % cpupath: 'cpu_cores'
+            "%s/cpu.*/online" % cpupath: 'cpu_cores',
+            "%s/cpu/cpu0/cpufreq/cpuinfo_max_freq" % cpupath:
+                'cpuinfo_max_freq'
         })
 
         self.add_copy_spec([
@@ -46,9 +48,9 @@ class Processor(Plugin, IndependentPlugin):
         self.add_cmd_output([
             "lscpu",
             "lscpu -ae",
+            "cpupower frequency-info",
             "cpupower info",
             "cpupower idle-info",
-            "cpupower frequency-info",
             "cpufreq-info",
             "cpuid",
             "cpuid -r",

--- a/sos/report/plugins/pulp.py
+++ b/sos/report/plugins/pulp.py
@@ -131,10 +131,13 @@ class Pulp(Plugin, RedHatPlugin):
         self.add_cmd_output(prun, suggest_filename="pulp-running_tasks")
         self.add_cmd_output(csizes, suggest_filename="mongo-collection_sizes")
         self.add_cmd_output(dbstats, suggest_filename="mongo-db_stats")
-        self.add_cmd_output([
-            "qpid-stat -%s --ssl-certificate=%s -b amqps://localhost:5671" %
-            (opt, self.messaging_cert_file) for opt in "quc"
-        ])
+
+        for opt in "quc":
+            self.add_cmd_output(
+                f"qpid-stat -{opt} --ssl-certificate="
+                f"{self.messaging_cert_file} -b amqps://localhost:5671",
+                tags=f"qpid_stat_{opt}")
+
         self.add_cmd_output(
             "sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' "
             "DJANGO_SETTINGS_MODULE='pulpcore.app.settings' dynaconf list",

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -38,10 +38,11 @@ class Puppet(Plugin, IndependentPlugin):
             "/var/lib/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/certs/ca.pem",
-            "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
             "/etc/puppetlabs/puppet/ssl/certs/{}.pem".format(_hostname),
             "/var/lib/puppet/ssl/certs/{}.pem".format(_hostname),
         ])
+        self.add_copy_spec("/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+                           tags="puppet_ssl_cert_ca_pem")
 
         self.add_cmd_output([
             'facter',

--- a/sos/report/plugins/rabbitmq.py
+++ b/sos/report/plugins/rabbitmq.py
@@ -36,7 +36,8 @@ class RabbitMQ(Plugin, IndependentPlugin):
                 self.add_cmd_output(
                     'rabbitmqctl report',
                     container=container,
-                    foreground=True
+                    foreground=True,
+                    tags="rabbitmq_report"
                 )
                 self.add_cmd_output(
                     "rabbitmqctl eval 'rabbit_diagnostics:maybe_stuck().'",
@@ -59,6 +60,11 @@ class RabbitMQ(Plugin, IndependentPlugin):
         self.add_copy_spec([
             "/var/log/rabbitmq/*",
         ])
+
+        self.add_file_tags({
+            "/var/log/rabbitmq/rabbit@.*[^-sasl].log": "rabbitmq_logs",
+            "/var/log/rabbitmq/startup_err": "rabbitmq_startup_err"
+        })
 
         # Crash dump can be large in some situation but it is useful to
         # investigate why rabbitmq crashes. So capture the file without

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -54,7 +54,7 @@ class Rpm(Plugin, RedHatPlugin):
             self.add_cmd_output("rpm -Va", root_symlink="rpm-Va",
                                 timeout=900, priority=100,
                                 tags=['rpm_va', 'rpm_V', 'rpm_v',
-                                      'insights_rpm_V_packages'])
+                                      'rpm_V_packages'])
 
         if self.get_option("rpmdb"):
             self.add_cmd_output("lsof +D /var/lib/rpm",

--- a/sos/report/plugins/samba.py
+++ b/sos/report/plugins/samba.py
@@ -33,8 +33,8 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
         if self.get_option("all_logs"):
             self.add_copy_spec("/var/log/samba/")
 
+        self.add_cmd_output("testparm -s", tags="testparm_s")
         self.add_cmd_output([
-            "testparm -s",
             "wbinfo --domain='.' --domain-users",
             "wbinfo --domain='.' --domain-groups",
             "wbinfo --trusted-domains --verbose",

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -47,7 +47,8 @@ class Scsi(Plugin, IndependentPlugin):
                     devsg = line.split()[-1]
                     self.add_cmd_output("sg_ses -p2 -b1 %s" % devsg)
 
-        self.add_cmd_output("lsscsi -i", suggest_filename="lsscsi")
+        self.add_cmd_output("lsscsi -i", suggest_filename="lsscsi",
+                            tags="lsscsi")
 
         self.add_cmd_output([
             "sg_map -x",

--- a/sos/report/plugins/services.py
+++ b/sos/report/plugins/services.py
@@ -40,7 +40,8 @@ class RedHatServices(Services, RedHatPlugin):
 
     def setup(self):
         super(RedHatServices, self).setup()
-        self.add_cmd_output("/sbin/chkconfig --list", root_symlink="chkconfig")
+        self.add_cmd_output("chkconfig --list", root_symlink="chkconfig",
+                            tags="chkconfig")
 
 
 class DebianServices(Services, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -57,12 +57,15 @@ class SubscriptionManager(Plugin, RedHatPlugin):
             "/var/lib/rhsm/",
             "/var/log/rhsm/rhsm.log",
             "/var/log/rhsm/rhsmcertd.log"])
+        self.add_cmd_output("subscription-manager identity",
+                            tags="subscription_manager_id")
+        self.add_cmd_output("subscription-manager list --consumed",
+                            tags="subscription_manager_list_consumed")
+        self.add_cmd_output("subscription-manager list --installed",
+                            tags="subscription_manager_installed")
         self.add_cmd_output([
-            "subscription-manager list --installed",
             "subscription-manager list --available",
             "subscription-manager list --all --available",
-            "subscription-manager list --consumed",
-            "subscription-manager identity",
             "subscription-manager release --show",
             "subscription-manager release --list",
             "syspurpose show",

--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -24,36 +24,36 @@ class Systemd(Plugin, IndependentPlugin):
     def setup(self):
 
         self.add_file_tags({
-            '/etc/systemd/journald.conf.*': 'insights_etc_journald_conf',
-            '/usr/lib/systemd/journald.conf.*': 'insights_usr_journald_conf_d',
-            '/etc/systemd/system.conf': 'insights_systemd_system_conf',
-            '/etc/systemd/logind.conf': 'insights_systemd_logind_conf'
+            '/etc/systemd/journald.conf': 'etc_journald_conf',
+            '/usr/lib/systemd/journald.conf': 'usr_journald_conf_d',
+            '/etc/systemd/system.conf': 'systemd_system_conf',
+            '/etc/systemd/logind.conf': 'systemd_logind_conf'
         })
 
         self.add_cmd_output([
-            "systemctl status --all",
-            "systemctl show --all",
-            "systemctl show *service --all",
+            "journalctl --list-boots",
+            "ls -lR /lib/systemd",
+            "systemctl list-dependencies",
+            "systemctl list-jobs",
+            "systemctl list-machines",
+            "systemctl list-unit-files",
+            "systemctl list-units",
+            "systemctl list-units --all",
+            "systemctl list-units --failed",
+            "systemctl list-timers --all",
             # It is possible to do systemctl show with target, slice,
             # device, socket, scope, and mount too but service and
             # status --all mostly seems to cover the others.
-            "systemctl list-units",
-            "systemctl list-units --failed",
-            "systemctl list-units --all",
-            "systemctl list-unit-files",
-            "systemctl list-jobs",
-            "systemctl list-dependencies",
-            "systemctl list-timers --all",
-            "systemctl list-machines",
+            "systemctl show --all",
+            "systemctl show *service --all",
             "systemctl show-environment",
+            "systemctl status --all",
             "systemd-delta",
             "systemd-analyze",
             "systemd-analyze blame",
             "systemd-analyze dump",
-            "systemd-inhibit --list",
-            "journalctl --list-boots",
-            "ls -lR /lib/systemd"
-        ])
+            "systemd-inhibit --list"
+        ], cmd_as_tag=True)
 
         self.add_cmd_output('timedatectl', root_symlink='date')
 

--- a/sos/report/plugins/teamd.py
+++ b/sos/report/plugins/teamd.py
@@ -24,10 +24,13 @@ class Teamd(Plugin, IndependentPlugin):
             "/usr/lib/systemd/system/teamd@.service"
         ])
 
+        self.add_device_cmd("teamdctl %(dev)s config dump", devices="team",
+                            tags="teamdctl_config_dump")
+        self.add_device_cmd("teamdctl %(dev)s state dump", devices="team",
+                            tags="teamdctl_state_dump")
+
         self.add_device_cmd([
             "teamdctl %(dev)s state",
-            "teamdctl %(dev)s state dump",
-            "teamdctl %(dev)s config dump",
             "teamnl %(dev)s option",
             "teamnl %(dev)s ports"
         ], devices='team')

--- a/sos/report/plugins/tomcat.py
+++ b/sos/report/plugins/tomcat.py
@@ -38,6 +38,12 @@ class Tomcat(Plugin, RedHatPlugin):
         else:
             self.add_copy_spec("/var/log/tomcat*/*")
 
+        self.add_file_tags({
+            "/etc/tomcat.*/web.xml": "tomcat_web_xml",
+            "/var/log/tomcat.*/catalina.out": "catalina_out",
+            "/var/log/tomcat.*/catalina.*.log": "catalina_server_log"
+        })
+
     def postproc(self):
         serverXmlPasswordAttributes = ['keyPass', 'keystorePass',
                                        'truststorePass', 'SSLPassword']

--- a/sos/report/plugins/tuned.py
+++ b/sos/report/plugins/tuned.py
@@ -19,18 +19,19 @@ class Tuned(Plugin, RedHatPlugin):
     plugin_name = 'tuned'
 
     def setup(self):
+        self.add_cmd_output("tuned-adm list",
+                            tags="tuned_adm")
         self.add_cmd_output([
-            "tuned-adm list",
             "tuned-adm active",
             "tuned-adm recommend",
             "tuned-adm verify"
         ])
-        self.add_copy_spec([
-            "/etc/tuned.conf",
-            "/etc/tune-profiles"
-        ])
+
+        self.add_copy_spec("/etc/tuned.conf",
+                           tags="tuned_conf")
         self.add_copy_spec([
             "/etc/tuned",
+            "/etc/tune-profiles",
             "/usr/lib/tuned",
             "/var/log/tuned/tuned.log"
         ])

--- a/sos/report/plugins/udev.py
+++ b/sos/report/plugins/udev.py
@@ -23,4 +23,9 @@ class Udev(Plugin, IndependentPlugin):
             "/etc/udev/rules.d/*"
         ])
 
+        self.add_file_tags({
+            "/etc/udev/rules.d/70-persistent-net.rules":
+                "udev_persistent_net_rules"
+        })
+
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/vdsm.py
+++ b/sos/report/plugins/vdsm.py
@@ -85,6 +85,12 @@ class Vdsm(Plugin, RedHatPlugin):
             '/var/lib/vdsm',
         ])
 
+        self.add_file_tags({
+            "/etc/vdsm/vdsm.conf": "vdsm_conf",
+            "/etc/vdsm/vdsm.id": "vdsm_id",
+            "/var/log/vdsm/import/import-*.log": "vdsm_import_log"
+        })
+
         qemu_pids = self.get_process_pids('qemu-kvm')
         if qemu_pids:
             files = ["cmdline", "status", "mountstats"]

--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -29,7 +29,6 @@ class LibvirtClient(Plugin, IndependentPlugin):
 
         # get host information
         subcmds = [
-            'list --all',
             'domcapabilities',
             'capabilities',
             'nodeinfo',
@@ -45,6 +44,9 @@ class LibvirtClient(Plugin, IndependentPlugin):
 
         for subcmd in subcmds:
             self.add_cmd_output('%s %s' % (cmd, subcmd), foreground=True)
+
+        self.add_cmd_output("%s list --all" % cmd,
+                            tags="virsh_list_all", foreground=True)
 
         # get network, pool and nwfilter elements
         for k in ['net', 'nwfilter', 'pool']:

--- a/sos/report/plugins/vmware.py
+++ b/sos/report/plugins/vmware.py
@@ -34,6 +34,10 @@ class VMWare(Plugin, RedHatPlugin):
             "/var/log/vmware-vmusr-root.log"
         ])
 
+        self.add_file_tags({
+            "/etc/vmware-tools/tools.conf": "vmware_tools_conf"
+        })
+
         self.add_cmd_output([
             "vmware-checkvm",
             "vmware-toolbox-cmd device list",

--- a/sos/report/plugins/xfs.py
+++ b/sos/report/plugins/xfs.py
@@ -30,7 +30,8 @@ class Xfs(Plugin, IndependentPlugin):
         for dev in zip(self.do_regex_find_all(ext_fs_regex, mounts)):
             for e in dev:
                 parts = e.split(' ')
-                self.add_cmd_output("xfs_info %s" % (parts[1]))
+                self.add_cmd_output("xfs_info %s" % (parts[1]),
+                                    tags="xfs_info")
                 self.add_cmd_output("xfs_admin -l -u %s" % (parts[0]))
 
         self.add_copy_spec([


### PR DESCRIPTION
* Added missing tags for plugins to match insights spec names, so they can be queried by insights when loading an archive. This will aid in spec loading via the manifest instead of defining the specs individually as we do now.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?