### PR TITLE
[specfile] add runtime requirement to python3-setuptools

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -13,6 +13,7 @@ BuildRequires: python3-setuptools
 BuildRequires: gettext
 Requires: python3-rpm
 Requires: python3-pexpect
+Requires: python3-setuptools
 Recommends: python3-magic
 Recommends: python3-pyyaml
 Obsoletes: sos-collector <= 1.9


### PR DESCRIPTION
As `pkg_resources` module from setuptools is used in `SosNode`.

Resolves: #3241

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?