### PR TITLE
[transport] Prevent package list for unresponsive nodes

### DIFF
--- a/sos/collector/transports/saltstack.py
+++ b/sos/collector/transports/saltstack.py
@@ -106,6 +106,8 @@ class SaltStackMaster(RemoteTransport):
         self.log_info("Transport is locally supported and service running. ")
         cmd = "echo Connected"
         result = self.run_command(cmd, timeout=180)
+        if result['status'] == 1:
+            raise ConnectionException(self.address)
         return result['status'] == 0
 
     def _disconnect(self):


### PR DESCRIPTION
Raise error when _connect() returns non zero status.

The salt `cmd.run` module obfuscates the exit codes of the commands executed on a minion. If a minion does not pickup the message in the queue then the master receives exit code of 1. If the minion picks up the message and upon execution returns any exit code besides 0, the salt master also gets an exit code of 1.

Closes #3457 
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?