### PR TITLE
[fwupd] Add SoSPredicate to check for service fwupd

### DIFF
--- a/sos/report/plugins/fwupd.py
+++ b/sos/report/plugins/fwupd.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
 
 
 class Fwupd(Plugin, IndependentPlugin):
@@ -19,6 +19,7 @@ class Fwupd(Plugin, IndependentPlugin):
     packages = ('fwupd',)
 
     def setup(self):
+        self.set_cmd_predicate(SoSPredicate(self, services=["fwupd"]))
         self.add_cmd_output([
             "fwupdmgr get-approved-firmware",
             "fwupdmgr get-devices --no-unreported-check",


### PR DESCRIPTION
Without SoSPredicate, the plugin was starting
the fwupd service.

Related: RH: RHEL-24342

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?