### PR TITLE
[collect] Imply --upload when --upload-url is set

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1270,7 +1270,7 @@ this utility or remote systems that it connects to.
             msg = 'No sosreports were collected, nothing to archive...'
             self.exit(msg, 1)
 
-        if self.opts.upload and self.policy.get_upload_url():
+        if self.opts.upload or self.opts.upload_url:
             try:
                 self.policy.upload_archive(arc_name)
                 self.ui_log.info("Uploaded archive successfully")


### PR DESCRIPTION
Setting --upload-url should imply uploading the tarball at the end, regardless of --upload is explicitly set or not.

The same is already in place for "sos report", so let unify it.

Resolves: #3464

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?