### PR TITLE
[collect] update for strict confinement for juju

### DIFF
--- a/tests/unittests/juju/juju_transports_test.py
+++ b/tests/unittests/juju/juju_transports_test.py
@@ -33,6 +33,9 @@ class JujuSSHTest(unittest.TestCase):
             address="model_abc:unit_abc",
         )
 
+    def get_juju_version():
+        return "2.9.45"
+
     @patch("sos.collector.transports.juju.subprocess.check_output")
     def test_check_juju_installed_err(self, mock_subprocess_check_output):
         """Raise error if juju is not installed."""
@@ -71,11 +74,15 @@ class JujuSSHTest(unittest.TestCase):
         )
 
     @patch(
+        "sos.collector.transports.juju.JujuSSH._get_juju_version",
+        side_effect=get_juju_version,
+    )
+    @patch(
         "sos.collector.transports.juju.sos_get_command_output",
         return_value={"status": 0},
     )
     @patch("sos.collector.transports.juju.JujuSSH._chmod", return_value=True)
-    def test_retrieve_file(self, mock_chmod, mock_sos_get_cmd_output):
+    def test_retrieve_file(self, mock_chmod, mock_sos_get_cmd_output, mock_get_juju_version):
         self.juju_ssh._retrieve_file(fname="file_abc", dest="/tmp/sos-juju/")
         mock_sos_get_cmd_output.assert_called_with(
             "juju scp -m model_abc -- -r unit_abc:file_abc /tmp/sos-juju/"


### PR DESCRIPTION
With juju versions 3 and above, when collecting the tarballs from machines it will grab them into a strictly confined area. This means that we need to be able to access this area via sudo.

In order for this now to be fully supported, we need sudo on the host that is running juju, otherwise sos collect on a juju environment will not work.

Related: #3399

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?