### PR TITLE
[ceph_mgr] Gather some commands in json format

### DIFF
--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -24,6 +24,12 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
     often not configured to successfully run the `ceph` commands collected by
     this plugin. These commands are majorily `ceph daemon` commands that will
     reference discovered admin sockets under /var/run/ceph.
+
+    Users may expect to see several collections twice - once in standard output
+    from the `ceph` command, and again in JSON format. The latter of which will
+    be placed in the `json_output/` subdirectory within this plugin's directory
+    in the report archive. These JSON formatted collections are intended to
+    aid in automated analysis.
     """
 
     short_desc = 'CEPH mgr'
@@ -58,16 +64,25 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
         ])
 
         # more commands to be added later
-        self.add_cmd_output([
-            "ceph balancer status",
-            "ceph orch host ls",
-            "ceph orch device ls",
-            "ceph orch ls --export",
-            "ceph orch ps",
-            "ceph orch status --detail",
-            "ceph orch upgrade status",
-            "ceph log last cephadm"
+        ceph_mgr_cmds = ([
+            "balancer status",
+            "orch host ls",
+            "orch device ls",
+            "orch ls",
+            "orch ls --export",
+            "orch ps",
+            "orch status --detail",
+            "orch upgrade status",
+            "log last cephadm"
         ])
+
+        self.add_cmd_output(
+            [f"ceph {cmd}" for cmd in ceph_mgr_cmds])
+        # get ceph_cmds again as json for easier automation parsing
+        self.add_cmd_output(
+            [f"ceph {cmd} --format json-pretty" for cmd in ceph_mgr_cmds],
+            subdir="json_output",
+        )
 
         cmds = [
             "config diff",


### PR DESCRIPTION
Capture the output of some ceph mgr commands in json 
format, and add a new command to be collected.

Related: RHBZ#2116602

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?