### PR TITLE
[AAP EDA] Add new preset

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -15,7 +15,7 @@ import re
 
 from sos.report.plugins import RedHatPlugin
 from sos.presets.redhat import (RHEL_PRESETS, RHV, RHEL, CB, RHOSP,
-                                RHOCP, RH_CFME, RH_SATELLITE)
+                                RHOCP, RH_CFME, RH_SATELLITE, AAPEDA)
 from sos.policies.distros import LinuxPolicy, ENV_HOST_SYSROOT
 from sos.policies.package_managers.rpm import RpmPackageManager
 from sos.policies.package_managers.flatpak import FlatpakPackageManager
@@ -421,6 +421,10 @@ support representative.
         if self.pkg_by_name("ovirt-engine") is not None or \
                 self.pkg_by_name("vdsm") is not None:
             return self.find_preset(RHV)
+        for pkg in ['automation-eda-controller',
+                    'automation-eda-controller-server']:
+            if self.pkg_by_name(pkg) is not None:
+                return self.find_preset(AAPEDA)
 
         # Vanilla RHEL is default
         return self.find_preset(RHEL)

--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -53,6 +53,17 @@ RH_SATELLITE = "satellite"
 RH_SATELLITE_DESC = "Red Hat Satellite"
 SAT_OPTS = SoSOptions(log_size=100, plugopts=['apache.log=on'])
 
+AAPEDA = 'aap_eda'
+AAPEDA_DESC = 'Ansible Automation Platform Event Driven Controller'
+AAPEDA_OPTS = SoSOptions(
+    enable_plugins=['containers_common'],
+    plugopts=[
+        'containers_common.rootlessusers=eda'
+    ])
+AAPEDA_NOTE = ('Collects \'eda\' user output for the containers_common plugin.'
+               ' If you need more users, do not forget to add \'eda\' '
+               'to your own list for the \'rootlessusers\' option.')
+
 CB = "cantboot"
 CB_DESC = "For use when normal system startup fails"
 CB_OPTS = SoSOptions(
@@ -66,6 +77,8 @@ NOTE_TIME = "This preset may increase report run time"
 NOTE_SIZE_TIME = "This preset may increase report size and run time"
 
 RHEL_PRESETS = {
+    AAPEDA: PresetDefaults(name=AAPEDA, desc=AAPEDA_DESC, opts=AAPEDA_OPTS,
+                           note=AAPEDA_NOTE),
     RHV: PresetDefaults(name=RHV, desc=RHV_DESC, note=NOTE_TIME,
                         opts=_opts_verify),
     RHEL: PresetDefaults(name=RHEL, desc=RHEL_DESC),


### PR DESCRIPTION
Adds a new preset for `aap_eda`, or Ansible Automation Platform Event Driven Controller.

This preset will set the `containers_common` plugin to collect output for the `eda` user.

Related: #3486

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?