### PR TITLE
[global] Replace use of `.format()` with f-strings

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -90,9 +90,7 @@ class SoS():
             aliases.insert(0, com)
             _com = ', '.join(aliases)
             desc = self._components[com][0].desc
-            _com_string += (
-                "\t{com:<30}{desc}\n".format(com=_com, desc=desc)
-            )
+            _com_string += (f"\t{_com:<30}{desc}\n")
         usage_string = ("%(prog)s <component> [options]\n\n"
                         "Available components:\n")
         usage_string = usage_string + _com_string

--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -110,7 +110,7 @@ class SoSObfuscationArchive():
 
     def report_msg(self, msg):
         """Helper to easily format ui messages on a per-report basis"""
-        self.ui_log.info("{:<50} {}".format(self.ui_name + ' :', msg))
+        self.ui_log.info(f"{self.ui_name + ' :':<50} {msg}")
 
     def _fmt_log_msg(self, msg):
         return "[cleaner:%s] %s" % (self.archive_name, msg)

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -516,7 +516,7 @@ class SoSCollector(SoSComponent):
         )
         for hsec in hsections:
             section.add_text(
-                "{:>8}{:<40}{:<30}".format(' ', bold(hsec), hsections[hsec]),
+                f"{' ':>8}{bold(hsec):<40}{hsections[hsec]:<30}",
                 newline=False
             )
 
@@ -650,9 +650,9 @@ class SoSCollector(SoSComponent):
         sys.stdout.write('Use the short name with --cluster-type or cluster '
                          'options (-c)\n\n')
         for cluster in sorted(self.clusters):
-            sys.stdout.write(" {:<15} {:30}\n".format(
-                                cluster,
-                                self.clusters[cluster].cluster_name))
+            sys.stdout.write(
+                f" {cluster:<15} {self.clusters[cluster].cluster_name:30}\n"
+            )
 
         _opts = {}
         for _cluster in self.clusters:
@@ -665,22 +665,18 @@ class SoSCollector(SoSComponent):
                             _opts[opt.name].cluster.append(clust)
 
         sys.stdout.write('\nThe following cluster options are available:\n\n')
-        sys.stdout.write(' {:25} {:15} {:<10} {:10} {:<}\n'.format(
-            'Cluster',
-            'Option Name',
-            'Type',
-            'Default',
-            'Description'
-        ))
+        sys.stdout.write(
+            f" {'Cluster':25} {'Option Name':15} {'Type':<10} {'Default':10} "
+            f"{'Description':<}\n"
+        )
 
         for _opt in sorted(_opts, key=lambda x: _opts[x].cluster):
             opt = _opts[_opt]
-            optln = ' {:25} {:15} {:<10} {:<10} {:<10}\n'.format(
-                ', '.join(c for c in sorted(opt.cluster)),
-                opt.name,
-                opt.opt_type.__name__,
-                str(opt.value),
-                opt.description)
+            optln = (
+                f"  {', '.join(c for c in sorted(opt.cluster)):25} "
+                f"{opt.name:15} {opt.opt_type.__name__:<10} "
+                f"{str(opt.value):<10} {opt.description:<10}\n"
+            )
             sys.stdout.write(optln)
         sys.stdout.write('\nOptions take the form of cluster.name=value'
                          '\nE.G. "ovirt.no-database=True" or '

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -145,10 +145,11 @@ class Cluster():
                 "These options may be toggled or changed using '%s'"
                 % bold("-c %s.$option=$value" % cls.__name__)
             )
