### PR TITLE
[snap][testing] Fix bionic snap runtime

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -167,6 +167,7 @@ report_stageone_task:
             apt -y install python3-pip snapd
             systemctl start snapd
             snap install ./sosreport_test_amd64.snap --classic --dangerous
+            snap alias sosreport.sos sos
         fi
         if [ $(command -v dnf) ]; then
             echo "$ARTCURL/rpm%20Build%20From%20Checkout%20-%20${BUILD_NAME}/packages/sos_${BUILD_NAME}.rpm"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ parts:
       - setuptools
       - wheel
       - python_magic
+      - packaging
 
 apps:
   sos:

--- a/sos/collector/clusters/pacemaker.py
+++ b/sos/collector/clusters/pacemaker.py
@@ -11,7 +11,7 @@
 import re
 
 from sos.collector.clusters import Cluster
-from setuptools._vendor.packaging import version
+from sos.utilities import parse_version
 from xml.etree import ElementTree
 
 
@@ -63,7 +63,7 @@ class pacemaker(Cluster):
         _ver = self.exec_primary_cmd('crm_mon --version')
         if _ver['status'] == 0:
             cver = _ver['output'].split()[1].split('-')[0]
-            if not version.parse(cver) > version.parse('2.0.3'):
+            if not parse_version(cver) > parse_version('2.0.3'):
                 xmlopt = '--as-xml'
         else:
             return

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -14,7 +14,6 @@ import logging
 import os
 import re
 
-from pkg_resources import parse_version
 from pipes import quote
 from sos.policies import load
 from sos.policies.init_systems import InitSystem
@@ -26,6 +25,7 @@ from sos.collector.exceptions import (CommandTimeoutException,
                                       ConnectionException,
                                       UnsupportedHostException,
                                       InvalidTransportException)
+from sos.utilities import parse_version
 
 TRANSPORTS = {
     'local': LocalTransport,

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -22,6 +22,11 @@ import io
 from contextlib import closing
 from collections import deque
 
+try:
+    from pkg_resources import parse_version as version_parse
+except SyntaxError:
+    from packaging.version import parse as version_parse
+
 # try loading magic>=0.4.20 which implements detect_from_filename method
 magic_mod = False
 try:
@@ -404,6 +409,12 @@ def recursive_dict_values_by_key(dobj, keys=[]):
         _items.extend(dobj)
 
     return [d for d in _items if d not in _filt]
+
+
+def parse_version(version):
+    """Parse the version string
+    """
+    return version_parse(version)
 
 
 class FakeReader():


### PR DESCRIPTION
When the snap is being packaged via core22, it used python3.10
but bionic used python3.6 and seems have runtime issues there.

Added the sos alias for testing, to ensure that when the stage
one testing is done, that sos is correctly tested within the
snap

This alternative ensures that the packaging module is packaged
in the snap, and can use this if the pkg_resources version does
not work

Add a wrapper function in utlities, so that the parse_version
can be used in a consistent way across the sos project

Closes: #3126

Signed-off-by: Arif Ali <arif.ali@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?