### PR TITLE
[docs] Fix warning generated when running sphinx

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3175,7 +3175,7 @@ class Plugin():
         :type subdir:       ``str``
 
         :param tags:        Tags to be added to this file in the manifest
-        :type tags:         ``str`` or ``list`` of ``str``s
+        :type tags:         ``str`` or ``list`` of ``str``
         """
         try:
             start = time()


### PR DESCRIPTION
When running sphinx-build to generate html documentation, we get the following warning:

sos/report/plugins/__init__.py:docstring of
sos.report.plugins.Plugin.collection_file:15:
WARNING: Inline literal start-string without end-string.

Related: RH: RHEL-17923

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?