### PR TITLE
[archive, component] Obfuscate upload password in sos.log and manifest.json

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -439,7 +439,7 @@ If this option is omitted and upload is requested, you will be prompted for one.
 If --batch is used, this prompt will not occur, so any uploads are likely to fail unless
 this option is used.
 
-Note that this will result in the plaintext string appearing in `ps` output that may
+Note that this may result in the plaintext string appearing in `ps` output that may
 be collected by sos and be in the archive. If a password must be provided by you
 for uploading, it is strongly recommended to not use --batch and enter the password
 when prompted rather than using this option.

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1360,6 +1360,7 @@ this utility or remote systems that it connects to.
                 self.archive.add_final_manifest_data(
                     self.opts.compression_type
                 )
+            self._obfuscate_upload_passwords()
             if do_clean:
                 _dir = os.path.join(self.tmpdir, self.archive._name)
                 cleaner.obfuscate_file(

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1515,6 +1515,8 @@ class SoSReport(SoSComponent):
         self._add_sos_logs()
         if self.manifest is not None:
             self.archive.add_final_manifest_data(self.opts.compression_type)
+        # Hide upload passwords in the log files
+        self._obfuscate_upload_passwords()
         # Now, separately clean the log files that cleaner also wrote to
         if do_clean:
             _dir = os.path.join(self.tmpdir, self.archive._name)

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1279,28 +1279,15 @@ class Plugin():
         """
         try:
             path = self._get_dest_for_srcpath(srcpath)
-            common_flags = re.IGNORECASE | re.MULTILINE
-            if hasattr(regexp, "pattern"):
-                pattern = regexp.pattern
-                flags = regexp.flags | common_flags
-            else:
-                pattern = regexp
-                flags = common_flags
             self._log_debug("substituting scrpath '%s'" % srcpath)
             self._log_debug("substituting '%s' for '%s' in '%s'"
-                            % (subst, pattern, path))
+                            % (subst,
+                               regexp.pattern if hasattr(regexp, "pattern")
+                               else regexp,
+                               path))
             if not path:
                 return 0
-            readable = self.archive.open_file(path)
-            content = readable.read()
-            if not isinstance(content, str):
-                content = content.decode('utf8', 'ignore')
-            result, replacements = re.subn(pattern, subst, content,
-                                           flags=flags)
-            if replacements:
-                self.archive.add_string(result, self.strip_sysroot(srcpath))
-            else:
-                replacements = 0
+            replacements = self.archive.do_file_sub(path, regexp, subst)
         except (OSError, IOError) as e:
             # if trying to regexp a nonexisting file, dont log it as an
             # error to stdout


### PR DESCRIPTION
sos_logs/sos.log and sos_reports/manifest.json tracks command line where we must obfuscate upload passwords like:

--upload-pass=PASSWORD
--upload-url https://user:PASSWORD@some.url

So let move the `do_file_sub` functionality into archive class and call that from report before finalizing the archive.

Resolves: #3463
Closes: #3462

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?