### PR TITLE
[plugins/ubuntu] Do not load tls module if not loaded

### DIFF
--- a/sos/report/plugins/ubuntu.py
+++ b/sos/report/plugins/ubuntu.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin
+from sos.report.plugins import Plugin, UbuntuPlugin, SoSPredicate
 from sos.utilities import is_executable
 
 
@@ -30,8 +30,11 @@ class Ubuntu(Plugin, UbuntuPlugin):
                 ua_tools_status = 'pro status'
             else:
                 ua_tools_status = 'ubuntu-advantage status'
-            self.add_cmd_output(ua_tools_status)
-            self.add_cmd_output("%s --format json" % ua_tools_status)
+            ua_pred = SoSPredicate(self, kmods=['tls'])
+            self.add_cmd_output(ua_tools_status,
+                                pred=ua_pred, changes=True)
+            self.add_cmd_output("%s --format json" % ua_tools_status,
+                                pred=ua_pred, changes=True)
 
             if not self.get_option("all_logs"):
                 self.add_copy_spec([


### PR DESCRIPTION
Adds a predicate to avoid loading the tls module if it is not loaded.

Resolves: #3326

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?