### PR TITLE
logs: Use journalctl -o with-unit for default logs

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -17,6 +17,12 @@ class LogsBase(Plugin):
     plugin_name = "logs"
     profiles = ('system', 'hardware', 'storage')
 
+    # The default journal output is syslog-compatible, but it's much
+    # more useful to have the systemd unit.  Related prior art:
+    # https://github.com/openshift/installer/pull/7371/commits/948df48aada21e47e9bb0d0a53366871aa21b40a
+    # https://github.com/coreos/coreos-assembler/commit/c931fe0e9aa6b7c20c8279fdce3b6ef448eac8b8
+    default_format = "with-unit"
+
     def setup(self):
         confs = ['/etc/syslog.conf', '/etc/rsyslog.conf']
         logs = []
@@ -64,11 +70,13 @@ class LogsBase(Plugin):
                        for p in ["/var", "/run"]])
         if journal and self.is_service("systemd-journald"):
             self.add_journal(since=since, tags=['journal_full', 'journal_all'],
-                             priority=100)
+                             priority=100, output=self.default_format)
             self.add_journal(boot="this", since=since,
-                             tags='journal_since_boot')
+                             tags='journal_since_boot',
+                             output=self.default_format)
             self.add_journal(boot="last", since=since,
-                             tags='journal_last_boot')
+                             tags='journal_last_boot',
+                             output=self.default_format)
             if self.get_option("all_logs"):
                 self.add_copy_spec([
                     "/var/log/journal/*",

--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -24,7 +24,7 @@ class LogsPluginTest(StageOneReportTest):
 
     def test_journalctl_collections(self):
         self.assertFileCollected('sos_commands/logs/journalctl_--disk-usage')
-        self.assertFileCollected('sos_commands/logs/journalctl_--no-pager_--boot')
+        self.assertFileCollected('sos_commands/logs/journalctl_-o_with-unit_--no-pager_--boot')
 
     def test_journal_runtime_collected(self):
         self.assertFileGlobInArchive('/var/log/journal/*')
@@ -70,13 +70,13 @@ class JournalSizeLimitTest(StageTwoReportTest):
             sosfd.write(rand[::-1] + '\n')
 
     def test_journal_size_limit(self):
-        journ = 'sos_commands/logs/journalctl_--no-pager'
+        journ = 'sos_commands/logs/journalctl_-o_with-unit_--no-pager'
         self.assertFileCollected(journ)
         jsize = os.stat(self.get_name_in_archive(journ)).st_size
         assert jsize <= 20971520, "Collected journal is larger than 20MB (size: %s)" % jsize
 
     def test_journal_tailed_and_linked(self):
-        tailed = self.get_name_in_archive('sos_strings/logs/journalctl_--no-pager.tailed')
+        tailed = self.get_name_in_archive('sos_strings/logs/journalctl_-o_with-unit_--no-pager.tailed')
         self.assertFileExists(tailed)
-        journ = self.get_name_in_archive('sos_commands/logs/journalctl_--no-pager')
+        journ = self.get_name_in_archive('sos_commands/logs/journalctl_-o_with-unit_--no-pager')
         assert os.path.islink(journ), "Journal in sos_commands/logs is not a symlink"


### PR DESCRIPTION
Before systemd was created, syslog was the dominant Unix logging system.

Later, systemd introduced the journal whose output intentionally exactly matched that of syslog for compatibility.

In systemd, the "unit" is the technical heart of things; yet the syslog output only includes the "syslog identifier" which might or might not look like the unit.

For many units that just run shell script, the syslog identifier is just "bash" which is not useful.

The `-o with-unit` is in RHEL8 and above; it's not in RHEL7.  I don't know if it is a goal of this project to ship the latest releases on very old operating systems.  If it is, we can try to do dynamic detection.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?