### PR TITLE
[sedutil.py] Added sedutil plugin to collect SED drives info

### DIFF
--- a/sos/report/plugins/sedutil.py
+++ b/sos/report/plugins/sedutil.py
@@ -1,0 +1,48 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
+
+
+class SEDUtility(Plugin, IndependentPlugin):
+    """
+    Collects information about SED drives installed on host system.
+    This plugin will capture data using sedutil utility
+    """
+
+    short_desc = 'Self Encrypting Drives'
+    plugin_name = 'sedutil'
+    profiles = ('security', 'system', 'storage', 'hardware')
+    packages = ('sedutil',)
+
+    option_list = [
+        PluginOpt('debug', default=False, desc='capture debug data'),
+    ]
+
+    def setup(self):
+        sed_list = []
+        result = self.collect_cmd_output('sedutil-cli --scan')
+
+        if self.get_option("debug"):
+            if 0 == result['status']:
+                # iterate over all the devices returned and
+                # create a list of SED drives.
+                for line in result['output'].splitlines():
+                    if line.startswith("/dev/"):
+                        line = line.split()
+                        disk, tcg_opal_dev = line[:2]
+                        # Check if it is SED device or not
+                        if "2" == tcg_opal_dev:
+                            sed_list.append(disk)
+            self.do_debug(sed_list)
+
+    def do_debug(self, sed_list):
+        for device in sed_list:
+            self.add_cmd_output(f"sedutil-cli --query {device}")
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
[sedutil.py] Added sedutil plugin to collect SED drives info
Now collecting Self Encrypting Drives info using sedutil utility
Signed-off-by: Bhushan Kale bhushanskale@hotmail.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?