### PR TITLE
[openvswitch] Add pmd-sleep-show command

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -151,7 +151,9 @@ class OpenVSwitch(Plugin):
             # Capture dpif implementations
             "ovs-appctl dpif-netdev/dpif-impl-get",
             # Capture miniflow extract implementations
-            "ovs-appctl dpif-netdev/miniflow-parser-get"
+            "ovs-appctl dpif-netdev/miniflow-parser-get",
+            # Capture DPDK pmd sleep config
+            "ovs-appctl dpif-netdev/pmd-sleep-show"
         ])
         # Capture DPDK and other parameters
         self.add_cmd_output("ovs-vsctl -t 5 get Open_vSwitch . other_config",


### PR DESCRIPTION
Since OVS 3.2 there is a command to capture the sleep configuration of DPDK PMD cores.

This shows the maximum amount of time the PMD cores may sleep for under low or no load traffic conditions.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?