### PR TITLE
[lvm2] Capture the contents of /run/lvm

### DIFF
--- a/sos/report/plugins/lvm2.py
+++ b/sos/report/plugins/lvm2.py
@@ -85,6 +85,7 @@ class Lvm2(Plugin, IndependentPlugin):
         ])
 
         self.add_copy_spec("/etc/lvm")
+        self.add_copy_spec("/run/lvm")
 
         if self.get_option('lvmdump'):
             self.do_lvmdump()


### PR DESCRIPTION
The directory /run/lvm contains information about
LVM autoactivation, and the files inside it
can help debug issues where an LV or a VG is not
being activated even after running commands
to explicitly do so.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?