### PR TITLE
[presets] Add new 'minimal' preset

### DIFF
--- a/sos/presets/__init__.py
+++ b/sos/presets/__init__.py
@@ -106,10 +106,24 @@ NO_PRESET = 'none'
 NO_PRESET_DESC = 'Do not load a preset'
 NO_PRESET_NOTE = 'Use to disable automatically loaded presets'
 
-GENERIC_PRESETS = {
-    NO_PRESET: PresetDefaults(name=NO_PRESET, desc=NO_PRESET_DESC,
-                              note=NO_PRESET_NOTE, opts=SoSOptions())
-}
+SMALL_PRESET = 'minimal'
+SMALL_PRESET_DESC = ('Small and quick report that reduces sos report resource '
+                     'consumption')
+SMALL_PRESET_NOTE = ('May be useful for low-resource systems, but may not '
+                     'provide sufficient data for analysis')
 
+SMALL_PRESET_OPTS = SoSOptions(log_size=10, journal_size=10, plugin_timeout=30,
+                               command_timeout=30, low_priority=True)
+
+GENERIC_PRESETS = {
+    NO_PRESET: PresetDefaults(
+        name=NO_PRESET, desc=NO_PRESET_DESC, note=NO_PRESET_NOTE,
+        opts=SoSOptions()
+    ),
+    SMALL_PRESET: PresetDefaults(
+        name=SMALL_PRESET, desc=SMALL_PRESET_DESC, note=SMALL_PRESET_NOTE,
+        opts=SMALL_PRESET_OPTS
+    )
+}
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adds a new 'minimal' preset that serves to provide a minimal set of data for analysis. This involves reducing plugin/command timeouts and log/journal collection sizes. The `--low-priority` option is also enabled to further reduce system resource usage during report execution.

Close: #2686

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?