### PR TITLE
[virsh] Add --all for virsh pool and net

### DIFF
--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -50,7 +50,8 @@ class LibvirtClient(Plugin, IndependentPlugin):
 
         # get network, pool and nwfilter elements
         for k in ['net', 'nwfilter', 'pool']:
-            k_list = self.collect_cmd_output('%s %s-list' % (cmd, k),
+            k_list = self.collect_cmd_output('%s %s-list %s' % (cmd, k, '--all'
+                                             if k in ['net', 'pool'] else ''),
                                              foreground=True)
             if k_list['status'] == 0:
                 k_lines = k_list['output'].splitlines()


### PR DESCRIPTION
Adding --all will also get inactive pools/net. This would be helpful when working with a pool/net which failed to startup.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?