### PR TITLE
[ssh] Disable option 'userconfs' by default

### DIFF
--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -19,7 +19,7 @@ class Ssh(Plugin, IndependentPlugin):
     profiles = ('services', 'security', 'system', 'identity')
 
     option_list = [
-        PluginOpt('userconfs', default=True, val_type=str,
+        PluginOpt('userconfs', default=False, val_type=str,
                   desc=('Changes whether module will '
                         'collect user .ssh configs'))
     ]


### PR DESCRIPTION
Having this option enabled by default
can cause problems when users have their
home directories on automount. Leave the
option disabled by default so if needed
we can enable it in the command line.

Related: RHEL-22389

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?