### PR TITLE
[networking] Collect `sysctl -a` from namespaces

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -210,6 +210,7 @@ class Networking(Plugin):
                     ns_cmd_prefix + "ip -4 rule list",
                     ns_cmd_prefix + "ip -6 rule list",
                     ns_cmd_prefix + "ip vrf show",
+                    ns_cmd_prefix + "sysctl -a",
                     ns_cmd_prefix + "netstat %s -neopa" % self.ns_wide,
                     ns_cmd_prefix + "netstat -s",
                     ns_cmd_prefix + "netstat %s -agn" % self.ns_wide,


### PR DESCRIPTION
Since some sysctl groups (e.g net.*) are namespaced, when gathering namespace data it's important to include the sysctl information as well.

Resolves: #3232

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?