### PR TITLE
[rhui] Obfuscate registry_password from answers files

### DIFF
--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -45,7 +45,7 @@ class Rhui(Plugin, RedHatPlugin):
         # hide rhui_manager_password value in (also rotated) answers file
         self.do_path_regex_sub(
                 r"/root/\.rhui/answers.yaml.*",
-                r"(\s*rhui_manager_password\s*:)\s*(\S+)",
+                r"(\s*(rhui_manager|registry)_password\s*:)\s*(\S+)",
                 r"\1********")
         # hide registry_password value in rhui-tools.conf
         self.do_path_regex_sub("/etc/rhui/rhui-tools.conf",


### PR DESCRIPTION
registry_passwords occur in rhui-tools.conf (#3138) but also in (backups of) answers.yaml files.

Relevant: #3138
Resolves: #3140

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?