### PR TITLE
[utilities] catch SoSTimeoutError in sos_get_command_output

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -233,7 +233,15 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
 
         if poller:
             while reader.running:
-                _check_poller(p)
+                try:
+                    _check_poller(p)
+                except SoSTimeoutError:
+                    p.terminate()
+                    if to_file:
+                        _output.close()
+                    reader.running = False
+                    return {'status': 124, 'output': reader.get_contents(),
+                            'truncated': reader.is_full}
         else:
             try:
                 # override timeout=0 to timeout=None, as Popen will treat the


### PR DESCRIPTION
When calling collect_cmd_output and timeout is hit, SoSTimeoutError is raised and never caught (until in plugin wrapper).

Resolves: #3331

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?