### PR TITLE
[cirrus] Move F38 image from Beta to GA

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@
 # Main environment vars to set for all tasks
 env:
 
-    FEDORA_NAME: "fedora-38-beta"
+    FEDORA_NAME: "fedora-38"
     FEDORA_PRIOR_NAME: "fedora-37"
 
     DEBIAN_NAME: "debian-11"
@@ -25,7 +25,7 @@ env:
     CENTOS_9_IMAGE_NAME: "centos-stream-9-v20221102"
     CENTOS_8_IMAGE_NAME: "centos-stream-8-v20230306"
     DEBIAN_IMAGE_NAME: "debian-11-bullseye-v20230306"
-    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-38-beta-1-3-x86-64"
+    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-38-1-6-x86-64"
     FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-37-1-7-x86-64"
     UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20230302"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2004-focal-v20230302"


### PR DESCRIPTION
F38 has been GA, so we should move off the Beta image for our testing.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?