### PR TITLE
[cleaner] skip shortstrings and substrings

### DIFF
--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -26,6 +26,7 @@ class SoSMap():
     skip_keys = []
     compile_regexes = True
     ignore_short_items = False
+    match_full_words_only = False
 
     def __init__(self):
         self.dataset = {}
@@ -97,7 +98,11 @@ class SoSMap():
         :returns:       A compiled regex pattern for the item
         :rtype:         ``re.Pattern``
         """
-        return re.compile(re.escape(item), re.I)
+        if self.match_full_words_only:
+            item = rf'(?=\b|_|-){re.escape(item)}(?=\b|_|-)'
+        else:
+            item = re.escape(item)
+        return re.compile(item, re.I)
 
     def sanitize_item(self, item):
         """Perform the obfuscation relevant to the item being added to the map.

--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -25,6 +25,7 @@ class SoSMap():
     # used for filename obfuscations in parser.parse_string_for_keys()
     skip_keys = []
     compile_regexes = True
+    ignore_short_items = False
 
     def __init__(self):
         self.dataset = {}
@@ -36,7 +37,8 @@ class SoSMap():
         """Some items need to be completely ignored, for example link-local or
         loopback addresses should not be obfuscated
         """
-        if not item or item in self.skip_keys or item in self.dataset.values():
+        if not item or item in self.skip_keys or item in self.dataset.values()\
+                or (self.ignore_short_items and len(item) <= 3):
             return True
         for skip in self.ignore_matches:
             if re.match(skip, item, re.I):

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -43,6 +43,7 @@ class SoSHostnameMap(SoSMap):
     strip_exts = ('.yaml', '.yml', '.crt', '.key', '.pem', '.log', '.repo',
                   '.rules', '.conf', '.cfg')
 
+    ignore_short_items = True
     host_count = 0
     domain_count = 0
     _domains = {}

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -44,6 +44,7 @@ class SoSHostnameMap(SoSMap):
                   '.rules', '.conf', '.cfg')
 
     ignore_short_items = True
+    match_full_words_only = True
     host_count = 0
     domain_count = 0
     _domains = {}

--- a/sos/cleaner/mappings/keyword_map.py
+++ b/sos/cleaner/mappings/keyword_map.py
@@ -21,6 +21,7 @@ class SoSKeywordMap(SoSMap):
     is an incrementing integer.
     """
 
+    match_full_words_only = True
     word_count = 0
 
     def sanitize_item(self, item):

--- a/sos/cleaner/mappings/username_map.py
+++ b/sos/cleaner/mappings/username_map.py
@@ -20,6 +20,7 @@ class SoSUsernameMap(SoSMap):
     Note that this specifically obfuscates user_names_ and not UIDs.
     """
 
+    ignore_short_items = True
     name_count = 0
 
     def sanitize_item(self, username):

--- a/sos/cleaner/mappings/username_map.py
+++ b/sos/cleaner/mappings/username_map.py
@@ -21,6 +21,7 @@ class SoSUsernameMap(SoSMap):
     """
 
     ignore_short_items = True
+    match_full_words_only = True
     name_count = 0
 
     def sanitize_item(self, username):

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -151,7 +151,8 @@ class SoSCleanerParser():
         if self.compile_regexes:
             for item, reg in self.mapping.compiled_regexes:
                 if reg.search(string_data):
-                    string_data = reg.sub(self.mapping.get(item), string_data)
+                    string_data = reg.sub(self.mapping.get(item.lower()),
+                                          string_data)
         else:
             for k, ob in sorted(self.mapping.dataset.items(), reverse=True,
                                 key=lambda x: len(x[0])):

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -164,6 +164,7 @@ class CleanerParserTests(unittest.TestCase):
         self.kw_parser.generate_item_regexes()
         self.uname_parser = SoSUsernameParser(config={})
         self.uname_parser.mapping.add('DOMAIN\myusername')
+        self.uname_parser.mapping.add('foo')
 
     def test_ip_parser_valid_ipv4_line(self):
         line = 'foobar foo 10.0.0.1/24 barfoo bar'
@@ -246,6 +247,11 @@ class CleanerParserTests(unittest.TestCase):
         _test = self.kw_parser.parse_line(line)[0]
         self.assertNotEqual(line, _test)
 
+    def test_keyword_parser_fullword_only(self):
+        line = 'notfoobar and foobars line'
+        _test = self.kw_parser.parse_line(line)[0]
+        self.assertEqual(line, _test)
+
     def test_keyword_parser_no_change_by_default(self):
         line = 'this is my foobar test line'
         _test = self.kw_parser_none.parse_line(line)[0]
@@ -279,6 +285,11 @@ class CleanerParserTests(unittest.TestCase):
         line = "DOMAIN\myusername"
         _test = self.uname_parser.parse_line(line)[0]
         self.assertNotEqual(line, _test)
+
+    def test_too_short_username(self):
+        line = "but foo is too short username"
+        _test = self.uname_parser.parse_line(line)[0]
+        self.assertEqual(line, _test)
 
 
 class PrepperTests(unittest.TestCase):


### PR DESCRIPTION
PR for https://github.com/sosreport/sos/issues/3403 . For relevant mappings (hostname, username, partly keyword), skip obfuscation of strings <4 length and skip obfuscation of substrings inside words.

Reproducer to play with:

    echo "repo" >> /etc/cron.deny
    echo "map" >> /etc/cron.deny
    echo "private" >> /etc/cron.deny
    rm -rf /etc/sos/cleaner/default_mapping
    sos report -o cron --batch --build --clean
    ..
    A mapping of obfuscated elements is available at
    	    /var/tmp/sosobfuscateduser2rt-pmoravec-rhel8-2024-01-28-ditdybr-obfuscateduser1_obfuscateduser0

while it should be:

        /var/tmp/sosreport-pmoravec-rhel8-2024-01-28-ditdybr-obfuscateduser0_map

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?