### PR TITLE
[tests] Skip /sys/class/net/bonding_* from netdevs

### DIFF
--- a/tests/report_tests/plugin_tests/networking.py
+++ b/tests/report_tests/plugin_tests/networking.py
@@ -33,6 +33,9 @@ class NetworkingPluginTest(StageOneReportTest):
 
     def test_netdevs_properly_iterated(self):
         for dev in os.listdir('/sys/class/net'):
-            self.assertFileGlobInArchive(
-                "sos_commands/networking/ethtool_*_%s" % dev
-            )
+            # some file(s) in the dir might not be real netdevs, see e.g.
+            # https://lwn.net/Articles/142330/
+            if not dev.startswith('bonding_'):
+                self.assertFileGlobInArchive(
+                    "sos_commands/networking/ethtool_*_%s" % dev
+                )


### PR DESCRIPTION
Avocado tests generate netdevs by listing /sys/class/net which can contain also bonding_masters that does not refer to any netdev. In such a case, the test case fails.

Resolves: #3176
Closes: #3178

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?