### PR TITLE
[ceph] Add Reef release commands

### DIFF
--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -46,6 +46,8 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
             "client ls",
             "config diff",
             "config show",
+            "counter dump",
+            "counter schema",
             "damage ls",
             "dump loads",
             "dump tree",
@@ -57,13 +59,13 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
             "get subtrees",
             "objecter_requests",
             "ops",
+            "perf dump",
             "perf histogram dump",
             "perf histogram schema",
             "perf schema",
-            "perf dump",
+            "session ls",
             "status",
             "version",
-            "session ls"
         ]
 
         mds_ids = []

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -72,6 +72,8 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
         cmds = [
             "config diff",
             "config show",
+            "counter dump",
+            "counter schema",
             "dump_cache",
             "dump_mempools",
             "dump_osd_network",
@@ -83,7 +85,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
             "perf histogram schema",
             "perf schema",
             "status",
-            "version"
+            "version",
         ]
 
         directory = ''
@@ -146,7 +148,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
         later versions of Ceph) which can be used for ceph daemon commands
         """
         ceph_sockets = []
-        for rdir, dirs, files in os.walk(directory):
+        for rdir, _, files in os.walk(directory):
             for file in files:
                 if file.startswith('ceph-mgr') and file.endswith('.asok'):
                     ceph_sockets.append(self.path_join(rdir, file))

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -86,29 +86,29 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             # The ceph_mon plugin will collect all the "ceph ..." commands
             # which typically require the keyring.
 
-            "ceph mon stat",
-            "ceph quorum_status",
-            "ceph-disk list",
-            "ceph versions",
+            "ceph config dump",
+            "ceph config generate-minimal-conf",
+            "ceph config log",
+            "ceph config-key dump",
+            "ceph crash stat",
             "ceph features",
             "ceph insights",
-            "ceph crash stat",
-            "ceph config dump",
-            "ceph config log",
-            "ceph config generate-minimal-conf",
-            "ceph config-key dump",
-            "ceph osd metadata",
-            "ceph osd erasure-code-profile ls",
-            "ceph osd crush dump",
-            "ceph osd crush show-tunables",
-            "ceph osd crush tree --show-shadow",
+            "ceph log last 10000 debug audit",
+            "ceph log last 10000 debug cluster",
             "ceph mgr dump",
             "ceph mgr metadata",
             "ceph mgr module ls",
             "ceph mgr services",
             "ceph mgr versions",
-            "ceph log last 10000 debug cluster",
-            "ceph log last 10000 debug audit"
+            "ceph mon stat",
+            "ceph osd crush dump",
+            "ceph osd crush show-tunables",
+            "ceph osd crush tree --show-shadow",
+            "ceph osd erasure-code-profile ls",
+            "ceph osd metadata",
+            "ceph quorum_status",
+            "ceph versions",
+            "ceph-disk list",
         ])
 
         crashes = self.collect_cmd_output('ceph crash ls')
@@ -119,26 +119,26 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
                     self.add_cmd_output(f"ceph crash info {cid}")
 
         ceph_cmds = [
-            "mon dump",
-            "status",
             "device ls",
-            "df",
             "df detail",
-            "fs ls",
+            "df",
             "fs dump",
+            "fs ls",
+            "mds stat",
+            "mon dump",
+            "osd blocked-by",
+            "osd df tree",
+            "osd df",
+            "osd dump",
+            "osd numa-status",
+            "osd perf",
+            "osd pool autoscale-status",
+            "osd pool ls detail",
+            "osd stat",
             "pg dump",
             "pg stat",
+            "status",
             "time-sync-status",
-            "osd stat",
-            "osd df tree",
-            "osd dump",
-            "osd df",
-            "osd perf",
-            "osd blocked-by",
-            "osd pool ls detail",
-            "osd pool autoscale-status",
-            "mds stat",
-            "osd numa-status"
         ]
 
         self.add_cmd_output("ceph health detail --format json-pretty",
@@ -176,7 +176,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
     def get_ceph_ids(self):
         ceph_ids = []
         # ceph version 14 correlates to RHCS 4
-        if self.ceph_version == 14 or self.ceph_version == 15:
+        if self.ceph_version in (14, 15):
             # Get the ceph user processes
             out = self.exec_cmd('ps -u ceph -o args')
 

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -41,33 +41,36 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
         microceph_pkg = self.policy.package_manager.pkg_by_name('microceph')
         cmds = [
             # will work pre quincy
-            "dump_reservations",
             "bluestore bluefs available",
+            "dump_reservations",
             # will work quincy onward
-            "bluestore bluefs device info",
             "bluefs stats",
+            "bluestore bluefs device info",
             "config diff",
             "config show",
-            "dump_blocklist",
+            "counter dump",
+            "counter schema",
             "dump_blocked_ops",
+            "dump_blocklist",
             "dump_historic_ops_by_duration",
             "dump_historic_slow_ops",
             "dump_mempools",
-            "dump_ops_in_flight",
             "dump_op_pq_state",
+            "dump_ops_in_flight",
             "dump_osd_network",
             "dump_pgstate_history",
             "dump_recovery_reservations",
             "dump_scrubs",
-            "get_mapped_pools",
             "dump_watchers",
-            "log dump",
+            "get_mapped_pools",
             "list_devices",
             "list_unfound",
-            "perf dump",
-            "perf histogram dump",
+            "log dump",
             "objecter_requests",
             "ops",
+            "perf dump",
+            "perf histogram dump",
+            "perf schema",
             "status",
             "version",
         ]
@@ -126,7 +129,7 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
         later versions of Ceph) which can be used for ceph daemon commands
         """
         ceph_sockets = []
-        for rdir, dirs, files in os.walk(directory):
+        for rdir, _, files in os.walk(directory):
             for file in files:
                 if file.endswith('.asok') and 'osd' in file:
                     ceph_sockets.append(self.path_join(rdir, file))


### PR DESCRIPTION
Ceph release 18.2.0 added a couple of new commands 'counter dump' and 'counter schema' and will supersede 'perf dump' and 'perf schema' which are deprecated now. For sosreport, we obviously need both commands to collect data on existing deployments.

At some point in the future, we can remove 'perf dump' and 'perf schema' from the list of commands for Ceph plugins.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?