### PR TITLE
[zvm] Don't require 'vmcp' and 'cpint' kernel modules

### DIFF
--- a/sos/report/plugins/zvm.py
+++ b/sos/report/plugins/zvm.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
+from sos.report.plugins import Plugin, IndependentPlugin
 from sos.utilities import is_executable
 
 
@@ -17,9 +17,6 @@ class ZVM(Plugin, IndependentPlugin):
     commands = ('vmcp', 'hcp')
 
     def setup(self):
-
-        zvm_pred = SoSPredicate(self, kmods=['vmcp', 'cpint'])
-        self.set_cmd_predicate(zvm_pred)
 
         self.vm_cmd = None
         for cmd in self.commands:


### PR DESCRIPTION
These modules are not present anymore, at least on RHEL8. The modules are not needed to execute 'vmcp' commands.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?