### PR TITLE
[report] Ignore case when scrubbing via do_file_sub

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1284,7 +1284,8 @@ class Plugin():
             content = readable.read()
             if not isinstance(content, str):
                 content = content.decode('utf8', 'ignore')
-            result, replacements = re.subn(regexp, subst, content)
+            result, replacements = re.subn(regexp, subst, content,
+                                           flags=re.IGNORECASE)
             if replacements:
                 self.archive.add_string(result, srcpath)
             else:

--- a/sos/report/plugins/candlepin.py
+++ b/sos/report/plugins/candlepin.py
@@ -128,7 +128,7 @@ class Candlepin(Plugin, RedHatPlugin):
         self.do_file_sub("/var/log/candlepin/cpdb.log", cpdbreg, repl)
         for key in ["trustStorePassword", "keyStorePassword"]:
             self.do_file_sub("/etc/candlepin/broker.xml",
-                             r"%s=(\w*)([;<])" % key,
-                             r"%s=********\2" % key)
+                             r"(%s)=(\w*)([;<])" % key,
+                             r"\1=********\3")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/cman.py
+++ b/sos/report/plugins/cman.py
@@ -53,7 +53,7 @@ class Cman(Plugin, RedHatPlugin):
             self.do_file_sub(
                 cluster_conf,
                 r"(\s*\<fencedevice\s*.*\s*passwd\s*=\s*)\S+(\")",
-                r"\1%s" % ('"***"')
+                r'\1"***"'
             )
 
         self.do_path_regex_sub(

--- a/sos/report/plugins/foreman_installer.py
+++ b/sos/report/plugins/foreman_installer.py
@@ -56,8 +56,8 @@ class ForemanInstaller(Plugin, DebianPlugin, UbuntuPlugin):
         # also hide passwords in yet different formats
         self.do_path_regex_sub(
             install_logs,
-            r"(\.|_|-)password(=\'|=|\", \")(\w*)",
-            r"\1password\2********")
+            r"((\.|_|-)password(=\'|=|\", \"))(\w*)",
+            r"\1********")
         self.do_path_regex_sub(
             "/var/log/foreman-installer/foreman-proxy*",
             r"(\s*proxy_password\s=) (.*)",

--- a/sos/report/plugins/fwupd.py
+++ b/sos/report/plugins/fwupd.py
@@ -34,14 +34,14 @@ class Fwupd(Plugin, IndependentPlugin):
     def postproc(self):
         self.do_path_regex_sub(
             "/etc/fwupd/remotes.d/*",
-            r"Password=(.*)",
-            r"Password=********"
+            r"(Password)=(.*)",
+            r"\1=********"
         )
 
         self.do_file_sub(
             "/etc/fwupd/redfish.conf",
-            r"Password=(.*)",
-            r"Password=********"
+            r"(Password)=(.*)",
+            r"\1=********"
         )
 
 

--- a/sos/report/plugins/gnocchi.py
+++ b/sos/report/plugins/gnocchi.py
@@ -59,18 +59,8 @@ class Gnocchi(Plugin):
     def postproc(self):
         self.do_file_sub(
             "/etc/gnocchi/gnocchi.conf",
-            r"ceph_secret\s?=(.*)",
-            r"ceph_secret=*****",
-        )
-        self.do_file_sub(
-            "/etc/gnocchi/gnocchi.conf",
-            r"password\s?=(.*)",
-            r"password=*****",
-        )
-        self.do_file_sub(
-            "/etc/gnocchi/gnocchi.conf",
-            r"memcache_secret_key\s?=(.*)",
-            r"memcache_secret_key=*****",
+            r"(ceph_secret|password|memcache_secret_key)\s?=(.*)",
+            r"\1=*****",
         )
 
 
@@ -100,8 +90,8 @@ class RedHatGnocchi(Gnocchi, RedHatPlugin):
         self.do_file_sub(
             self.var_puppet_gen + "/etc/gnocchi/"
             "gnocchi.conf",
-            r"password=(.*)",
-            r"password=*****",
+            r"(ceph_secret|password|memcache_secret_key)\s?=(.*)",
+            r"\1=*****",
         )
 
 

--- a/sos/report/plugins/landscape.py
+++ b/sos/report/plugins/landscape.py
@@ -45,55 +45,17 @@ class Landscape(Plugin, UbuntuPlugin):
             r"registration_password(.*)",
             r"registration_password[********]"
         )
