### PR TITLE
[report] Allow users to constrain sos process priority

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -33,6 +33,7 @@ sos report \- Collect and package diagnostic and support data
           [--skip-commands commands]\fR
           [--skip-files files]\fR
           [--allow-system-changes]\fR
+          [--low-priority]\fR
           [-z|--compression-type method]\fR
           [--encrypt]\fR
           [--encrypt-key KEY]\fR
@@ -230,6 +231,11 @@ for example \fB/etc/sos/*\fR.
 .B \--allow-system-changes
 Run commands even if they can change the system (e.g. load kernel modules).
 .TP
+.B \--low-priority
+Set sos to execute as a low priority process so that is does not interfere with
+other processes running on the system. Specific distributions may set their own
+constraints, but by default this involves setting process niceness to 19 and, if
+available, setting an idle IO class via ionice.
 .B \-z, \--compression-type METHOD
 Override the default compression type specified by the active policy.
 .TP

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -95,6 +95,7 @@ class SoSCollector(SoSComponent):
         'label': '',
         'list_options': False,
         'log_size': 0,
+        'low_priority': False,
         'map_file': '/etc/sos/cleaner/default_mapping',
         'primary': '',
         'namespaces': None,
@@ -309,6 +310,8 @@ class SoSCollector(SoSComponent):
         sos_grp.add_argument('--log-size', default=0, type=int,
                              help='Limit the size of individual logs '
                                   '(not journals) in MiB')
+        sos_grp.add_argument('--low-priority', action='store_true',
+                             default=False, help='Run reports as low priority')
         sos_grp.add_argument('-n', '--skip-plugins', action="extend",
                              help='Skip these plugins')
         sos_grp.add_argument('-o', '--only-plugins', action="extend",

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -648,6 +648,8 @@ class SosNode():
         if self.check_sos_version('4.5.2'):
             if self.opts.journal_size:
                 sos_opts.append(f"--journal-size={self.opts.journal_size}")
+            if self.opts.low_priority:
+                sos_opts.append('--low-priority')
 
         self.update_cmd_from_cluster()
 

--- a/tests/report_tests/low_priority_tests.py
+++ b/tests/report_tests/low_priority_tests.py
@@ -1,0 +1,33 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from os.path import exists
+from sos_tests import StageOneReportTest
+
+
+class LowPrioTest(StageOneReportTest):
+    """
+    Ensures that --low-priority properly sets our defined constraints on our
+    own process
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '--low-priority -o kernel'
+
+    def test_ionice_class_set(self):
+        _class = self.manifest['components']['report']['priority']['io_class']
+        if exists('/usr/bin/ionice'):
+            self.assertSosLogContains('Set IO class to idle')
+            self.assertEqual(_class, 'idle')
+        else:
+            self.assertEqual(_class, 'unknown')
+
+    def test_niceness_set(self):
+        self.assertSosLogContains('Set niceness of report to 19')
+        self.assertEqual(self.manifest['components']['report']['priority']['niceness'], 19)


### PR DESCRIPTION
Adds a new `--low-priority` option to report, which will attempt to constrain the process priority for the report generation. We do this by attempting to set ourselves to an 'idle' IO class, as well as setting our niceness to 19 to avoid contending for CPU time.

This is also exposed via `sos collect`, however users should note that this will not be effective until the sos-4.5.1 release.

Closes: #3127

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?