### PR TITLE
[redhat] Add debugging output to failed SFTP uploads

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -346,7 +346,9 @@ class SoSComponent():
     def add_ui_log_to_stdout(self):
         ui_console = logging.StreamHandler(sys.stdout)
         ui_console.setFormatter(logging.Formatter('%(message)s'))
-        ui_console.setLevel(logging.INFO)
+        ui_console.setLevel(
+            logging.DEBUG if self.opts.verbosity > 1 else logging.INFO
+        )
         self.ui_log.addHandler(ui_console)
 
     def set_loggers_verbosity(self, verbosity):
@@ -392,7 +394,9 @@ class SoSComponent():
 
         # ui log
         self.ui_log = logging.getLogger('sos_ui')
-        self.ui_log.setLevel(logging.INFO)
+        self.ui_log.setLevel(
+            logging.DEBUG if self.opts.verbosity > 1 else logging.INFO
+        )
         if not self.check_listing_options():
             self.sos_ui_log_file = self.get_temp_file()
             ui_fhandler = logging.StreamHandler(self.sos_ui_log_file)

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -338,6 +338,10 @@ support representative.
                 _user = self.get_upload_user()
                 _token = json.loads(ret.text)['token']
             else:
+                self.ui_log.debug(
+                    f"DEBUG: auth attempt failed (status: {ret.status_code}): "
+                    f"{ret.json()}"
+                )
                 self.ui_log.error(
                     "Unable to retrieve Red Hat auth token using provided "
                     "credentials. Will try anonymous."
@@ -354,6 +358,12 @@ support representative.
                     _(f"User {_user} used for anonymous upload. Please inform "
                       f"your support engineer so they may retrieve the data.")
                 )
+            else:
+                self.ui_log.debug(
+                    f"DEBUG: anonymous request failed (status: "
+                    f"{anon.status_code}): {anon.json()}"
+                )
+
         if _user and _token:
             return super(RHELPolicy, self).upload_sftp(user=_user,
                                                        password=_token)


### PR DESCRIPTION
2-patch set first allows `ui_log` to print debug level messages if verbosity is set high enough, and second adds debugging output to failed SFTP uploads when using the RHEL policy.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?