### PR TITLE
[grub2] Capture /etc/grub2-efi.cfg

### DIFF
--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -35,7 +35,8 @@ class Grub2(Plugin, IndependentPlugin):
             "/boot/grub2/user.cfg",
             "/etc/default/grub",
             "/etc/grub2.cfg",
-            "/etc/grub.d"
+            "/etc/grub.d",
+            "/etc/grub2-efi.cfg"
         ])
 
         self.add_cmd_output("ls -lanR /boot", tags="ls_boot")


### PR DESCRIPTION
sos report does not gather the symlink
/etc/grub2-efi.cfg when present.
If a system is legacy, but has this file,
grubby default to using this one first in
some cases. Therefore we need to know if
it's present or not.

Closes: RHBZ#2218563

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?