### PR TITLE
[hardware] Include basic info from device tree

### DIFF
--- a/sos/report/plugins/hardware.py
+++ b/sos/report/plugins/hardware.py
@@ -21,6 +21,8 @@ class Hardware(Plugin, IndependentPlugin):
         self.add_copy_spec("/proc/interrupts", tags='interrupts')
 
         self.add_copy_spec([
+            "/proc/device-tree/compatible",
+            "/proc/device-tree/model",
             "/proc/irq",
             "/proc/dma",
             "/proc/devices",


### PR DESCRIPTION
ARM devices often don't have SMBIOS information, so dmidecode does not return anything useful. Add the device tree model information and compatible string, which at least provides the basics.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?