### PR TITLE
[docs] Update maintainer field in man pages

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -135,7 +135,7 @@ on the system from a previous execution.
 
 .SH MAINTAINER
 .nf
-Jake Hunsaker <jhunsake@redhat.com>
+Maintained on GitHub at https://github.com/sosreport/sos
 .fi
 .SH AUTHORS & CONTRIBUTORS
 See \fBAUTHORS\fR file in the package documentation.

--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -395,4 +395,8 @@ Sosreport option. Override the default compression type.
 .BR sos.conf (5)
 
 .SH MAINTAINER
-    Jake Hunsaker <jhunsake@redhat.com>
+.nf
+Maintained on GitHub at https://github.com/sosreport/sos
+.fi
+.SH AUTHORS & CONTRIBUTORS
+See \fBAUTHORS\fR file in the package documentation.

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -494,7 +494,7 @@ Display usage message.
 
 .SH MAINTAINER
 .nf
-Jake Hunsaker <jhunsake@redhat.com>
+Maintained on GitHub at https://github.com/sosreport/sos
 .fi
 .SH AUTHORS & CONTRIBUTORS
 See \fBAUTHORS\fR file in the package documentation.

--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -165,7 +165,7 @@ Display usage message.
 .BR sos.conf (5)
 .SH MAINTAINER
 .nf
-Jake Hunsaker <jhunsake@redhat.com>
+Maintained on GitHub at https://github.com/sosreport/sos
 .fi
 .SH AUTHORS & CONTRIBUTORS
 See \fBAUTHORS\fR file in the package documentation.


### PR DESCRIPTION
Update the maintainer field to be more generic and direct readers to the upstream repo.

Closes: #3290

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?