### PR TITLE
[build] Drop old dependencies from sos.spec

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -12,8 +12,6 @@ BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: gettext
 Requires: python3-rpm
-Requires: tar
-Requires: xz
 Requires: python3-pexpect
 Recommends: python3-magic
 Recommends: python3-pyyaml


### PR DESCRIPTION
Removes the lingering dependencies on `tar` and `xz` from `sos.spec`, as we have for some time now stopped shelling out to those tools and instead have leveraged their native python modules.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?