### PR TITLE
[mutter] Add a new mutter plugin

### DIFF
--- a/sos/report/plugins/mutter.py
+++ b/sos/report/plugins/mutter.py
@@ -1,0 +1,42 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+
+from pathlib import Path
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Mutter(Plugin, IndependentPlugin):
+
+    short_desc = 'GNOME X11 window manager and Wayland compositor'
+
+    plugin_name = 'mutter'
+    profiles = ('desktop',)
+    packages = ('mutter',)
+
+    def setup(self):
+        # Get the monitors.xml file that persists the monitor setup
+        monitors_xml = os.path.join(Path.home(), '.config', 'monitors.xml')
+        self.add_copy_spec(monitors_xml)
+
+        # Call mutter's DisplayConfig.GetCurrentState() to get even more info.
+        # Note that both of these calls do the same thing, but one can be
+        # parsed into a GVariant, while the other is easier to read immediately
+        self.add_cmd_output('gdbus call -e '
+                            '-d org.gnome.Mutter.DisplayConfig '
+                            '-o /org/gnome/Mutter/DisplayConfig '
+                            '-m org.gnome.Mutter.DisplayConfig.GetCurrentState'
+                            )
+        self.add_cmd_output('dbus-send --session --print-reply '
+                            '--dest=org.gnome.Mutter.DisplayConfig '
+                            '/org/gnome/Mutter/DisplayConfig '
+                            'org.gnome.Mutter.DisplayConfig.GetCurrentState'
+                            )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Mutter provides useful information about the monitors it knows about, which can be useful when debugging issues related to resolutions, used connectors, etc.

Signed-off-by: Niels De Graef <ndegraef@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?