### PR TITLE
[frr] Add vtysh command collection

### DIFF
--- a/sos/report/plugins/frr.py
+++ b/sos/report/plugins/frr.py
@@ -10,6 +10,14 @@ from sos.report.plugins import Plugin, RedHatPlugin
 
 
 class Frr(Plugin, RedHatPlugin):
+    """
+    FRR is a routing project that provides numerous traditional routing
+    protocols for Linux platforms. In particular, OpenStack uses FRR to provide
+    BGP functionality for the overcloud nodes.
+
+    This plugin is primarily designed the deployment of FRR within OSP
+    environments, which deploy FRR in a container.
+    """
 
     short_desc = 'Frr routing service'
 
@@ -18,8 +26,30 @@ class Frr(Plugin, RedHatPlugin):
 
     files = ('/etc/frr/zebra.conf',)
     packages = ('frr',)
+    containers = ('frr',)
 
     def setup(self):
         self.add_copy_spec("/etc/frr/")
+
+        if self.container_exists('frr'):
+            subcmds = [
+                'show bgp detail',
+                'show bgp neighbors',
+                'show bgp summary',
+                'show history',
+                'show ip bgp detail',
+                'show ip bgp neighbors',
+                'show ip bgp summary',
+                'show ip bgp',
+                'show ip route',
+                'show ipv6 route',
+                'show running-config',
+                'show version',
+            ]
+
+            self.add_cmd_output(
+                [f"vtysh -c '{subcmd}'" for subcmd in subcmds],
+                container='frr'
+            )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
FRR is deployed in a container for certain (RH)OSP deployments. As such, the `frr` plugin should attempt to collect various command outputs from that container if it exists.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?