### PR TITLE
[pulp] Fix dynaconf obfuscation and add AUTH_LDAP_BIND_PASSWORD

### DIFF
--- a/sos/report/plugins/pulp.py
+++ b/sos/report/plugins/pulp.py
@@ -170,10 +170,13 @@ class Pulp(Plugin, RedHatPlugin):
         repl = r"\1********"
         self.do_path_regex_sub("/etc/pulp(.*)(.json$)", jreg, repl)
 
-        # obfuscate SECRET_KEY = .. and 'PASSWORD': .. in dynaconf list output
-        # and also in settings.py
+        # obfuscate SECRET_KEY = .., 'PASSWORD': ..,
+        # and AUTH_LDAP_BIND_PASSWORD = ..
+        # in dynaconf list output and also in settings.py
         # count with option that PASSWORD is with(out) quotes or in capitals
-        key_pass_re = r"(SECRET_KEY\s*=|(password|PASSWORD)(\"|'|:)+)\s*(\S*)"
+        key_pass_re = r"((?:SECRET_KEY|AUTH_LDAP_BIND_PASSWORD)" \
+                      r"(?:\<.+\>)?(\s*=)?|(password|PASSWORD)" \
+                      r"(\"|'|:)+)\s*(\S*)"
         repl = r"\1 ********"
         self.do_path_regex_sub("/etc/pulp/settings.py", key_pass_re, repl)
         self.do_cmd_output_sub("dynaconf list", key_pass_re, repl)


### PR DESCRIPTION
An LDAP bind password can be present in `/etc/pulp/settings.py` when running an Ansible private automation hub. This needs to be obfuscated in both the `settings.py` file and in the `dynaconf list` output.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?