### PR TITLE
[tests] Drop obsolete TestCase.assertEquals()

### DIFF
--- a/tests/report_tests/timeout/timeout_tests.py
+++ b/tests/report_tests/timeout/timeout_tests.py
@@ -20,7 +20,7 @@ class PluginTimeoutTest(StageTwoReportTest):
 
     def test_correct_plugin_timeout(self):
         man = self.get_plugin_manifest('timeout_test')
-        self.assertEquals(man['timeout'], 10)
+        self.assertEqual(man['timeout'], 10)
 
     def test_plugin_timed_out(self):
         self.assertSosLogNotContains('collected plugin \'timeout_test\' in')
@@ -41,9 +41,9 @@ class NativeCmdTimeoutTest(StageTwoReportTest):
 
     def test_correct_plugin_timeout(self):
         man = self.get_plugin_manifest('timeout_test')
-        self.assertEquals(man['timeout'], 100)
+        self.assertEqual(man['timeout'], 100)
         hman = self.get_plugin_manifest('host')
-        self.assertEquals(hman['timeout'], 300)
+        self.assertEqual(hman['timeout'], 300)
 
     def test_plugin_completed(self):
         self.assertSosLogContains('collected plugin \'timeout_test\' in')
@@ -64,6 +64,6 @@ class MultipleTimeoutValues(NativeCmdTimeoutTest):
 
     def test_correct_plugin_timeout(self):
         man = self.get_plugin_manifest('timeout_test')
-        self.assertEquals(man['timeout'], 60)
+        self.assertEqual(man['timeout'], 60)
         hman = self.get_plugin_manifest('host')
-        self.assertEquals(hman['timeout'], 30)
+        self.assertEqual(hman['timeout'], 30)

--- a/tests/unittests/archive_tests.py
+++ b/tests/unittests/archive_tests.py
@@ -92,7 +92,7 @@ class TarFileArchiveTest(unittest.TestCase):
         self.tf.add_string('this is my content', 'tests/string_test.txt')
 
         afp = self.tf.open_file('tests/string_test.txt')