-            optsec.add_text(bold(
-                "\n{:<4}{:<20}{:<30}{:<20}\n".format(
-                    ' ', "Option Name", "Default", "Description")
-                ), newline=False
+            optsec.add_text(
+                bold(
+                    f"\n{' ':<4}{'Option Name':<20}{'Default':<30}"
+                    f"{'Description':<20}\n"),
+                newline=False
             )
             for opt in cls.option_list:
                 val = opt[1]
@@ -157,8 +158,7 @@ class Cluster():
                         val = 'True/On'
                     else:
                         val = 'False/Off'
-                _ln = "{:<4}{:<20}{:<30}{:<20}".format(' ', opt[0], val,
-                                                       opt[2])
+                _ln = f"{' ':<4}{opt[0]:<20}{val:<30}{opt[2]:<20}"
                 optsec.add_text(_ln, newline=False)
 
     @classmethod
@@ -185,13 +185,13 @@ class Cluster():
             'The following cluster profiles are locally available:\n'
         )
         section.add_text(
-            "{:>8}{:<40}{:<30}".format(' ', 'Name', 'Description'),
+            f"{' ':>8}{'Name':<40}{'Description':<30}",
             newline=False
         )
         for cluster in clusters:
             _sec = bold("collect.clusters.%s" % cluster[0])
             section.add_text(
-                "{:>8}{:<40}{:<30}".format(' ', _sec, cluster[1].cluster_name),
+                f"{' ':>8}{_sec:<40}{cluster[1].cluster_name:<30}",
                 newline=False
             )
 

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -153,20 +153,18 @@ class ovirt(Cluster):
         return False
 
     def collect_database(self):
+        plugin = 'postgresql'
         sos_opt = (
-                   '-k {plugin}.dbname={db} '
-                   '-k {plugin}.dbhost={dbhost} '
-                   '-k {plugin}.dbport={dbport} '
-                   '-k {plugin}.username={dbuser} '
-                   ).format(plugin='postgresql',
-                            db=self.conf['ENGINE_DB_DATABASE'],
-                            dbhost=self.conf['ENGINE_DB_HOST'],
-                            dbport=self.conf['ENGINE_DB_PORT'],
-                            dbuser=self.conf['ENGINE_DB_USER']
-                            )
-        cmd = ('PGPASSWORD={} /usr/sbin/sosreport --name=postgresql '
-               '--batch -o postgresql {}'
-               ).format(self.conf['ENGINE_DB_PASSWORD'], sos_opt)
+            f"-k {plugin}.dbname={self.conf['ENGINE_DB_DATABASE']} "
+            f"-k {plugin}.dbhost={self.conf['ENGINE_DB_HOST']} "
+            f"-k {plugin}.dbport={self.conf['ENGINE_DB_PORT']} "
+            f"-k {plugin}.dbuser={self.conf['ENGINE_DB_USER']}"
+        )
+
+        cmd = (
+            f"PGPASSWORD={self.conf['ENGINE_DB_PASSWORD']} /usr/sbin/sos "
+            f"report --name=postgresql --batch -o postgresql {sos_opt}"
+        )
         db_sos = self.exec_primary_cmd(cmd, need_root=True)
         for line in db_sos['output'].splitlines():
             if fnmatch.fnmatch(line, '*sosreport-*tar*'):

--- a/sos/collector/clusters/saltstack.py
+++ b/sos/collector/clusters/saltstack.py
@@ -46,14 +46,16 @@ class saltstack(Cluster):
 
     def _get_hostnames_from_grain(self, manage_status: dict) -> list:
         hostnames = []
-        fqdn_cmd = "salt --out=newline_values_only {minion} grains.get fqdn"
         for status, minions in manage_status.items():
             if status == "down":
                 self.log_warn(f"Node(s) {minions} are status down.")
                 hostnames.extend(minions)
             else:
                 for minion in minions:
-                    node_cmd = fqdn_cmd.format(minion=minion)
+                    node_cmd = (
+                        f"salt --out=newline_values_only {minion} "
+                        f"grains.get fqdn"
+                    )
                     hostnames.append(
                         self.exec_primary_cmd(node_cmd)["output"].strip()
                     )

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -135,7 +135,7 @@ class SosNode():
         return SSHControlPersist(self.address, commons)
 
     def _fmt_msg(self, msg):
-        return '{:<{}} : {}'.format(self._hostname, self.hostlen + 1, msg)
+        return f"{self._hostname:<{self.hostlen + 1}} : {msg}"
 
     @property
     def env_vars(self):

--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -134,7 +134,7 @@ class RemoteTransport():
             _sec = bold("collect.transports.%s" % transport)
             _desc = "The '%s' transport" % transport.lower()
             section.add_text(
-                "{:>8}{:<45}{:<30}".format(' ', _sec, _desc),
+                f"{' ':>8}{_sec:<45}{_desc:<30}",
                 newline=False
             )
 

