### PR TITLE
powerpc: collect RMC status logs

### DIFF
--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -39,7 +39,8 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/proc/swaps",
                 "/proc/version",
                 "/dev/nvram",
-                "/var/lib/lsvpd/"
+                "/var/lib/lsvpd/",
+                "/etc/ct_node_id"
             ])
             self.add_cmd_output([
                 "ppc64_cpu --info",
@@ -55,7 +56,11 @@ class PowerPC(Plugin, IndependentPlugin):
                 "lscfg -v",
                 "opal-elog-parse -s",
                 "opal-elog-parse -a",
-                "opal-elog-parse -l"
+                "opal-elog-parse -l",
+                "lssrc -a",
+                "lsrsrc IBM.MCP",
+                "rmcdomainstatus -s ctrmc",
+                "rmcdomainstatus -s ctrmc -a ip"
             ])
 
         if ispSeries:
@@ -87,7 +92,10 @@ class PowerPC(Plugin, IndependentPlugin):
                 "lsslot",
                 "amsstat"
             ])
-            self.add_service_status("hcn-init")
+            self.add_service_status([
+                "hcn-init",
+                "ctrmc"
+            ])
 
         if isPowerNV:
             self.add_copy_spec([


### PR DESCRIPTION
Resource Monitoring and Control (RMC) responsible for establishing management connection between HMC (Hardware Management Console) and Logical partition (LPAR).

Add commands to collect the status/info of RMC service, node, and other system resource. Additionally collect RSCT node ID file.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?