### PR TITLE
[cxl] Add a new Compute Express Link (CXL) plugin

### DIFF
--- a/sos/report/plugins/cxl.py
+++ b/sos/report/plugins/cxl.py
@@ -1,0 +1,46 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class cxl(Plugin, IndependentPlugin):
+    """This plugin collects data from Compute Express Link (CXL) devices
+    """
+
+    short_desc = 'Compute Express Link (CXL)'
+    plugin_name = 'cxl'
+    profiles = ('storage', 'hardware', 'memory')
+    # Utilities can be installed by package or self compiled
+    packages = ('cxl-cli', 'daxctl')
+    commands = ('cxl', 'daxctl')
+
+    def setup(self):
+        """ Use the daxctl-list(1) command to collect disabled, devices,
+        mapping, and region information
+
+        Output is JSON formatted
+        """
+        self.add_cmd_output([
+            "daxctl version",
+            "daxctl list",
+            "daxctl list -iDRM"
+        ])
+
+        """ Use the cxl-list(1) command to collect data about
+        all CXL devices.
+
+        Output is JSON formatted
+        """
+        self.add_cmd_output([
+            "cxl version",
+            "cxl list",
+            "cxl list -vvv"
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Compute Express Link (CXL) is an industry-supported Cache-Coherent Interconnect for Processors, Memory Expansion, and Accelerators.

The CXL Consortium (https://www.computeexpresslink.org/) is an open industry standard group formed to develop technical specifications that facilitate breakthrough performance for emerging usage models while supporting an open ecosystem for data center accelerators and other high-speed enhancements.

There are currently three specifications (v1.1, 2.0, and v3.0) publicly available. CPUs are available from Intel and AMD that support CXL v1.1. Hardware is emerging that supports up to CXL v3.0.

This plugin uses open-source utilities from
https://github.com/pmem/ndctl that introduce new and updated commands to support CXL devices in the Linux Kernel.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?