### PR TITLE
[kernel] verify also kernel-redhat on RedHatPolicy

### DIFF
--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
+from sos.policies.distros.redhat import RedHatPolicy
 import glob
 
 
@@ -42,6 +43,11 @@ class Kernel(Plugin, IndependentPlugin):
     ]
 
     def setup(self):
+        # RedHat distributions can deliver kernel in RPM named either 'kernel'
+        # or 'kernel-redhat', so we must verify both
+        if isinstance(self.policy, RedHatPolicy):
+            self.verify_packages = ('kernel$', 'kernel-redhat$')
+
         # compat
         self.add_cmd_output("uname -a", root_symlink="uname", tags="uname")
         self.add_cmd_output("lsmod", root_symlink="lsmod", tags="lsmod")


### PR DESCRIPTION
RedHat distributions can deliver kernel in RPM named either 'kernel' or 'kernel-redhat', in which case we must verify both package names.

See e.g. https://fedoramagazine.org/changes-eln-kernel-rpm-nvr/ for the background.

It can be bit controversial to customize an `IndependentPlugin` subclass and not using `RedHatPlugin`. But having `class RedHatKernel(Plugin, RedHatPlugin)` would need to replace:

    - class Kernel(Plugin, IndependentPlugin):
    + class Kernel(Plugin, UbuntuPlugin, OpenEulerPlugin, CosPlugin, ..):

to list all other distros-plugins, *and maintain the list*. Since `Kernel` plugin being a subclass of `IndependentPlugin` would be honoured also on `redhat` distro/policy.

From a few options (like the "list all `*Plugin`s") I found neither as optimal and the chosen one as the least intruding.

Resolves: #3274

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?