### PR TITLE
[ceph] Ensure `all-logs` is enforced for Ceph plugins

### DIFF
--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -54,14 +54,18 @@ class CephCommon(Plugin, RedHatPlugin, UbuntuPlugin):
             })
 
             if not all_logs:
-                self.add_copy_spec("/var/log/calamari/*.log",)
+                self.add_copy_spec([
+                    "/var/log/calamari/*.log",
+                    "/var/log/ceph/**/ceph.log",
+                ])
             else:
-                self.add_copy_spec("/var/log/calamari",)
+                self.add_copy_spec([
+                    "/var/log/calamari",
+                    "/var/log/ceph/**/ceph.log*",
+                ])
 
             self.add_copy_spec([
-                "/var/log/ceph/**/ceph.log",
                 "/var/log/ceph/**/ceph.audit.log*",
-                "/var/log/calamari/*.log",
                 "/etc/ceph/",
                 "/etc/calamari/",
                 "/var/lib/ceph/tmp/",
@@ -80,10 +84,16 @@ class CephCommon(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/etc/ceph/*bindpass*"
             ])
         else:
-            self.add_copy_spec([
-                "/var/snap/microceph/common/logs/ceph.log",
-                "/var/snap/microceph/common/logs/ceph.audit.log",
-            ])
+            if not all_logs:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/ceph.log",
+                    "/var/snap/microceph/common/logs/ceph.audit.log",
+                ])
+            else:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/ceph.log*",
+                    "/var/snap/microceph/common/logs/ceph.audit.log*",
+                ])
 
         self.add_cmd_output([
             "ceph -v",

--- a/sos/report/plugins/ceph_iscsi.py
+++ b/sos/report/plugins/ceph_iscsi.py
@@ -20,14 +20,26 @@ class CephISCSI(Plugin, RedHatPlugin, UbuntuPlugin):
     containers = ("rbd-target-api.*", "rbd-target-gw.*")
 
     def setup(self):
-        self.add_copy_spec([
-            "/etc/tcmu/tcmu.conf",
-            "/var/log/**/ceph-client.*.log",
-            "/var/log/**/rbd-target-api.log",
-            "/var/log/**/rbd-target-gw.log",
-            "/var/log/**/tcmu-runner.log",
-            "/var/log/tcmu-runner.log"
-        ])
+        all_logs = self.get_option("all_logs")
+
+        self.add_copy_spec(["/etc/tcmu/tcmu.conf",])
+
+        if not all_logs:
+            self.add_copy_spec([
+                "/var/log/**/ceph-client.*.log",
+                "/var/log/**/rbd-target-api.log",
+                "/var/log/**/rbd-target-gw.log",
+                "/var/log/**/tcmu-runner.log",
+                "/var/log/tcmu-runner.log"
+            ])
+        else:
+            self.add_copy_spec([
+                "/var/log/**/ceph-client.*.log*",
+                "/var/log/**/rbd-target-api.log*",
+                "/var/log/**/rbd-target-gw.log*",
+                "/var/log/**/tcmu-runner.log*",
+                "/var/log/tcmu-runner.log*"
+            ])
 
         self.add_cmd_output([
             "gwcli info",

--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -18,12 +18,22 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
     files = ('/var/lib/ceph/mds/*',)
 
     def setup(self):
+        all_logs = self.get_option("all_logs")
+
         self.add_file_tags({
             '/var/log/ceph/ceph-mds.*.log': 'ceph_mds_log',
         })
 
+        if not all_logs:
+            self.add_copy_spec([
+                "/var/log/ceph/ceph-mds*.log",
+            ])
+        else:
+            self.add_copy_spec([
+                "/var/log/ceph/ceph-mds*.log*",
+            ])
+
         self.add_copy_spec([
-            "/var/log/ceph/ceph-mds*.log",
             "/var/lib/ceph/bootstrap-mds/",
             "/var/lib/ceph/mds/",
             "/run/ceph/ceph-mds*",

--- a/sos/report/plugins/ceph_mgr.py
+++ b/sos/report/plugins/ceph_mgr.py
@@ -43,6 +43,7 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
     containers = ('ceph-(.*-)?mgr.*',)
 
     def setup(self):
+        all_logs = self.get_option("all_logs")
         microceph_pkg = self.policy.package_manager.pkg_by_name('microceph')
 
         ceph_mgr_cmds = ([
@@ -106,8 +107,16 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/etc/ceph/*bindpass*",
             ])
 
+            if not all_logs:
+                self.add_copy_spec([
+                    "/var/log/ceph/**/ceph-mgr*.log",
+                ])
+            else:
+                self.add_copy_spec([
+                    "/var/log/ceph/**/ceph-mgr*.log*",
+                ])
+
             self.add_copy_spec([
-                "/var/log/ceph/**/ceph-mgr*.log",
                 "/var/lib/ceph/**/mgr*",
                 "/var/lib/ceph/**/bootstrap-mgr/",
                 "/run/ceph/**/ceph-mgr*",
@@ -124,9 +133,14 @@ class CephMGR(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/var/snap/microceph/common/**/*keyring*",
             ])
 
-            self.add_copy_spec([
-                "/var/snap/microceph/common/logs/ceph-mgr*.log",
-            ])
+            if not all_logs:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/ceph-mgr*.log",
+                ])
+            else:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/ceph-mgr*.log*",
+                ])
 
         self.add_cmd_output(
             [f"ceph {cmd}" for cmd in ceph_mgr_cmds])

--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -42,7 +42,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
     ceph_version = 0
 
     def setup(self):
-
+        all_logs = self.get_option("all_logs")
         self.ceph_version = self.get_ceph_version()
 
         microceph_pkg = self.policy.package_manager.pkg_by_name('microceph')
@@ -61,10 +61,18 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/etc/ceph/*bindpass*"
             ])
 
+            if not all_logs:
+                self.add_copy_spec([
+                    "/var/log/ceph/**/*ceph-mon*.log"
+                ])
+            else:
+                self.add_copy_spec([
+                    "/var/log/ceph/**/*ceph-mon*.log*"
+                ])
+
             self.add_copy_spec([
                 "/run/ceph/**/ceph-mon*",
                 "/var/lib/ceph/**/kv_backend",
-                "/var/log/ceph/**/*ceph-mon*.log"
             ])
 
         else:
