### PR TITLE
[deb][pkg] Update control for downstream build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,6 +28,7 @@ env:
     DEBIAN_IMAGE_NAME: "debian-11-bullseye-v20230809"
     FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-38-1-6-x86-64"
     FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-37-1-7-x86-64"
+    UBUNTU_DEB_IMAGE_NAME: "ubuntu-minimal-2310-mantic-amd64-v20231030"
     UBUNTU_LATEST_IMAGE_NAME: "ubuntu-2310-mantic-amd64-v20231031"
     UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20231030"
     UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2004-focal-v20231101"
@@ -123,7 +124,7 @@ deb_build_task:
     name: "deb Build From Checkout"
     gce_instance:
         image_project: "${UBUNTU_PROJECT}"
-        image_name: "${UBUNTU_LATEST_IMAGE_NAME}"
+        image_name: "${UBUNTU_DEB_IMAGE_NAME}"
         type: e2-medium
     setup_script: |
         apt update --allow-releaseinfo-change

--- a/debian/control
+++ b/debian/control
@@ -10,10 +10,12 @@ Build-Depends:
  python3-all,
  python3-coverage,
  python3-nose,
+ python3-setuptools,
  python3-sphinx,
  python3-magic,
  python3-pexpect,
  python3-packaging,
+ python3-yaml,
 Homepage: https://github.com/sosreport/sos
 Vcs-Browser: https://salsa.debian.org/sosreport-team/sosreport
 Vcs-Git: https://salsa.debian.org/sosreport-team/sosreport.git

--- a/debian/rules
+++ b/debian/rules
@@ -12,4 +12,4 @@ override_dh_install:
 	rm -rf debian/sosreport/usr/config
 
 override_dh_auto_test:
-	nosetests3 -v --with-cover --cover-package=sos tests/unittests
+	nosetests3 -v --with-cover --cover-package=sos tests/unittests --ignore-files="policy_tests\.py"

--- a/sos/policies/runtimes/lxd.py
+++ b/sos/policies/runtimes/lxd.py
@@ -94,7 +94,8 @@ class LxdContainerRuntime(ContainerRuntime):
             if out['status'] == 0:
                 out_json = json.loads(out['output'])
                 for profile in out_json:
-                    if profile['name'] == 'default':
+                    if (profile['name'] == 'default' and
+                            'root' in profile['devices']):
                         stg_pool = profile['devices']['root']['pool']
                         break
 


### PR DESCRIPTION
* python3-setuptools is still required for building the package
* python3-yaml is required for build for tests with the conformance_tests
* Add the same ignores as dowstream build, so that we don't have to keep changing these. Once the avocado is packaged, we can take this out
* Update image for the deb creation, so that it can be minimal
* Fix lxd runtime, so that if the root device is not available, it will not look at the storage pools

Downstream build machines are much more minimal compared to gce instances, so we require more dependencies to be added.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?