### PR TITLE
[filesys] Capture /run/mount/utab

### DIFF
--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -44,7 +44,8 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
             "/proc/self/mountstats",
             "/proc/[0-9]*/mountinfo",
             "/etc/mtab",
-            "/etc/fstab"
+            "/etc/fstab",
+            "/run/mount/utab",
         ])
         self.add_cmd_output("mount -l", root_symlink="mount",
                             tags="mount")


### PR DESCRIPTION
The file is libmount private (and optional)
but may provide important information as it stores userspace-specific mount data

Related: #3497

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?