### PR TITLE
[cleaner] Use data filter for extraction

### DIFF
--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -25,6 +25,12 @@ from sos.utilities import file_is_binary
 def extract_archive(archive_path, tmpdir):
     archive = tarfile.open(archive_path)
     path = os.path.join(tmpdir, 'cleaner')
+    # set extract filter since python 3.12 (see PEP-706 for more)
+    # Because python 3.10 and 3.11 raises false alarms as exceptions
+    # (see #3330 for examples), we can't use data filter but must
+    # fully trust the archive (legacy behaviour)
+    archive.extraction_filter = getattr(tarfile, 'fully_trusted_filter',
+                                        (lambda member, path: member))
     archive.extractall(path)
     archive.close()
     return os.path.join(path, archive.name.split('/')[-1].split('.tar')[0])


### PR DESCRIPTION
Since Python 3.12, archive.extractall would require setting an extraction filter otherwise an exception is raised. See PEP 706 for more.

Since sos extracts just tarballs that should be compliant with safe extraction (no extracted file outside the target directory etc.), we should stick to the data filter.

Relevant: #3319
Closes: #3330

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?