### PR TITLE
[nvidia] collect nvidia-persistenced service status

### DIFF
--- a/sos/report/plugins/nvidia.py
+++ b/sos/report/plugins/nvidia.py
@@ -30,6 +30,7 @@ class Nvidia(Plugin, IndependentPlugin):
             'nvlink -e'
         ]
 
+        self.add_service_status("nvidia-persistenced")
         self.add_cmd_output(["nvidia-smi %s" % cmd for cmd in subcmds])
 
         query = ('gpu_name,gpu_bus_id,vbios_version,temperature.gpu,'


### PR DESCRIPTION
Having nvidia-persistenced service status helps debugging issues with NVIDIA kernel driver behaviour with persistence mode on.


suggested-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>
Tested-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?