### PR TITLE
[tests] Add version consistency test

### DIFF
--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -6,8 +6,9 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-
-from sos_tests import StageOneReportTest
+from avocado.core.exceptions import TestSkipError
+from avocado.utils import process
+from sos_tests import StageOneReportTest, redhat_only
 
 
 class NormalSoSReport(StageOneReportTest):
@@ -42,6 +43,15 @@ class NormalSoSReport(StageOneReportTest):
             isinstance(self.manifest['components']['report']['tag_summary'], dict),
             "Tag summary malformed"
         )
+
+    @redhat_only
+    def test_version_matches_package(self):
+        if not self.params.get('TESTLOCAL') == 'true':
+            raise TestSkipError("Not testing local package installation")
+        _pkg_ver = process.run('rpm -q sos').stdout.decode().split('-')[1]
+        self.assertSosUILogContains(f"(version {_pkg_ver})")
+        self.assertEqual(self.manifest['version'], _pkg_ver)
+
 
 class LogLevelTest(StageOneReportTest):
     """


### PR DESCRIPTION
Commits a downstream test from RHEL to ensure that a given release has a consistent version string in the UI report, manifest, and most importantly for the package nvr for an sos package built from the current branch. Note that this test is only implemented for RPM installations at this time.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?