### PR TITLE
[powerpc] collect rtas_errd.log and lp_diag.log files

### DIFF
--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -40,6 +40,7 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/proc/version",
                 "/dev/nvram",
                 "/var/lib/lsvpd/",
+                "/var/log/lp_diag.log",
                 "/etc/ct_node_id"
             ])
             self.add_cmd_output([
@@ -72,6 +73,7 @@ class PowerPC(Plugin, IndependentPlugin):
                 "/var/log/drmgr",
                 "/var/log/drmgr.0",
                 "/var/log/hcnmgr",
+                "/var/log/rtas_errd.log",
                 "/var/ct/IBM.DRM.stderr",
                 "/var/ct/IW/log/mc/IBM.DRM/trace*"
             ])


### PR DESCRIPTION
On power systems, rtas_errd daemon logs RTAS events to servicelog database. This daemon uses /var/log/rtas_errd.log file to store debug logs.

Similarly, light path diagnostics log messages are written to /var/log/lp_diag.log file.

Signed-off-by: Sathvika Vasireddy <sv@linux.ibm.com>
Reviewed-by: Sourabh Jain <sourabhjain@linux.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?