### PR TITLE
[networking] Collect IPv4 and IPv6 routes

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -82,7 +82,8 @@ class Networking(Plugin):
 
         self.add_cmd_output("ip -o addr", root_symlink="ip_addr",
                             tags='ip_addr')
-        self.add_cmd_output("route -n", root_symlink="route", tags='route')
+        self.add_cmd_output("ip route show table all", root_symlink="ip_route",
+                            tags=['ip_route', 'iproute_show_table_all'])
         self.add_cmd_output("plotnetcfg")
 
         self.add_cmd_output("netstat %s -neopa" % self.ns_wide,
@@ -93,7 +94,6 @@ class Networking(Plugin):
             "netstat -s",
             "netstat %s -agn" % self.ns_wide,
             "networkctl status -a",
-            "ip route show table all",
             "ip -6 route show table all",
             "ip -d route show cache",
             "ip -d -6 route show cache",
@@ -253,7 +253,6 @@ class Networking(Plugin):
             "ethtool -k.*": "ethtool_k",
             "ip -d address": "ip_addr",
             "ip -s -s neigh show": "ip_neigh_show",
-            "ip route show table all": "iproute_show_table_all",
             "ip -s -d link": "ip_s_link",
             "netstat.*-neopa": "netstat",
             "netstat.*-agn": "netstat_agn",


### PR DESCRIPTION
With this PR we are deprecating `route` command in favour of `ip route`.
We are also creating a single root symlink `ip_route` that will contain
aggregated IPv4 and IPv6 routes.

Closes: #3220

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?