### PR TITLE
[doc] Update README.md with new way to generate html docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pip install -r requirements.txt
 and run
 
 ```
-python3 setup.py build_sphinx -a
+sphinx-build -b html docs <destination dir> 
 ```
 
 


### PR DESCRIPTION
Commit ac17ca4f4 removed the command build_sphinx from setup.py, but the README.md file still references it. This patch offers an alternative for uses wishing to generate html docs, using the command sphinx-build.

Related: RH: RHEL-17924

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?