### PR TITLE
[pacemaker] Use pep440 formatted version for pcs version

### DIFF
--- a/sos/collector/clusters/juju.py
+++ b/sos/collector/clusters/juju.py
@@ -13,7 +13,7 @@ import json
 import re
 
 from sos.collector.clusters import Cluster
-from sos.utilities import parse_version
+from sos.utilities import sos_parse_version
 from sos.utilities import sos_get_command_output
 
 
@@ -161,12 +161,13 @@ class juju(Cluster):
     def _get_juju_version(self):
         """Grab the version of juju"""
         res = sos_get_command_output("juju version")
-        return res['output'].split("-")[0]
+        return res['output']
 
     def _execute_juju_status(self, model_name):
         model_option = f"-m {model_name}" if model_name else ""
         format_option = "--format json"
-        if parse_version(self._get_juju_version()) > parse_version("3"):
+        juju_version = self._get_juju_version()
+        if sos_parse_version(juju_version) > sos_parse_version("3"):
             format_option += " --no-color"
         status_cmd = f"{self.cmd} status {model_option} {format_option}"
         res = self.exec_primary_cmd(status_cmd)

--- a/sos/collector/clusters/pacemaker.py
+++ b/sos/collector/clusters/pacemaker.py
@@ -11,7 +11,7 @@
 import re
 
 from sos.collector.clusters import Cluster
-from sos.utilities import parse_version
+from sos.utilities import sos_parse_version
 from xml.etree import ElementTree
 
 
@@ -63,7 +63,7 @@ class pacemaker(Cluster):
         _ver = self.exec_primary_cmd('crm_mon --version')
         if _ver['status'] == 0:
             cver = _ver['output'].split()[1].split('-')[0]
-            if not parse_version(cver) > parse_version('2.0.3'):
+            if not sos_parse_version(cver) > sos_parse_version('2.0.3'):
                 xmlopt = '--as-xml'
         else:
             return

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -26,7 +26,7 @@ from sos.collector.exceptions import (CommandTimeoutException,
                                       ConnectionException,
                                       UnsupportedHostException,
                                       InvalidTransportException)
-from sos.utilities import parse_version
+from sos.utilities import sos_parse_version
 
 TRANSPORTS = {
     'local': LocalTransport,
@@ -412,31 +412,9 @@ class SosNode():
         :returns:   True if installed version is at least ``ver``, else False
         :rtype:     ``bool``
         """
-        def _format_version_to_pep440(ver):
-            """ Convert the version into a PEP440 compliant version scheme."""
-            public_version_re = re.compile(
-                    r"^([0-9][0-9.]*(?:(?:a|b|rc|.post|.dev)[0-9]+)*)\+?"
-                    )
-            try:
-                _, public, local = public_version_re.split(ver, maxsplit=1)
-                if not local:
-                    return ver
-                sanitized_local = re.sub("[+~]+", ".", local).strip("-")
-                pep440_version = f"{public}+{sanitized_local}"
-                return pep440_version
-            except Exception as err:
-                self.log_debug(f"Unable to format {ver} to pep440 format: "
-                               f"{err}")
-                return ver
-
-        _ver = _format_version_to_pep440(ver)
-        _node_formatted_version = _format_version_to_pep440(
-                self.sos_info['version'])
-
         try:
-            _node_ver = parse_version(_node_formatted_version)
-            _test_ver = parse_version(_ver)
-            return _node_ver >= _test_ver
+            _node_ver = self.sos_info['version']
+            return sos_parse_version(_node_ver) >= sos_parse_version(ver)
         except Exception as err:
             self.log_error("Error checking sos version: %s" % err)
             return False

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -8,7 +8,7 @@
 
 from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
                                 UbuntuPlugin, PluginOpt)
-from sos.utilities import parse_version
+from sos.utilities import sos_parse_version
 from datetime import datetime, timedelta
 import re
 
@@ -55,7 +55,7 @@ class Pacemaker(Plugin):
         ])
 
         pcs_version = '.'.join(pcs_pkg['version'])
-        if parse_version(pcs_version) > parse_version('0.10.8'):
+        if sos_parse_version(pcs_version) > sos_parse_version('0.10.8'):
             self.add_cmd_output("pcs property config --all")
         else:
             self.add_cmd_output("pcs property list --all")

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -73,6 +73,32 @@ __all__ = [
 ]
 
 
+def format_version_to_pep440(ver):
+    """ Convert the version into a PEP440 compliant version scheme."""
+    public_version_re = re.compile(
+            r"^([0-9][0-9.]*(?:(?:a|b|rc|.post|.dev)[0-9]+)*)\+?"
+            )
+    try:
+        _, public, local = public_version_re.split(ver, maxsplit=1)
+        if not local:
+            return ver
+        sanitized_local = re.sub("[+~]+", ".", local).strip("-")
+        pep440_version = f"{public}+{sanitized_local}"
+        return pep440_version
+    except Exception as err:
+        log.debug(f"Unable to format {ver} to pep440 format: {err}")
+        return ver
+
+
+def sos_parse_version(ver, pep440=True):
+    """ Converts the version to PEP440 format before parsing """
+    if pep440:
+        ver_pep440 = format_version_to_pep440(ver)
+        return parse_version(ver_pep440)
+
+    return parse_version(ver)
+
+
 def tail(filename, number_of_bytes):
     """Returns the last number_of_bytes of filename"""
     with open(filename, "rb") as f:


### PR DESCRIPTION
There are couple of instances (both on pacemaker) of `parse_version` being used to compare the package
versions. In cases, notably on Ubuntu, where the version comform to PEP440, this fails. So we now convert those to PEP440 format before comparing.

Fixes #3548.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?