-        self.do_file_sub(
-            "/etc/landscape/service.conf",
-            r"password = (.*)",
-            r"password = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf",
-            r"store_password = (.*)",
-            r"store_password = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf",
-            r"secret-token = (.*)",
-            r"secret-token = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf",
-            r"oidc-client-secret = (.*)",
-            r"oidc-client-secret = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf",
-            r"oidc-client-id = (.*)",
-            r"oidc-client-id = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf.old",
-            r"password = (.*)",
-            r"password = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf.old",
-            r"store_password = (.*)",
-            r"store_password = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf.old",
-            r"secret-token = (.*)",
-            r"secret-token = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf.old",
-            r"oidc-client-secret = (.*)",
-            r"oidc-client-secret = [********]"
-        )
-        self.do_file_sub(
-            "/etc/landscape/service.conf.old",
-            r"oidc-client-id = (.*)",
-            r"oidc-client-id = [********]"
+        keys = [
+            "password",
+            "store_password",
+            "secret-token",
+            "oidc-client-secret",
+            "oidc-client-id",
+        ]
+        self.do_path_regex_sub(
+            "/etc/landscape/service.conf*",
+            r"(%s) = (.*)" % "|".join(keys),
+            r"\1 = [********]"
         )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ldap.py
+++ b/sos/report/plugins/ldap.py
@@ -51,16 +51,12 @@ class RedHatLdap(Ldap, RedHatPlugin):
 
     def postproc(self):
         super(RedHatLdap, self).postproc()
-        self.do_file_sub(
-            "/etc/nslcd.conf",
-            r"(\s*bindpw\s*)\S+",
-            r"\1********"
-        )
-        self.do_file_sub(
-            "/etc/pam_ldap.conf",
-            r"(\s*bindpw\s*)\S+",
-            r"\1********"
-        )
+        for f in ["/etc/nslcd.conf", "/etc/pam_ldap.conf"]:
+            self.do_file_sub(
+                f,
+                r"(\s*bindpw\s*)\S+",
+                r"\1********"
+            )
 
 
 class DebianLdap(Ldap, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -97,13 +97,8 @@ class Logs(Plugin, IndependentPlugin):
     def postproc(self):
         self.do_path_regex_sub(
             r"/etc/rsyslog*",
-            r"ActionLibdbiPassword (.*)",
-            r"ActionLibdbiPassword [********]"
-        )
-        self.do_path_regex_sub(
-            r"/etc/rsyslog*",
-            r"pwd=.*",
-            r"pwd=[******]"
+            r"(ActionLibdbiPassword |pwd=)(.*)",
+            r"\1[********]"
         )
 
 

--- a/sos/report/plugins/mongodb.py
+++ b/sos/report/plugins/mongodb.py
@@ -37,17 +37,13 @@ class MongoDb(Plugin, DebianPlugin, UbuntuPlugin):
         self.add_cmd_output("du -sh /var/lib/mongodb/")
 
     def postproc(self):
-        self.do_file_sub(
-            "/etc/mongodb.conf",
-            r"(mms-token\s*=\s*.*)",
-            r"mms-token = ********"
-        )
-
-        self.do_file_sub(
-            self.var_puppet_gen + "/etc/mongodb.conf",
-            r"(mms-token\s*=\s*.*)",
-            r"mms-token = ********"
-        )
+        for f in ["/etc/mongodb.conf",
+                  self.var_puppet_gen + "/etc/mongodb.conf"]:
+            self.do_file_sub(
+                f,
+                r"(mms-token)\s*=\s*(.*)",
+                r"\1 = ********"
+            )
 
 
 class RedHatMongoDb(MongoDb, RedHatPlugin):

--- a/sos/report/plugins/monit.py
+++ b/sos/report/plugins/monit.py
@@ -43,29 +43,13 @@ class Monit(Plugin, RedHatPlugin):
         for file in self.monit_conf:
             # Remove username:password from files
             self.do_file_sub(file,
-                             r"allow (.*):(.*)",
-                             r"allow ********:********"
-                             )
-            self.do_file_sub(file,
-                             r"ALLOW (.*):(.*)",
-                             r"ALLOW ********:********"
+                             r"(allow) (.*):(.*)",
+                             r"\1 ********:********"
                              )
             # Remove MAILSERVER username/password
             self.do_file_sub(file,
-                             r"username (\w)+",
-                             r"username ********"
-                             )
-            self.do_file_sub(file,
-                             r"password (\w)+",
-                             r"password ********"
-                             )
-            self.do_file_sub(file,
-                             r"USERNAME (\w)+",
-                             r"USERNAME ********"
-                             )
-            self.do_file_sub(file,
-                             r"PASSWORD (\w)+",
-                             r"PASSWORD ********"
+                             r"(username|password) (\w)+",
+                             r"\1 ********"
                              )
 
 # vim: et ts=4 sw=4

--- a/sos/report/plugins/openhpi.py
+++ b/sos/report/plugins/openhpi.py
@@ -24,7 +24,7 @@ class OpenHPI(Plugin, RedHatPlugin):
 
     def postproc(self):
         self.do_file_sub("/etc/openhpi/openhpi.conf",
-                         r'(\s*[Pp]ass.*\s*=\s*).*', r'\1********')
+                         r'(\s*pass.*\s*=\s*).*', r'\1********')
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openstack_horizon.py
+++ b/sos/report/plugins/openstack_horizon.py
@@ -51,22 +51,11 @@ class OpenStackHorizon(Plugin):
         ]
 
         regexp = r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys)
