### PR TITLE
[contrail] add another container regex

### DIFF
--- a/sos/report/plugins/opencontrail.py
+++ b/sos/report/plugins/opencontrail.py
@@ -16,7 +16,10 @@ class OpenContrail(Plugin, IndependentPlugin):
     plugin_name = 'opencontrail'
     profiles = ("network",)
     packages = ('opencontrail',)
-    containers = ('opencontrail.*',)
+    containers = (
+        'opencontrail.*',
+        'vrouter.*',
+    )
 
     def setup(self):
         # assuming the container names will start with "opencontrail"


### PR DESCRIPTION
In a contrail environment, the container name could also start with `vrouter.*`, this then ensures that the relevant details are also collected from any host that has the containers running

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?