### PR TITLE
[cleaner] dont clean sys_tmp from final_path

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -400,8 +400,9 @@ third party.
                     cf.write(checksum)
             self.write_cleaner_log()
 
-        final_path = self.obfuscate_string(
-            os.path.join(self.sys_tmp, arc_path.split('/')[-1])
+        final_path = os.path.join(
+            self.sys_tmp,
+            self.obfuscate_string(arc_path.split('/')[-1])
         )
         shutil.move(arc_path, final_path)
         arcstat = os.stat(final_path)


### PR DESCRIPTION
When generating location of final tarball, apply cleaner obfuscation to the filename but not to the tmp path itself. Otherwise

sos clean --keywords tmp

fails in attempt to move file to nonexisting /var/obfuscatedword0 directory.

Resolves: #3160

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?