### PR TITLE
[ssh/control_persist] Add option to set ControlPath directory

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -121,6 +121,7 @@ class SoSCollector(SoSComponent):
         'ssh_key': '',
         'ssh_port': 22,
         'ssh_user': 'root',
+        'ssh_control_path_dir': '',
         'timeout': 600,
         'transport': 'auto',
         'verify': False,
@@ -405,6 +406,9 @@ class SoSCollector(SoSComponent):
                                  help='Specify a sos preset to use')
         collect_grp.add_argument('--ssh-user',
                                  help='Specify an SSH user. Default root')
+        collect_grp.add_argument('--ssh-control-path-dir',
+                                 help='Override the SSH ControlPath directory.'
+                                      ' Default is under tmp-dir')
         collect_grp.add_argument('--timeout', type=int, required=False,
                                  help='Timeout for sosreport on each node.')
         collect_grp.add_argument('--transport', default='auto', type=str,

--- a/sos/collector/transports/control_persist.py
+++ b/sos/collector/transports/control_persist.py
@@ -95,8 +95,9 @@ class SSHControlPersist(RemoteTransport):
                            "Please update your OpenSSH installation.")
             raise
         self.log_info('Opening SSH session to create control socket')
-        self.control_path = ("%s/.sos-collector-%s" % (self.tmpdir,
-                                                       self.address))
+        self.control_path = ("%s/.sos-collector-%s" %
+                             (self.opts.ssh_control_path_dir or self.tmpdir,
+                              self.address))
         self.ssh_cmd = ''
         connected = False
         ssh_key = ''


### PR DESCRIPTION
The directory currently defaults to something under tmp-dir.
Allow this to be set since this is limited to 100 characters total.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?