### PR TITLE
[report] Clean tmpdir when adding or deleting preset

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1809,12 +1809,14 @@ class SoSReport(SoSComponent):
                 self.list_presets()
                 raise SystemExit
             if self.opts.add_preset:
-                return self.add_preset(self.opts.add_preset)
+                self.add_preset(self.opts.add_preset)
+                raise SystemExit
             if self.opts.del_preset:
-                return self.del_preset(self.opts.del_preset)
+                self.del_preset(self.opts.del_preset)
+                raise SystemExit
             # verify that at least one plug-in is enabled
             if not self.verify_plugins():
-                return False
+                raise SystemExit
 
             self.batch()
             self.prework()


### PR DESCRIPTION
When adding or deleting preset (and also when detecting no plugin leaves enabled), sos.report.execute must cleanup its working dir.

Since we don't use return value of the execute method, we can skip the return command.

Resolves: #3430
Closes: #3431

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?