### PR TITLE
[maas] remove the collection of apache2 logs

### DIFF
--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -90,7 +90,6 @@ class Maas(Plugin, UbuntuPlugin):
                 "/var/lib/maas/http/*.conf",
                 "/var/lib/maas/*.conf",
                 "/var/lib/maas/rsyslog",
-                "/var/log/apache2*",
                 "/var/log/maas*",
                 "/var/log/upstart/maas-*",
             ])


### PR DESCRIPTION
MAAS no longer uses apache2 for it web hosting, so no longer required for this plugin

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?