-        self.assertEquals('this is my content', afp.read())
+        self.assertEqual('this is my content', afp.read())
 
     def test_rewrite_file(self):
         """Test that re-writing a file with add_string() modifies the content.
@@ -101,7 +101,7 @@ class TarFileArchiveTest(unittest.TestCase):
         self.tf.add_string('this is my new content', 'tests/string_test.txt')
 
         afp = self.tf.open_file('tests/string_test.txt')
-        self.assertEquals('this is my new content', afp.read())
+        self.assertEqual('this is my new content', afp.read())
 
     def test_make_link(self):
         self.tf.add_file('tests/ziptest')

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -50,12 +50,12 @@ class CleanerMapTests(unittest.TestCase):
 
     def test_mac_map_skip_ignores(self):
         _test = self.mac_map.get('ff:ff:ff:ff:ff:ff')
-        self.assertEquals(_test, 'ff:ff:ff:ff:ff:ff')
+        self.assertEqual(_test, 'ff:ff:ff:ff:ff:ff')
 
     def test_mac_map_avoid_duplicate_obfuscation(self):
         _test = self.mac_map.get('ab:cd:ef:fe:dc:ba')
         _dup = self.mac_map.get(_test)
-        self.assertEquals(_test, _dup)
+        self.assertEqual(_test, _dup)
 
     def test_ip_map_obfuscate_v4_with_cidr(self):
         _test = self.ip_map.get('192.168.1.0/24')
@@ -77,7 +77,7 @@ class CleanerMapTests(unittest.TestCase):
 
     def test_ip_skip_ignores(self):
         _test = self.ip_map.get('127.0.0.1')
-        self.assertEquals(_test, '127.0.0.1')
+        self.assertEqual(_test, '127.0.0.1')
 
     def test_hostname_obfuscate_domain_options(self):
         _test = self.host_map.get('www.redhat.com')

--- a/tests/unittests/option_tests.py
+++ b/tests/unittests/option_tests.py
@@ -45,10 +45,10 @@ class GlobalOptionTest(unittest.TestCase):
         self.plugin = MockPlugin(self.commons)
 
     def test_simple_lookup(self):
-        self.assertEquals(self.plugin.get_option('test_option'), 'foobar')
+        self.assertEqual(self.plugin.get_option('test_option'), 'foobar')
 
     def test_cascade(self):
-        self.assertEquals(self.plugin.get_option(('baz')), False)
+        self.assertEqual(self.plugin.get_option(('baz')), False)
 
 
 if __name__ == "__main__":

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -133,36 +133,36 @@ class PluginToolTests(unittest.TestCase):
             ['this is only a test', 'there are only two lines'])
         test_fo = StringIO(test_s)
         matches = regex_findall(r".*lines$", test_fo)
-        self.assertEquals(matches, ['there are only two lines'])
+        self.assertEqual(matches, ['there are only two lines'])
 
     def test_regex_findall_miss(self):
         test_s = u"\n".join(
             ['this is only a test', 'there are only two lines'])
         test_fo = StringIO(test_s)
         matches = regex_findall(r".*not_there$", test_fo)
-        self.assertEquals(matches, [])
+        self.assertEqual(matches, [])
 
     def test_regex_findall_bad_input(self):
         matches = regex_findall(r".*", None)
-        self.assertEquals(matches, [])
+        self.assertEqual(matches, [])
         matches = regex_findall(r".*", [])
-        self.assertEquals(matches, [])
+        self.assertEqual(matches, [])
         matches = regex_findall(r".*", 1)
-        self.assertEquals(matches, [])
+        self.assertEqual(matches, [])
 
     def test_mangle_command(self):
         name_max = 255
-        self.assertEquals("foo", _mangle_command("/usr/bin/foo", name_max))
-        self.assertEquals(
+        self.assertEqual("foo", _mangle_command("/usr/bin/foo", name_max))
+        self.assertEqual(
             "foo_-x", _mangle_command("/usr/bin/foo -x", name_max))
-        self.assertEquals(
+        self.assertEqual(
             "foo_--verbose", _mangle_command("/usr/bin/foo --verbose",
                                              name_max))
-        self.assertEquals("foo_.path.to.stuff", _mangle_command(
+        self.assertEqual("foo_.path.to.stuff", _mangle_command(
             "/usr/bin/foo /path/to/stuff", name_max))
         longcmd = "foo is " + "a" * 256 + " long_command"
         expected = longcmd[0:name_max].replace(' ', '_')
-        self.assertEquals(expected, _mangle_command(longcmd, name_max))
+        self.assertEqual(expected, _mangle_command(longcmd, name_max))
 
 
 class PluginTests(unittest.TestCase):
@@ -185,7 +185,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.name(), "mockplugin")
+        self.assertEqual(p.name(), "mockplugin")
 
     def test_plugin_set_name(self):
         p = NamedMockPlugin({
@@ -194,7 +194,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.name(), "testing")
+        self.assertEqual(p.name(), "testing")
 
     def test_plugin_no_descrip(self):
         p = MockPlugin({
@@ -203,7 +203,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_description(), "<no description available>")
+        self.assertEqual(p.get_description(), "<no description available>")
 
     def test_plugin_has_descrip(self):
         p = NamedMockPlugin({
@@ -212,7 +212,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_description(),
+        self.assertEqual(p.get_description(),
                           "This plugin has a description.")
 
     def test_set_plugin_option(self):
@@ -223,7 +223,7 @@ class PluginTests(unittest.TestCase):
             'devices': {}
         })
         p.set_option("opt", "testing")
-        self.assertEquals(p.get_option("opt"), "testing")
+        self.assertEqual(p.get_option("opt"), "testing")
 
     def test_set_nonexistant_plugin_option(self):
         p = MockPlugin({
@@ -241,7 +241,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_option("badopt"), 0)
+        self.assertEqual(p.get_option("badopt"), 0)
 
     def test_get_unset_plugin_option(self):
         p = MockPlugin({
@@ -250,7 +250,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_option("opt"), None)
+        self.assertEqual(p.get_option("opt"), None)
 
     def test_get_unset_plugin_option_with_default(self):
         # this shows that even when we pass in a default to get,
@@ -262,7 +262,7 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_option("opt", True), True)
+        self.assertEqual(p.get_option("opt", True), True)
 
     def test_get_unset_plugin_option_with_default_not_none(self):
         # this shows that even when we pass in a default to get,
@@ -275,17 +275,17 @@ class PluginTests(unittest.TestCase):
             'cmdlineopts': MockOptions(),
             'devices': {}
         })
-        self.assertEquals(p.get_option("opt2", True), False)
+        self.assertEqual(p.get_option("opt2", True), False)
 
     def test_copy_dir(self):
         self.mp._do_copy_path("tests")
-        self.assertEquals(
+        self.assertEqual(
             self.mp.archive.m["tests/unittests/plugin_tests.py"],
             'tests/unittests/plugin_tests.py')
 
     def test_copy_dir_bad_path(self):
         self.mp._do_copy_path("not_here_tests")
-        self.assertEquals(self.mp.archive.m, {})
+        self.assertEqual(self.mp.archive.m, {})
 
     def test_copy_dir_forbidden_path(self):
         p = ForbiddenMockPlugin({
@@ -297,7 +297,7 @@ class PluginTests(unittest.TestCase):
         p.archive = MockArchive()
         p.setup()
         p.collect_plugin()
-        self.assertEquals(p.archive.m, {})
+        self.assertEqual(p.archive.m, {})
 
     def test_postproc_default_on(self):
         p = PostprocMockPlugin({
@@ -318,11 +318,11 @@ class PluginTests(unittest.TestCase):
         })
         e = {'TORVALDS': 'Linus'}
         p.set_default_cmd_environment(e)
-        self.assertEquals(p.default_environment, e)
+        self.assertEqual(p.default_environment, e)
         add_e = {'GREATESTSPORT': 'hockey'}
         p.add_default_cmd_environment(add_e)
-        self.assertEquals(p.default_environment['GREATESTSPORT'], 'hockey')
-        self.assertEquals(p.default_environment['TORVALDS'], 'Linus')
+        self.assertEqual(p.default_environment['GREATESTSPORT'], 'hockey')
+        self.assertEqual(p.default_environment['TORVALDS'], 'Linus')
 
 
 class AddCopySpecTests(unittest.TestCase):
@@ -344,7 +344,7 @@ class AddCopySpecTests(unittest.TestCase):
                 path = path[1:]
             return os.path.join(self.mp.sysroot, path)
         expected_paths = set(map(pathmunge, self.expect_paths))
-        self.assertEquals(self.mp.copy_paths, expected_paths)
+        self.assertEqual(self.mp.copy_paths, expected_paths)
 
     def test_single_file_no_limit(self):
         self.mp.add_copy_spec("tests/unittests/tail_test.txt")
@@ -361,7 +361,7 @@ class AddCopySpecTests(unittest.TestCase):
         fname, _size = self.mp._tail_files_list[0]
         self.assertTrue(fname == fn)
         self.assertTrue("tmp" in fname)
-        self.assertEquals(1024 * 1024, _size)
+        self.assertEqual(1024 * 1024, _size)
         os.unlink(fn)
 
     def test_bad_filename(self):
@@ -379,7 +379,7 @@ class AddCopySpecTests(unittest.TestCase):
         create_file(2, dir=tmpdir)
         create_file(2, dir=tmpdir)
         self.mp.add_copy_spec(tmpdir + "/*")
-        self.assertEquals(len(self.mp.copy_paths), 2)
+        self.assertEqual(len(self.mp.copy_paths), 2)
         shutil.rmtree(tmpdir)
 
     def test_glob_file_over_limit(self):
@@ -388,18 +388,18 @@ class AddCopySpecTests(unittest.TestCase):
         create_file(2, dir=tmpdir)
         create_file(2, dir=tmpdir)
         self.mp.add_copy_spec(tmpdir + "/*", 1)
-        self.assertEquals(len(self.mp._tail_files_list), 1)
+        self.assertEqual(len(self.mp._tail_files_list), 1)
         fname, _size = self.mp._tail_files_list[0]
-        self.assertEquals(1024 * 1024, _size)
+        self.assertEqual(1024 * 1024, _size)
         shutil.rmtree(tmpdir)
 
     def test_multiple_files_no_limit(self):
         self.mp.add_copy_spec(['tests/unittests/tail_test.txt', 'tests/unittests/test.txt'])
-        self.assertEquals(len(self.mp.copy_paths), 2)
+        self.assertEqual(len(self.mp.copy_paths), 2)
 
     def test_multiple_files_under_limit(self):
         self.mp.add_copy_spec(['tests/unittests/tail_test.txt', 'tests/unittests/test.txt'], 1)
-        self.assertEquals(len(self.mp.copy_paths), 2)
+        self.assertEqual(len(self.mp.copy_paths), 2)
 
 
 class CheckEnabledTests(unittest.TestCase):
@@ -443,7 +443,7 @@ class RegexSubTests(unittest.TestCase):
         self.mp.archive = MockArchive()
 
     def test_file_never_copied(self):
-        self.assertEquals(0, self.mp.do_file_sub(
+        self.assertEqual(0, self.mp.do_file_sub(
             "never_copied", r"^(.*)$", "foobar"))
 
     def test_no_replacements(self):
@@ -452,7 +452,7 @@ class RegexSubTests(unittest.TestCase):
         self.mp.collect_plugin()
         replacements = self.mp.do_file_sub(
             j("tail_test.txt"), r"wont_match", "foobar")
-        self.assertEquals(0, replacements)
+        self.assertEqual(0, replacements)
 
     def test_replacements(self):
         # test uses absolute paths
@@ -461,7 +461,7 @@ class RegexSubTests(unittest.TestCase):
         self.mp.collect_plugin()
         replacements = self.mp.do_file_sub(
             j("tail_test.txt"), r"(tail)", "foobar")
-        self.assertEquals(1, replacements)
+        self.assertEqual(1, replacements)
         self.assertTrue("foobar" in self.mp.archive.m.get(j('tail_test.txt')))
 
 

--- a/tests/unittests/policy_tests.py
+++ b/tests/unittests/policy_tests.py
@@ -88,17 +88,17 @@ class PackageManagerTests(unittest.TestCase):
         self.pm = PackageManager()
 
     def test_default_all_pkgs(self):
-        self.assertEquals(self.pm.packages, {})
+        self.assertEqual(self.pm.packages, {})
 
     def test_default_all_pkgs_by_name(self):
-        self.assertEquals(self.pm.all_pkgs_by_name('doesntmatter'), [])
+        self.assertEqual(self.pm.all_pkgs_by_name('doesntmatter'), [])
 
     def test_default_all_pkgs_by_name_regex(self):
-        self.assertEquals(
+        self.assertEqual(
             self.pm.all_pkgs_by_name_regex('.*doesntmatter$'), [])
 
     def test_default_pkg_by_name(self):
-        self.assertEquals(self.pm.pkg_by_name('foo'), None)
+        self.assertEqual(self.pm.pkg_by_name('foo'), None)
 
 
 class RpmPackageManagerTests(unittest.TestCase):
@@ -115,7 +115,7 @@ class RpmPackageManagerTests(unittest.TestCase):
         kpkg = self.pm.pkg_by_name('coreutils')
         self.assertIsInstance(kpkg, dict)
         self.assertIsInstance(kpkg['version'], list)
-        self.assertEquals(kpkg['pkg_manager'], 'rpm')
+        self.assertEqual(kpkg['pkg_manager'], 'rpm')
 
 
 class DpkgPackageManagerTests(unittest.TestCase):
@@ -132,7 +132,7 @@ class DpkgPackageManagerTests(unittest.TestCase):
         kpkg = self.pm.pkg_by_name('coreutils')
         self.assertIsInstance(kpkg, dict)
         self.assertIsInstance(kpkg['version'], list)
-        self.assertEquals(kpkg['pkg_manager'], 'dpkg')
+        self.assertEqual(kpkg['pkg_manager'], 'dpkg')
 
 
 class MultiPackageManagerTests(unittest.TestCase):
@@ -150,9 +150,9 @@ class MultiPackageManagerTests(unittest.TestCase):
         self.assertIsInstance(kpkg['version'], list)
         _local = distro.detect().name
         if _local in ['Ubuntu', 'debian']:
-            self.assertEquals(kpkg['pkg_manager'], 'dpkg')
+            self.assertEqual(kpkg['pkg_manager'], 'dpkg')
         else:
-            self.assertEquals(kpkg['pkg_manager'], 'rpm')
+            self.assertEqual(kpkg['pkg_manager'], 'rpm')
 
 
 if __name__ == "__main__":

--- a/tests/unittests/report_tests.py
+++ b/tests/unittests/report_tests.py
@@ -23,7 +23,7 @@ class ReportTest(unittest.TestCase):
 
         expected = json.dumps({})
 
-        self.assertEquals(expected, str(report))
+        self.assertEqual(expected, str(report))
 
     def test_nested_section(self):
         report = Report()
@@ -32,7 +32,7 @@ class ReportTest(unittest.TestCase):
 
         expected = json.dumps({"section": {}})
 
-        self.assertEquals(expected, str(report))
+        self.assertEqual(expected, str(report))
 
     def test_multiple_sections(self):
         report = Report()
@@ -45,7 +45,7 @@ class ReportTest(unittest.TestCase):
         expected = json.dumps({"section": {},
                                "section2": {}, })
 
-        self.assertEquals(expected, str(report))
+        self.assertEqual(expected, str(report))
 
     def test_deeply_nested(self):
         report = Report()
@@ -61,7 +61,7 @@ class ReportTest(unittest.TestCase):
                           "return_code": 0,
                           "href": "does/not/matter"}]}})
 
-        self.assertEquals(expected, str(report))
+        self.assertEqual(expected, str(report))
 
 
 class TestPlainReport(unittest.TestCase):
@@ -78,13 +78,13 @@ class TestPlainReport(unittest.TestCase):
         ])
 
     def test_basic(self):
-        self.assertEquals(self.pluglist.format(pluglist=""),
+        self.assertEqual(self.pluglist.format(pluglist=""),
                           PlainTextReport(self.report).unicode())
 
     def test_one_section(self):
         self.report.add(self.section)
 
-        self.assertEquals(self.defaultheader,
+        self.assertEqual(self.defaultheader,
                           PlainTextReport(self.report).unicode() + '\n')
 
     def test_two_sections(self):
@@ -92,7 +92,7 @@ class TestPlainReport(unittest.TestCase):
         section2 = Section(name="second")
         self.report.add(section1, section2)
 
-        self.assertEquals(u''.join([
+        self.assertEqual(u''.join([
             self.pluglist.format(pluglist="  first  second"),
             self.div,
             "\nfirst",
@@ -108,7 +108,7 @@ class TestPlainReport(unittest.TestCase):
         self.section.add(cmd)
         self.report.add(self.section)
 
-        self.assertEquals(u''.join([
+        self.assertEqual(u''.join([
             self.defaultheader,
             "-  commands executed:\n  * ls -al /foo/bar/baz"
         ]),
@@ -119,7 +119,7 @@ class TestPlainReport(unittest.TestCase):
         self.section.add(cf)
         self.report.add(self.section)
 
-        self.assertEquals(u''.join([
+        self.assertEqual(u''.join([
             self.defaultheader,
             "-  files copied:\n  * /etc/hosts"
         ]),
@@ -131,7 +131,7 @@ class TestPlainReport(unittest.TestCase):
         self.section.add(crf)
         self.report.add(self.section)
 
-        self.assertEquals(u''.join([
+        self.assertEqual(u''.join([
             self.defaultheader,
             "-  files created:\n  * sample.txt"
         ]),
@@ -142,7 +142,7 @@ class TestPlainReport(unittest.TestCase):
         self.section.add(alrt)
         self.report.add(self.section)
 
-        self.assertEquals(u''.join([
+        self.assertEqual(u''.join([
             self.defaultheader,
             "-  alerts:\n  ! this is an alert"
         ]),

--- a/tests/unittests/utilities_tests.py
+++ b/tests/unittests/utilities_tests.py
@@ -24,32 +24,32 @@ class GrepTest(unittest.TestCase):
             ['this is only a test', 'there are only two lines'])
         test_fo = StringIO(test_s)
         matches = grep(".*test$", test_fo)
-        self.assertEquals(matches, ['this is only a test\n'])
+        self.assertEqual(matches, ['this is only a test\n'])
 
     def test_real_file(self):
         matches = grep(".*unittest$", __file__.replace(".pyc", ".py"))
-        self.assertEquals(matches, ['import unittest\n'])
+        self.assertEqual(matches, ['import unittest\n'])
 
     def test_open_file(self):
         matches = grep(".*unittest$", open(__file__.replace(".pyc", ".py")))
-        self.assertEquals(matches, ['import unittest\n'])
+        self.assertEqual(matches, ['import unittest\n'])
 
     def test_grep_multiple_files(self):
         matches = grep(".*unittest$",
                        __file__.replace(".pyc", ".py"), "does_not_exist.txt")
-        self.assertEquals(matches, ['import unittest\n'])
+        self.assertEqual(matches, ['import unittest\n'])
 
 
 class TailTest(unittest.TestCase):
 
     def test_tail(self):
         t = tail("tests/unittests/tail_test.txt", 10)
-        self.assertEquals(t, b"last line\n")
+        self.assertEqual(t, b"last line\n")
 
     def test_tail_too_many(self):
         t = tail("tests/unittests/tail_test.txt", 200)
         expected = open("tests/unittests/tail_test.txt", "r").read()
-        self.assertEquals(t, str.encode(expected))
+        self.assertEqual(t, str.encode(expected))
 
 
 class ExecutableTest(unittest.TestCase):
@@ -66,23 +66,23 @@ class ExecutableTest(unittest.TestCase):
 
     def test_output(self):
         result = sos_get_command_output("echo executed")
-        self.assertEquals(result['status'], 0)
-        self.assertEquals(result['output'], "executed\n")
+        self.assertEqual(result['status'], 0)
+        self.assertEqual(result['output'], "executed\n")
 
     def test_output_non_exe(self):
         path = os.path.join(TEST_DIR, 'utility_tests.py')
         result = sos_get_command_output(path)
-        self.assertEquals(result['status'], 127)
-        self.assertEquals(result['output'], b"")
+        self.assertEqual(result['status'], 127)
+        self.assertEqual(result['output'], b"")
 
     def test_output_chdir(self):
         cmd = "/bin/bash -c 'echo $PWD'"
         result = sos_get_command_output(cmd, chdir=TEST_DIR)
-        self.assertEquals(result['status'], 0)
+        self.assertEqual(result['status'], 0)
         self.assertTrue(result['output'].strip().endswith(TEST_DIR))
 
     def test_shell_out(self):
-        self.assertEquals("executed\n", shell_out('echo executed'))
+        self.assertEqual("executed\n", shell_out('echo executed'))
 
 
 class FindTest(unittest.TestCase):


### PR DESCRIPTION
`unittest.TestCase.assertEquals()` was deprecated in Python 3 [1], and finally dropped in Python 3.12. This now causes the unit tests to fail [2].

[1] https://docs.python.org/3.5/library/unittest.html#deprecated-aliases
[2] https://bugs.debian.org/1058214

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?