### PR TITLE
[rhui] Obfuscate registry_password in rhui-tools.conf

### DIFF
--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -47,6 +47,10 @@ class Rhui(Plugin, RedHatPlugin):
                 r"/root/\.rhui/answers.yaml.*",
                 r"(\s*rhui_manager_password\s*:)\s*(\S+)",
                 r"\1********")
+        # hide registry_password value in rhui-tools.conf
+        self.do_path_regex_sub("/etc/rhui/rhui-tools.conf",
+                               r"(registry_password:)\s*(.+)",
+                               r"\1 ********")
         # obfuscate twoo cookies for login session
         for cookie in ["csrftoken", "sessionid"]:
             self.do_path_regex_sub(


### PR DESCRIPTION
Scrub registry_password value in /etc/rhui/rhui-tools.conf

Relevant: rhbz#2170893
Resolves: #3138

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?