### PR TITLE
[logs] Fix loading of CosLogs variant for every distro

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -10,7 +10,7 @@ import glob
 from sos.report.plugins import Plugin, PluginOpt, IndependentPlugin, CosPlugin
 
 
-class Logs(Plugin, IndependentPlugin):
+class LogsBase(Plugin):
 
     short_desc = 'System logs'
 
@@ -102,7 +102,23 @@ class Logs(Plugin, IndependentPlugin):
         )
 
 
-class CosLogs(Logs, CosPlugin):
+class IndependentLogs(LogsBase, IndependentPlugin):
+    """
+    This plugin will collect logs traditionally considered to be "system" logs,
+    meaning those such as /var/log/messages, rsyslog, and journals that are
+    not limited to unit-specific entries.
+
+    Note that the --since option will apply to journal collections by this
+    plugin as well as the typical application to log files. Most users can
+    expect typical journal collections to include the "full" journal, as well
+    as journals limited to this boot and the previous boot.
+    """
+
+    plugin_name = "logs"
+    profiles = ('system', 'hardware', 'storage')
+
+
+class CosLogs(LogsBase, CosPlugin):
     option_list = [
         PluginOpt(name="log_days", default=3,
                   desc="the number of days logs to collect")


### PR DESCRIPTION
Previously, the way the distro tags were applied to the `Logs` and the `CosLogs` variant, the `CosLogs` plugin would be used for every distribution.

Fix this by separating an `IndependentLogs` class and marking the actual plugin content as a "base" plugin to build upon, and have the `CosLogs` plugin continue to subclass the base plugin, without inheriting the `IndependentPlugin` subclass.

Do this rather than folding the `CosLogs` plugin and `log_days` option back into the main `Logs` class as CoS seems to prefer an exported binary journal rather than the standard text output favored by other distributions.

Closes: #3166

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?