### PR TITLE
[juju] Ensure to collect hidden files

### DIFF
--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -44,7 +44,8 @@ class Juju(Plugin, UbuntuPlugin):
             # want all logs you want this too.
             self.add_copy_spec([
                 "/var/log/juju",
-                "/var/lib/juju"
+                "/var/lib/juju",
+                "/var/lib/juju/**/.*",
             ])
             self.add_forbidden_path("/var/lib/juju/kvm")
         else:


### PR DESCRIPTION
Currently, it was inconsistent with the hidden file collection, this line ensures that we collect these files for better support

Closes: #3242

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?