### PR TITLE
[discovery] collect also logs from container discovery-toolbox

### DIFF
--- a/sos/report/plugins/discovery.py
+++ b/sos/report/plugins/discovery.py
@@ -16,7 +16,7 @@ class Discovery(Plugin, RedHatPlugin):
     short_desc = 'Discovery inspection and reporting tool'
     plugin_name = 'discovery'
     packages = ('discovery', 'discovery-tools',)
-    containers = ('dsc-db', 'discovery',)
+    containers = ('dsc-db', 'discovery', 'discovery-toolbox')
 
     def setup(self):
         self.add_copy_spec([
@@ -27,8 +27,5 @@ class Discovery(Plugin, RedHatPlugin):
             "/var/discovery/server/volumes/log/",
         ])
 
-        self.add_container_logs([
-            'discovery',
-            'dsc-db'
-        ])
+        self.add_container_logs(list(self.containers))
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
As part of the discovery is also discovery-toolbox plugin we should collect also logs from this plugin which may be helpful in debugging issues.

Resolves: #3442

Signed-off-by: Jan Jansky <jjansky@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?