--- a/sos/help/__init__.py
+++ b/sos/help/__init__.py
@@ -211,7 +211,7 @@ class SoSHelper(SoSComponent):
 
         for sect in sections:
             avail_help.add_text(
-                "\t{:<36}{}".format(bold(sect), sections[sect]),
+                f"\t{bold(sect):<36}{sections[sect]}",
                 newline=False
             )
 

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -242,24 +242,17 @@ any third party.
         rand = ''.join(random.choice(string.ascii_lowercase) for x in range(7))
 
         if self.name_pattern == 'legacy':
-            nstr = "sosreport-{name}{case}{date}"
             case = '.' + case if case else ''
             date = '-%Y%m%d%H%M%S'
+            nstr = f"sosreport-{name}{case}{date}"
         elif self.name_pattern == 'friendly':
-            nstr = "sosreport-{name}{label}{case}{date}-{rand}"
             case = '-' + case if case else ''
             label = '-' + label if label else ''
             date = '-%Y-%m-%d'
+            nstr = f"sosreport-{name}{label}{case}{date}-{rand}"
         else:
             nstr = self.name_pattern
 
-        nstr = nstr.format(
-            name=name,
-            label=label,
-            case=case,
-            date=date,
-            rand=rand
-        )
         return self.sanitize_filename(time.strftime(nstr))
 
     # for some specific binaries like "xz", we need to determine package
@@ -409,8 +402,10 @@ any third party.
             "For more information on distribution policies, see below\n"
         )
         for pol in pols:
-            seealso.add_text("{:>8}{:<20}{:<30}".format(' ', pol, pols[pol]),
-                             newline=False)
+            seealso.add_text(
+                f"{' ':>8}{pol:<20}{pols[pol]:<30}",
+                newline=False
+            )
 
     def display_results(self, archive, directory, checksum, archivestat=None,
                         map_file=None):
@@ -501,10 +496,9 @@ any third party.
         :rtype:     ``str``
         """
         width = max([len(v[0]) for v in self.vendor_urls])
-        return "\n".join("\t{desc:<{width}} : {url}".format(
-                         desc=u[0], width=width, url=u[1])
-                         for u in self.vendor_urls
-                         )
+        return "\n".join(
+            f"\t{url[0]:<{width}} : {url[1]}" for url in self.vendor_urls
+        )
 
     def register_presets(self, presets, replace=False):
         """Add new presets to this policy object.

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -199,17 +199,13 @@ class LinuxPolicy(Policy):
 
         refsec = section.add_section('Reference URLs')
         for url in cls.vendor_urls:
-            refsec.add_text(
-                "{:>8}{:<30}{:<40}".format(' ', url[0], url[1]),
-                newline=False
-            )
+            refsec.add_text(f"{' ':>8}{url[0]:<30}{url[1]:<40}", newline=False)
 
         presec = section.add_section('Presets Available With This Policy\n')
         presec.add_text(
             bold(
-                "{:>8}{:<20}{:<45}{:<30}".format(' ', 'Preset Name',
-                                                 'Description',
-                                                 'Enabled Options')
+                f"{' ':>8}{'Preset Name':<20}{'Description':<45}"
+                f"{'Enabled Options':<30}"
             ),
             newline=False
         )
@@ -217,9 +213,7 @@ class LinuxPolicy(Policy):
             _preset = _pol.presets[preset]
             _opts = ' '.join(_preset.opts.to_args())
             presec.add_text(
-                "{:>8}{:<20}{:<45}{:<30}".format(
-                    ' ', preset, _preset.desc, _opts
-                ),
+                f"{' ':>8}{preset:<20}{_preset.desc:<45}{_opts:<30}",
                 newline=False
             )
 

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -117,7 +117,7 @@ class RedHatPolicy(LinuxPolicy):
         for subc in subs:
             subln = bold("policies.%s" % subc)
             section.add_text(
-                "{:>8}{:<35}{:<30}".format(' ', subln, subs[subc].distro),
+                f"{' ':>8}{subln:<35}{subs[subc].distro:<30}",
                 newline=False
             )
 
