### PR TITLE
[MAAS] Remove snap TLS private key from report

### DIFF
--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -85,7 +85,10 @@ class Maas(Plugin, UbuntuPlugin):
                 self.add_journal(units="snap.maas.pebble", since=since)
 
             # Don't send secrets
-            self.add_forbidden_path("/var/snap/maas/current/bind/session.key")
+            self.add_forbidden_path([
+                "/var/snap/maas/current/bind/session.key",
+                "/var/snap/maas/current/http/certs/regiond-proxy-key.pem",
+            ])
             self.add_copy_spec([
                 "/var/snap/maas/common/log",
                 "/var/snap/maas/common/snap_mode",


### PR DESCRIPTION
Remove file /var/snap/maas/current/http/certs/regiond-proxy-key.pem so that it is not collected by sosreport. This is a private key

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?