### PR TITLE
[docker] collect on Debian too

### DIFF
--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -9,7 +9,8 @@
 # See the LICENSE file in the source distribution for further information.
 
 from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
-                                SoSPredicate, CosPlugin, PluginOpt)
+                                SoSPredicate, CosPlugin, PluginOpt,
+                                DebianPlugin)
 
 
 class Docker(Plugin, CosPlugin):
@@ -133,7 +134,7 @@ class RedHatDocker(Docker, RedHatPlugin):
         ])
 
 
-class UbuntuDocker(Docker, UbuntuPlugin):
+class UbuntuDocker(Docker, UbuntuPlugin, DebianPlugin):
 
     packages = ('docker.io', 'docker-engine', 'docker-ce', 'docker-ee')
 


### PR DESCRIPTION
Tested by:
 - manually patching file on Debian 11 and 12 (both on sos version 4.0.2)
 - sudo ./bin/sos report from this commit (and on python 3.11)

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?