### PR TITLE
[kernelrt] Update options format for tuna

### DIFF
--- a/sos/report/plugins/kernelrt.py
+++ b/sos/report/plugins/kernelrt.py
@@ -9,7 +9,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, SoSPredicate
 
 
 class KernelRT(Plugin, RedHatPlugin):
@@ -36,6 +36,12 @@ class KernelRT(Plugin, RedHatPlugin):
         # note: rhbz#1059685 'tuna - NameError: global name 'cgroups' is not
         # defined this command throws an exception on versions prior to
         # 0.10.4-5.
-        self.add_cmd_output('tuna -CP')
+        co = {'cmd': 'tuna --help', 'output': '-P'}
+        option_present = self.test_predicate(
+            self, pred=SoSPredicate(self, cmd_outputs=co)
+        )
+        self.add_cmd_output(
+            f"tuna {'-CP' if option_present else 'show_threads -C'}"
+        )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
In newer versions of tuna, the option -P has been
substituted for 'show_threads'.
Test if the new option is present in 'tuna --help' and if so, use it.

Closes: RH SUPDEV-150

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?