### PR TITLE
[Plugin|Archive] Fix handling of symlink resolution within containers

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -73,7 +73,7 @@ class Archive(object):
     # this is our contract to clients of the Archive class hierarchy.
     # All sub-classes need to implement these methods (or inherit concrete
     # implementations from a parent class.
-    def add_file(self, src, dest=None):
+    def add_file(self, src, dest=None, force=False):
         raise NotImplementedError
 
     def add_string(self, content, dest, mode='w'):
@@ -344,12 +344,12 @@ class FileCacheArchive(Archive):
             self.log_debug("caught '%s' setting attributes of '%s'"
                            % (e, dest))
 
-    def add_file(self, src, dest=None):
+    def add_file(self, src, dest=None, force=False):
         with self._path_lock:
             if not dest:
                 dest = src
 
-            dest = self.check_path(dest, P_FILE)
+            dest = self.check_path(dest, P_FILE, force=force)
             if not dest:
                 return
 

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -45,7 +45,7 @@ class MockArchive(TarFileArchive):
     def name(self):
         return "mock.archive"
 
-    def add_file(self, src, dest=None):
+    def add_file(self, src, dest=None, force=False):
         if not dest:
             dest = src
         self.m[src] = dest


### PR DESCRIPTION
If we make an `add_copy_spec()` call to a file that is a symlink, and we are running in a container such that the host's `/` filesystem is one we leverage as our `sysroot`, if the symlink uses a short relative path, we were inadvertently copying the location with the container, rather than tracking the relative location to be from the sysroot path.

Fix this by forcing the use of the sysroot path in the event that we are executing from a container, and only if we are executing from a container as far as the loaded Policy is concerned.

Resolves: rhbz#2075720

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?