### PR TITLE
[report] Clean up reference to obsolete ticket-number option

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -225,7 +225,7 @@ any third party.
 
             * name  - the short hostname of the system
             * label - the label given by --label
-            * case  - the case id given by --case-id or --ticker-number
+            * case  - the case id given by --case-id
             * rand  - a random string of 7 alpha characters
 
         Note that if a datestamp is needed, the substring should be set


### PR DESCRIPTION
Clean up one old reference to an obsolete option.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?