### PR TITLE
[foreman] Stop scrubbing secrets in Apache access logs

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -306,10 +306,6 @@ class Foreman(Plugin):
 
     def postproc(self):
         self.do_path_regex_sub(
-            "/var/log/%s*/foreman-ssl_access_ssl.log*" % self.apachepkg,
-            r"(.*\?(passw|cred|token|secret|key).*=)(.*) (HTTP.*(.*))",
-            r"\1******** \4")
-        self.do_path_regex_sub(
             r"/etc/foreman/(.*)((conf)(.*)?)",
             r"((\:|\s*)(passw|cred|token|secret|key).*(\:\s|=))(.*)",
             r"\1********")


### PR DESCRIPTION
No URI shall contain a secret or token so there is no need to scrub that file.

Resolves: #3477

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?