### PR TITLE
[conntrack] collect conntrack commands only when kmods are loaded

### DIFF
--- a/sos/report/plugins/conntrack.py
+++ b/sos/report/plugins/conntrack.py
@@ -7,7 +7,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
+from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate,
+                                PluginOpt)
 
 
 class Conntrack(Plugin, IndependentPlugin):
@@ -37,11 +38,18 @@ class Conntrack(Plugin, IndependentPlugin):
             "conntrackd -s expect",
         ])
 
-        # Collect info from conntrack
+        # Collect info from conntrack, only when all required kmods are loaded
+        ct_pred = SoSPredicate(self,
+                               kmods=['nf_conntrack',
+                                      'nf_conntrack_netlink',
+                                      'nf_defrag_ipv4',
+                                      'nf_defrag_ipv6',
+                                      'nfnetlink'],
+                               required={'kmods': 'all'})
         self.add_cmd_output([
             "conntrack -L -o extended",
             "conntrack -S",
-        ])
+        ], pred=ct_pred)
 
         # Capture additional data from namespaces; each command is run
         # per-namespace


### PR DESCRIPTION
Two conntrack commands require several kmods - guard collection of the commands by relevant SoSPredicate.

Resolves: #3279

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?