### PR TITLE
[powerpc] Collect nvdimm logs

### DIFF
--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -115,6 +115,9 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/var/log/opal-prd",
                 "/var/log/opal-prd.log*"
             ])
+            self.add_cmd_output([
+                "opal-prd --expert-mode run nvdimm_info"
+            ])
             if self.path_isdir("/var/log/dump"):
                 self.add_cmd_output("ls -l /var/log/dump")
 


### PR DESCRIPTION
Run an opal-prd command to collect nvdimm NV DIMM info which includes:

- Number of NV DIMMs
- Active slot
- Falsh lifetime
- Serial Number
- Runtime

The data generated by the opal-prd for NV DIMM info command is usually
around 1K.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?