@@ -75,9 +83,17 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/var/snap/microceph/common/state/*",
             ])
 
+            if not all_logs:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/*ceph-mon*.log",
+                ])
+            else:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/*ceph-mon*.log*",
+                ])
+
             self.add_copy_spec([
                 "/var/snap/microceph/common/data/mon/*",
-                "/var/snap/microceph/common/logs/*ceph-mon*.log",
                 "/var/snap/microceph/current/conf/*",
             ])
 

--- a/sos/report/plugins/ceph_osd.py
+++ b/sos/report/plugins/ceph_osd.py
@@ -37,6 +37,7 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
              '/var/snap/microceph/common/data/osd/*')
 
     def setup(self):
+        all_logs = self.get_option("all_logs")
         directory = ''
         microceph_pkg = self.policy.package_manager.pkg_by_name('microceph')
         cmds = [
@@ -103,6 +104,12 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
                 "ceph-volume lvm list"
             ])
 
+            if all_logs:
+                self.add_copy_spec([
+                    "/var/log/ceph/**/ceph-osd*.log*",
+                    "/var/log/ceph/**/ceph-volume*.log*",
+                ])
+
         else:
             directory = '/var/snap/microceph'
             # Only collect microceph files, don't run any commands
@@ -116,6 +123,11 @@ class CephOSD(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/var/snap/microceph/common/data/osd/*",
                 "/var/snap/microceph/common/logs/*ceph-osd*.log",
             ])
+
+            if all_logs:
+                self.add_copy_spec([
+                    "/var/snap/microceph/common/logs/*ceph-osd*.log*",
+                ])
 
         # common add_cmd_output for ceph and microceph
         self.add_cmd_output([

--- a/sos/report/plugins/ceph_rgw.py
+++ b/sos/report/plugins/ceph_rgw.py
@@ -19,8 +19,14 @@ class CephRGW(Plugin, RedHatPlugin, UbuntuPlugin):
     files = ('/var/lib/ceph/radosgw/*',)
 
     def setup(self):
-        self.add_copy_spec('/var/log/ceph/ceph-client.rgw*.log',
-                           tags='ceph_rgw_log')
+        all_logs = self.get_option("all_logs")
+
+        if not all_logs:
+            self.add_copy_spec('/var/log/ceph/ceph-client.rgw*.log',
+                               tags='ceph_rgw_log')
+        else:
+            self.add_copy_spec('/var/log/ceph/ceph-client.rgw*.log*',
+                               tags='ceph_rgw_log')
 
         self.add_forbidden_path([
             "/etc/ceph/*keyring*",


### PR DESCRIPTION
Currently Ceph plugins do not take the `all-logs` flag into account 
which means that even if this flag is set compressed log files are 
not collected

This patch fixes that.

Resolves: SET-480

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ x ] Is the subject and message clear and concise?
- [ x ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ x ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ x ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?