### PR TITLE
[hpssm] handle new names and higher slot positions

### DIFF
--- a/sos/report/plugins/hpssm.py
+++ b/sos/report/plugins/hpssm.py
@@ -45,7 +45,7 @@ class Hpssm(Plugin, IndependentPlugin):
             ["%s %s" % (cmd, subcmd) for subcmd in subcmds]
         )
 
-        pattern = re.compile("^HP.*Smart Array (.*) in Slot ([0123456789])")
+        pattern = re.compile("^HP[E] (.*) in Slot ([0123456789]+)")
         config_detail_cmd = cmd + ' ctrl all show config detail'
         config_detail = self.collect_cmd_output(config_detail_cmd)
         ctrl_slots = []


### PR DESCRIPTION
This change adds new non "Smart Array" labeled controllers to the pattern match for each slot and includes controllers now showing up in slots 10+. 

It continues to honor older Smart Array Firmware which may report as `HP` instead of `HPE`.

Closes #3341
 
Signed-off-by: Trevor Benson <trevor.benson@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?