### PR TITLE
[openshift_ovn] Collect logs from ovnkube-controller container

### DIFF
--- a/sos/report/plugins/openshift_ovn.py
+++ b/sos/report/plugins/openshift_ovn.py
@@ -16,7 +16,8 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
     """
     short_desc = 'Openshift OVN'
     plugin_name = "openshift_ovn"
-    containers = ('ovnkube-master', 'ovnkube-node', 'ovn-ipsec')
+    containers = ('ovnkube-master', 'ovnkube-node', 'ovn-ipsec',
+                  'ovnkube-controller')
     profiles = ('openshift',)
 
     def setup(self):
@@ -54,6 +55,10 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
             'ovs-appctl -t /var/run/ovn/ovn-controller.*.ctl ' +
             'ct-zone-list'],
             container='ovnkube-node')
+        self.add_cmd_output([
+            'ovs-appctl -t /var/run/ovn/ovn-controller.*.ctl ' +
+            'ct-zone-list'],
+            container='ovnkube-controller')
         # Collect ovs ct-zone-list directly on host for interconnect setup.
         self.add_cmd_output([
             'ovs-appctl -t /var/run/ovn-ic/ovn-controller.*.ctl ' +


### PR DESCRIPTION
This enables ovn sos report plugin to collect logs ovnkube-controller container because ovn-kubernetes now provides option to run both ovnkube-node and ovnkube-controller in same container with this PR https://github.com/ovn-org/ovn-kubernetes/pull/3807.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?