### PR TITLE
[ssh] Disable default collection of users' .ssh dirs

### DIFF
--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -19,7 +19,7 @@ class Ssh(Plugin, IndependentPlugin):
     profiles = ('services', 'security', 'system', 'identity')
 
     option_list = [
-        PluginOpt('userconfs', default=True, val_type=str,
+        PluginOpt('userconfs', default=False, val_type=str,
                   desc=('Changes whether module will '
                         'collect user .ssh configs'))
     ]


### PR DESCRIPTION
Those data are usually not important and collecting them can cause performance issues when the dirs are mounted via NFS.

Closes: #3549

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?