### PR TITLE
[nfs] Add nfsconf, mountstats, and rpcctl commands

### DIFF
--- a/sos/report/plugins/nfs.py
+++ b/sos/report/plugins/nfs.py
@@ -36,6 +36,11 @@ class Nfs(Plugin, IndependentPlugin):
             "nfsstat -o all",
             "exportfs -v",
             "nfsdclnts",
+            "nfsconf -d",
+            "mountstats -n",
+            "mountstats -r",
+            "mountstats -x",
+            "rpcctl xprt show",
         ])
 
 


### PR DESCRIPTION
Collect useful info by executing some more commands in nfs-utils package:
  - nfsconf for the current configuration.
  - mountstats for various NFS client statistics.
  - rpcctl for SunRPC connection information.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?