### PR TITLE
[flatpak] Prevent flatpak commands to mount gvfs

### DIFF
--- a/sos/report/plugins/flatpak.py
+++ b/sos/report/plugins/flatpak.py
@@ -19,6 +19,7 @@ class Flatpak(Plugin, IndependentPlugin):
     packages = ("flatpak",)
 
     def setup(self):
+        env = {"GVFS_REMOTE_VOLUME_MONITOR_IGNORE": "1"}
         self.add_cmd_output([
             "flatpak --version",
             "flatpak --default-arch",
@@ -31,8 +32,8 @@ class Flatpak(Plugin, IndependentPlugin):
             "flatpak list --runtime --show-details",
             "flatpak list --app --show-details",
             "flatpak history --columns=all",
-        ])
+        ], env=env)
         if self.get_option("verify"):
-            self.add_cmd_output("flatpak repair --dry-run")
+            self.add_cmd_output("flatpak repair --dry-run", env=env)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Running various flatpak commands can start gvfs mount, which is undesirable outcome of sos. Calling the commands with GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1 env.variable prevents that behaviour.

Relevant: RHEL-14328
Closes: #3528

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?