### PR TITLE
[subscription_manager] collect subscription-manager status

### DIFF
--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -70,6 +70,7 @@ class SubscriptionManager(Plugin, RedHatPlugin):
             "subscription-manager release --list",
             "syspurpose show",
             "subscription-manager syspurpose --show",
+            "subscription-manager status",
         ], cmd_as_tag=True)
         self.add_cmd_output("rhsm-debug system --sos --no-archive "
                             "--no-subscriptions --destination %s"


### PR DESCRIPTION
Collect "subscription-manager status" mainly to detect the current Simple Content Access mode of the RHSM server.

Resolves: #3173

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?