### PR TITLE
[component] Check loggers attributes before referencing them

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -402,15 +402,13 @@ class SoSComponent():
         self.ui_log.addHandler(ui_console)
 
     def set_loggers_verbosity(self, verbosity):
-        if verbosity:
-            if self.flog:
-                self.flog.setLevel(logging.DEBUG)
-            if self.opts.verbosity > 1:
+        if getattr(self, 'flog', None) and verbosity:
+            self.flog.setLevel(logging.DEBUG)
+        if getattr(self, 'console', None):
+            if verbosity and self.opts.verbosity > 1:
                 self.console.setLevel(logging.DEBUG)
             else:
                 self.console.setLevel(logging.WARNING)
-        else:
-            self.console.setLevel(logging.WARNING)
 
     def _setup_logging(self):
         """Creates the log handler that shall be used by all components and any


### PR DESCRIPTION
When using own preset, loggers verbosity is set even before they are configured. In such a case, we must guard accessing them properly.

Resolves: #3491
Relevant: RHEL-22395

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?