### PR TITLE
Separating Ext2/3/4 from filesys and using lsblk -rpo instead /proc/mounts

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1616,6 +1616,19 @@ class Plugin():
                 tags.extend(val)
         return tags
 
+    def get_devices_by_fstype(self, fstype):
+        """Get list of devices based on fstype and returns empty array in case
+        of failure.
+        """
+        dev = []
+        all_devs = self.exec_cmd("lsblk -rpo NAME,FSTYPE")
+        if (all_devs['status'] == 0 and not all_devs['truncated']):
+            if all_devs['status'] == 0:
+                for line in all_devs['output'].splitlines():
+                    if (fstype in line) and (line.split()[0] not in dev):
+                        dev.append(line.split()[0])
+        return dev
+
     def generate_copyspec_tags(self):
         """After file collections have completed, retroactively generate
         manifest entries to apply tags to files copied by generic copyspecs

--- a/sos/report/plugins/ext.py
+++ b/sos/report/plugins/ext.py
@@ -1,0 +1,57 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
+
+
+class Ext(Plugin, IndependentPlugin):
+    """This plugin collects information on mounted Ext2/3/4 filessystems on
+    the local system.
+
+    Users should expect `dumpe2fs -h` or `dumpe2fs` collections by this
+    plugin for each Ext2/3/4 filesystem that is recognized by lsblk.
+    """
+
+    short_desc = 'Ext2/3/4 filesystem'
+
+    plugin_name = 'ext'
+    profiles = ('storage',)
+    files = ('/sys/fs/ext4/', '/proc/fs/ext4/', '/proc/fs/jbd2/')
+
+    option_list = [
+        PluginOpt('dumpe2fs', default=False, desc='dump filesystem info'),
+        PluginOpt('frag', default=False,
+                  desc='collect filesystem fragmentation status')
+    ]
+
+    def setup(self):
+        dumpe2fs_opts = '-h'
+        if self.get_option('dumpe2fs'):
+            dumpe2fs_opts = ''
+        allfs = self.get_devices_by_fstype('ext')
+        if allfs:
+            for fs in allfs:
+                self.add_cmd_output(f"dumpe2fs {dumpe2fs_opts} {fs}",
+                                    tags="dumpe2fs_h")
+
+                if self.get_option('frag'):
+                    self.add_cmd_output(f"e2freefrag {fs}", priority=100)
+
+        else:
+            mounts = '/proc/mounts'
+            ext_fs_regex = r"^(/dev/\S+).+ext[234]\s+"
+            for dev in self.do_regex_find_all(ext_fs_regex, mounts):
+                self.add_cmd_output(f"dumpe2fs {dumpe2fs_opts} {fs}",
+                                    tags="dumpe2fs_h")
+
+            if self.get_option('frag'):
+                self.add_cmd_output(f"e2freefrag {fs}", priority=100)
+
+        self.add_copy_spec(self.files)
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -29,9 +29,6 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
     option_list = [
         PluginOpt('lsof', default=False,
                   desc='collect information on all open files'),
-        PluginOpt('dumpe2fs', default=False, desc='dump filesystem info'),
-        PluginOpt('frag', default=False,
-                  desc='collect filesystem fragmentation status')
     ]
 
     def setup(self):
@@ -75,18 +72,36 @@ class Filesys(Plugin, DebianPlugin, UbuntuPlugin, CosPlugin):
         if self.get_option('lsof'):
             self.add_cmd_output("lsof -b +M -n -l -P", root_symlink="lsof",
                                 priority=50)
+        option_list = [
+            PluginOpt('dumpe2fs', default=False, desc='dump filesystem info'),
+            PluginOpt('frag', default=False,
+                      desc='collect filesystem fragmentation status')
+        ]
 
+    def setup(self):
         dumpe2fs_opts = '-h'
         if self.get_option('dumpe2fs'):
             dumpe2fs_opts = ''
-        mounts = '/proc/mounts'
-        ext_fs_regex = r"^(/dev/\S+).+ext[234]\s+"
-        for dev in self.do_regex_find_all(ext_fs_regex, mounts):
-            self.add_cmd_output("dumpe2fs %s %s" % (dumpe2fs_opts, dev),
-                                tags="dumpe2fs_h")
+        allfs = self.get_devices_by_fstype('ext')
+        if allfs:
+            for fs in allfs:
+                self.add_cmd_output(f"dumpe2fs {dumpe2fs_opts} {fs}",
+                                    tags="dumpe2fs_h")
+
+                if self.get_option('frag'):
+                    self.add_cmd_output(f"e2freefrag {fs}", priority=100)
+
+        else:
+            mounts = '/proc/mounts'
+            ext_fs_regex = r"^(/dev/\S+).+ext[234]\s+"
+            for dev in self.do_regex_find_all(ext_fs_regex, mounts):
+                self.add_cmd_output(f"dumpe2fs {dumpe2fs_opts} {fs}",
+                                    tags="dumpe2fs_h")
 
             if self.get_option('frag'):
-                self.add_cmd_output("e2freefrag %s" % (dev), priority=100)
+                self.add_cmd_output(f"e2freefrag {fs}", priority=100)
+
+        self.add_copy_spec(self.files)
 
     def postproc(self):
         self.do_file_sub(


### PR DESCRIPTION

 [xfs,filesys,ext] Get list of devices by lsblk -lpo NAME,FSTYPE.

It can happen the FS of interest is not actually mounted and then we have no info about it. This is revorks of how we should get list of devices. It adds a new __init__.py fuction to decrease code duplication get_dev_by_fstype(self,fstype). It is using lsblk instead of /proc/mounts. Last change is separation of Ext2/3/4 info into separate module from filesys.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?