-        self.do_path_regex_sub(
-            r"/etc/openstack-dashboard/.*\.json",
-            regexp, r"\1*********"
-        )
-        self.do_path_regex_sub(
-            var_puppet_gen + r"/etc/openstack-dashboard/.*\.json",
-            regexp, r"\1*********"
-        )
-        self.do_path_regex_sub(
-            "/etc/openstack-dashboard/local_settings$",
-            regexp, r"\1*********"
-        )
-        self.do_path_regex_sub(
-            var_puppet_gen + "/etc/openstack-dashboard/local_settings$",
-            regexp, r"\1*********"
-        )
+        for regpath in [r"/etc/openstack-dashboard/.*\.json",
+                        "/etc/openstack-dashboard/local_settings$"]:
+            self.do_path_regex_sub(regpath, regexp, r"\1*********")
+            self.do_path_regex_sub(var_puppet_gen + regpath,
+                                   regexp, r"\1*********")
 
 
 class DebianHorizon(OpenStackHorizon, DebianPlugin):

--- a/sos/report/plugins/openstack_instack.py
+++ b/sos/report/plugins/openstack_instack.py
@@ -113,27 +113,25 @@ class OpenStackInstack(Plugin):
                                 "tripleo-ui-logs tripleo-ui.logs --file -")
 
     def postproc(self):
