### PR TITLE
[ebpf] Check for bpftool presence before running plugin

### DIFF
--- a/sos/report/plugins/ebpf.py
+++ b/sos/report/plugins/ebpf.py
@@ -15,6 +15,7 @@ class Ebpf(Plugin, IndependentPlugin):
     short_desc = 'eBPF tool'
     plugin_name = 'ebpf'
     profiles = ('system', 'kernel', 'network')
+    commands = ('bpftool',)
 
     option_list = [
         PluginOpt("namespaces", default=None, val_type=int,


### PR DESCRIPTION
The plugin was running even when the bpftool was
not present, throwing an exception when it tried to parse a json output:

INFO: [plugin:ebpf] Could not parse bpftool prog list as
JSON: Expecting value: line 1 column 1 (char 0)

It now checks if the program is present before running any command at all.

Related: RH SUPDEV-151

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?