### PR TITLE
[report] Don't use sysroot for network device enumeration

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -612,10 +612,18 @@ class SoSReport(SoSComponent):
         filt_devs = ['bonding_masters']
         _eth_devs = []
         if not namespace:
-            _eth_devs = [
-                dev for dev in listdir('/sys/class/net', self.opts.sysroot)
-                if dev not in filt_devs
-            ]
+            try:
+                # Override checking sysroot here, as network devices will not
+                # be under the sysroot in live environments or in containers
+                # that are correctly setup to collect from the host
+                _eth_devs = [
+                    dev for dev in listdir('/sys/class/net', None)
+                    if dev not in filt_devs
+                ]
+            except Exception as err:
+                self.soslog.warning(
+                    f'Failed to manually determine network devices: {err}'
+                )
         else:
             try:
                 _nscmd = "ip netns exec %s ls /sys/class/net" % namespace


### PR DESCRIPTION
If sos is being used in a live environment to diagnose an issue, using sysroot can cause the network device enumeration via /sys/class/net crawling to fail. This will be the case for systems that do not use `nmcli`.

When in a live environment, network devices will not be under `/$sysroot/sys/class/net` but the "regular" path for the booted environment. Similarly, if sos is being run in a container that is properly configured, network devices will appear under `/sys/class/net` and not (necessarily) under the sysroot path that mounts the host's filesystem.

As such, disregard a configured sysroot when enumerating network devices by crawling `/sys/class/net`, and trap any exceptions that may percolate up from this in edge case environments.

Closes: #3307

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?