### PR TITLE
[ocp] Replace 'oc --config' command

### DIFF
--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -93,7 +93,8 @@ class ocp(Cluster):
                     self.log_debug("Locating 'oc' failed: %s"
                                    % _oc_path['output'])
             if self.get_option('kubeconfig'):
-                self._oc_cmd += " --config %s" % self.get_option('kubeconfig')
+                self._oc_cmd += " --kubeconfig " \
+                        f"{self.get_option('kubeconfig')}"
             self.log_debug("oc base command set to %s" % self._oc_cmd)
         return self._oc_cmd
 


### PR DESCRIPTION
The option --config was moved to --kubeconfig in
OCP 4.7.

Related: RH: RHEL-24402

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?