### PR TITLE
[targetcli] Don't collect passwords from iscsi configs

### DIFF
--- a/sos/report/plugins/targetcli.py
+++ b/sos/report/plugins/targetcli.py
@@ -23,9 +23,13 @@ class TargetCli(Plugin, IndependentPlugin):
             "targetcli ls",
             "targetcli status",
         ])
+        sys_conf_dir = '/sys/kernel/config/target'
+        self.add_forbidden_path([
+            self.path_join(sys_conf_dir, '**/password*'),
+        ])
         self.add_service_status("target")
         self.add_journal(units="targetcli")
-        self.add_copy_spec("/sys/kernel/config/target")
+        self.add_copy_spec(sys_conf_dir)
         self.add_copy_spec("/etc/target")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add passwords stored in /sys/kernel/config/target/ to the list of forbidden paths.

Related: RH RHEL-19056

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?