### PR TITLE
[Plugin] Fix exception when calling os.makedirs

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2176,7 +2176,7 @@ class Plugin():
         if name:
             cmd_output_path = os.path.join(cmd_output_path, name)
         if make:
-            os.makedirs(cmd_output_path)
+            os.makedirs(cmd_output_path, exist_ok=True)
 
         return cmd_output_path
 


### PR DESCRIPTION
When calling get_cmd_output_path() to create a directory via the plugin hpssm, sos threw the following exception:

Traceback (most recent call last):
  File "/root/sos/sos/report/__init__.py", line 1224, in setup
    plug.setup()
  File "/root/sos/sos/report/plugins/hpssm.py", line 67, in setup
    logpath = self.get_cmd_output_path()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sos/sos/report/plugins/__init__.py", line 2168,
	in get_cmd_output_path
    os.makedirs(cmd_output_path)
  File "<frozen os>", line 225, in makedirs
FileExistsError: [Errno 17] File exists:
'/var/tmp/sos.1gdy83zb/sosreport-localhost-vbwfnpn/sos_commands/hpssm'

This was happening because the directory 'hpssm' was already created. With this change we avoid any race where we call os.makedirs() after we have already created the plugin directory.

Closes: RHBZ #2216608

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?