### PR TITLE
[ubuntu] Fix missing return in ubuntu policy

### DIFF
--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -78,6 +78,6 @@ class UbuntuPolicy(DebianPolicy):
                 return self._upload_url
             fname = os.path.basename(self.upload_archive_name)
             return self._upload_url + fname
-        super(UbuntuPolicy, self).get_upload_url()
+        return super(UbuntuPolicy, self).get_upload_url()
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Ubuntu policy is missing a `return`  in `get_upload_url()` method that causes the upload to be implictly disabled when `--upload-url` is specified.

Closes: #3183

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?