### PR TITLE
[report] Update preset opts already in SoSComponent

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -142,7 +142,6 @@ class SoSReport(SoSComponent):
         self.archive = None
         self._args = args
         self.sysroot = "/"
-        self.preset = None
         self.estimated_plugsizes = {}
 
         self.print_header()
@@ -152,25 +151,6 @@ class SoSReport(SoSComponent):
 
         # add a manifest section for report
         self.report_md = self.manifest.components.add_section('report')
-
-        # user specified command line preset
-        if self.opts.preset != self.arg_defaults["preset"]:
-            self.preset = self.policy.find_preset(self.opts.preset)
-            if not self.preset:
-                sys.stderr.write("Unknown preset: '%s'\n" % self.opts.preset)
-                self.preset = self.policy.probe_preset()
-                self.opts.list_presets = True
-
-        # --preset=auto
-        if not self.preset:
-            self.preset = self.policy.probe_preset()
-        # now merge preset options to self.opts
-        self.opts.merge(self.preset.opts)
-        # re-apply any cmdline overrides to the preset
-        self.opts = self.apply_options_from_cmdline(self.opts)
-        if hasattr(self.preset.opts, 'verbosity') and \
-                self.preset.opts.verbosity > 0:
-            self.set_loggers_verbosity(self.preset.opts.verbosity)
 
         self._set_directories()
 


### PR DESCRIPTION
As SoSComponent already works with --tmp-dir and it can be declared in a preset, we need to move whole options evaluation from SoSReport to SoSComponent constructor.

Resolves: #3425
Closes: #3432

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?