### PR TITLE
[networkmanager] Add "NetworkManager --print-config" command

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -31,6 +31,8 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.add_journal(units="NetworkManager")
 
+        self.add_cmd_output("NetworkManager --print-config")
+
         # There are some incompatible changes in nmcli since
         # the release of NetworkManager >= 0.9.9. In addition,
         # NetworkManager >= 0.9.9 will use the long names of


### PR DESCRIPTION
There are some configuration files which could affect NetworkManager's behaviors. "NetworkManager --print-config" is useful to verify the current configuration at a glance.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?