### PR TITLE
[release] collect /etc/machine-id from RHEL

### DIFF
--- a/sos/report/plugins/release.py
+++ b/sos/report/plugins/release.py
@@ -39,6 +39,7 @@ class RedHatRelease(Release, RedHatPlugin):
 
     def setup(self):
         self.add_file_tags({'/etc/redhat-release': 'redhat_release'})
+        self.add_file_tags({'/etc/machine-id': 'machine_id'})
         super(RedHatRelease, self).setup()
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
[release] collect /etc/machine-id from RHEL

Drafting a PR to pull the `/etc/machine-id` from the rhel.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?