### PR TITLE
[containerd] Enable plugin when RPM name is containerd.io

### DIFF
--- a/sos/report/plugins/containerd.py
+++ b/sos/report/plugins/containerd.py
@@ -14,7 +14,7 @@ class Containerd(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
     short_desc = 'Containerd containers'
     plugin_name = 'containerd'
     profiles = ('container',)
-    packages = ('containerd',)
+    packages = ('containerd', 'containerd.io',)
 
     def setup(self):
         self.add_copy_spec([


### PR DESCRIPTION
This PR adds `containerd.io` RPM name to the packages set of the containerd.py plugin. While most sources of containerd RPMs name them `containerd` the docker repository names them `containerd.io`.

Closes #3321

Signed-off-by: Trevor Benson <trevor.benson@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?