### PR TITLE
[plugins/ceph] Don't trigger ceph_common on cinder nodes

### DIFF
--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -27,7 +27,6 @@ class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin):
         'libcephfs1',
         'ceph-fs-common',
         'calamari-server',
-        'librados2'
     )
 
     services = (


### PR DESCRIPTION
ceph_common is triggered due to librados2 package on cinder nodes, so remove librados2 packages trigger for ceph_common plugin.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?