### PR TITLE
[utilities][ceph] wildcard support for path in files, fix ceph plugin paths

### DIFF
--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -14,7 +14,7 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'ceph_mds'
     profiles = ('storage', 'virt', 'container', 'ceph')
     containers = ('ceph-(.*-)?fs.*',)
-    files = ('/var/lib/ceph/mds/',)
+    files = ('/var/lib/ceph/mds/*',)
 
     def setup(self):
         self.add_file_tags({

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -36,7 +36,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
 
     plugin_name = 'ceph_mgr'
     profiles = ('storage', 'virt', 'container', 'ceph')
-    files = ('/var/lib/ceph/mgr/', '/var/lib/ceph/*/mgr*')
+    files = ('/var/lib/ceph/mgr/*', '/var/lib/ceph/*/mgr*')
     containers = ('ceph-(.*-)?mgr.*',)
 
     def setup(self):

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -37,7 +37,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
     # but by default they are not capable of running various ceph commands in
     # this plugin - the `ceph` binary is functional directly on the host
     containers = ('ceph-(.*-)?mon.*',)
-    files = ('/var/lib/ceph/mon/', '/var/lib/ceph/*/mon*',
+    files = ('/var/lib/ceph/mon/*', '/var/lib/ceph/*/mon*',
              '/var/snap/microceph/common/data/mon/*')
     ceph_version = 0
 

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -31,7 +31,7 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'ceph_osd'
     profiles = ('storage', 'virt', 'container', 'ceph')
     containers = ('ceph-(.*-)?osd.*',)
-    files = ('/var/lib/ceph/osd/', '/var/lib/ceph/*/osd*',
+    files = ('/var/lib/ceph/osd/*', '/var/lib/ceph/*/osd*',
              '/var/snap/microceph/common/data/osd/*')
 
     def setup(self):

--- a/sos/report/plugins/ceph_rgw.py
+++ b/sos/report/plugins/ceph_rgw.py
@@ -16,7 +16,7 @@ class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'ceph_rgw'
     profiles = ('storage', 'virt', 'container', 'webserver', 'ceph')
     containers = ('ceph-(.*)?rgw.*',)
-    files = ('/var/lib/ceph/radosgw',)
+    files = ('/var/lib/ceph/radosgw/*',)
 
     def setup(self):
         self.add_copy_spec('/var/log/ceph/ceph-client.rgw*.log',

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -319,6 +319,8 @@ def _os_wrapper(path, sysroot, method, module=os.path):
 
 
 def path_exists(path, sysroot):
+    if '*' in path:
+        return _os_wrapper(path, sysroot, 'glob', module=glob)
     return _os_wrapper(path, sysroot, 'exists')
 
 


### PR DESCRIPTION
This lets files triggers use * and also updates the ceph plugins to trigger only if folders are non empty

Closes: #3311

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?