### PR TITLE
[ocp] Fix edge case handling of failure to remove temporary project

### DIFF
--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -294,7 +294,7 @@ class Cluster():
         """
         return node.address == self.primary.address
 
-    def exec_primary_cmd(self, cmd, need_root=False):
+    def exec_primary_cmd(self, cmd, need_root=False, timeout=180):
         """Used to retrieve command output from a (primary) node in a cluster
 
         :param cmd: The command to run
@@ -303,11 +303,15 @@ class Cluster():
         :param need_root: Does the command require root privileges
         :type need_root: ``bool``
 
+        :param timeout:  Amount of time to allow cmd to run in seconds
+        :type timeout: ``int``
+
         :returns: The output and status of `cmd`
         :rtype: ``dict``
         """
         pty = self.primary.local is False
-        res = self.primary.run_command(cmd, get_pty=pty, need_root=need_root)
+        res = self.primary.run_command(cmd, get_pty=pty, need_root=need_root,
+                                       timeout=timeout)
         if res['output']:
             res['output'] = res['output'].replace('Password:', '')
         return res

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -808,8 +808,9 @@ class SosNode():
         except CommandTimeoutException:
             self.log_error('Timeout exceeded')
             raise
-        except Exception as e:
-            self.log_error('Error running sos report: %s' % e)
+        except Exception as err:
+            self.log_info(f"Exception during sos report execution: {err}")
+            self.ui_msg(f"Error running sos report: {err}")
             raise
 
     def retrieve_file(self, path):


### PR DESCRIPTION
First patch makes us handle errors in deleting the temporary project more gracefully, and informs the user that manual intervention is needed.

Second patch is a minor change noticed during testing to make `SosNode` report errors with sos execution using the `SosNode.ui_msg()` method, rather than directly printing the error to console in the log file format.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?