### PR TITLE
[nfs] remove duplicate rpcinfo_-p_localhost log

### DIFF
--- a/sos/report/plugins/nfs.py
+++ b/sos/report/plugins/nfs.py
@@ -33,7 +33,6 @@ class Nfs(Plugin, IndependentPlugin):
         ])
 
         self.add_cmd_output([
-            "rpcinfo -p localhost",
             "nfsstat -o all",
             "exportfs -v",
             "nfsdclnts",


### PR DESCRIPTION
 This commit removes the duplicate "rpcinfo_-p_localhost" log
 from the sos_commands/nfs directory. Currently, the same log
 file is being created in sos_commands/sunrpc/ directory,
 as shown below:
```
  # ls sos_commands/nfs/rpcinfo_-p_localhost
  sos_commands/nfs/rpcinfo_-p_localhost
  # ls sos_commands/sunrpc/rpcinfo_-p_localhost
  sos_commands/sunrpc/rpcinfo_-p_localhost
```
Since rpcinfo command is included in rpcbind package, let's remove the one in the nfs directory.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?