### PR TITLE
[options] compatibility fix for python 3.12

### DIFF
--- a/sos/options.py
+++ b/sos/options.py
@@ -226,7 +226,7 @@ class SoSOptions():
         try:
             try:
                 with open(config_file) as f:
-                    config.readfp(f)
+                    config.read_file(f, config_file)
             except DuplicateOptionError as err:
                 raise exit("Duplicate option '%s' in section '%s' in file %s"
                            % (err.option, err.section, config_file))


### PR DESCRIPTION
Addresses ConfigParser.readfp removal in 3.12.

Fixes #3308

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2223526

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?