### PR TITLE
[report] Set log verbosity from presets properly

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -337,6 +337,17 @@ class SoSComponent():
         ui_console.setLevel(logging.INFO)
         self.ui_log.addHandler(ui_console)
 
+    def set_loggers_verbosity(self, verbosity):
+        if verbosity:
+            if self.flog:
+                self.flog.setLevel(logging.DEBUG)
+            if self.opts.verbosity > 1:
+                self.console.setLevel(logging.DEBUG)
+            else:
+                self.console.setLevel(logging.WARNING)
+        else:
+            self.console.setLevel(logging.WARNING)
+
     def _setup_logging(self):
         """Creates the log handler that shall be used by all components and any
         and all related bits to those components that need to log either to the
@@ -345,28 +356,20 @@ class SoSComponent():
         # main soslog
         self.soslog = logging.getLogger('sos')
         self.soslog.setLevel(logging.DEBUG)
-        flog = None
+        self.flog = None
         if not self.check_listing_options():
             self.sos_log_file = self.get_temp_file()
-            flog = logging.StreamHandler(self.sos_log_file)
-            flog.setFormatter(logging.Formatter(
+            self.flog = logging.StreamHandler(self.sos_log_file)
+            self.flog.setFormatter(logging.Formatter(
                 '%(asctime)s %(levelname)s: %(message)s'))
-            flog.setLevel(logging.INFO)
-            self.soslog.addHandler(flog)
+            self.flog.setLevel(logging.INFO)
+            self.soslog.addHandler(self.flog)
 
         if not self.opts.quiet:
-            console = logging.StreamHandler(sys.stdout)
-            console.setFormatter(logging.Formatter('%(message)s'))
-            if self.opts.verbosity:
-                if flog:
-                    flog.setLevel(logging.DEBUG)
-                if self.opts.verbosity > 1:
-                    console.setLevel(logging.DEBUG)
-                else:
-                    console.setLevel(logging.WARNING)
-            else:
-                console.setLevel(logging.WARNING)
-            self.soslog.addHandler(console)
+            self.console = logging.StreamHandler(sys.stdout)
+            self.console.setFormatter(logging.Formatter('%(message)s'))
+            self.set_loggers_verbosity(self.opts.verbosity)
+            self.soslog.addHandler(self.console)
         # still log ERROR level message to console, but only setup this handler
         # when --quiet is used, as otherwise we'll double log
         else:

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -170,10 +170,7 @@ class SoSReport(SoSComponent):
         self.opts = self.apply_options_from_cmdline(self.opts)
         if hasattr(self.preset.opts, 'verbosity') and \
                 self.preset.opts.verbosity > 0:
-            print('\nWARNING: It is not recommended to set verbosity via the '
-                  'preset as it might have\nunforseen consequences for your '
-                  'report logs.\n')
-            self._setup_logging()
+            self.set_loggers_verbosity(self.preset.opts.verbosity)
 
         self._set_directories()
 


### PR DESCRIPTION
When a loaded preset sets verbosity, we should just set it to relevant loggers without redeclaring or adding new ones.

Resolves: #3149
Closes: #3171

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?