### PR TITLE
[auditd] Collect ausearch with more human readable output

### DIFF
--- a/sos/report/plugins/auditd.py
+++ b/sos/report/plugins/auditd.py
@@ -29,7 +29,7 @@ class Auditd(Plugin, IndependentPlugin):
         ])
 
         self.add_cmd_output(
-            "ausearch --input-logs -m avc,user_avc,fanotify -ts today"
+            "ausearch -i --input-logs -m avc,user_avc,fanotify -ts today"
         )
         self.add_cmd_output("auditctl -l", tags="auditctl_rules")
         self.add_cmd_output("auditctl -s", tags="auditctl_status")


### PR DESCRIPTION
ausearch sometimes outputs hexstream instead of raw text esp for "proctitle" values. Let collect more human readable output.

Resolves: #3461
Related: RHEL-19434

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?