### PR TITLE
[report] Fix duplicate records returned by lsblk.

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -683,7 +683,7 @@ class SoSReport(SoSComponent):
 
     def _get_devices_by_fstype(self):
         _dev_fstypes = {}
-        _devs = sos_get_command_output("lsblk -nrpo FSTYPE,NAME")
+        _devs = sos_get_command_output("lsblk -snrpo FSTYPE,NAME")
         if _devs['status'] != 0:
             return _dev_fstypes
         for line in (_devs['output'].splitlines()):


### PR DESCRIPTION
Prevously the lsblk would return single FSTYPE multiple times as I forgot to add -s to it. Quick fix for this.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?