### PR TITLE
[ceph_mgr] collect healthcheck history

### DIFF
--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -47,6 +47,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
 
         ceph_mgr_cmds = ([
             "balancer status",
+            "healthcheck history ls",
             "log last cephadm",
             "mgr dump",
             "mgr metadata",


### PR DESCRIPTION
It's part of a Ceph mgr module `prometheus` and the example output is as follows. That would be helpful to understand the timeline and the history of issues in Ceph.

[ceph healthcheck history ls]
```
Healthcheck Name          First Seen (UTC)      Last seen (UTC)       Count  Active
MON_DISK_LOW              2024/02/08 12:53:46   2024/02/08 12:53:46       1   Yes
MON_DOWN                  2024/02/08 12:58:46   2024/02/08 12:58:46       1    No
2 health check(s) listed
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?