### PR TITLE
[Kubernetes] Extend plugin to support microk8s

### DIFF
--- a/sos/report/plugins/microk8s.py
+++ b/sos/report/plugins/microk8s.py
@@ -40,6 +40,9 @@ class Microk8s(Plugin, UbuntuPlugin):
             'status',
             'version'
         ]
+        self.add_copy_spec(
+            "/var/snap/microk8s/current/credentials/client.config"
+        )
 
         self.add_cmd_output([
             f"microk8s {subcmd}" for subcmd in microk8s_subcmds


### PR DESCRIPTION
Currently, we are not supporting microk8s with the
same options as provided by kubernetes. This PR
extends the UbuntuKubernetes to get information
from microk8s.

Following the review, it also extends microk8s plugin
to add the credentials file in the copy spec and
runs the postproc() routine.

Closes: https://github.com/sosreport/sos/issues/3500

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X ] Is the subject and message clear and concise?
- [X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?