### PR TITLE
[rhui] Fix small typo while obfuscating cookies

### DIFF
--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -51,7 +51,7 @@ class Rhui(Plugin, RedHatPlugin):
         self.do_path_regex_sub("/etc/rhui/rhui-tools.conf",
                                r"(registry_password:)\s*(.+)",
                                r"\1 ********")
-        # obfuscate twoo cookies for login session
+        # obfuscate two cookies for login session
         for cookie in ["csrftoken", "sessionid"]:
             self.do_path_regex_sub(
                 r"/root/\.rhui/.*/cookies.txt",


### PR DESCRIPTION
Fix small typo while obfuscating cookies.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?