### PR TITLE
[package_managers] Add MultiPackageManager support for policies

### DIFF
--- a/sos/policies/package_managers/dpkg.py
+++ b/sos/policies/package_managers/dpkg.py
@@ -15,7 +15,7 @@ class DpkgPackageManager(PackageManager):
     """Subclass for dpkg-based distrubitons
     """
 
-    query_command = "dpkg-query -W -f='${Package}|${Version}\\n'"
+    query_command = "dpkg-query -W -f='${Package}|${Version}|${Status}\\n'"
     query_path_command = "dpkg -S"
     verify_command = "dpkg --verify"
     verify_filter = ""
@@ -24,7 +24,9 @@ class DpkgPackageManager(PackageManager):
         for pkg in pkg_list.splitlines():
             if '|' not in pkg:
                 continue
-            name, version = pkg.split('|')
+            name, version, status = pkg.split('|')
+            if 'deinstall' in status:
+                continue
             yield (name, version, None)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/policies/package_managers/dpkg.py
+++ b/sos/policies/package_managers/dpkg.py
@@ -20,5 +20,11 @@ class DpkgPackageManager(PackageManager):
     verify_command = "dpkg --verify"
     verify_filter = ""
 
+    def _parse_pkg_list(self, pkg_list):
+        for pkg in pkg_list.splitlines():
+            if '|' not in pkg:
+                continue
+            name, version = pkg.split('|')
+            yield (name, version, None)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/policies/package_managers/rpm.py
+++ b/sos/policies/package_managers/rpm.py
@@ -21,5 +21,11 @@ class RpmPackageManager(PackageManager):
     verify_command = 'rpm -V'
     verify_filter = ["debuginfo", "-devel"]
 
+    def _parse_pkg_list(self, pkg_list):
+        for pkg in pkg_list.splitlines():
+            if '|' not in pkg:
+                continue
+            name, version, release = pkg.split('|')
+            yield (name, version, release)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/policies/package_managers/snap.py
+++ b/sos/policies/package_managers/snap.py
@@ -25,10 +25,7 @@ class SnapPackageManager(PackageManager):
         super(SnapPackageManager, self).__init__(chroot=chroot,
                                                  remote_exec=remote_exec)
 
-    def _generate_pkg_list(self):
-        cmd = self.query_command
-        pkg_list = self.exec_cmd(cmd, timeout=30, chroot=self.chroot)
-
+    def _parse_pkg_list(self, pkg_list):
         for line in pkg_list.splitlines():
             if line == "":
                 continue
@@ -36,10 +33,6 @@ class SnapPackageManager(PackageManager):
             if pkg[0] == "Name" or pkg[0] == "Connection":
                 continue
             name, version = pkg[0], pkg[1]
-            self._packages[name] = {
-                'name': name,
-                'version': version.split("."),
-                'release': None
-            }
+            yield (name, version, None)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -267,7 +267,7 @@ class RedHatNetworking(Networking, RedHatPlugin):
     def setup(self):
         # Handle change from -T to -W in Red Hat netstat 2.0 and greater.
         try:
-            netstat_pkg = self.policy.package_manager.packages['net-tools']
+            netstat_pkg = self.policy.package_manager.pkg_by_name('net-tools')
             # major version
             if int(netstat_pkg['version'][0]) < 2:
                 self.ns_wide = "-T"


### PR DESCRIPTION
Adds a new `MultiPackageManager` class to handle systems that have multiple distinct package managers on them.

This initial implementation requires policies that will leverage this to define a `primary` package manager, and at least one fallback package manager. Policies will need to pass the uninstantiated class object to the initializing call to `MultiPackageManager`, for example:

    self.pkgman = MultiPackageManager(primary=RpmPackageManager,
                                      fallbacks=[DpkgPackageManager])

When a call to a `PackageManager` method is made to `MultiPackageManager`, the call is first directed to the primary manager. If that response is empty, None, etc... then the call is forwarded to each of the fallback managers in the order they were defined, until either a non-empty response is returned or we run out of fallbacks to try.

In order to allow for some introspection of which defined manager provides a non-empty response for package queries, a new `pkg_manager` entry in the contents of the `packages` property has been added.

Closes: #2237
Related: #3214

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?