### PR TITLE
[tests] Add test for AD username obfuscation

### DIFF
--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -14,6 +14,7 @@ from sos.cleaner.parsers.mac_parser import SoSMacParser
 from sos.cleaner.parsers.hostname_parser import SoSHostnameParser
 from sos.cleaner.parsers.keyword_parser import SoSKeywordParser
 from sos.cleaner.parsers.ipv6_parser import SoSIPv6Parser
+from sos.cleaner.parsers.username_parser import SoSUsernameParser
 from sos.cleaner.mappings.ip_map import SoSIPMap
 from sos.cleaner.mappings.mac_map import SoSMacMap
 from sos.cleaner.mappings.hostname_map import SoSHostnameMap
@@ -156,6 +157,8 @@ class CleanerParserTests(unittest.TestCase):
         self.kw_parser = SoSKeywordParser(config={}, keywords=['foobar'])
         self.kw_parser_none = SoSKeywordParser(config={})
         self.kw_parser.generate_item_regexes()
+        self.uname_parser = SoSUsernameParser(config={},
+                                              opt_names=['DOMAIN\myusername'])
 
     def test_ip_parser_valid_ipv4_line(self):
         line = 'foobar foo 10.0.0.1/24 barfoo bar'
@@ -266,3 +269,8 @@ class CleanerParserTests(unittest.TestCase):
         logln = 'Automatically imported trusted_ca::ca from trusted_ca/ca into production'
         log_test = self.ipv6_parser.parse_line(logln)[0]
         self.assertEqual(logln, log_test, "IPv6 parser incorrectly matched a log line of 'trusted_ca::ca'")
+
+    def test_ad_username(self):
+        line = "DOMAIN\myusername"
+        _test = self.uname_parser.parse_line(line)[0]
+        self.assertNotEqual(line, _test)


### PR DESCRIPTION
Add unit test for #3030.

Relevant: #3030
Resolves: #3135

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?