### PR TITLE
[rhc] New plugin for RHC

### DIFF
--- a/sos/report/plugins/rhc.py
+++ b/sos/report/plugins/rhc.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2023 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class Rhc(Plugin, RedHatPlugin):
+
+    """
+    RHC is a client tool and daemon that connects the system
+    to Red Hat hosted services enabling system and
+    subscription management. This plugin captures
+    configuration files and the output of 'rhc status'.
+    """
+    short_desc = 'Red Hat client for remote host configured services'
+
+    plugin_name = "rhc"
+    packages = ("rhc", )
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/rhc/*",
+        ])
+
+        self.add_cmd_output([
+            "rhc status",
+        ])
+
+    def postproc(self):
+        # hide workers/foreman_rh_cloud.toml FORWARDER_PASSWORD
+        # Example for scrubbing FORWARDER_PASSWORD
+        #
+        # "FORWARDER_PASSWORD=F0rW4rd3RPassW0rD"
+        #
+        # to
+        #
+        # "FORWARDER_PASSWORD= ********
+
+        self.do_path_regex_sub("/etc/rhc/workers/foreman_rh_cloud.toml",
+                               r"(FORWARDER_PASSWORD\s*=\s*)(.+)(\"\,)",
+                               r"\1********\3")
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
RHC is a client tool and daemon that connects the system to 
Red Hat hosted services enabling system and
subscription management. This plugin captures
configuration files and the output of 'rhc status'.

Closes: RHBZ#2196649

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?