### PR TITLE
[samba] Capture test commands from wbinfo and net ads

### DIFF
--- a/sos/report/plugins/samba.py
+++ b/sos/report/plugins/samba.py
@@ -38,8 +38,10 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "wbinfo --domain='.' --domain-users",
             "wbinfo --domain='.' --domain-groups",
             "wbinfo --trusted-domains --verbose",
+            "wbinfo --check-secret",
             "net primarytrust dumpinfo",
             "net ads info",
+            "net ads testjoin",
         ])
 
 


### PR DESCRIPTION
'wbinfo -t/--check-secret' is one of the basic commands to check if the trust secret for domain is still valid.

'net ads testjoin' is used to check if participation in a domain is still valid.

Related: #RHEL-23665

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?