### PR TITLE
[report] Add flags from regex if they exist

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1274,7 +1274,12 @@ class Plugin():
         """
         try:
             path = self._get_dest_for_srcpath(srcpath)
-            pattern = regexp.pattern if hasattr(regexp, "pattern") else regexp
+            if hasattr(regexp, "pattern"):
+                pattern = regexp.pattern
+                flags = regexp.flags | re.IGNORECASE
+            else:
+                pattern = regexp
+                flags = re.IGNORECASE
             self._log_debug("substituting scrpath '%s'" % srcpath)
             self._log_debug("substituting '%s' for '%s' in '%s'"
                             % (subst, pattern, path))
@@ -1284,8 +1289,8 @@ class Plugin():
             content = readable.read()
             if not isinstance(content, str):
                 content = content.decode('utf8', 'ignore')
-            result, replacements = re.subn(regexp, subst, content,
-                                           flags=re.IGNORECASE)
+            result, replacements = re.subn(pattern, subst, content,
+                                           flags=flags)
             if replacements:
                 self.archive.add_string(result, self.strip_sysroot(srcpath))
             else:


### PR DESCRIPTION
Now that we ae using flags in re.subn, it doesn't like the full pattern that is being passed through via do_file_private_sub. So, we separete pattern and the flags, and pass these through to re.subn

Closes: #3261

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?