### PR TITLE
[networkmanager] collect all fields of connections

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -53,6 +53,7 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
             self.add_cmd_output([
                 "nmcli general status",
                 "nmcli con",
+                "nmcli -f all con",
                 "nmcli con show --active",
                 "nmcli dev"])
             nmcli_con_details_cmd = nmcli_con_details_template % "show"


### PR DESCRIPTION
By default "nmcli con" only shows few fields of connections; many others are skipped and some of them are quite important like the filename, the autoconnect flag, and the last activation timestamp.

Add the full dump of connection fields. Since the output can be harder to quickly parse, also leave the plain "nmcli con" output.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?