### PR TITLE
[ansible] Skip collecting redundant dirs and files from /etc/ansible

### DIFF
--- a/sos/report/plugins/ansible.py
+++ b/sos/report/plugins/ansible.py
@@ -29,7 +29,11 @@ class Ansible(Plugin, RedHatPlugin, UbuntuPlugin):
             "ansible --version"
         ])
 
-        # let rhui plugin collects the RHUI specific files
-        self.add_forbidden_path("/etc/ansible/facts.d/rhui_*.fact")
+        # don't generic & collect potentially sensitive files and dirs
+        self.add_forbidden_path([
+            "/etc/ansible/facts.d/",
+            "/etc/ansible/roles/",
+            "/etc/ansible/hosts",
+        ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Forbid collecting some files and dirs from /etc/ansible that are not interesting for any investigation but might potentially collect sensitive data.

Resolves: #3423

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?