### PR TITLE
[ovn_central] Remove duplicate commands

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -131,10 +131,6 @@ class OVNCentral(Plugin):
             'ovn-nbctl --no-leader-only show',
             'ovn-nbctl --no-leader-only get-ssl',
             'ovn-nbctl --no-leader-only get-connection',
-            'ovn-nbctl --no-leader-only list loadbalancer',
-            'ovn-nbctl --no-leader-only list Load_Balancer',
-            'ovn-nbctl --no-leader-only list ACL',
-            'ovn-nbctl --no-leader-only list Logical_Switch_Port',
         ]
 
         sbctl_cmds = [
@@ -161,8 +157,9 @@ class OVNCentral(Plugin):
         cmds += sbctl_cmds
 
         # If OVN is containerized, we need to run the above commands inside
-        # the container.
-
+        # the container. Removing duplicates (in case there are) to avoid
+        # failing on collecting output to file on container running commands
+        cmds = list(set(cmds))
         self.add_cmd_output(
             cmds, foreground=True, container=self._container_name
         )


### PR DESCRIPTION
When a list of command are sent to run on a container the output is
printed to file on sos_commands/<plugin> folder, but also a symbolic
link is created from the sos_container/<container> file to the
sos_commands/<plugin> file. When a command is duplicated, we get an
exception on the plugin and the rest of commands are not executed.

This patch removes some hardcoded commands, and clean the list from
duplicated commands before sending to the container.

Signed-off-by: Fernando Royo <froyo@redhat.com>
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?