### PR TITLE
[collect] Refactor `get_pty` functionality

### DIFF
--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -294,7 +294,8 @@ class Cluster():
         """
         return node.address == self.primary.address
 
-    def exec_primary_cmd(self, cmd, need_root=False, timeout=180):
+    def exec_primary_cmd(self, cmd, need_root=False, timeout=180,
+                         use_shell='auto'):
         """Used to retrieve command output from a (primary) node in a cluster
 
         :param cmd: The command to run
@@ -306,12 +307,14 @@ class Cluster():
         :param timeout:  Amount of time to allow cmd to run in seconds
         :type timeout: ``int``
 
+        :param use_shell:   Does the command required execution within a shell?
+        :type use_shell:    ``auto`` or ``bool``
+
         :returns: The output and status of `cmd`
         :rtype: ``dict``
         """
-        pty = self.primary.local is False
-        res = self.primary.run_command(cmd, get_pty=pty, need_root=need_root,
-                                       timeout=timeout)
+        res = self.primary.run_command(cmd, need_root=need_root,
+                                       use_shell=use_shell, timeout=timeout)
         if res['output']:
             res['output'] = res['output'].replace('Password:', '')
         return res

--- a/sos/collector/transports/oc.py
+++ b/sos/collector/transports/oc.py
@@ -208,15 +208,15 @@ class OCTransport(RemoteTransport):
         return super(OCTransport, self)._format_cmd_for_exec(cmd)
 
     def run_command(self, cmd, timeout=180, need_root=False, env=None,
-                    get_pty=False):
+                    use_shell=False):
         # debug pod setup is slow, extend all timeouts to account for this
         if timeout:
             timeout += 10
 
-        # since we always execute within a bash shell, force disable get_pty
+        # since we always execute within a bash shell, force disable use_shell
         # to avoid double-quoting
         return super(OCTransport, self).run_command(cmd, timeout, need_root,
-                                                    env, False)
+                                                    env, use_shell=False)
 
     def _disconnect(self):
         if os.path.exists(self.pod_tmp_conf):

--- a/sos/collector/transports/saltstack.py
+++ b/sos/collector/transports/saltstack.py
@@ -33,14 +33,14 @@ class SaltStackMaster(RemoteTransport):
     def _convert_output_json(self, json_output):
         return list(json.loads(json_output).values())[0]
 
-    def run_command(
-            self, cmd, timeout=180, need_root=False, env=None, get_pty=False):
+    def run_command(self, cmd, timeout=180, need_root=False, env=None,
+                    use_shell=False):
         """
         Run a command on the remote host using SaltStack Master.
         If the output is json, convert it to a string.
         """
         ret = super(SaltStackMaster, self).run_command(
-            cmd, timeout, need_root, env, get_pty)
+            cmd, timeout, need_root, env, use_shell)
         with contextlib.suppress(Exception):
             ret['output'] = self._convert_output_json(ret['output'])
         return ret

--- a/sos/policies/package_managers/__init__.py
+++ b/sos/policies/package_managers/__init__.py
@@ -72,7 +72,7 @@ class PackageManager():
         return self.__class__.__name__.lower().split('package')[0]
 
     def exec_cmd(self, command, timeout=30, need_root=False, env=None,
-                 get_pty=False, chroot=None):
+                 use_shell=False, chroot=None):
         """
         Runs a package manager command, either via sos_get_command_output() if
         local, or via a SoSTransport's run_command() if this needs to be run
@@ -90,9 +90,9 @@ class PackageManager():
         :param env:         Environment variables to set
         :type env:          ``dict`` with keys being env vars to define
 
-        :param get_pty:     If running remotely, does the command require
-                            obtaining a pty?
-        :type get_pty:      ``bool``
+        :param use_shell:   If running remotely, does the command require
+                            obtaining a shell?
+        :type use_shell:      ``bool``
 
         :param chroot:      If necessary, chroot command execution to here
         :type chroot:       ``None`` or ``str``
@@ -101,7 +101,7 @@ class PackageManager():
         :rtype:     ``str``
         """
         if self.remote_exec:
-            ret = self.remote_exec(command, timeout, need_root, env, get_pty)
+            ret = self.remote_exec(command, timeout, need_root, env, use_shell)
         else:
             ret = sos_get_command_output(command, timeout, chroot=chroot,
                                          env=env)


### PR DESCRIPTION
The `get_pty` parameter for remote executed commands was both a bit of a misnomer and applied too broadly.

Refactor this to `use_shell` to be more obvious about what the intent behind the option is, and default all transports to `False`, so that by default we do not wrap any commands in a bash shell.

This may be overriden on a per-transport basis via the ned `_need_shell` property within transport subclasses. Further, this facility has been expanded to be allowed on a per-command basis from `SoSNode.run_command()` and wherever that is linked.

Related: #3399
Related: #3400

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?