### PR TITLE
[global] Fix alerts for mixing implicit and explicit returns

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -428,6 +428,7 @@ third party.
                          "representative and keep the mapping file private")
 
         self.cleanup()
+        return None
 
     def rebuild_nested_archive(self):
         """Handles repacking the nested tarball, now containing only obfuscated
@@ -750,7 +751,7 @@ third party.
         """
         if not filename:
             # the requested file doesn't exist in the archive
-            return
+            return None
         subs = 0
         if not short_name:
             short_name = filename.split('/')[-1]

--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -41,6 +41,7 @@ class SoSMap():
         for skip in self.ignore_matches:
             if re.match(skip, item, re.I):
                 return True
+        return False
 
     def add(self, item):
         """Add a particular item to the map, generating an obfuscated pair

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -215,6 +215,7 @@ class SoSHostnameMap(SoSMap):
             if all([h.isupper() for h in host]):
                 _fqdn = _fqdn.upper()
             return _fqdn
+        return None
 
     def sanitize_short_name(self, hostname):
         """Obfuscate the short name of the host with an incremented counter

--- a/sos/cleaner/mappings/mac_map.py
+++ b/sos/cleaner/mappings/mac_map.py
@@ -77,3 +77,4 @@ class SoSMacMap(SoSMap):
         # match 48-bit IPv4 MAC addresses
         if re.match('([0-9a-fA-F][:_]?){12}', item):
             return self.mac_template % hextets
+        return None

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -598,6 +598,7 @@ class SoSCollector(SoSComponent):
                     return True
                 else:
                     return False
+        self.exit(f"Unknown option type: {cli.opt_type}")
 
     def log_info(self, msg):
         """Log info messages to both console and log file"""

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -127,7 +127,7 @@ class ocp(Cluster):
         collection via a container image
         """
         if not self.set_transport_type() == 'oc':
-            return
+            return None
 
         out = self.exec_primary_cmd(self.fmt_oc_cmd("auth can-i '*' '*'"))
         self.oc_cluster_admin = out['status'] == 0

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -213,6 +213,7 @@ class SosNode():
                 self.log_error("Could not create container on host: %s"
                                % res['output'])
                 raise Exception
+        return False
 
     def get_container_auth(self):
         """Determine what the auth string should be to pull the image used to
@@ -331,6 +332,7 @@ class SosNode():
             self._load_sos_plugins(sosinfo['output'])
         if self.check_sos_version('3.6'):
             self._load_sos_presets()
+        return None
 
     def _load_sos_presets(self):
         cmd = '%s --list-presets' % self.sos_bin

--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -102,6 +102,7 @@ class RemoteTransport():
             section.add_text(
                 'Detailed information not available for this transport'
             )
+        return None
 
     @classmethod
     def display_self_help(cls, section):
@@ -299,6 +300,11 @@ class RemoteTransport():
             return {'status': result.exitstatus, 'output': out}
         elif index == 1:
             raise CommandTimeoutException(cmd)
+        # if we somehow manage to flow to this point, use this bogus exit code
+        # as a signal to debugging efforts that whatever went sideways did so
+        # as part of the above block
+        self.log_debug(f"Unexpected index {index} from pexpect: {result}")
+        return {'status': 999, 'output': ''}
 
     def _send_pexpect_password(self, index, result):
         """Handle password prompts for sudo and su usage for non-root SSH users

--- a/sos/collector/transports/control_persist.py
+++ b/sos/collector/transports/control_persist.py
@@ -176,6 +176,7 @@ class SSHControlPersist(RemoteTransport):
                 return False
         self.log_debug("Control socket not present when attempting to "
                        "terminate session")
+        return False
 
     @property
     def connected(self):

--- a/sos/component.py
+++ b/sos/component.py
@@ -182,6 +182,7 @@ class SoSComponent():
         opts = [o for o in self.opts.dict().keys() if o.startswith('list')]
         if opts:
             return any([getattr(self.opts, opt) for opt in opts])
+        return False
 
     @classmethod
     def add_parser_options(cls, parser):

--- a/sos/help/__init__.py
+++ b/sos/help/__init__.py
@@ -126,6 +126,7 @@ class SoSHelper(SoSComponent):
         _transport = self.opts.topic.split('.')[-1]
         if _transport in TRANSPORTS:
             return TRANSPORTS[_transport]
+        return None
 
     def _get_collect_cluster(self):
         from sos.collector import SoSCollector
@@ -135,6 +136,7 @@ class SoSHelper(SoSComponent):
         for cluster in clusters:
             if cluster[0] == self.opts.topic.split('.')[-1]:
                 return cluster[1]
+        return None
 
     def _get_plugin_variant(self):
         mod = importlib.import_module('sos.' + self.opts.topic)
@@ -145,6 +147,7 @@ class SoSHelper(SoSComponent):
             if plugin.__subclasses__():
                 cls = self.policy.match_plugin(plugin.__subclasses__())
                 return cls
+        return None
 
     def _get_policy_by_name(self):
         _topic = self.opts.topic.split('.')[-1]
@@ -157,6 +160,7 @@ class SoSHelper(SoSComponent):
                 _p = policy.__name__.lower().replace('policy', '')
                 if _p == _topic:
                     return policy
+        return None
 
     def display_self_help(self):
         """Displays the help information for this component directly, that is

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -467,6 +467,7 @@ any third party.
             self.ui_log.info(
                 _("\nPlease send this file to your support representative.\n")
             )
