### PR TITLE
[ipa] add EPN log file (ipaepn.log)

### DIFF
--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -121,7 +121,8 @@ class Ipa(Plugin, RedHatPlugin):
             "/var/lib/ipa/certs/httpd.crt",
             "/var/kerberos/krb5kdc/kdc.crt",
             "/var/lib/ipa/sysrestore/sysrestore.state",
-            "/var/log/ipa/healthcheck/healthcheck.log*"
+            "/var/log/ipa/healthcheck/healthcheck.log*",
+            "/var/log/ipaepn.log*"
         ])
 
         #  Make sure to use the right PKI config and NSS DB folders


### PR DESCRIPTION
Since https://www.freeipa.org/page/Releases/4.8.7, IPA includes a tool to send email notifications to users when their passwords are about to expire.
This logs into: /var/log/ipaepn.log

More information: https://pagure.io/freeipa/issue/3687

Resolves: #3272

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?