### PR TITLE
[clean] Respect permissions of sanitised files

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -778,7 +778,7 @@ third party.
                                        % (short_name, err), caller=arc_name)
             tfile.seek(0)
             if subs:
-                shutil.copy(tfile.name, filename)
+                shutil.copyfile(tfile.name, filename)
             tfile.close()
 
         _ob_short_name = self.obfuscate_string(short_name.split('/')[-1])


### PR DESCRIPTION
When copying files we applied a substitution in, we must replace just original file content (`shutil.copyfile`) and not also its stat data (`shutil.copy`).

Resolves: #3292

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?