### PR TITLE
[composer] Capure /etc/osbuild-composer file

### DIFF
--- a/sos/report/plugins/composer.py
+++ b/sos/report/plugins/composer.py
@@ -35,10 +35,11 @@ class Composer(Plugin, IndependentPlugin):
             "/etc/osbuild-composer/osbuild-composer.toml",
             "/etc/osbuild-worker/osbuild-worker.toml",
             "/etc/lorax/composer.conf",
+            "/etc/osbuild-composer",
             "/var/log/lorax-composer/composer.log",
             "/var/log/lorax-composer/dnf.log",
             "/var/log/lorax-composer/program.log",
-            "/var/log/lorax-composer/server.log",
+            "/var/log/lorax-composer/server.log"
         ])
         blueprints = self._get_entries("composer-cli blueprints list")
         for blueprint in blueprints:


### PR DESCRIPTION
/etc/osbuild-composer contains customizations users create for Image Builder. This directory
is not currently owned by any package but if present, it, and all files inside, should be 
gathered as well.

Related: RHBZ#2169776

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?