### PR TITLE
[Plugin] Avoid overwrite existing symbolic link for a command output

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -16,7 +16,7 @@ from sos.utilities import (sos_get_command_output, import_module, grep,
                            listdir, path_join, bold, file_is_binary,
                            recursive_dict_values_by_key)
 
-from sos.archive import P_FILE
+from sos.archive import P_FILE, P_LINK
 import contextlib
 import os
 import glob
@@ -2645,8 +2645,11 @@ class Plugin():
         cmdfn = self._mangle_command(cmd)
         conlnk = "%s/%s" % (_cdir, cmdfn)
 
-        self.archive.check_path(conlnk, P_FILE)
-        os.symlink(_outloc, self.archive.dest_path(conlnk))
+        # If check_path return None, it means that the sym link already exits,
+        # so to avoid Error 17, trying to recreate, we will skip creation and
+        # trust on the existing sym link (e.g. duplicate command)
+        if self.archive.check_path(conlnk, P_LINK):
+            os.symlink(_outloc, self.archive.dest_path(conlnk))
 
         manifest['filepath'] = conlnk
         self.manifest.containers[container]['commands'].append(manifest)


### PR DESCRIPTION
Every output of a command run on a container is saved in the 
sos_commands folder, also additionally a symbolic link is created from 
the sos_container folder to link the container where it was run to the 
output file. When there is a duplicated command on the list to be run 
on the container, the symbolic link creation will fail due to file 
already exists error.

To avoid this error we can trust on the check_path 
method, that will give us a clue avoid if the file already exists or 
not to continue with the symbolic link creation.

Closes #3131

Signed-off-by: Fernando Royo <froyo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?