### PR TITLE
[microshift] Fix microshift get and add commands

### DIFF
--- a/sos/report/plugins/microshift.py
+++ b/sos/report/plugins/microshift.py
@@ -86,9 +86,10 @@ class Microshift(Plugin, RedHatPlugin):
 
     def _get_namespaces(self):
         res = self.exec_cmd(
-            'microshift get namespaces'
+            'oc get namespaces'
             ' -o custom-columns=NAME:.metadata.name'
-            ' --no-headers')
+            ' --no-headers'
+            ' --kubeconfig=%s' % self.get_option('kubeconfig'))
         if res['status'] == 0:
             return self._reduce_namespace_list(res['output'].split('\n'))
         return []
@@ -146,6 +147,10 @@ class Microshift(Plugin, RedHatPlugin):
         which is used to retrieve all API resources from the cluster.
         """
         self.add_forbidden_path('/var/lib/microshift')
+        self.add_cmd_output([
+            'microshift version',
+            'microshift show-config -m effective'
+        ])
 
         _cluster_resources_to_collect = ",".join(
             self._get_cluster_resources())


### PR DESCRIPTION
Use `oc get` instead of `microshift get`, which got dropped before the release.
Add `show-config` and `version` commands to the report.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?