### PR TITLE
[pm] Update plugins to use package_manager

### DIFF
--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -17,7 +17,7 @@ class LXD(Plugin, UbuntuPlugin):
     plugin_name = 'lxd'
     profiles = ('container',)
     packages = ('lxd',)
-    commands = ('lxd',)
+    commands = ('lxc', 'lxd',)
 
     def setup(self):
 
@@ -41,8 +41,8 @@ class LXD(Plugin, UbuntuPlugin):
         lxd_pred = SoSPredicate(self, kmods=lxd_kmods,
                                 required={'kmods': 'all'})
 
-        snap_list = self.exec_cmd('snap list lxd')
-        if snap_list["status"] == 0:
+        lxd_pkg = self.policy.package_manager.pkg_by_name('lxd')
+        if lxd_pkg and lxd_pkg['pkg_manager'] == 'snap':
             self.add_cmd_output("lxd.buginfo", pred=lxd_pred)
 
             self.add_copy_spec([

--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -57,14 +57,10 @@ class Maas(Plugin, UbuntuPlugin):
         return ret['status'] == 0
 
     def _is_snap_installed(self):
-        return self.exec_cmd('snap list maas')["status"] == 0
-
-    def check_enabled(self):
-        if super().check_enabled():
-            # deb-based MAAS and existing triggers
-            return True
-        # Do we have the snap installed?
-        return self._is_snap_installed()
+        maas_pkg = self.policy.package_manager.pkg_by_name('maas')
+        if maas_pkg:
+            return maas_pkg['pkg_manager'] == 'snap'
+        return False
 
     def setup(self):
         self._is_snap = self._is_snap_installed()


### PR DESCRIPTION
Remove `check_enabled()` for the maas plugin, as that is now not required with `SnapPackageManager` now enabled for the `UbuntuPlugin`

Use package manager to detrmine is package is a snap rather than `snap list`

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?