### PR TITLE
Add support for RHOSP 18 Openstack EDPM deployment

### DIFF
--- a/sos/report/plugins/frr.py
+++ b/sos/report/plugins/frr.py
@@ -29,7 +29,11 @@ class Frr(Plugin, RedHatPlugin):
     containers = ('frr',)
 
     def setup(self):
-        self.add_copy_spec("/etc/frr/")
+        var_ansible_gen = "/var/lib/config-data/ansible-generated/frr"
+        self.add_copy_spec([
+            "/etc/frr/",
+            var_ansible_gen + "/etc/frr/",
+        ])
 
         if self.container_exists('frr'):
             subcmds = [

--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -15,7 +15,7 @@ class Libvirt(Plugin, IndependentPlugin):
     short_desc = 'libvirt virtualization API'
 
     plugin_name = 'libvirt'
-    profiles = ('system', 'virt')
+    profiles = ('system', 'virt', 'openstack_edpm')
 
     def setup(self):
         libvirt_keytab = "/etc/libvirt/krb5.tab"
@@ -44,6 +44,8 @@ class Libvirt(Plugin, IndependentPlugin):
             "/etc/libvirt/virtlockd.conf",
             "/var/lib/libvirt/dnsmasq/*",
             "/var/lib/libvirt/qemu/snapshot/*/*.xml",
+            "/var/lib/openstack/config/libvirt",
+            "/var/lib/openstack/containers/libvirt*.json",
         ])
 
         if not self.get_option("all_logs"):
@@ -58,10 +60,15 @@ class Libvirt(Plugin, IndependentPlugin):
                 "/var/log/containers/libvirt/lxc/*.log",
                 "/var/log/containers/libvirt/swtpm/libvirt/qemu/*.log",
                 "/var/log/containers/libvirt/uml/*.log",
+                "/var/log/containers/qemu/*.log",
+                "/var/log/containers/libvirt/*.log",
             ])
         else:
-            self.add_copy_spec("/var/log/libvirt")
-            self.add_copy_spec("/var/log/containers/libvirt")
+            self.add_copy_spec([
+                "/var/log/libvirt",
+                "/var/log/containers/qemu/",
+                "/var/log/containers/libvirt/",
+            ])
 
         if self.path_exists(self.path_join(libvirt_keytab)):
             self.add_cmd_output("klist -ket %s" % libvirt_keytab)

