### PR TITLE
[docker] Fix runtime check_is_active sysroot consideration

### DIFF
--- a/sos/policies/runtimes/docker.py
+++ b/sos/policies/runtimes/docker.py
@@ -18,9 +18,9 @@ class DockerContainerRuntime(ContainerRuntime):
     name = 'docker'
     binary = 'docker'
 
-    def check_is_active(self, sysroot=None):
+    def check_is_active(self):
         # the daemon must be running
-        if (is_executable('docker', sysroot) and
+        if (is_executable('docker', self.policy.sysroot) and
                 (self.policy.init_system.is_running('docker') or
                  self.policy.init_system.is_running('snap.docker.dockerd'))):
             self.active = True
@@ -28,6 +28,6 @@ class DockerContainerRuntime(ContainerRuntime):
         return False
 
     def check_can_copy(self):
-        return self.check_is_active(sysroot=self.policy.sysroot)
+        return self.active
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
A runtime's `check_is_active()` does not get passed a sysroot at any point, so the docker runtime abstraction should just use the policy sysroot directly.

Additionally, `check_can_copy()` should be simplified to simply return the already-determined active state of the runtime.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?