### PR TITLE
[containerd] obtain CNI config files

### DIFF
--- a/sos/report/plugins/containerd.py
+++ b/sos/report/plugins/containerd.py
@@ -19,6 +19,7 @@ class Containerd(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/containerd/",
+            "/etc/cni/net.d/",
         ])
 
         self.add_cmd_output('containerd config dump')


### PR DESCRIPTION
containerd uses CNI to configure the container's network.

The CNI uses different configuration files that by default are installed in `/etc/cni/net.d`, these files are important to understand how the network is configured.

Closes #3482
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?