### PR TITLE
[policy] Fix a couple of typos

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -375,7 +375,7 @@ class LinuxPolicy(Policy):
         Entry point for sos attempts to upload the generated archive to a
         policy or user specified location.
 
-        Curerntly there is support for HTTPS, SFTP, and FTP. HTTPS uploads are
+        Currently there is support for HTTPS, SFTP, and FTP. HTTPS uploads are
         preferred for policy-defined defaults.
 
         Policies that need to override uploading methods should override the
@@ -456,7 +456,7 @@ class LinuxPolicy(Policy):
         :param password: Password for `user` to use for upload
         :type password: ``str``
 
-        :returns: The user/password auth suitable for use in reqests calls
+        :returns: The user/password auth suitable for use in requests calls
         :rtype: ``requests.auth.HTTPBasicAuth()``
         """
         if not user:


### PR DESCRIPTION
Fix a couple of typos.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?