### PR TITLE
[tests] Add test for #3071

### DIFF
--- a/tests/cleaner_tests/basic_function_tests/report_with_mask.py
+++ b/tests/cleaner_tests/basic_function_tests/report_with_mask.py
@@ -60,7 +60,14 @@ class ReportWithCleanedKeywords(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '--clean -o filesys,kernel --keywords=fstab,Linux'
+    sos_cmd = '--clean -o filesys,kernel --keywords=fstab,Linux,tmp'
+
+    # Will the 'tmp' be properly treated in path to working dir without raising an error?
+    # To make this test effective, we assume the test runs on a system / with Policy
+    # returning '/var/tmp' as temp.dir
+    def test_keyword_in_tempdir_path(self):
+        self.assertOutputContains('Your sosreport has been generated and saved in:')
+        self.assertTrue('tmp/' in self.archive)
 
     # Ok, sort of cheesy here but this does actually test filename changes on
     # a file common to all distros


### PR DESCRIPTION
Add test for #3071 : Prevent obfuscating tmpDir

Resolves: #3136

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?