### PR TITLE
[apache] collect all /etc/httpd/conf/*.conf files

### DIFF
--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -99,7 +99,7 @@ class RedHatApache(Apache, RedHatPlugin):
         # relevant config files within each
         etcdirs = ["/etc/httpd%s" % ver for ver in vers]
         confs = [
-            "conf/httpd.conf",
+            "conf/*.conf",
             "conf.d/*.conf",
             "conf.modules.d/*.conf"
         ]


### PR DESCRIPTION
httpd.conf can refer to files in either conf.d or directly in conf dir, so let collect all configs by default.

Resolves: #3264

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?