### PR TITLE
[pam] Collect authselect command, not file

### DIFF
--- a/sos/report/plugins/pam.py
+++ b/sos/report/plugins/pam.py
@@ -41,7 +41,7 @@ class RedHatPam(Pam, RedHatPlugin):
 
     def setup(self):
         super(RedHatPam, self).setup()
-        self.add_copy_spec(["authselect current"])
+        self.add_cmd_output(["authselect current"])
 
 
 class DebianPam(Pam, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Evident s/add_copy_spec/add_cmd_output/ fix-up from #3438 .

Resolves: #3479

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?