### PR TITLE
[avocado_tests] added default_mapping test

### DIFF
--- a/tests/cleaner_tests/basic_function_tests/report_with_mask.py
+++ b/tests/cleaner_tests/basic_function_tests/report_with_mask.py
@@ -87,7 +87,7 @@ class DefaultRemoveBinaryFilesTest(StageTwoReportTest):
 
     files = [('binary_test.tar.xz', '/var/log/binary_test.tar.xz')]
     install_plugins = ['binary_test']
-    sos_cmd = '--clean -o binary_test,kernel,host'
+    sos_cmd = '--clean -o binary_test,kernel,host --no-update'
 
     def test_binary_removed(self):
         self.assertFileNotCollected('var/log/binary_test.tar.xz')
@@ -104,7 +104,7 @@ class KeepBinaryFilesTest(StageTwoReportTest):
 
     files = [('binary_test.tar.xz', '/var/log/binary_test.tar.xz')]
     install_plugins = ['binary_test']
-    sos_cmd = '--clean --keep-binary-files -o binary_test,kernel,host'
+    sos_cmd = '--clean --keep-binary-files -o binary_test,kernel,host --no-update'
 
     def test_warning_message_shown(self):
         self.assertOutputContains(

--- a/tests/cleaner_tests/existing_archive.py
+++ b/tests/cleaner_tests/existing_archive.py
@@ -22,7 +22,7 @@ class ExistingArchiveCleanTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = '-v tests/test_data/%s.tar.xz' % ARCHIVE
+    sos_cmd = '-v tests/test_data/%s.tar.xz --no-update' % ARCHIVE
     sos_component = 'clean'
 
     def test_obfuscation_log_created(self):

--- a/tests/cleaner_tests/full_report/full_report_run.py
+++ b/tests/cleaner_tests/full_report/full_report_run.py
@@ -45,6 +45,14 @@ class FullCleanTest(StageTwoReportTest):
             % (host.lower(), host.upper(), short.lower(), short.upper())
         )
 
+    def test_default_mapping(self):
+        self.assertFileExists('/etc/sos/cleaner/default_mapping')
+        self.assertOutputContains('Wrote mapping to')
+        with open('/etc/sos/cleaner/default_mapping') as ref:
+            ref_data = ref.read()
+        map_count = ref_data.count("map")
+        self.assertNotEqual(ref_data.count("_map"), 0)
+
     def test_private_map_was_generated(self):
         self.assertOutputContains('A mapping of obfuscated elements is available at')
         map_file = re.findall('/.*sosreport-.*-private_map', self.cmd_output.stdout)[-1]

--- a/tests/cleaner_tests/help_output_tests.py
+++ b/tests/cleaner_tests/help_output_tests.py
@@ -16,7 +16,7 @@ class CleanHelpTest(StageOneOutputTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = 'clean --help'
+    sos_cmd = 'clean --help --no-update'
 
     def test_all_help_sections_present(self):
         self.assertOutputContains('Global Options:')

--- a/tests/cleaner_tests/ipv6_test/ipv6_test.py
+++ b/tests/cleaner_tests/ipv6_test/ipv6_test.py
@@ -19,7 +19,7 @@ class IPv6Test(StageTwoReportTest):
     """
 
     install_plugins = ['ipv6']
-    sos_cmd = '-v --clean -o ipv6'
+    sos_cmd = '-v --clean -o ipv6 --no-update'
     sos_timeout = 600
     # replace default mapping to avoid being influenced by previous runs
     # place mock file with crafted address used by mocked plugin

--- a/tests/cleaner_tests/report_disabled_parsers.py
+++ b/tests/cleaner_tests/report_disabled_parsers.py
@@ -18,7 +18,7 @@ class ReportDisabledParsersTest(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '--clean -o host,kernel,networking --disable-parsers=ip'
+    sos_cmd = '--clean -o host,kernel,networking --disable-parsers=ip --no-update'
 
     def test_local_ip_not_obfuscated(self):
         self.assertFileHasContent('ip_addr', self.sysinfo['pre']['networking']['ip_addr'])

--- a/tests/cleaner_tests/skip_versioning/skip_version_ip_parser.py
+++ b/tests/cleaner_tests/skip_versioning/skip_version_ip_parser.py
@@ -23,7 +23,7 @@ class SkipVersionIPParser(StageTwoReportTest):
         ('sos-test-version-noskip', NO_SKIP)
     ]
     install_plugins = ['skip_versions']
-    sos_cmd = '--clean -o skip_versions'
+    sos_cmd = '--clean -o skip_versions --no-update'
 
     def test_version_file_skipped(self):
         self.assertFileCollected(DO_SKIP)

--- a/tests/cleaner_tests/unicode_open/unicode_in_file.py
+++ b/tests/cleaner_tests/unicode_open/unicode_in_file.py
@@ -17,7 +17,7 @@ class UnicodeOpenTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = '--clean -o unicode_test,networking,host'
+    sos_cmd = '--clean -o unicode_test,networking,host --no-update'
     files = [('sos-test-unicode.txt', '/tmp/sos-test-unicode.txt')]
     install_plugins = ['unicode_test']
 

--- a/tests/report_tests/encryption_tests.py
+++ b/tests/report_tests/encryption_tests.py
@@ -39,7 +39,7 @@ class EncryptedCleanedReportTest(EncryptedReportTest):
     """
 
     encrypt_pass = 'sostest'
-    sos_cmd = "-o host,networking --clean --encrypt-pass %s" % encrypt_pass
+    sos_cmd = "-o host,networking --clean --encrypt-pass %s --no-update" % encrypt_pass
 
     def test_hostname_obfuscated(self):
         self.assertFileHasContent('hostname', 'host0')

--- a/tests/vendor_tests/redhat/rhbz1950350/rhbz1950350.py
+++ b/tests/vendor_tests/redhat/rhbz1950350/rhbz1950350.py
@@ -23,7 +23,7 @@ class rhbz1950350(StageTwoReportTest):
         ('clean_config_test.txt', '/var/log/clean_config_test.txt')
     ]
 
-    sos_cmd = '-v -o sos_extras --clean'
+    sos_cmd = '-v -o sos_extras --clean --no-update'
 
     def test_clean_config_loaded(self):
         self.assertSosLogContains("effective options now: (.*)? --clean --domains (.*)? --keywords (.*)?")


### PR DESCRIPTION
Added default mapping test and made it so all cleaner tests have the --no-update option as in issue #3254 

Close #3254 

Signed-off-by: Daniel Zhou <dzhou@redhat.com>
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?