### PR TITLE
[tests] search for fixed strings, not regexps

### DIFF
--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -390,11 +390,16 @@ class BaseSoSReportTest(BaseSoSTest):
             raise
         return _archive
 
-    def grep_for_content(self, search):
+    def grep_for_content(self, search, regexp=False):
         """Call out to grep for finding a specific string 'search' in any place
         in the archive
+
+        :param search: string to search
+        :param regexp: use regular expression search (default False
+                       means "grep -F")
         """
-        cmd = "grep -ril '%s' %s" % (search, self.archive_path)
+        fixed_opt = "" if regexp else "F"
+        cmd = "grep -ril%s '%s' %s" % (fixed_opt, search, self.archive_path)
         try:
             out = process.run(cmd)
             rc = out.exit_status


### PR DESCRIPTION
grep_for_content should search for a fixed string, not for regexp. The reason is sos is unable to identify 1a2b3c4 as an IP address (which it is not), but grep_for_content would raise false match against 1.2.3.4 .

Resolves: #3320

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?