### PR TITLE
[tests] Call cleaner with --no-update when using keywords

### DIFF
--- a/tests/cleaner_tests/basic_function_tests/report_with_mask.py
+++ b/tests/cleaner_tests/basic_function_tests/report_with_mask.py
@@ -60,7 +60,7 @@ class ReportWithCleanedKeywords(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '--clean -o filesys,kernel --keywords=fstab,Linux,tmp'
+    sos_cmd = '--clean -o filesys,kernel --keywords=fstab,Linux,tmp --no-update'
 
     # Will the 'tmp' be properly treated in path to working dir without raising an error?
     # To make this test effective, we assume the test runs on a system / with Policy

--- a/tests/vendor_tests/redhat/rhbz1950350/sos.conf
+++ b/tests/vendor_tests/redhat/rhbz1950350/sos.conf
@@ -10,7 +10,7 @@
 [clean]
 keywords = shibboleth
 domains = sosexample.com
-#no-update = true
+no-update = true
 
 [plugin_options]
 #rpm.rpmva = off


### PR DESCRIPTION
When running avocado tests in a sequence on the same host, further tests are affected by cleaner default_mapping built from obfuscating specific keywords also. Prevent adding those keywords to the mapping.

Resolves: #3165

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?