### PR TITLE
[filesys] skip filesystems picked up by other plugins

### DIFF
--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -56,7 +56,21 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "lslocks"
         ])
 
-        self.add_forbidden_path('/proc/fs/panfs')
+        self.add_forbidden_path([
+            # cifs plugin
+            '/proc/fs/cifs',
+            # lustre plugin
+            '/proc/fs/ldiskfs',
+            '/proc/fs/lustre',
+            # nfs plugin
+            '/proc/fs/nfsd',
+            '/proc/fs/nfsfs',
+            # panfs (from Panasas company) provides statistics which can be
+            # very large (100s of GB)
+            '/proc/fs/panfs',
+            # xfs plugin
+            '/proc/fs/xfs'
+        ])
 
         if self.get_option('lsof'):
             self.add_cmd_output("lsof -b +M -n -l -P", root_symlink="lsof",


### PR DESCRIPTION
Fix forbidding panfs - add_forbidden_path() needs to be called prior to add_copy_spec() for it to be useful.
Skip /proc/fs/FS for FS picked up by other plugins

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?