### PR TITLE
[sssd] Handle spaces in postproc regex substitution

### DIFF
--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -54,10 +54,10 @@ class Sssd(Plugin):
                 self.add_cmd_output("sssctl domain-status -o " + domain_name)
 
     def postproc(self):
-        regexp = r"(\s*ldap_default_authtok\s*=\s*)\S+"
+        regexp = r"((\s*ldap_default_authtok\s*=)(.*))"
 
-        self.do_file_sub("/etc/sssd/sssd.conf", regexp, r"\1********")
-        self.do_path_regex_sub("/etc/sssd/conf.d/*", regexp, r"\1********")
+        self.do_file_sub("/etc/sssd/sssd.conf", regexp, r"\2 ********")
+        self.do_path_regex_sub("/etc/sssd/conf.d/*", regexp, r"\2 ********")
 
 
 class RedHatSssd(Sssd, RedHatPlugin):


### PR DESCRIPTION
Widen the capturing of strings for the `ldap_default_authtok` substitution performed on sssd configuration files to also capture strings with spaces.

Closes: #3266

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?