### PR TITLE
[ssh] Add User .ssh Config File Option

### DIFF
--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Ssh(Plugin, IndependentPlugin):
@@ -17,6 +17,12 @@ class Ssh(Plugin, IndependentPlugin):
 
     plugin_name = 'ssh'
     profiles = ('services', 'security', 'system', 'identity')
+
+    option_list = [
+        PluginOpt('userconfs', default=True, val_type=str,
+                  desc=('Changes whether module will '
+                        'collect user .ssh configs'))
+    ]
 
     def setup(self):
 
@@ -34,7 +40,10 @@ class Ssh(Plugin, IndependentPlugin):
         self.add_copy_spec(sshcfgs)
 
         self.included_configs(sshcfgs)
-        self.user_ssh_files_permissions()
+
+        # If userconfs option is set to False, skips this
+        if self.get_option('userconfs'):
+            self.user_ssh_files_permissions()
 
     def included_configs(self, sshcfgs):
         # Read configs for any includes and copy those


### PR DESCRIPTION
Resolves issue SUPDEV-137.
Adds a plugin option for the ssh module, defining whether it will or will not collect .ssh config files per user.
Default for new option is True

Signed-off-by: Daniel Zhou <dzhou@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X ] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?