### PR TITLE
[Plugin] Add missing DebianPlugins

### DIFF
--- a/sos/report/plugins/alternatives.py
+++ b/sos/report/plugins/alternatives.py
@@ -8,7 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
 class Alternatives(Plugin):
@@ -58,7 +59,7 @@ class RedHatAlternatives(Alternatives, RedHatPlugin):
         })
 
 
-class UbuntuAlternatives(Alternatives, UbuntuPlugin):
+class UbuntuAlternatives(Alternatives, UbuntuPlugin, DebianPlugin):
 
     packages = ('dpkg',)
     commands = ('update-alternatives',)

--- a/sos/report/plugins/ansible.py
+++ b/sos/report/plugins/ansible.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class Ansible(Plugin, RedHatPlugin, UbuntuPlugin):
+class Ansible(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'Ansible configuration management'
 

--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -8,11 +8,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin, RedHatPlugin
+from sos.report.plugins import (Plugin, UbuntuPlugin, RedHatPlugin,
+                                DebianPlugin)
 import os
 
 
-class Azure(Plugin, UbuntuPlugin):
+class Azure(Plugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'Microsoft Azure client'
 

--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -6,11 +6,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 from socket import gethostname
 
 
-class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin):
+class Ceph_Common(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'CEPH common'
 

--- a/sos/report/plugins/ceph_iscsi.py
+++ b/sos/report/plugins/ceph_iscsi.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class CephISCSI(Plugin, RedHatPlugin, UbuntuPlugin):
+class CephISCSI(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = "CEPH iSCSI"
 

--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
+class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     short_desc = 'CEPH mds'
     plugin_name = 'ceph_mds'
     profiles = ('storage', 'virt', 'container', 'ceph')

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -10,10 +10,11 @@
 
 import os
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
+class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     """
     This plugin is for capturing information from Ceph mgr nodes. While the
     majority of this plugin should be version-agnostic, several collections are

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -8,10 +8,11 @@
 
 import re
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
+class CephMON(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     """
     This plugin serves to collect information on monitor nodes within a Ceph
     or microceph cluster. It is designed to collect from several versions of

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -10,10 +10,11 @@
 
 import os
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
+class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     """
     This plugin is for capturing information from Ceph OSD nodes. While the
     majority of this plugin should be version agnotics, several collections are

--- a/sos/report/plugins/ceph_rgw.py
+++ b/sos/report/plugins/ceph_rgw.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin):
+class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'CEPH rgw'
 

--- a/sos/report/plugins/console.py
+++ b/sos/report/plugins/console.py
@@ -7,10 +7,11 @@
 # See the LICENSE file in the source distribution for further information.
 
 from glob import glob
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class Console(Plugin, RedHatPlugin, UbuntuPlugin):
+class Console(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'Console and keyboard information'
 

--- a/sos/report/plugins/containerd.py
+++ b/sos/report/plugins/containerd.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin)
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin,
+                                DebianPlugin)
 
 
-class Containerd(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
+class Containerd(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin, DebianPlugin):
 
     short_desc = 'Containerd containers'
     plugin_name = 'containerd'

--- a/sos/report/plugins/containers_common.py
+++ b/sos/report/plugins/containers_common.py
@@ -8,11 +8,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt,
+                                DebianPlugin)
 import os
 
 
-class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin):
+class ContainersCommon(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'Common container configs under {/etc,/usr/share}/containers'
     plugin_name = 'containers_common'

--- a/sos/report/plugins/dhcp.py
+++ b/sos/report/plugins/dhcp.py
@@ -6,7 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
 class Dhcp(Plugin):
@@ -30,7 +31,7 @@ class RedHatDhcp(Dhcp, RedHatPlugin):
         ])
 
 
-class UbuntuDhcp(Dhcp, UbuntuPlugin):
+class UbuntuDhcp(Dhcp, UbuntuPlugin, DebianPlugin):
 
     files = ('/etc/init.d/udhcpd',)
     packages = ('udhcpd',)

--- a/sos/report/plugins/drbd.py
+++ b/sos/report/plugins/drbd.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class drbd(Plugin, RedHatPlugin, UbuntuPlugin):
+class drbd(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'Distributed Replicated Block Device (DRBD)'
 

--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -8,10 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin, SoSPredicate
+from sos.report.plugins import (Plugin, UbuntuPlugin, SoSPredicate,
+                                DebianPlugin)
 
 
-class LXD(Plugin, UbuntuPlugin):
+class LXD(Plugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'LXD container hypervisor'
     plugin_name = 'lxd'

--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -6,11 +6,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 import os
 
 
-class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
+class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'NetworkManager service configuration'
 

--- a/sos/report/plugins/omnipath_client.py
+++ b/sos/report/plugins/omnipath_client.py
@@ -14,11 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 from os.path import join
 
 
-class OmnipathClient(Plugin, RedHatPlugin, UbuntuPlugin):
+class OmnipathClient(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'OmniPath Tools and Fast Fabric Client'
 

--- a/sos/report/plugins/omnipath_manager.py
+++ b/sos/report/plugins/omnipath_manager.py
@@ -14,10 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin,
+                                DebianPlugin)
 
 
-class OmnipathManager(Plugin, RedHatPlugin, UbuntuPlugin):
+class OmnipathManager(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'OmniPath Fabric Manager'
 

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -8,10 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt,
+                                DebianPlugin)
 
 
-class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
+class Podman(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
     """Podman is a daemonless container management engine, and this plugin is
     meant to provide diagnostic information for both the engine and the
     containers that podman is managing.

--- a/sos/report/plugins/selinux.py
+++ b/sos/report/plugins/selinux.py
@@ -6,10 +6,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
+from sos.report.plugins import (Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt,
+                                DebianPlugin)
 
 
-class SELinux(Plugin, RedHatPlugin, UbuntuPlugin):
+class SELinux(Plugin, RedHatPlugin, UbuntuPlugin, DebianPlugin):
 
     short_desc = 'SELinux access control'
 

--- a/sos/report/plugins/slurm.py
+++ b/sos/report/plugins/slurm.py
@@ -6,11 +6,12 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin, RedHatPlugin
+from sos.report.plugins import (Plugin, UbuntuPlugin, RedHatPlugin,
+                                DebianPlugin)
 from sos.utilities import is_executable
 
 
-class Slurm(Plugin, UbuntuPlugin, RedHatPlugin):
+class Slurm(Plugin, UbuntuPlugin, RedHatPlugin, DebianPlugin):
 
     short_desc = "Slurm Workload Manager"
 


### PR DESCRIPTION
There are some missing DebianPlugin imports
in a number of plugins, that causes errors like
this one:

a non-existing plugin (ansible) was specified
in the command line.

When running these plugins.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?