### PR TITLE
[snap] Add snapcraft for strictmode

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,11 +142,16 @@ deb_build_task:
 # Make sure a user can manually build a snap from the checkout
 snap_build_task:
     alias: "snap_build"
-    name: "snap Build From Checkout"
+    name: "snap Build From Checkout - ${SNAP} snap"
     gce_instance:
         image_project: "${UBUNTU_PROJECT}"
         image_name: "${UBUNTU_SNAP_IMAGE_NAME}"
         type: e2-medium
+    matrix:
+        - env:
+            SNAP: "classic"
+        - env:
+            SNAP: "strictmode"
     setup_script: |
         apt update
         apt -y install snapd
@@ -154,6 +159,10 @@ snap_build_task:
         sed -i -e 's/adopt-info.*/version: test/g' -e '/set version/d' snap/snapcraft.yaml
         snap install snapcraft --classic
     main_script: |
+        if [ ${SNAP} == "strictmode" ]; then
+            cp snap/snapcraft_strictmode.yaml snapcraft.yaml
+            sed -i -e 's/adopt-info.*/version: test/g' -e '/set version/d' snapcraft.yaml
+        fi
         snapcraft --destructive-mode
     packages_artifacts:
         path: "*.snap"
@@ -182,16 +191,23 @@ report_stageone_task:
             BUILD_NAME: ${UBUNTU_NAME}
             VM_IMAGE_NAME: ${UBUNTU_IMAGE_NAME}
             PKG: "snap"
+            SNAP: "classic"
         - env: &ubuntuprior
             PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: ${UBUNTU_PRIOR_NAME}
             VM_IMAGE_NAME: ${UBUNTU_PRIOR_IMAGE_NAME}
             PKG: "snap"
+            SNAP: "classic"
         - env: &ubuntuprior2
             PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: ${UBUNTU_PRIOR2_NAME}
             VM_IMAGE_NAME: ${UBUNTU_PRIOR2_IMAGE_NAME}
             PKG: "snap"
+            SNAP: "classic"
+        - env:
+            <<: *ubuntu
+            BUILD_NAME: ${UBUNTU_NAME}-snap
+            SNAP: "strictmode"
         - env: &ubuntu-latest
             PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: ${UBUNTU_LATEST_NAME}
@@ -203,10 +219,19 @@ report_stageone_task:
             apt update --allow-releaseinfo-change
             apt -y install python3-pip snapd
             if [ ${PKG} == "snap" ] ; then
-                echo "$ARTCURL/snap%20Build%20From%20Checkout/packages/sosreport_test_amd64.snap"
-                $ARTCURL/snap%20Build%20From%20Checkout/packages/sosreport_test_amd64.snap
+                echo "$ARTCURL/snap%20Build%20From%20Checkout%20-%20${SNAP}%20snap/packages/sosreport_test_amd64.snap"
+                $ARTCURL/snap%20Build%20From%20Checkout%20-%20${SNAP}%20snap/packages/sosreport_test_amd64.snap
                 systemctl start snapd
