### PR TITLE
[networking] Add extra modules being loaded for ss

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -134,8 +134,16 @@ class Networking(Plugin):
 
         ss_cmd = "ss -peaonmi"
         ss_pred = SoSPredicate(self, kmods=[
-            'tcp_diag', 'udp_diag', 'inet_diag', 'unix_diag', 'netlink_diag',
-            'af_packet_diag', 'xsk_diag'
+            'af_packet_diag',
+            'inet_diag',
+            'mptcp_diag',
+            'netlink_diag',
+            'raw_diag',
+            'tcp_diag',
+            'udp_diag',
+            'unix_diag',
+            'vsock_diag',
+            'xsk_diag',
         ], required={'kmods': 'all'})
         self.add_cmd_output(ss_cmd, pred=ss_pred, changes=True)
 


### PR DESCRIPTION
The command beig used `ss -peaonmi` loads a lot more modules, this amends the list of these based on testing in Ubutu 23.04

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?