### PR TITLE
[foreman] collect qpid-stat -q

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -131,6 +131,13 @@ class Foreman(Plugin):
             'ping -c1 -W1 %s' % _host_f,
             'ping -c1 -W1 localhost'
         ])
+        self.add_cmd_output(
+            'qpid-stat -b amqps://localhost:5671 -q \
+                    --ssl-certificate=/etc/pki/katello/qpid_router_client.crt \
+                    --ssl-key=/etc/pki/katello/qpid_router_client.key \
+                    --sasl-mechanism=ANONYMOUS',
+            suggest_filename='qpid-stat_-q'
+        )
         self.add_cmd_output("hammer ping", tags="hammer_ping")
 
         # Dynflow Sidekiq


### PR DESCRIPTION
When katello-agent is (still) enabled, "qpid-stat -q" provides a great overview of pending requests and connected agents.

As there is no katello plugin, we must collect it in foreman directly.

Resolves: #3251

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?