### PR TITLE
[kubernetes] Add DebianPlugin to plugin kubernetes

### DIFF
--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -9,7 +9,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 from fnmatch import translate
 import re
 
@@ -205,7 +206,7 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
         super(RedHatKubernetes, self).setup()
 
 
-class UbuntuKubernetes(Kubernetes, UbuntuPlugin):
+class UbuntuKubernetes(Kubernetes, UbuntuPlugin, DebianPlugin):
 
     packages = ('kubernetes',)
     files = (


### PR DESCRIPTION
Add DebianPlugin to the list of imports and
the class UbuntuKubernetes.

Related: #3484

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?