+        # do_file_sub is case insensitive, so protected_keys can be lowercase
+        # only
         protected_keys = [
-            "UNDERCLOUD_TUSKAR_PASSWORD", "UNDERCLOUD_ADMIN_PASSWORD",
-            "UNDERCLOUD_CEILOMETER_METERING_SECRET",
-            "UNDERCLOUD_CEILOMETER_PASSWORD",
-            "UNDERCLOUD_CEILOMETER_SNMPD_PASSWORD",
-            "UNDERCLOUD_DB_PASSWORD", "UNDERCLOUD_GLANCE_PASSWORD",
-            "UNDERCLOUD_HEAT_PASSWORD",
-            "UNDERCLOUD_HEAT_STACK_DOMAIN_ADMIN_PASSWORD",
-            "UNDERCLOUD_HORIZON_SECRET_KEY", "UNDERCLOUD_IRONIC_PASSWORD",
-            "UNDERCLOUD_NEUTRON_PASSWORD", "UNDERCLOUD_NOVA_PASSWORD",
-            "UNDERCLOUD_RABBIT_PASSWORD", "UNDERCLOUD_SWIFT_PASSWORD",
-            "UNDERCLOUD_TUSKAR_PASSWORD", "OS_PASSWORD",
-            "undercloud_db_password", "undercloud_admin_password",
-            "undercloud_glance_password", "undercloud_heat_password",
-            "undercloud_neutron_password", "undercloud_nova_password",
-            "undercloud_ironic_password", "undercloud_tuskar_password",
-            "undercloud_ceilometer_password",
+            "os_password",
+            "undercloud_admin_password",
             "undercloud_ceilometer_metering_secret",
+            "undercloud_ceilometer_password",
             "undercloud_ceilometer_snmpd_password",
-            "undercloud_swift_password", "undercloud_rabbit_password",
-            "undercloud_heat_stack_domain_admin_password"
+            "undercloud_db_password",
+            "undercloud_glance_password",
+            "undercloud_heat_password",
+            "undercloud_heat_stack_domain_admin_password",
+            "undercloud_horizon_secret_key",
+            "undercloud_ironic_password",
+            "undercloud_neutron_password",
+            "undercloud_nova_password",
+            "undercloud_rabbit_password",
+            "undercloud_swift_password",
+            "undercloud_tuskar_password",
         ]
         regexp = r"((?m)(%s)=)(.*)" % "|".join(protected_keys)
         self.do_file_sub("/home/stack/.instack/install-undercloud.log",

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -106,8 +106,11 @@ class OpenStackKeystone(Plugin):
         )
 
         # obfuscate LDAP plaintext passwords in domain config dir
-        self.do_path_regex_sub(self.domain_config_dir,
-                               r"((?m)^\s*(%s)\s*=\s*)(.*)", r"\1********")
+        self.do_path_regex_sub(
+            self.domain_config_dir,
+            r"((?m)^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"\1********"
+        )
 
 
 class DebianKeystone(OpenStackKeystone, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/openstack_novajoin.py
+++ b/sos/report/plugins/openstack_novajoin.py
@@ -25,12 +25,9 @@ class OpenStackNovajoin(Plugin):
             self.add_copy_spec("/var/log/novajoin/*.log")
 
     def postproc(self):
-        regexp = (r"(?i)password=(.*)")
+        regexp = (r"(password|memcache_secret_key)=(.*)")
         self.do_file_sub("/etc/novajoin/join.conf", regexp,
-                         r"password=*********")
-        regexp = (r"(?i)memcache_secret_key=(.*)")
-        self.do_file_sub("/etc/novajoin/join.conf", regexp,
-                         r"password=*********")
+                         r"\1=*********")
 
 
 class RedHatNovajoin(OpenStackNovajoin, RedHatPlugin):

--- a/sos/report/plugins/openstack_tripleo.py
+++ b/sos/report/plugins/openstack_tripleo.py
@@ -9,7 +9,6 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, IndependentPlugin
-import re
 
 
 class OpenStackTripleO(Plugin, IndependentPlugin):
@@ -36,11 +35,9 @@ class OpenStackTripleO(Plugin, IndependentPlugin):
         # Ensures we do not leak passwords from the tripleo-config and
         # hieradata locations.
         # Other locations don't have sensitive data.
-        secrets = r'(".*(key|password|pass|secret|database_connection))' \
-                  r'([":\s]+)(.*[^"])([",]+)'
-        rgxp = re.compile(secrets, re.IGNORECASE)
-
+        regexp = r'(".*(key|password|pass|secret|database_connection))' \
+                 r'([":\s]+)(.*[^"])([",]+)'
         for path in self.tripleo_log_paths:
-            self.do_path_regex_sub(path, rgxp, r'\1\3*********\5')
+            self.do_path_regex_sub(path, regexp, r'\1\3*********\5')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/origin.py
+++ b/sos/report/plugins/origin.py
@@ -201,14 +201,11 @@ class OpenShiftOrigin(Plugin):
                      r'|PASS|PWD|KEY|TOKEN|CRED|SECRET)[^,]*,' \
                      r'\s*"value":)[^}]*'
         self.do_cmd_output_sub('oc*json', env_regexp, r'\g<var> "********"')
