### PR TITLE
[cirrus] Bump Fedora release/image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@
 # Main environment vars to set for all tasks
 env:
 
-    FEDORA_NAME: "fedora-38"
-    FEDORA_PRIOR_NAME: "fedora-37"
+    FEDORA_NAME: "fedora-39"
+    FEDORA_PRIOR_NAME: "fedora-38"
 
     DEBIAN_NAME: "debian-11"
 
@@ -26,8 +26,8 @@ env:
     CENTOS_9_IMAGE_NAME: "centos-stream-9-v20230809"
     CENTOS_8_IMAGE_NAME: "centos-stream-8-v20230809"
     DEBIAN_IMAGE_NAME: "debian-11-bullseye-v20230809"
-    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-38-1-6-x86-64"
-    FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-37-1-7-x86-64"
+    FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-39-beta-1-1-x86-64"
+    FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-38-1-6-x86-64"
     UBUNTU_DEB_IMAGE_NAME: "ubuntu-minimal-2310-mantic-amd64-v20231030"
     UBUNTU_LATEST_IMAGE_NAME: "ubuntu-2310-mantic-amd64-v20231031"
     UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20231030"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,10 +15,10 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-      - fedora-development-ppc64le
-      - fedora-development-s390x
+      - fedora-all-x86_64
+      - fedora-all-aarch64
+      - fedora-all-ppc64le
+      - fedora-all-s390x
 
 notifications:
   pull_request:


### PR DESCRIPTION
As Fedora 39 is out, let bump its versions in copr builds and GCE testing.

Also, let `packit` prepares builds on all supported Fedora releases, not only for rawhide / development.

Sadly, GCE images offer F39 beta only, so far..

Resolves: #3448
Relevant: #3447

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?