@@ -504,18 +504,20 @@ support representative.
         return self.find_preset(RHOCP)
 
     def create_sos_container(self, image=None, auth=None, force_pull=False):
-        _cmd = ("{runtime} run -di --name {name} --privileged --ipc=host"
-                " --net=host --pid=host -e HOST=/host -e NAME={name} -e "
-                "IMAGE={image} {pull} -v /run:/run -v /var/log:/var/log -v "
-                "/etc/machine-id:/etc/machine-id -v "
-                "/etc/localtime:/etc/localtime -v /:/host {auth} {image}")
         _image = image or self.container_image
         _pull = '--pull=always' if force_pull else ''
-        return _cmd.format(runtime=self.container_runtime,
-                           name=self.sos_container_name,
-                           image=_image,
-                           pull=_pull,
-                           auth=auth or '')
+        return (
+            f"{self.container_runtime} run -di "
+            f"--name {self.sos_container_name} --privileged --ipc=host "
+            f"--net=host --pid=host -e HOST=/host "
+            f"-e NAME={self.sos_container_name} -e "
+            f"IMAGE={_image} {_pull} "
+            f"-v /run:/run -v /var/log:/var/log "
+            f"-v /etc/machine-id:/etc/machine-id "
+            f"-v /etc/localtime:/etc/localtime "
+            f"-v /:/host "
+            f"{auth or ''} {_image}"
+        )
 
     def set_cleanup_cmd(self):
         return 'podman rm --force %s' % self.sos_container_name

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -61,7 +61,7 @@ def _format_since(date):
     didn't. It's used in the _get_parser.
     This will also be a good place to add human readable and relative
     date parsing (like '2 days ago') in the future """
-    return datetime.strptime('{:<014s}'.format(date), '%Y%m%d%H%M%S')
+    return datetime.strptime(f"{date:<014s}", '%Y%m%d%H%M%S')
 
 
 # valid modes for --chroot
@@ -432,8 +432,7 @@ class SoSReport(SoSComponent):
         }
         helpln = ''
         for ln in help_lines:
-            ssec.add_text("\t{:<36}{}".format(ln, help_lines[ln]),
-                          newline=False)
+            ssec.add_text(f"\t{ln:<36}{help_lines[ln]}", newline=False)
         ssec.add_text(helpln)
 
     def print_header(self):

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -844,10 +844,10 @@ class Plugin():
             "These options may be toggled or changed using '%s'"
             % bold("-k %s.option_name=$value" % cls.plugin_name)
         )
-        optsec.add_text(bold(
-            "\n{:<4}{:<20}{:<30}{:<20}\n".format(
-                ' ', "Option Name", "Default", "Description")
-            ), newline=False
+        optsec.add_text(
+            bold((f"\n{' ':<4}{'Option Name':<20}{'Default':<30}"
+                  f"{'Description':<20}")),
+            newline=False
         )
 
         opt_indent = ' ' * 54
@@ -861,8 +861,7 @@ class Plugin():
                     _def = "True/On"
                 else:
                     _def = "False/Off"
-            _ln = "{:<4}{:<20}{:<30}{:<20}".format(' ', opt.name, _def,
-                                                   opt.desc)
+            _ln = f"{' ':<4}{opt.name:<20}{_def:<30}{opt.desc:<20}"
             optsec.add_text(
                 textwrap.fill(_ln, width=TERMSIZE,
                               subsequent_indent=opt_indent),
@@ -932,7 +931,7 @@ class Plugin():
         seealso.add_text(
             "Additional relevant information may be available in these "
             "help sections:\n\n%s" % "\n".join(
-                "{:>8}{:<30}{:<30}".format(' ', sec, desc)
+                f"{' ':>8}{sec:<30}{desc:<30}"
                 for sec, desc in _also.items()
             ), newline=False
         )

--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -41,7 +41,7 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
         pkg_list = ' '.join(
             [v.split('\t')[0] for v in dpkg_output if 'ok installed' in v])
         self.add_cmd_output(
-            "apt-cache policy {}".format(pkg_list),
+            f"apt-cache policy {pkg_list}",
             suggest_filename="apt-cache_policy_details"
         )
 

--- a/sos/report/plugins/clear_containers.py
+++ b/sos/report/plugins/clear_containers.py
@@ -26,12 +26,12 @@ class ClearContainers(Plugin, IndependentPlugin):
 
         # start with the default file locations
         config_files = [
-                '/etc/clear-containers/configuration.toml'
-                '/usr/share/defaults/clear-containers/configuration.toml'
+            '/etc/clear-containers/configuration.toml'
+            '/usr/share/defaults/clear-containers/configuration.toml'
         ]
 
         # obtain a list of config files by asking the runtime
-        cmd = '{} --cc-show-default-config-paths'.format(self.runtime)
+        cmd = f"{self.runtime} --cc-show-default-config-paths"
         configs = self.exec_cmd(cmd)['output']
 
         for config in configs.splitlines():
@@ -50,7 +50,7 @@ class ClearContainers(Plugin, IndependentPlugin):
         ]
 
         # query the runtime to find the configured global log file
-        cmd = '{} cc-env'.format(self.runtime)
+        cmd = f"{self.runtime} cc-env"
         output = self.exec_cmd(cmd)['output']
         for line in output.splitlines():
             result = re.search(r'\bGlobalLogPath\b\s+=\s+"(.+)"', line)
@@ -72,7 +72,7 @@ class ClearContainers(Plugin, IndependentPlugin):
             # no limit on amount of data recorded
             self.limit = None
 
-        self.add_cmd_output('{} cc-env'.format(self.runtime))
+        self.add_cmd_output(f"{self.runtime} cc-env")
         self.attach_cc_config_files()
 
         self.attach_cc_log_files()

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -92,7 +92,7 @@ class Foreman(Plugin):
         # Collect these completely everytime
         self.add_copy_spec([
             "/var/log/foreman/production.log",
-            "/var/log/{}*/foreman-ssl_*_ssl.log".format(self.apachepkg)
+            f"/var/log/{self.apachepkg}*/foreman-ssl_*_ssl.log"
         ], sizelimit=0)
 
         # Allow limiting these
@@ -111,14 +111,12 @@ class Foreman(Plugin):
             "/var/log/foreman-selinux-install.log",
             "/var/log/foreman-proxy-certs-generate*",
             "/usr/share/foreman/Gemfile*",
-            "/var/log/{}*/foreman*".format(self.apachepkg),
-            "/var/log/{}*/katello-reverse-proxy_access_ssl.log*".format(
-                self.apachepkg),
-            "/var/log/{}*/katello-reverse-proxy_error_ssl.log*".format(
-                self.apachepkg),
-            "/var/log/{}*/error_log*".format(self.apachepkg),
-            "/etc/{}*/conf/".format(self.apachepkg),
-            "/etc/{}*/conf.d/".format(self.apachepkg)
+            f"/var/log/{self.apachepkg}*/foreman*",
+            f"/var/log/{self.apachepkg}*/katello-reverse-proxy_error_ssl.log*",
+            f"/var/log/{self.apachepkg}*/error_log*",
+            f"/etc/{self.apachepkg}*/conf/",
+            f"/etc/{self.apachepkg}*/conf.d/",
+            f"/var/log/{self.apachepkg}*/katello-reverse-proxy_access_ssl.log*"
         ])
 
         self.add_cmd_output([

--- a/sos/report/plugins/foreman_proxy.py
+++ b/sos/report/plugins/foreman_proxy.py
@@ -34,14 +34,10 @@ class ForemanProxy(Plugin):
             "/etc/foreman-proxy/",
             "/etc/smart_proxy_dynflow_core/settings.yml",
             "/var/log/foreman-proxy/*log*",
-            "/var/log/{}*/katello-reverse-proxy_access_ssl.log*".format(
-                self.apachepkg),
-            "/var/log/{}*/katello-reverse-proxy_error_ssl.log*".format(
-                self.apachepkg),
-            "/var/log/{}*/rhsm-pulpcore-https-*_access_ssl.log*".format(
-                self.apachepkg),
-            "/var/log/{}*/rhsm-pulpcore-https-*_error_ssl.log*".format(
-                self.apachepkg),
+            f"/var/log/{self.apachepkg}*/katello-reverse-proxy_error_ssl.log*",
+            f"/var/log/{self.apachepkg}*/rhsm-pulpcore-https-*access_ssl.log*",
+            f"/var/log/{self.apachepkg}*/rhsm-pulpcore-https-*error_ssl.log*",
+            f"/var/log/{self.apachepkg}*/katello-reverse-proxy_access_ssl.log*"
         ])
 
         # collect http[|s]_proxy env.variables

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -84,8 +84,8 @@ class RedHatKDump(KDump, RedHatPlugin):
             # set no filesystem and default path
             path = "/var/crash"
 
-        self.add_copy_spec("{}/*/vmcore-dmesg.txt".format(path))
-        self.add_copy_spec("{}/*/kexec-dmesg.log".format(path))
+        self.add_copy_spec(f"{path}/*/vmcore-dmesg.txt")
+        self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
 
 
 class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):

--- a/sos/report/plugins/omsa.py
+++ b/sos/report/plugins/omsa.py
@@ -32,16 +32,16 @@ class omsa(Plugin, IndependentPlugin):
         ])
 
         self.add_cmd_output([
-            "{0} system alertaction".format(self.omreport),
-            "{0} system alertlog".format(self.omreport),
-            "{0} system cmdlog".format(self.omreport),
-            "{0} system pedestinations".format(self.omreport),
-            "{0} system platformevents".format(self.omreport),
-            "{0} system summary".format(self.omreport),
-            "{0} system events".format(self.omreport),
-            "{0} chassis info".format(self.omreport),
-            "{0} chassis biossetup".format(self.omreport),
-            "{0} storage controller".format(self.omreport),
+            f"{self.omreport} system alertaction",
+            f"{self.omreport} system alertlog",
+            f"{self.omreport} system cmdlog",
+            f"{self.omreport} system pedestinations",
+            f"{self.omreport} system platformevents",
+            f"{self.omreport} system summary",
+            f"{self.omreport} system events",
+            f"{self.omreport} chassis info",
+            f"{self.omreport} chassis biossetup",
+            f"{self.omreport} storage controller",
         ], timeout=30)
 
 # vim: et ts=4 sw=4

--- a/sos/report/plugins/openstack_aodh.py
+++ b/sos/report/plugins/openstack_aodh.py
@@ -34,12 +34,12 @@ class OpenStackAodh(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/aodh/*",
-                "/var/log/{}*/aodh*".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/aodh*",
             ])
         else:
             self.add_copy_spec([
                 "/var/log/aodh/*.log",
-                "/var/log/{}*/aodh*.log".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/aodh*.log",
             ])
 
         vars_all = [p in os.environ for p in [

--- a/sos/report/plugins/openstack_cinder.py
+++ b/sos/report/plugins/openstack_cinder.py
@@ -63,12 +63,12 @@ class OpenStackCinder(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/cinder/",
-                "/var/log/{}*/cinder*".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/cinder*",
             ])
         else:
             self.add_copy_spec([
                 "/var/log/cinder/*.log",
-                "/var/log/{}*/cinder*.log".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/cinder*.log",
             ])
 
     def apply_regex_sub(self, regexp, subst):

--- a/sos/report/plugins/openstack_gnocchi.py
+++ b/sos/report/plugins/openstack_gnocchi.py
@@ -28,12 +28,12 @@ class Gnocchi(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/gnocchi/*",
-                "/var/log/{}*/gnocchi*".format(self.apachepkg)
+                f"/var/log/{self.apachepkg}*/gnocchi*"
             ])
         else:
             self.add_copy_spec([
                 "/var/log/gnocchi/*.log",
-                "/var/log/{}*/gnocchi*.log".format(self.apachepkg)
+                f"/var/log/{self.apachepkg}*/gnocchi*.log"
             ])
 
         vars_all = [p in os.environ for p in [

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -44,12 +44,12 @@ class OpenStackKeystone(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/keystone/",
-                "/var/log/{}*/keystone*".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/keystone*",
             ])
         else:
             self.add_copy_spec([
                 "/var/log/keystone/*.log",
-                "/var/log/{}*/keystone*.log".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/keystone*.log",
             ])
 
         # collect domain config directory, if specified

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -93,7 +93,7 @@ class OpenStackNova(Plugin):
         if self.get_option("all_logs"):
             self.add_copy_spec([
                 "/var/log/nova/",
-                "/var/log/{}*/nova*".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/nova*",
             ])
         else:
             novadir = '/var/log/nova/'
@@ -109,8 +109,8 @@ class OpenStackNova(Plugin):
             for novalog in novalogs:
                 self.add_copy_spec(self.path_join(novadir, novalog))
             self.add_copy_spec([
-                "/var/log/{}*/nova*.log".format(self.apachepkg),
-                "/var/log/{}*/placement*.log".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/nova*.log",
+                f"/var/log/{self.apachepkg}*/placement*.log",
             ])
 
         pp = ['', '_libvirt', '_metadata', '_placement']

--- a/sos/report/plugins/openstack_placement.py
+++ b/sos/report/plugins/openstack_placement.py
@@ -44,14 +44,14 @@ class OpenStackPlacement(Plugin):
                 "/var/log/placement/",
                 "/var/log/containers/placement/",
                 "/var/log/containers/httpd/placement-api/",
-                "/var/log/{}*/placement*".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/placement*",
             ])
         else:
             self.add_copy_spec([
                 "/var/log/placement/*.log",
                 "/var/log/containers/placement/*.log",
                 "/var/log/containers/httpd/placement-api/*log",
-                "/var/log/{}*/placement*.log".format(self.apachepkg),
+                f"/var/log/{self.apachepkg}*/placement*.log",
             ])
 
         self.add_copy_spec([

--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -252,7 +252,7 @@ class Ovirt(Plugin, RedHatPlugin):
         ):
             self.do_path_regex_sub(
                 r'/var/lib/ovirt-engine/setup/answers/.*',
-                r'(?P<key>[^=]*{item}[^=]*)=.*'.format(item=item),
+                rf'(?P<key>[^=]*{item}[^=]*)=.*',
                 r'\g<key>=********'
             )
 

--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -115,19 +115,14 @@ class OVNCentral(Plugin):
                                            self.ovn_northd_sock_regex)
 
         # ovsdb nb/sb cluster status commands
-        self.add_cmd_output(
-            [
-                'ovs-appctl -t {} cluster/status OVN_Northbound'.format(
-                    self.ovn_nbdb_sock_path),
-                'ovs-appctl -t {} cluster/status OVN_Southbound'.format(
-                    self.ovn_sbdb_sock_path),
-                'ovn-appctl -t {} status'.format(northd_sock_path),
-                'ovn-appctl -t {} debug/chassis-features-list'.format(
-                    northd_sock_path),
-                'ovn-appctl -t {} connection-status'.format(
-                    ovn_controller_sock_path),
-            ],
-            foreground=True, container=self._container_name, timeout=30
+        cstat = "cluster/status"
+        self.add_cmd_output([
+            f"ovs-appctl -t {self.ovn_nbdb_sock_path} {cstat} OVN_Northbound",
+            f"ovs-appctl -t {self.ovn_sbdb_sock_path} {cstat} OVN_Southbound",
+            f"ovn-appctl -t {northd_sock_path} status",
+            f"ovn-appctl -t {northd_sock_path} debug/chassis-features-list",
+            f"ovn-appctl -t {ovn_controller_sock_path} connection-status",
+        ], foreground=True, container=self._container_name, timeout=30
         )
 
         # Some user-friendly versions of DB output

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -38,8 +38,8 @@ class Puppet(Plugin, IndependentPlugin):
             "/var/lib/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/certs/ca.pem",
-            "/etc/puppetlabs/puppet/ssl/certs/{}.pem".format(_hostname),
-            "/var/lib/puppet/ssl/certs/{}.pem".format(_hostname),
+            f"/etc/puppetlabs/puppet/ssl/certs/{_hostname}.pem",
+            f"/var/lib/puppet/ssl/certs/{_hostname}.pem",
         ])
         self.add_copy_spec("/etc/puppetlabs/puppet/ssl/certs/ca.pem",
                            tags="puppet_ssl_cert_ca_pem")

--- a/sos/report/plugins/rhv_analyzer.py
+++ b/sos/report/plugins/rhv_analyzer.py
@@ -22,20 +22,11 @@ class Rhv_Analyzer(Plugin, RedHatPlugin):
 
     def setup(self):
         tool_name = 'rhv-log-collector-analyzer'
-        report = "{dircmd}/analyzer-report.html".format(
-            dircmd=self.get_cmd_output_path()
-        )
+        report = f"{self.get_cmd_output_path()}/analyzer-report.html"
 
-        self.add_cmd_output(
-            "{tool_name}"
-            " --live"
-            " --html={report}".format(
-                report=report, tool_name=tool_name)
-        )
-
-        self.add_cmd_output(
-            "{tool_name}"
-            " --json".format(tool_name=tool_name)
-        )
+        self.add_cmd_output([
+            f"{tool_name} --live --html={report}",
+            f"{tool_name} --json"
+        ])
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -87,7 +87,7 @@ class Ssh(Plugin, IndependentPlugin):
             try:
                 home_dir = self.path_join(usr_line.split(':')[5], '.ssh')
                 if self.path_isdir(home_dir):
-                    self.add_cmd_output('ls -laZ {}'.format(home_dir))
+                    self.add_cmd_output(f"ls -laZ {home_dir}")
             except IndexError:
                 pass
 

--- a/sos/report/plugins/vdsm.py
+++ b/sos/report/plugins/vdsm.py
@@ -129,8 +129,8 @@ class Vdsm(Plugin, RedHatPlugin):
                 pools = json.loads(res['output'])
                 for pool in pools:
                     self.add_cmd_output(
-                        'vdsm-client StoragePool getSpmStatus'
-                        ' storagepoolID={}'.format(pool)
+                        f"vdsm-client StoragePool getSpmStatus "
+                        f"storagepoolID={pool}"
                     )
         except ValueError as e:
             self._log_error(

--- a/sos/report/plugins/virsh.py
+++ b/sos/report/plugins/virsh.py
@@ -77,12 +77,13 @@ class LibvirtClient(Plugin, IndependentPlugin):
                     self.add_cmd_output('%s %s %s' % (cmd, x, d),
                                         foreground=True)
 
-        nodedev_output = self.exec_cmd(
-            '{0} nodedev-list'.format(cmd), foreground=True)
+        nodedev_output = self.exec_cmd(f"{cmd} nodedev-list", foreground=True)
         if nodedev_output['status'] == 0:
             for n in nodedev_output['output'].splitlines():
                 self.add_cmd_output(
-                    '{0} nodedev-dumpxml {1}'.format(cmd, n), foreground=True)
+                    f"{cmd} nodedev-dumpxml {n}",
+                    foreground=True
+                )
 
     def postproc(self):
         match_exp = r"(\s*passwd\s*=\s*\")([^\"]*)(\".*)"

--- a/sos/report/reporting.py
+++ b/sos/report/reporting.py
@@ -166,7 +166,7 @@ class PlainTextReport(object):
         i = 0
         plugcount = len(self.report_data)
         for section_name, _ in self.report_data:
-            line += self.PLUGLISTITEM.format(name=section_name)
+            line += f"  {section_name}"
             i += 1
             if (i % self.PLUGLISTMAXITEMS == 0) and (i < plugcount):
                 line += self.PLUGLISTSEP
@@ -175,7 +175,7 @@ class PlainTextReport(object):
 
         for section_name, section_contents in self.report_data:
             line_buf.append(self.PLUGDIVIDER)
-            line_buf.append(self.PLUGINFORMAT.format(name=section_name))
+            line_buf.append(f"{section_name}")
             for type_, format_, header, footer in self.subsections:
                 self.process_subsection(section_contents, type_.ADDS_TO,
                                         header, format_, footer)


### PR DESCRIPTION
As part of the project's effort to modernize on f-strings, this commit replaces all usage of .format() with f-string equivalents. The vast majority of these are in-place syntax changes, but a limited number change the order of list items or some formatting tricks in order to appease PEP8.

None of these conversions change the underlying logic of the flows they appear in.

Related: #3472 discussion

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?