### PR TITLE
[ipa] add SID log file (ipaserver-enable-sid.log)

### DIFF
--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -88,6 +88,7 @@ class Ipa(Plugin, RedHatPlugin):
             self.add_copy_spec([
                 "/var/log/ipaserver-install.log",
                 "/var/log/ipaserver-kra-install.log",
+                "/var/log/ipaserver-enable-sid.log",
                 "/var/log/ipareplica-install.log",
                 "/var/log/ipareplica-ca-install.log",
                 "/var/log/ipa-custodia.audit.log"


### PR DESCRIPTION
Since https://www.freeipa.org/page/Releases/4.9.8, SID configuration is instegrated in the base installer. This logs into: /var/log/ipaserver-enable-sid.log
More information: https://pagure.io/freeipa/issue/8995

Resolves: #3268

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?