### PR TITLE
[coredump] New plugin to capture coredump info

### DIFF
--- a/sos/report/plugins/coredump.py
+++ b/sos/report/plugins/coredump.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2023 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
+
+
+class Coredump(Plugin, IndependentPlugin):
+
+    short_desc = 'Retrieve coredump information'
+
+    plugin_name = "coredump"
+    profiles = ('system', 'debug')
+    packages = ('systemd-udev', 'systemd-coredump')
+
+    option_list = [
+        PluginOpt("detailed", default=False,
+                  desc="collect detailed information for every report")
+    ]
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/systemd/coredump.conf",
+            "/etc/systemd/coredump.conf.d/",
+            "/run/systemd/coredump.conf.d/",
+            "/usr/lib/systemd/coredump.conf.d/"
+        ])
+
+        self.add_cmd_output("coredumpctl dump")
+
+        coredump_list = self.collect_cmd_output("coredumpctl list")
+        if self.get_option("detailed") and coredump_list['status'] == 0:
+            for line in coredump_list["output"].splitlines()[1:]:
+                self.add_cmd_output("coredumpctl info "
+                                    f"{line.split()[4]}")
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This plugin captures information about core dumps
on these systems where it's active and has replaced abrt.

Closes: #3325

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?