### PR TITLE
[tests] Make options_tests faster by calling them on a few plugins only

### DIFF
--- a/tests/report_tests/options_tests/options_tests.py
+++ b/tests/report_tests/options_tests/options_tests.py
@@ -22,8 +22,8 @@ class OptionsFromConfigTest(StageTwoReportTest):
     def test_case_id_from_config(self):
         self.assertTrue('8675309' in self.archive)
 
-    def test_plugins_skipped_from_config(self):
-        self.assertPluginNotIncluded(['networking', 'logs'])
+    def test_plugins_only_from_config(self):
+        self.assertOnlyPluginsIncluded(['host', 'kernel'])
 
     def test_plugopts_logged_from_config(self):
         self.assertSosLogContains(
@@ -41,5 +41,5 @@ class OptionsFromConfigTest(StageTwoReportTest):
 
     def test_effective_options_logged_correctly(self):
         self.assertSosLogContains(
-            "effective options now: --batch --case-id 8675309 --plugopts kernel.with-timer=on,kernel.trace=yes --skip-plugins networking,logs"
+            "effective options now: --batch --case-id 8675309 --only-plugins host,kernel --plugopts kernel.with-timer=on,kernel.trace=yes"
         )

--- a/tests/report_tests/options_tests/options_tests_sos.conf
+++ b/tests/report_tests/options_tests/options_tests_sos.conf
@@ -2,7 +2,7 @@
 #verbose = 3
 
 [report]
-skip-plugins = networking,logs
+only-plugins = host,kernel
 case-id = 8675309
 
 [collect]


### PR DESCRIPTION
options_tests.py tests -n option which means tens of plugins are redundantly collected. Testing -o option is effectively the same while the sosreport run needs a half time only.

The functionality of -n option is tested elsewhere, thus the change does not shrink test coverage.

Resolves: #3288

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?