### PR TITLE
[ocp] Add an option to specify API URL

### DIFF
--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -69,7 +69,8 @@ class ocp(Cluster):
         ('role', 'master', 'Colon delimited list of roles to filter on'),
         ('kubeconfig', '', 'Path to the kubeconfig file'),
         ('token', '', 'Service account token to use for oc authorization'),
-        ('with-api', False, 'Collect OCP API data from a master node')
+        ('with-api', False, 'Collect OCP API data from a master node'),
+        ('api-url', '', 'Alternate API URL of an external control-plane'),
     ]
 
     @property
@@ -109,8 +110,9 @@ class ocp(Cluster):
         token
         """
         _res = self.exec_primary_cmd(
-            self.fmt_oc_cmd("login --insecure-skip-tls-verify=True --token=%s"
-                            % self.token)
+            self.fmt_oc_cmd("login --insecure-skip-tls-verify=True "
+                            f"--token={self.token} "
+                            f"{self.get_option('api-url')}")
         )
         return _res['status'] == 0
 


### PR DESCRIPTION
If no API url is specified, it will use
localhost always. In some cases, specially
when using Ansible, we'll want to specify
another API URL.

Related: RH: RHEL-24523

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?