### PR TITLE
[openvswitch] Add driverctl verbose option

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -102,7 +102,9 @@ class OpenVSwitch(Plugin):
             "dpdk_nic_bind --status",
             "dpdk-devbind.py --status",
             "driverctl list-devices",
+            "driverctl -v list-devices",
             "driverctl list-overrides",
+            "driverctl -v list-overrides",
             # Capture a list of all bond devices
             "ovs-appctl bond/list",
             # Capture more details from bond devices


### PR DESCRIPTION
driverctl commands give info about which drivers are used for devices. They list PCI address and driver used e.g.

0000:01:00.0 vfio-pci

This can usually be correlated to the device type through lspci. However, lspci may not be available if only some plugins were captured as part of the report.

Even when lspci info is available, it is still convienent to have the device type co-located with the driver and override information.

Add verbose option to driverctl commands that support it to also list device type. e.g. (wrapped for line length)

0000:01:00.0 vfio-pci
 (82599ES 10-Gigabit SFI/SFP+ Network Connection
 (Ethernet 10G 4P X520/I350 rNDC))

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?