### PR TITLE
[foreman] Call gem list outside scl

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3570,20 +3570,6 @@ class SCLPlugin(RedHatPlugin):
     to match these against all found SCLs on the system. SCLs that do match
     class.files or class.packages are then accessible via self.scls_matched
     when the plugin is invoked.
-
-    Additionally, this plugin class provides "add_cmd_output_scl" (run
-    a command in context of given SCL), and "add_copy_spec_scl" and
-    "add_copy_spec_limit_scl" (copy package from file system of given SCL).
-
-    For example, you can implement a plugin that will list all global npm
-    packages in every SCL that contains "npm" package:
-
-    class SCLNpmPlugin(Plugin, SCLPlugin):
-        packages = ("%(scl_name)s-npm",)
-
-        def setup(self):
-            for scl in self.scls_matched:
-                self.add_cmd_output_scl(scl, "npm ls -g --json")
     """
 
     @property
@@ -3601,19 +3587,6 @@ class SCLPlugin(RedHatPlugin):
         """
         scl_cmd = "scl enable %s \"%s\"" % (scl, cmd)
         return scl_cmd
-
-    def add_cmd_output_scl(self, scl, cmds, **kwargs):
-        """Same as add_cmd_output, except that it wraps command in
-        "scl enable" call and sets proper PATH.
-        """
-        if scl not in self.scls_matched:
-            return
-        if isinstance(cmds, str):
-            cmds = [cmds]
-        scl_cmds = []
-        for cmd in cmds:
-            scl_cmds.append(self.convert_cmd_scl(scl, cmd))
-        self.add_cmd_output(scl_cmds, **kwargs)
 
     # config files for Software Collections are under /etc/${prefix}/${scl} and
     # var files are under /var/${prefix}/${scl} where the ${prefix} is distro

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -335,8 +335,7 @@ class RedHatForeman(Foreman, SCLPlugin, RedHatPlugin):
             self.pumactl = "scl enable tfm '%s'" % self.pumactl
 
         super(RedHatForeman, self).setup()
-        self.add_cmd_output_scl('tfm', 'gem list',
-                                suggest_filename='scl enable tfm gem list')
+        self.add_cmd_output('gem list')
 
 
 class DebianForeman(Foreman, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Since scl is RHEL7-only related and foreman on RHEL7 is not further supported, let fully remove from scl wrapper.

Resolves: #3353

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?