### PR TITLE
[report] Print work outcome even in quiet mode

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -331,6 +331,12 @@ class SoSComponent():
 
         self.archive.set_debug(self.opts.verbosity > 2)
 
+    def add_ui_log_to_stdout(self):
+        ui_console = logging.StreamHandler(sys.stdout)
+        ui_console.setFormatter(logging.Formatter('%(message)s'))
+        ui_console.setLevel(logging.INFO)
+        self.ui_log.addHandler(ui_console)
+
     def _setup_logging(self):
         """Creates the log handler that shall be used by all components and any
         and all related bits to those components that need to log either to the
@@ -381,10 +387,7 @@ class SoSComponent():
             self.ui_log.addHandler(ui_fhandler)
 
         if not self.opts.quiet:
-            ui_console = logging.StreamHandler(sys.stdout)
-            ui_console.setFormatter(logging.Formatter('%(message)s'))
-            ui_console.setLevel(logging.INFO)
-            self.ui_log.addHandler(ui_console)
+            self.add_ui_log_to_stdout()
 
     def get_temp_file(self):
         return self.tempfile_util.new()

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1531,6 +1531,12 @@ class SoSReport(SoSComponent):
                 short_name='manifest.json'
             )
 
+        # Now, just (optionally) pack the report and print work outcome; let
+        # print ui_log to stdout also in quiet mode. For non-quiet mode we
+        # already added the handler
+        if self.opts.quiet:
+            self.add_ui_log_to_stdout()
+
         # print results in estimate mode (to include also just added manifest)
         if self.opts.estimate_only:
             from sos.utilities import get_human_readable


### PR DESCRIPTION
sos report should print generated sosreport directory or tarball or etimate of size even with --quiet option.

Resolves: #3142
Closes: #3143

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?