### PR TITLE
[openvswitch] Add shorter pmd rxq usage periods

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -129,6 +129,8 @@ class OpenVSwitch(Plugin):
             # Capture OVS datapath list
             "ovs-vsctl -t 5 list datapath",
             # Capture DPDK queue to pmd mapping
+            "ovs-appctl dpif-netdev/pmd-rxq-show -secs 5",
+            "ovs-appctl dpif-netdev/pmd-rxq-show -secs 30",
             "ovs-appctl dpif-netdev/pmd-rxq-show",
             # Capture DPDK pmd stats
             "ovs-appctl dpif-netdev/pmd-stats-show",


### PR DESCRIPTION
Since OVS 3.1 'ovs-appctl dpif-netdev/pmd-rxq-show' also supports showing the pmd rxq % usage over shorter timeframes than the default 1 minute, down to a granularity of 5 secs.

A user testing may send traffic and have a steady state for less than 1 min, so it is useful to also see pmd rxq % usage over some shorter time periods.

Add pmd-rxq-show stats for 5 and 30 secs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?