### PR TITLE
[foreman] - fetch id in foreman_auth_table

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -188,7 +188,7 @@ class Foreman(Plugin):
         )
 
         authcmd = (
-            'select type,name,host,port,account,base_dn,attr_login,'
+            'select id,type,name,host,port,account,base_dn,attr_login,'
             'onthefly_register,tls from auth_sources'
         )
 


### PR DESCRIPTION
---


Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

Having an ID of the foreman_auth_table helps in sosreport will help to quickly identify the right auth source especially the LDAP auth provider source and provide further instructions to fetch data foreman-rake console for further troubleshooting. 

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?