### PR TITLE
[man] Fix typos in sos-collect manpage

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -176,7 +176,7 @@ to none.
 \fB\-\-save\-group\fR GROUP
 Save the results of this run of sos collect to a host group definition.
 
-sos-colllector will write a JSON-formatted file with name GROUP to /var/lib/sos collect/
+sos-collector will write a JSON-formatted file with name GROUP to /var/lib/sos collect/
 with the settings for cluster-type, primary, and the node list as discovered by cluster enumeration.
 Note that this means regexes are not directly saved to host groups, but the results of matching against
 those regexes are.
@@ -258,7 +258,7 @@ the type of cluster in use.
 .TP
 \fB\-\-image IMAGE\fR
 Specify an image to use for the temporary container created for collections on
-containerized host, if you do not want to use the default image specifed by the
+containerized host, if you do not want to use the default image specified by the
 host's policy. Note that this should include the registry.
 .TP
 \fB\-\-force-pull-image TOGGLE, \-\-pull TOGGLE\fR
@@ -378,7 +378,7 @@ This is NOT the same as specifying a temporary directory for sosreport on the re
 \fB\-v\fR \fB\-\-verbose\fR
 Print debug information to screen.
 .TP
-\fB\-\-verfiy\fR
+\fB\-\-verify\fR
 Sosreport option. Passes the "--verify" option to sosreport on the nodes which 
 causes sosreport to validate plugin-specific data during collection.
 


### PR DESCRIPTION
Trivial change to fix a few minor typos in the sos-collect manpage

Closes: #3184

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?