### PR TITLE
[iprconfig] guard whole plugin by sg kmod predicate

### DIFF
--- a/sos/report/plugins/iprconfig.py
+++ b/sos/report/plugins/iprconfig.py
@@ -9,7 +9,7 @@
 # This plugin enables collection of logs for Power systems
 
 import re
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
 class IprConfig(Plugin, IndependentPlugin):
@@ -21,6 +21,13 @@ class IprConfig(Plugin, IndependentPlugin):
     architectures = ('ppc64.*',)
 
     def setup(self):
+
+        show_ioas = self.collect_cmd_output(
+                "iprconfig -c show-ioas",
+                pred=SoSPredicate(self, kmods=['sg'])
+        )
+        if not show_ioas['status'] == 0:
+            return
 
         self.add_cmd_output([
             "iprconfig -c show-config",
@@ -34,10 +41,6 @@ class IprConfig(Plugin, IndependentPlugin):
             "iprconfig -c show-slots",
             "iprconfig -c dump"
         ])
-
-        show_ioas = self.collect_cmd_output("iprconfig -c show-ioas")
-        if not show_ioas['status'] == 0:
-            return
 
         devices = []
         if show_ioas['output']:


### PR DESCRIPTION
Calling any iprconfig command loads 'sg' kernel module. So guard collecting anything from the plugin by that kmod predicate.

Resolves: #3159

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?