### PR TITLE
[openstack_keystone] Obfuscate OIDC client secret

### DIFF
--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -91,17 +91,22 @@ class OpenStackKeystone(Plugin):
             self.var_puppet_gen + "/etc/keystone/*",
             regexp, subst
         )
+        self.do_path_regex_sub(
+            self.var_puppet_gen + "/etc/httpd/conf.d/",
+            regexp, subst
+        )
 
     def postproc(self):
         protect_keys = [
             "password", "qpid_password", "rabbit_password", "ssl_key_password",
             "ldap_dns_password", "neutron_admin_password", "host_password",
-            "admin_password", "admin_token", "ca_password", "transport_url"
+            "admin_password", "admin_token", "ca_password", "transport_url",
+            "OIDCClientSecret",
         ]
         connection_keys = ["connection"]
 
         self.apply_regex_sub(
-            r"(^\s*(%s)\s*=\s*)(.*)" % "|".join(protect_keys),
+            r"(^\s*(%s)\s*(=\s*)?)(.*)" % "|".join(protect_keys),
             r"\1*********"
         )
         self.apply_regex_sub(


### PR DESCRIPTION
Obfuscate OIDC client secret inside
/var/lib/config-data/puppet-generated/keystone/
	etc/httpd/conf.d/10-keystone_wsgi.conf 

The secret looks like this:
 
 OIDCClientSecret "Password"

And after obfuscation, it will look like this:

OIDCClientSecret *********

Related: RH: RHEL-26720

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?