### PR TITLE
[tests] Allow tests to restrict execution architecture

### DIFF
--- a/tests/product_tests/foreman/foreman_tests.py
+++ b/tests/product_tests/foreman/foreman_tests.py
@@ -26,6 +26,7 @@ class ForemanBasicTest(StageOneReportTest):
     """
 
     sos_cmd = '-v'
+    arch = ['x86_64']
 
     def test_tfm_plugins_ran(self):
         self.assertPluginIncluded([
@@ -102,6 +103,7 @@ class ForemanWithOptionsTest(StageOneReportTest):
     """
 
     sos_cmd = '-v -k foreman.proxyfeatures=on'
+    arch = ['x86_64']
 
     @redhat_only
     def test_proxyfeatures_collected(self):
@@ -115,6 +117,7 @@ class ForemanInstallerTest(StageOneReportTest):
     """
 
     sos_cmd = '-v -o foreman_installer'
+    arch = ['x86_64']
 
     def test_foreman_installer_etc_collected(self):
         self.assertFileCollected("/etc/foreman-installer/scenarios.d")
@@ -127,6 +130,7 @@ class ForemanProxyTest(StageOneReportTest):
     """
 
     sos_cmd = '-v -o foreman_proxy'
+    arch = ['x86_64']
 
     def test_foreman_proxy_settings_collected(self):
         self.assertFileCollected("/etc/foreman-proxy/settings.yml")


### PR DESCRIPTION
Adds a new `arch` class attr that allows test classes to specify which architecture(s) they are allowed/designed to execute on. If the test is attempted to be executed on an architecture that is not in the specified list, we will skip the test before any setup or sos executions are done.

By default, the `arch` class attr is an empty list, which implies that the test can run on _any_ architecture. Tests should specify `arch` as a list even for single-arch tests.

Included in this change is restricting the Foreman tests to x86_64 only, as that is the only architecture on which that product is supported.

Closes: #3186

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?