### PR TITLE
[virsh] Scrub passwords in virt-manager logs.

### DIFF
--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -82,4 +82,20 @@ class LibvirtClient(Plugin, IndependentPlugin):
             for n in nodedev_output['output'].splitlines():
                 self.add_cmd_output(
                     '{0} nodedev-dumpxml {1}'.format(cmd, n), foreground=True)
+
+    def postproc(self):
+        match_exp = r"(\s*passwd\s*=\s*\")([^\"]*)(\".*)"
+        virsh_path_exps = [
+            r"/root/\.cache/virt-manager/.*\.log",
+            r"/root/\.virt-manager/.*\.log"
+        ]
+        for path_exp in virsh_path_exps:
+            # Scrub passwords in virt-manager logs
+            # Example of scrubbing:
+            #
+            #   passwd="hackme"
+            # To:
+            #   passwd="******"
+            #
+            self.do_path_regex_sub(path_exp, match_exp, r"\1******\3")
 # vim: et ts=4 sw=4


### PR DESCRIPTION
The virt-manager logs in /root/.cache/virt-manager/*.log and /root/.virt-manager/*.log may contain display spice passwords.

This patch ensures those are scrubbed off correctly.

Example of scrubbing:

   passwd="hackme"
 To:
   passwd="******"

Resolves: #3181

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?