### PR TITLE
[powerpc]: To collect lparnumascore logs

### DIFF
--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -76,6 +76,9 @@ class PowerPC(Plugin, IndependentPlugin):
                 "serv_config -l",
                 "bootlist -m both -r",
                 "lparstat -i",
+                "lparnumascore",
+                "lparnumascore -c cpu -d 4",
+                "lparnumascore -c mem -d 3",
                 "ctsnap -xrunrpttr -d %s" % (ctsnap_path),
                 "lsdevinfo"
             ])


### PR DESCRIPTION
This patch is to update powerpc plugin to collect
lparnumascore logs.

lparnumascore displays the NUMA affinity score for the running LPAR.Following commands are added
lparnumascore
lparnumascore -c cpu -d 4
lparnumascore -c mem -d 3

Suggested-by: Laurent Dufour <ldufour@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?