### PR TITLE
[tests] workaround puppet bug in foreman-installer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -261,7 +261,7 @@ report_stagetwo_task:
         log_artifacts: *logs
 
 report_foreman_task:
-    skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py')"
+    skip: "!changesInclude('.cirrus.yml', '**/{__init__,apache,foreman,foreman_tests,candlepin,pulp,pulpcore}.py', '**/foreman_setup.sh')"
     timeout_in: 45m
     alias: "foreman_integration"
     name: "Integration Test - Foreman ${FOREMAN_VER} - ${BUILD_NAME}"

--- a/tests/test_data/foreman_setup.sh
+++ b/tests/test_data/foreman_setup.sh
@@ -5,6 +5,9 @@ SUCCESS=0
 if grep -iq centos /etc/os-release; then
     if  [[ `echo | awk "{print ($FOREMAN_VER >= 3.4)}"` -eq 1 ]]; then
         dnf -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
+        # workaround for https://community.theforeman.org/t/puppet-7-29-0-8-5-0-breaks-our-installer/37075
+        # can be removed once https://github.com/puppetlabs/puppet/pull/9269 is in downstream
+        echo "excludepkgs=puppet-agent-7.29.0*" >> /etc/yum.repos.d/puppet7-release.repo
         dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VER/el8/x86_64/foreman-release.rpm
         dnf -y module enable foreman:el8
     else
@@ -21,6 +24,11 @@ elif grep -iq debian /etc/os-release; then
     export LC_ALL=en_US.UTF-8
     export LANG=en_US.UTF-8
     curl https://apt.puppet.com/puppet7-release-bullseye.deb --output /root/puppet7-release-bullseye.deb
+    # workaround for https://community.theforeman.org/t/puppet-7-29-0-8-5-0-breaks-our-installer/37075
+    # can be removed once https://github.com/puppetlabs/puppet/pull/9269 is in downstream
+    cat <<< 'Package: puppet-agent
+    Pin: version 7.29.0*
+    Pin-Priority: -10' | sed "s/^    //g" > /etc/apt/preferences.d/puppet.pref
     apt-get install /root/puppet7-release-bullseye.deb
     curl https://deb.theforeman.org/foreman.asc --output /etc/apt/trusted.gpg.d/foreman.asc
     echo "deb http://deb.theforeman.org/ bullseye $FOREMAN_VER" | tee /etc/apt/sources.list.d/foreman.list


### PR DESCRIPTION
A puppet regression in version 7.29.0 prevents foreman-installer to run.

Let prevent installing the buggy puppet-agent-7.29.0* .

Resolves: #3542
Closes: #3555

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?