### PR TITLE
[salt] Update salt plugins to gather more data

### DIFF
--- a/sos/report/plugins/salt.py
+++ b/sos/report/plugins/salt.py
@@ -5,6 +5,7 @@
 # version 2 of the GNU General Public License.
 #
 # See the LICENSE file in the source distribution for further information.
+import re
 
 from sos.report.plugins import Plugin, IndependentPlugin
 
@@ -16,7 +17,7 @@ class Salt(Plugin, IndependentPlugin):
     plugin_name = 'salt'
     profiles = ('sysmgmt',)
 
-    packages = ('salt', 'salt-minion', 'salt-common',)
+    packages = ('salt', 'salt-minion', 'venv-salt-minion', 'salt-common',)
 
     def setup(self):
         all_logs = self.get_option("all_logs")
@@ -26,12 +27,41 @@ class Salt(Plugin, IndependentPlugin):
         else:
             self.add_copy_spec("/var/log/salt")
 
-        self.add_copy_spec("/etc/salt")
-        self.add_forbidden_path("/etc/salt/pki/*/*.pem")
+        self.add_copy_spec([
+            "/var/log/venv-salt-minion.log",
+            "/var/log/salt-ssh.log",
+        ])
+
+        self.add_copy_spec([
+            "/etc/salt",
+            "/etc/venv-salt-minion/",
+            "/usr/local/etc/salt",
+        ])
+        self.add_forbidden_path([
+            "/etc/salt/pki/*/*.pem",
+            "/etc/venv-salt-minion/pki/*/*.pem",
+            "/usr/local/etc/salt/pki/*/*.pem",
+        ])
+
+        self.add_cmd_output([
+            "systemctl --full status salt-minion",
+            "systemctl --full status venv-salt-minion",
+            "salt-minion --versions-report",
+            "venv-salt-minion --versions-report",
+            "salt-call --local grains.items --out yaml",
+            "venv-salt-call --local grains.items --out yaml",
+        ], timeout=30)
 
     def postproc(self):
         regexp = r'(^\s+.*(pass|secret|(?<![A-z])key(?![A-z])).*:\ ).+$'
         subst = r'\1******'
         self.do_path_regex_sub("/etc/salt/*", regexp, subst)
+
+        # Obfuscate grain entries like `password: mypass` or
+        # `secret: mysecret`
+        grain_regexp = re.compile("(^.*(pass|secret|key).*:)(.*)$",
+                                  re.MULTILINE)
+        self.do_cmd_output_sub("salt-call", grain_regexp, subst)
+        self.do_cmd_output_sub("venv-salt-call", grain_regexp, subst)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
I'd like to modify the `salt` and `saltmaster` plugins to:

- Add support for the `venv-salt-minion` package
- Gather more useful data, such as:
  - Systemctl status information
  - Version reports
  - Running job reports
  - Grains/pillars

and others.

Related downstream issue: https://github.com/SUSE/spacewalk/issues/22700

---
- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?

