### PR TITLE
[cleaner] Raise error for long filenames

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -752,6 +752,7 @@ third party.
         if not filename:
             # the requested file doesn't exist in the archive
             return
+        self.length_check(filename)
         subs = 0
         if not short_name:
             short_name = filename.split('/')[-1]
@@ -817,6 +818,7 @@ third party.
         """
         self.log_info("Obfuscating symlink names", caller=archive.archive_name)
         for symlink in archive.get_symlinks():
+            self.length_check(symlink)
             try:
                 # relative name of the symlink in the archive
                 _sym = symlink.split(archive.extracted_path)[1].lstrip('/')
@@ -849,6 +851,7 @@ third party.
         for dirpath in sorted(archive.get_directory_list(), reverse=True):
             for _name in os.listdir(dirpath):
                 _dirname = os.path.join(dirpath, _name)
+                self.length_check(_dirname)
                 _arc_dir = _dirname.split(archive.extracted_path)[-1]
                 if os.path.isdir(_dirname):
                     _ob_dirname = self.obfuscate_string(_name)
@@ -904,5 +907,9 @@ third party.
         for parser in self.parsers:
             _sec = parse_sec.add_section(parser.name.replace(' ', '_').lower())
             _sec.add_field('entries', len(parser.mapping.dataset.keys()))
+
+    def length_check(self, fname):
+        if len(fname) > 64:
+            self.log_error("Failed to obfuscate, filename too long", fname)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Partially resolves issue #3018 
This fix just adds a debug error message stating that the filename was too long to obfuscate. 
Does not terminate the cleaner or change the filename, thinking of more complete fix now.

Signed-off-by: Daniel Zhou <dzhou@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?