### PR TITLE
[cockpit] Expand plugin to capture cockpit-bridge

### DIFF
--- a/sos/report/plugins/cockpit.py
+++ b/sos/report/plugins/cockpit.py
@@ -16,15 +16,17 @@ class Cockpit(Plugin, IndependentPlugin):
     short_desc = 'Cockpit Web Service'
 
     plugin_name = 'cockpit'
-    packages = ('cockpit-ws', 'cockpit-system')
+    packages = ('cockpit-ws', 'cockpit-system',
+                'cockpit-bridge')
     services = ('cockpit',)
 
     def setup(self):
+        self.add_forbidden_path('/etc/cockpit/ws-certs.d/')
         self.add_copy_spec([
-            '/etc/cockpit/cockpit.conf',
+            '/etc/cockpit/',
             '/etc/pam.d/cockpit'
         ])
 
-        self.add_cmd_output('remotectl certificate')
+        self.add_cmd_output('cockpit-bridge --packages')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Expand the cockpit plugin to capture configuration and output of cockpit-bridge.  
Also remove deprecated command 'remotectl'.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?