-                snap install ./sosreport_test_amd64.snap --classic --dangerous
+                if [ ${SNAP} == "classic" ] ; then
+                    SNAP_ARGS="--classic --dangerous"
+                elif [ ${SNAP} == "strictmode" ] ; then
+                    SNAP_ARGS="--devmode"
+                    SOS_SNAP=/snap/sosreport/current
+                    CORE_SNAP=/snap/core22/current
+                    PYTHONPATH=${SOS_SNAP}/lib/python3.10/site-packages:${SOS_SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
+                    PYTHONPATH=${CORE_SNAP}/lib/python3.10/site-packages:${CORE_SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
+                fi
+                snap install ./sosreport_test_amd64.snap ${SNAP_ARGS}
                 snap alias sosreport.sos sos
             elif [ ${PKG} == "deb" ]; then
                 echo "$ARTCURL/deb%20Build%20From%20Checkout/packages/sos_cirrus.deb"
@@ -226,8 +251,8 @@ report_stageone_task:
         pip3 install avocado-framework==94.0 ${PIP_EXTRA}
     # run the unittests separately as they require a different PYTHONPATH in
     # order for the imports to work properly under avocado
-    unittest_script: PYTHONPATH=. avocado run tests/unittests/
-    main_script: PYTHONPATH=tests/ avocado run -p TESTLOCAL=true --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
+    unittest_script: PYTHONPATH=.:${PYTHONPATH} avocado run tests/unittests/
+    main_script: PYTHONPATH=tests/:${PYTHONPATH} avocado run -p TESTLOCAL=true --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
     on_failure:
         fail_script: &faillogs |
             ls -d /var/tmp/avocado* /root/avocado* 2> /dev/null | xargs tar cf sos-fail-logs.tar

--- a/.github/workflows/snap_strictmode.yaml
+++ b/.github/workflows/snap_strictmode.yaml
@@ -1,0 +1,45 @@
+name: snap_strictmode
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: snap-strictmode-build
+      cancel-in-progress: true
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: |
+        sudo cp snap/snapcraft_strictmode.yaml snapcraft.yaml
+    - uses: snapcore/action-build@v1
+      id: build-snap
+    # Make sure the snap is installable
+    - run: |
+        sudo apt -y remove sosreport
+        sudo snap install --devmode ${{ steps.build-snap.outputs.snap }}
+        sudo snap alias sosreport.sos sos
+    # Do some testing with the snap
+    - run: |
+        sudo sos help
+    - uses: snapcore/action-publish@v1
+      if: ${{ github.event_name == 'push' }}
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build-snap.outputs.snap }}
+        release: "strictmode/edge"
+    - uses: snapcore/action-publish@v1
+      if: ${{ github.event_name == 'release' }}
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build-snap.outputs.snap }}
+        release: "strictmode/beta"

--- a/snap/snapcraft_strictmode.yaml
+++ b/snap/snapcraft_strictmode.yaml
@@ -1,0 +1,69 @@
+name: sosreport
+summary: Sos is an extensible, portable, support data collection tool
+description: |
+  Sos is an extensible, portable, support data collection tool
+  primarily aimed at Linux distributions and other UNIX-like operating
+  systems.
+grade: stable
+base: core22
+confinement: strict
+adopt-info: sos
+license: GPL-2.0-or-later
+environment:
+  PYTHONPATH: ${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages:${PYTHONPATH}
+  MAGIC: ${SNAP}/usr/share/file/magic.mgc
+
+parts:
+  sos:
+    plugin: python
+    source: .
+    override-pull: |
+      craftctl default
+      craftctl set version="$(git describe --tags --always)"
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - git
+      - python3
+      - snapcraft
+      - gettext
+      - python3-venv
+    stage-packages:
+      - coreutils
+      - cloud-init
+      - cryptsetup-bin
+      - e2fsprogs
+      - fdisk
+      - iproute2
+      - libatm1
+      - libpam-modules-bin
+      - mount
+      - procps
+      - systemd
+      - udev
+      - util-linux
+      - python3-magic
+      - python3-packaging
+      - python3-pexpect
+  cleanup:
+    after: [sos]
+    plugin: nil
+    build-snaps: [core22]
+    override-prime: |
+      set -eux
+      for snap in "core22"; do  # List all content-snaps you're using here
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" "$SNAPCRAFT_PRIME/usr/{}" \;
+      done
+      for CRUFT in bug lintian man; do
+        rm -rf $SNAPCRAFT_PRIME/usr/share/$CRUFT
+      done
+      find $SNAPCRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
+      find $SNAPCRAFT_PRIME/usr/share -type d -empty -delete
+
+apps:
+  sos:
+    command: bin/sos
+  sosreport:
+    command: bin/sos report
+  sos-collector:
+    command: bin/sos collector


### PR DESCRIPTION
With Ubuntu Desktop Core to be available in April, a new sosreport may be required for debugging annd grabbing data of these systems. This is an inital start to get this implemented and automated in publishing for usage.

Related: SET-380

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does tsnap/snapcraft_strictmode.yamlhe subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?