### PR TITLE
[networkmanager] Add config files to be collected

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -22,7 +22,11 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
         self.add_copy_spec([
             "/etc/NetworkManager/NetworkManager.conf",
             "/etc/NetworkManager/system-connections",
-            "/etc/NetworkManager/dispatcher.d"
+            "/etc/NetworkManager/dispatcher.d",
+            "/etc/NetworkManager/conf.d",
+            "/usr/lib/NetworkManager/conf.d",
+            "/run/NetworkManager/conf.d",
+            "/var/lib/NetworkManager/NetworkManager-intern.conf"
         ])
 
         self.add_journal(units="NetworkManager")


### PR DESCRIPTION
This patch add some configuration files to be collected based on the description of man 5 NetworkManager.conf.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?