### PR TITLE
[plugins][scsi] Enhance data gathering of tape devices

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -424,7 +424,8 @@ class SoSReport(SoSComponent):
         self.devices = {
             'storage': {
                 'block': self._get_block_devs(),
-                'fibre': self._get_fibre_devs()
+                'fibre': self._get_fibre_devs(),
+                'tape': self._get_tape_devs(),
             },
             'network': self._get_network_devs(),
             'namespaced_network': self._get_network_namespace_devices()
@@ -504,6 +505,26 @@ class SoSReport(SoSComponent):
             return dev_list
         except Exception as err:
             self.soslog.error("Could not get block device list: %s" % err)
+            return []
+
+    def _get_tape_devs(self):
+        """Enumerate a list of tape devices on this system so that plugins
+        can iterate over them
+
+        These devices are used by add_device_cmd() in the Plugin class.
+        """
+        try:
+            devs = []
+            devdirs = [
+                'scsi_tape',
+                'lin_tape'
+            ]
+            for devdir in devdirs:
+                if os.path.isdir(f"/sys/class/{devdir}"):
+                    devs.extend(glob.glob(f"/sys/class/{devdir}/*"))
+            return devs
+        except Exception as err:
+            self.soslog.error(f"Could not get tape device list: {err}")
             return []
 
     def _get_namespaces(self):

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -520,8 +520,7 @@ class SoSReport(SoSComponent):
                 'lin_tape'
             ]
             for devdir in devdirs:
-                if os.path.isdir(f"/sys/class/{devdir}"):
-                    devs.extend(glob.glob(f"/sys/class/{devdir}/*"))
+                devs.extend(glob.glob(f"/sys/class/{devdir}/*"))
             return devs
         except Exception as err:
             self.soslog.error(f"Could not get tape device list: {err}")

--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -63,6 +63,7 @@ class Scsi(Plugin, IndependentPlugin):
 
         scsi_hosts = glob("/sys/class/scsi_host/*")
         self.add_device_cmd("udevadm info -a %(dev)s", devices=scsi_hosts)
+        self.add_device_cmd("udevadm info -a %(dev)s", devices="tape")
 
         self.add_device_cmd([
             "sg_persist --in -k -d %(dev)s",


### PR DESCRIPTION
- Add a function to iterate through tape devices, similar to
_get_block_devs() and _get_fibre_devs(), and
- Capture udevadm info for tape devices. 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?