### PR TITLE
[openshift_ovn] Collect additional ovnkube node logs

### DIFF
--- a/sos/report/plugins/openshift_ovn.py
+++ b/sos/report/plugins/openshift_ovn.py
@@ -20,19 +20,28 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
     profiles = ('openshift',)
 
     def setup(self):
+        all_logs = self.get_option("all_logs")
+
         self.add_copy_spec([
             "/var/lib/ovn/etc/ovnnb_db.db",
             "/var/lib/ovn/etc/ovnsb_db.db",
-            "/var/lib/openvswitch/etc/keys",
-            "/var/log/openvswitch/libreswan.log",
-            "/var/log/openvswitch/ovs-monitor-ipsec.log"
-        ])
-        # Collect ovn interconnect specific files if exists.
+            "/var/lib/openvswitch/etc/keys"
+        ], sizelimit=300)
+
+        # Collect ovn interconnect specific db files if exists.
         self.add_copy_spec([
             "/var/lib/ovn-ic/etc/ovnnb_db.db",
-            "/var/lib/ovn-ic/etc/ovnsb_db.db",
-            "/var/lib/ovn-ic/etc/libovsdb*log*"
-        ])
+            "/var/lib/ovn-ic/etc/ovnsb_db.db"
+        ], sizelimit=300)
+
+        # Collect libovsdb logs in case of ovn interconnect setup.
+        if not all_logs:
+            self.add_copy_spec([
+                "/var/lib/ovn-ic/etc/libovsdb.log",
+                "/var/lib/ovn-ic/etc/libovsdb*log.gz"
+            ], sizelimit=100)
+        else:
+            self.add_copy_spec("/var/lib/ovn-ic/etc/libovsdb*log*")
 
         # The ovn cluster/status is not valid anymore for interconnect setup.
         self.add_cmd_output([

--- a/sos/report/plugins/openshift_ovn.py
+++ b/sos/report/plugins/openshift_ovn.py
@@ -30,7 +30,8 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
         # Collect ovn interconnect specific files if exists.
         self.add_copy_spec([
             "/var/lib/ovn-ic/etc/ovnnb_db.db",
-            "/var/lib/ovn-ic/etc/ovnsb_db.db"
+            "/var/lib/ovn-ic/etc/ovnsb_db.db",
+            "/var/lib/ovn-ic/etc/libovsdb*log*"
         ])
 
         # The ovn cluster/status is not valid anymore for interconnect setup.


### PR DESCRIPTION
With Interconnect support in latest OVN-Kubernetes, ovnkube-nodes logs grew large. This commit adds the ability to collect those additional logs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?