### PR TITLE
[apt] mask credentials in list files

### DIFF
--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -45,4 +45,18 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
             suggest_filename="apt-cache_policy_details"
         )
 
+    def postproc(self):
+        super(Apt, self).postproc()
+        self.do_file_sub(
+            "/etc/apt/sources.list",
+            r"(deb\shttp(s)?://)\S+:\S+(@.*)",
+            r"\1******:******\3"
+        )
+        self.do_path_regex_sub(
+            "/etc/apt/sources.list.d/",
+            r"(deb\shttp(s)?://)\S+:\S+(@.*)",
+            r"\1******:******\3"
+        )
+
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The /etc/apt/sources.list or files in /etc/apt/sources.list.d may have credentials for private repositories. This change should mask the files and remove the username and the password.

Resolves: #1514

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?