### PR TITLE
[foreman] Change scope of tasks history

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -25,8 +25,8 @@ class Foreman(Plugin):
     profiles = ('sysmgmt',)
     packages = ('foreman',)
     option_list = [
-        PluginOpt('months', default=1,
-                  desc='number of months for dynflow output'),
+        PluginOpt('days', default=14,
+                  desc='number of days for dynflow output'),
         PluginOpt('proxyfeatures', default=False,
                   desc='collect features of smart proxies'),
         PluginOpt('puma-gc', default=False,
@@ -179,9 +179,9 @@ class Foreman(Plugin):
         self.add_cmd_output(_cmd, suggest_filename='foreman_db_tables_sizes',
                             env=self.env)
 
-        months = '%s months' % self.get_option('months')
+        days = '%s days' % self.get_option('days')
 
-        # Construct the DB queries, using the months option to limit the range
+        # Construct the DB queries, using the days option to limit the range
         # of entries returned
 
         scmd = (
@@ -198,7 +198,7 @@ class Foreman(Plugin):
             'select dynflow_execution_plans.* from foreman_tasks_tasks join '
             'dynflow_execution_plans on (foreman_tasks_tasks.external_id = '
             'dynflow_execution_plans.uuid::varchar) where foreman_tasks_tasks.'
-            'started_at > NOW() - interval %s' % quote(months)
+            'started_at > NOW() - interval %s' % quote(days)
         )
 
         dactioncmd = (
@@ -206,7 +206,7 @@ class Foreman(Plugin):
              'dynflow_actions on (foreman_tasks_tasks.external_id = '
              'dynflow_actions.execution_plan_uuid::varchar) where '
              'foreman_tasks_tasks.started_at > NOW() - interval %s'
-             % quote(months)
+             % quote(days)
         )
 
         dstepscmd = (
@@ -214,7 +214,7 @@ class Foreman(Plugin):
             'dynflow_steps on (foreman_tasks_tasks.external_id = '
             'dynflow_steps.execution_plan_uuid::varchar) where '
             'foreman_tasks_tasks.started_at > NOW() - interval %s'
-            % quote(months)
+            % quote(days)
         )
 
         # counts of fact_names prefixes/types: much of one type suggests


### PR DESCRIPTION
Collect up to 14 days of dynflow data instead of one month.

Also, change granularity of the plugin option from months to days - we are almost never interested in tasks older than one month.

Resolves: #3437

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?