### PR TITLE
[lustre] Collect ldiskfs sysfs/proc info

### DIFF
--- a/sos/report/plugins/lustre.py
+++ b/sos/report/plugins/lustre.py
@@ -42,8 +42,8 @@ class Lustre(Plugin, RedHatPlugin):
 
         # Client Specific
         self.add_cmd_output([
-                "lfs df",
-                "lfs df -i"
+            "lfs df",
+            "lfs df -i"
         ])
 
         # Server Specific
@@ -51,6 +51,11 @@ class Lustre(Plugin, RedHatPlugin):
                                 "kbytes*,blocksize,brw_stats}"])
         self.get_params("quota", ["osd-*.*.quota_slave." +
                                   "{info,limit_*,acct_*}"])
+
+        self.add_copy_spec([
+            "/sys/fs/ldiskfs",
+            "/proc/fs/ldiskfs",
+        ])
 
         # Grab emergency ring buffer dumps
         if self.get_option("all_logs"):


### PR DESCRIPTION
ldiskfs is one of the backing filesystems for Lustre servers. Collect debug information from it.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?