### PR TITLE
[policies] Fix dist_version for Ubuntu

### DIFF
--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -70,7 +70,7 @@ class UbuntuPolicy(DebianPolicy):
                 lines = fp.readlines()
                 for line in lines:
                     if "DISTRIB_RELEASE" in line:
-                        return int(line.split("=")[1].strip())
+                        return float(line.split("=")[1].strip())
             return False
         except (IOError, ValueError):
             return False


### PR DESCRIPTION
DISTRIB_RELEASE variable contains a float value for the Ubuntu releases and not an integer value.

Example, a 22.04 release is an LTS release, and a 22.10 release is an interim non-LTS release, changing this value to a float allows us to retrieve the full version rather than just the int.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?