+        return None
 
     def get_msg(self):
         """This method is used to prepare the preamble text to display to

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1385,6 +1385,7 @@ class SoSReport(SoSComponent):
             self.handle_exception(plugname, "collect")
         except Exception:
             self.handle_exception(plugname, "collect")
+        return None
 
     def ui_progress(self, status_line):
         if self.opts.verbosity == 0 and not self.opts.batch:

--- a/sos/report/plugins/autofs.py
+++ b/sos/report/plugins/autofs.py
@@ -40,6 +40,7 @@ class Autofs(Plugin):
                                   *self.files)
         for i in debugout:
             return i[1]
+        return None
 
     def setup(self):
         self.add_copy_spec("/etc/auto*")

--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -37,14 +37,17 @@ class Ipa(Plugin, RedHatPlugin):
 
     def ca_installed(self):
         # Follow the same checks as IPA CA installer code
-        if self.path_exists("%s/conf/ca/CS.cfg" % self.pki_tomcat_dir_v4) \
-                or self.path_exists("%s/conf/CS.cfg" % self.pki_tomcat_dir_v3):
-            return True
+        return any(
+            self.path_exists(path) for path in [
+                f"{self.pki_tomcat_dir_v4}/conf/ca/CS.cfg",
+                f"{self.pki_tomcat_dir_v3}/conf/CS.cfg"
+            ]
+        )
 
     def ipa_server_installed(self):
-        if self.is_installed("ipa-server") \
-                or self.is_installed("freeipa-server"):
-            return True
+        return any(
+            self.is_installed(pkg) for pkg in ['ipa-server', 'freeipa-server']
+        )
 
     def retrieve_pki_logs(self, ipa_version):
         if ipa_version == "v4":

--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -51,12 +51,12 @@ class OVNCentral(Plugin):
             if res['status'] != 0:
                 self._log_error("Could not retrieve DB schema file from "
                                 "container %s" % self._container_name)
-                return
+                return None
             try:
                 db = json.loads(res['output'])
             except Exception:
                 self._log_error("Cannot parse JSON file %s" % filename)
-                return
+                return None
         else:
             try:
                 with open(self.path_join(filename), 'r') as f:
@@ -65,16 +65,17 @@ class OVNCentral(Plugin):
                     except Exception:
                         self._log_error(
                             "Cannot parse JSON file %s" % filename)
-                        return
+                        return None
             except IOError as ex:
                 self._log_error(
                     "Could not open DB schema file %s: %s" % (filename, ex))
-                return
+                return None
         try:
             return [table for table in dict.keys(
                 db['tables']) if table not in skip]
         except AttributeError:
             self._log_error("DB schema %s has no 'tables' key" % filename)
+        return None
 
     def add_database_output(self, tables, cmds, ovn_cmd):
         if not tables:

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -533,8 +533,7 @@ class ImporterHelper(object):
             pnames = self._get_plugins_from_list(py_files)
             if pnames:
                 return pnames
-            else:
-                return []
+        return []
 
     def get_modules(self):
         """Returns the list of importable modules in the configured python


### PR DESCRIPTION
This commit resolves the alerts generated by GitHub code scanning for mixing implicit and explicit returns. In most cases this is simply changing empty or implicit returns to `return None`, while in a few other places the return logic is slightly reworked.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?