### PR TITLE
[sapnw] Remove capture of deprecated sapconf command

### DIFF
--- a/sos/report/plugins/sapnw.py
+++ b/sos/report/plugins/sapnw.py
@@ -130,13 +130,4 @@ class sapnw(Plugin, RedHatPlugin):
         self.collect_list_instances()
         self.collect_list_dbs()
 
-        # run sapconf in check mode
-        #
-        # since the command creates a limits.d file on its own,
-        # we must predicate it by presence of the file
-        if self.path_exists('/etc/security/limits.d/99-sap-limits.conf') \
-                or self.get_option('allow_system_changes'):
-            self.add_cmd_output("sapconf -n",
-                                suggest_filename="sapconf_checkmode")
-
 # vim: et ts=4 sw=4


### PR DESCRIPTION
The sapconf command is not distributed in RHEL 8 and 9, so the code is never executed, and its safe to remove.

Related: RH: RHEL-27830 and RHEL-27831

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?