### PR TITLE
[subscription_manager] Scrub proxy passwords from repo_server_val

### DIFF
--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -105,5 +105,16 @@ class SubscriptionManager(Plugin, RedHatPlugin):
         passwdreg = r"(proxy_password(\s)*=(\s)*)(\S+)\n"
         repl = r"\1********\n"
         self.do_path_regex_sub("/etc/rhsm/rhsm.conf", passwdreg, repl)
+        # Scrub passwords in repositories
+        # Example of scrubbing:
+        #
+        #   password=hackme
+        # To:
+        #   password=********
+        #
+        # Whitespace around '=' is allowed.
+        regexp = r"(password(\s)*=(\s)*)(\S+)\n"
+        repl = r"\1********\n"
+        self.do_path_regex_sub("/var/lib/rhsm/repo_server_val/*", regexp, repl)
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Make sure that passwords are scrubbed from files in /var/lib/rhsm/repo_server_val.

Example of scrubbing:

   proxy_password=hackme
 To:
   proxy_password=********

Whitespace around '=' is allowed.

Fixes: #3163

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?