### PR TITLE
Support running inside Toolbx containers

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -51,6 +51,9 @@ class SoS():
     """
 
     def __init__(self, args):
+        if not os.getenv('HOST', None) and os.path.isfile('/run/.toolboxenv'):
+            os.environ['HOST'] = '/run/host'
+
         self.cmdline = args
         # define the local subcommands that exist on the system
         # first import the necessary module, then add an entry to the dict that

--- a/sos/component.py
+++ b/sos/component.py
@@ -159,7 +159,9 @@ class SoSComponent():
         else:
             tmpdir = os.getenv('TMPDIR', None) or '/var/tmp'
 
-        if os.getenv('HOST', None) and os.getenv('container', None):
+        if os.getenv('HOST', None) \
+           and (os.path.isfile('/run/.containerenv')
+                or os.path.isfile('/.dockerenv')):
             tmpdir = os.path.join(os.getenv('HOST'), tmpdir.lstrip('/'))
 
         # no standard library method exists for this, so call out to stat to


### PR DESCRIPTION
[Toolbx](https://containertoolbx.org/) containers are Podman containers that are designed to be used as interactive command line environments for development and troubleshooting the host operating system.  Therefore, a well working `sos(1)` will improve the troubleshooting experience inside these containers.

Currently, those trying to use Toolbx containers for troubleshooting with `sos report` have been setting the `HOST` environment variable inside their containers.

The problem with doing that is that `HOST` is a very generic name without any namespacing.  Not every user is going to use `sos report`, and it can easily conflict with a variable of the same name being used for a different purpose.  This is similar to the `NAME` and `VERSION` environment variables that used to be set inside Toolbx containers due to outdated or wrong information in Fedora's [container guidelines](https://docs.fedoraproject.org/en-US/containers/guidelines/creation/).  They were a constant source of [complaints](https://github.com/containers/toolbox/issues/188) and were recently [fixed](https://github.com/containers/toolbox/commit/9506173f88dc26bf).  The same logic applies to `HOST`.

Note that there is an ongoing effort to change the implementation of the `toolbox` RPM in various Red Hat products from github.com/coreos/toolbox to github.com/containers/toolbox or [Toolbx](https://containertoolbx.org/).  The latter was inspired by the former, and is the more widely used of the two.  eg., Toolbx is installed by default on Fedora CoreOS, Silverblue and Workstation.

So far, this change has been made in Red Hat Enterprise Linux 8.5 onwards, but not in other products like Red Hat OpenShift Container Platform.
