### PR TITLE
[ceph] Add a new profile for Ceph plugins

### DIFF
--- a/sos/report/plugins/ceph_ansible.py
+++ b/sos/report/plugins/ceph_ansible.py
@@ -14,7 +14,7 @@ class CephAnsible(Plugin, RedHatPlugin, DebianPlugin):
     short_desc = 'CEPH distributed storage - Ansible installer'
 
     plugin_name = 'ceph_ansible'
-    profiles = ('storage',)
+    profiles = ('storage', 'ceph')
 
     packages = ('ceph-ansible',)
 

--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -15,7 +15,7 @@ class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH common'
 
     plugin_name = 'ceph_common'
-    profiles = ('storage', 'virt', 'container')
+    profiles = ('storage', 'virt', 'container', 'ceph')
 
     containers = ('ceph-(.*-)?(mon|rgw|osd).*',)
     ceph_hostname = gethostname()

--- a/sos/report/plugins/ceph_iscsi.py
+++ b/sos/report/plugins/ceph_iscsi.py
@@ -14,7 +14,7 @@ class CephISCSI(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = "CEPH iSCSI"
 
     plugin_name = "ceph_iscsi"
-    profiles = ("storage", "virt", "container")
+    profiles = ("storage", "virt", "container", "ceph")
     packages = ("ceph-iscsi",)
     services = ("rbd-target-api", "rbd-target-gw")
     containers = ("rbd-target-api.*", "rbd-target-gw.*")

--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -12,7 +12,7 @@ from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH mds'
     plugin_name = 'ceph_mds'
-    profiles = ('storage', 'virt', 'container')
+    profiles = ('storage', 'virt', 'container', 'ceph')
     containers = ('ceph-(.*-)?fs.*',)
     files = ('/var/lib/ceph/mds/',)
 

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -35,7 +35,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH mgr'
 
     plugin_name = 'ceph_mgr'
-    profiles = ('storage', 'virt', 'container')
+    profiles = ('storage', 'virt', 'container', 'ceph')
     files = ('/var/lib/ceph/mgr/', '/var/lib/ceph/*/mgr*')
     containers = ('ceph-(.*-)?mgr.*',)
 

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -32,7 +32,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH mon'
 
     plugin_name = 'ceph_mon'
-    profiles = ('storage', 'virt', 'container')
+    profiles = ('storage', 'virt', 'container', 'ceph')
     # note: for RHCS 5 / Ceph v16 the containers serve as an enablement trigger
     # but by default they are not capable of running various ceph commands in
     # this plugin - the `ceph` binary is functional directly on the host

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -29,7 +29,7 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH osd'
 
     plugin_name = 'ceph_osd'
-    profiles = ('storage', 'virt', 'container')
+    profiles = ('storage', 'virt', 'container', 'ceph')
     containers = ('ceph-(.*-)?osd.*',)
     files = ('/var/lib/ceph/osd/', '/var/lib/ceph/*/osd*')
 

--- a/sos/report/plugins/ceph_rgw.py
+++ b/sos/report/plugins/ceph_rgw.py
@@ -14,7 +14,7 @@ class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin):
     short_desc = 'CEPH rgw'
 
     plugin_name = 'ceph_rgw'
-    profiles = ('storage', 'virt', 'container', 'webserver')
+    profiles = ('storage', 'virt', 'container', 'webserver', 'ceph')
     containers = ('ceph-(.*)?rgw.*',)
     files = ('/var/lib/ceph/radosgw',)
 


### PR DESCRIPTION
This patch helps simplify the capture of data
from ceph plugins. After the original code was
divided in 8 different plugins, it may be a bit
confusing which plugins to use when running
sos and attempting to capture only ceph data.
By selecting the profile, sos will activate only
these ceph_* plugins that apply to a specific
ceph node.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?