--- a/sos/report/plugins/logrotate.py
+++ b/sos/report/plugins/logrotate.py
@@ -17,6 +17,7 @@ class LogRotate(Plugin, IndependentPlugin):
     profiles = ('system',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/crond"
+    var_ansible_gen = "/var/lib/config-data/ansible-generated/crond"
 
     def setup(self):
         self.add_cmd_output("logrotate --debug /etc/logrotate.conf",
@@ -26,7 +27,9 @@ class LogRotate(Plugin, IndependentPlugin):
             "/var/lib/logrotate.status",
             "/var/lib/logrotate/logrotate.status",
             self.var_puppet_gen + "/etc/logrotate-crond.conf",
-            self.var_puppet_gen + "/var/spool/cron/root"
+            self.var_puppet_gen + "/var/spool/cron/root",
+            self.var_ansible_gen + "/etc/logrotate-crond.conf",
+            self.var_ansible_gen + "/var/spool/cron/root"
         ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openstack_edpm.py
+++ b/sos/report/plugins/openstack_edpm.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Red Hat, Inc., Roberto Alfieri <ralfieri@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class OpenStackEDPM(Plugin, RedHatPlugin):
+
+    short_desc = 'Installation information from OpenStack EDPM deployment'
+
+    plugin_name = 'openstack_edpm'
+    profiles = ('openstack', 'openstack_edpm')
+    services = ('edpm-container-shutdown')
+
+    def setup(self):
+        # Notes: recursion is max 2 for edpm-config
+        # Those directories are present on all OpenStack nodes
+        self.edpm_log_paths = [
+            '/var/lib/edpm-config/'
+        ]
+        self.add_copy_spec(self.edpm_log_paths)
+
+    def postproc(self):
+        # Ensures we do not leak passwords from the edpm related locations
+        # Other locations don't have sensitive data.
+        regexp = r'(".*(key|password|pass|secret|database_connection))' \
+                 r'([":\s]+)(.*[^"])([",]+)'
+        for path in self.edpm_log_paths:
+            self.do_path_regex_sub(path, regexp, r'\1\3*********\5')
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openstack_neutron.py
+++ b/sos/report/plugins/openstack_neutron.py
@@ -17,7 +17,8 @@ class OpenStackNeutron(Plugin):
 
     short_desc = 'OpenStack Networking'
     plugin_name = "openstack_neutron"
-    profiles = ('openstack', 'openstack_controller', 'openstack_compute')
+    profiles = ('openstack', 'openstack_controller',
+                'openstack_compute', 'openstack_edpm')
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/neutron"
 
@@ -125,9 +126,15 @@ class DebianNeutron(OpenStackNeutron, DebianPlugin, UbuntuPlugin):
 class RedHatNeutron(OpenStackNeutron, RedHatPlugin):
 
     packages = ('openstack-selinux',)
+    var_ansible_gen = "/var/lib/config-data/ansible-generated/"
 
     def setup(self):
         super(RedHatNeutron, self).setup()
-        self.add_copy_spec("/etc/sudoers.d/neutron-rootwrap")
+        self.add_copy_spec([
+            "/etc/sudoers.d/neutron-rootwrap",
+            self.var_ansible_gen + "/neutron-dhcp-agent/",
+            self.var_ansible_gen + "/neutron-dhcp-ovn/",
+            self.var_ansible_gen + "/neutron-sriov-agent/"
+        ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -22,7 +22,8 @@ class OpenStackNova(Plugin):
 
     short_desc = 'OpenStack Nova'
     plugin_name = "openstack_nova"
-    profiles = ('openstack', 'openstack_controller', 'openstack_compute')
+    profiles = ('openstack', 'openstack_controller',
+                'openstack_compute', 'openstack_edpm')
     containers = ('.*nova_api',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/nova"
@@ -150,7 +151,8 @@ class OpenStackNova(Plugin):
             "xenapi_connection_password", "password", "host_password",
             "vnc_password", "admin_password", "connection_password",
             "memcache_secret_key", "s3_secret_key",
-            "metadata_proxy_shared_secret", "fixed_key", "transport_url"
+            "metadata_proxy_shared_secret", "fixed_key", "transport_url",
+            "rbd_secret_uuid"
         ]
         connection_keys = ["connection", "sql_connection"]
 
@@ -215,15 +217,24 @@ class RedHatNova(OpenStackNova, RedHatPlugin):
             "/etc/polkit-1/localauthority/50-local.d/50-nova.pkla",
             "/etc/sudoers.d/nova",
             "/etc/security/limits.d/91-nova.conf",
-            "/etc/sysconfig/openstack-nova-novncproxy"
+            "/etc/sysconfig/openstack-nova-novncproxy",
+            "/var/lib/openstack/config/nova",
+            "/var/lib/openstack/containers/nova*.json"
         ])
+
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/httpd/placement*",
+                "/var/log/containers/nova/*"
             ])
         else:
             self.add_copy_spec([
                 "/var/log/httpd/placement*.log",
+                "/var/log/containers/nova/*.log"
             ])
+
+        self.add_forbidden_path([
+            "/var/lib/openstack/config/nova/ssh-privatekey"
+        ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ovn_host.py
+++ b/sos/report/plugins/ovn_host.py
@@ -24,7 +24,7 @@ class OVNHost(Plugin):
 
     short_desc = 'OVN Controller'
     plugin_name = "ovn_host"
-    profiles = ('network', 'virt')
+    profiles = ('network', 'virt', 'openstack_edpm')
 
     def setup(self):
         if os.environ.get('OVS_RUNDIR'):
@@ -56,6 +56,22 @@ class OVNHost(Plugin):
 class RedHatOVNHost(OVNHost, RedHatPlugin):
 
     packages = ('openvswitch-ovn-host', 'ovn.*-host', )
+    var_ansible_gen = "/var/lib/config-data/ansible-generated/ovn-bgp-agent"
+
+    def setup(self):
+        super(RedHatOVNHost, self).setup()
+        self.add_copy_spec([
+            self.var_ansible_gen,
+        ])
+
+        if self.get_option("all_logs"):
+            self.add_copy_spec([
+                "/var/log/containers/ovn-bgp-agent/",
+            ])
+        else:
+            self.add_copy_spec([
+                "/var/log/containers/ovn-bgp-agent/*.log",
+            ])
 
 
 class DebianOVNHost(OVNHost, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
EDPM (External DataPlane Management) will be the new way to deploy compute nodes startin from RHOSP 18 which will replace TripleO/Director.

- Added `openstack_edpm` plugin
- Added custom path for config and logs in frr/libvirt/logrotate/openstack_neutron/openstack_nova/ovn_host modules
- Tagged libvirt/openstack_neutron/openstack_nova/ovn_host modules as `openstack_edpm_compute`

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?