### PR TITLE
[grub2] Capture user created configuration files

### DIFF
--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -31,6 +31,8 @@ class Grub2(Plugin, IndependentPlugin):
             "/boot/grub2/grubenv",
             "/boot/grub/grub.cfg",
             "/boot/loader/entries",
+            "/boot/grub2/custom.cfg",
+            "/boot/grub2/user.cfg",
             "/etc/default/grub",
             "/etc/grub2.cfg",
             "/etc/grub.d"


### PR DESCRIPTION
For now neither "/boot/grub2/custom.cfg" nor
"/boot/grub2/user.cfg" are embedded in the sosreport,
 which may contain critical information when troubleshooting
boot issues.
Indeed it happens customers create the files badly, e.g. create a copy 
of "boot/grub2/grub.cfg" itself, which ends up having a dead loop 
in Grub and preventing the system to boot.

With such information, we would troubleshoot such issues more rapidly.

Resolves: RHBZ#2213951

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?