-        # LDAP identity provider
+        # LDAP identity provider (bindPassword)
+        # and github/google/OpenID identity providers (clientSecret)
         self.do_file_sub(self.master_cfg,
-                         r"(bindPassword:\s*)(.*)",
-                         r'\1"********"')
-        # github/google/OpenID identity providers
-        self.do_file_sub(self.master_cfg,
-                         r"(clientSecret:\s*)(.*)",
-                         r'\1"********"')
+                         r"(bindPassword|clientSecret):\s*(.*)",
+                         r'\1:"********"')
 
 
 class AtomicOpenShift(OpenShiftOrigin, RedHatPlugin):

--- a/sos/report/plugins/rear.py
+++ b/sos/report/plugins/rear.py
@@ -39,8 +39,8 @@ class Rear(Plugin, RedHatPlugin):
     def postproc(self):
         self.do_path_regex_sub(
             '/etc/rear/*',
-            r'SSH_ROOT_PASSWORD=(.*)',
-            r'SSH_ROOT_PASSWORD=********'
+            r'(SSH_ROOT_PASSWORD)=(.*)',
+            r'\1=********'
         )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/redis.py
+++ b/sos/report/plugins/redis.py
@@ -59,13 +59,8 @@ class Redis(Plugin, SCLPlugin):
                      "/etc/opt/rh/rh-redis5/"]:
             self.do_file_sub(
                 path + "redis.conf",
-                r"(masterauth\s).*",
-                r"\1********"
-            )
-            self.do_file_sub(
-                path + "redis.conf",
-                r"(requirepass\s).*",
-                r"requirepass = ********"
+                r"(masterauth|requirepass)\s.*",
+                r"\1 ********"
             )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/saltmaster.py
+++ b/sos/report/plugins/saltmaster.py
@@ -30,7 +30,7 @@ class SaltMaster(Plugin, IndependentPlugin):
 
     def postproc(self):
         regexp = r'((?m)^\s+.*(pass|secret|(?<![A-z])key(?![A-z])).*:\ ).+$'
-        subst = r'$1******'
+        subst = r'\1******'
         self.do_path_regex_sub("/etc/salt/*", regexp, subst)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ssmtp.py
+++ b/sos/report/plugins/ssmtp.py
@@ -29,8 +29,8 @@ class Ssmtp(Plugin, RedHatPlugin):
     def postproc(self):
         self.do_file_sub(
             '/etc/ssmtp/ssmtp.conf',
-            r'AuthPass=(\S*)',
-            r'AuthPass=********'
+            r'(AuthPass)=(\S*)',
+            r'\1=********'
         )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/tomcat.py
+++ b/sos/report/plugins/tomcat.py
@@ -47,16 +47,15 @@ class Tomcat(Plugin, RedHatPlugin):
     def postproc(self):
         serverXmlPasswordAttributes = ['keyPass', 'keystorePass',
                                        'truststorePass', 'SSLPassword']
-        for attr in serverXmlPasswordAttributes:
-            self.do_path_regex_sub(
-                r"\/etc\/tomcat.*\/server.xml",
-                r"%s=(\S*)" % attr,
-                r'%s="********"' % attr
-            )
+        self.do_path_regex_sub(
+            r"\/etc\/tomcat.*\/server.xml",
+            r"(%s)=(\S*)" % "|".join(serverXmlPasswordAttributes),
+            r'\1="********"'
+        )
         self.do_path_regex_sub(
             r"\/etc\/tomcat.*\/tomcat-users.xml",
-            r"password=(\S*)",
-            r'password="********"'
+            r"(password)=(\S*)",
+            r'\1="********"'
         )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
File content substitutions done via do_file_sub will newly work case insensitive. This simplifies detection and description of sensitive content, while a risk to obfuscate a regular content is pretty low.

The change is followed by simplification of do_file_sub and do_path_regex_sub calls in individual plugins, and also making them more generic: bfuscated string should not contain explicit case-sensitive key, but \1 rather, to prevent unintentional change of case of the key.

Closes: #3070
Resolves: #3156

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?