### PR TITLE
[policy] Fix TypeError if snap or deb is not installed

### DIFF
--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -42,9 +42,13 @@ class UbuntuPolicy(DebianPolicy):
             chroot=self.sysroot,
             remote_exec=remote_exec)
 
-        if self.package_manager.pkg_by_name(
-                'sosreport')['pkg_manager'] == 'snap':
-            self.sos_bin_path = '/snap/bin'
+        try:
+            if self.package_manager.pkg_by_name(
+                    'sosreport')['pkg_manager'] == 'snap':
+                self.sos_bin_path = '/snap/bin'
+        except TypeError:
+            # Use the default sos_bin_path
+            pass
 
         self.valid_subclasses += [UbuntuPlugin]
 


### PR DESCRIPTION
If running tests or sos without the snap or deb installed, then this will fail with TypeError as the sosreport package will not be installed. This will ensure we catch this, and use the default path.

Resolves: SET-338

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?