### PR TITLE
[SCLPlugin] Drop SCLPlugin support

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -116,7 +116,6 @@ any third party.
     vendor_urls = [('Example URL', "http://www.example.com/")]
     vendor_text = ""
     PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-    default_scl_prefix = ""
     name_pattern = 'legacy'
     presets = {"": PresetDefaults()}
     presets_path = PRESETS_PATH
@@ -265,9 +264,6 @@ any third party.
         if not opt_tmp_dir:
             return tempfile.gettempdir()
         return opt_tmp_dir
-
-    def get_default_scl_prefix(self):
-        return self.default_scl_prefix
 
     def match_plugin(self, plugin_classes):
         """Determine what subclass of a Plugin should be used based on the

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -43,7 +43,6 @@ class RedHatPolicy(LinuxPolicy):
     ]
     _tmp_dir = "/var/tmp"
     _in_container = False
-    default_scl_prefix = '/opt/rh'
     name_pattern = 'friendly'
     upload_url = None
     upload_user = None

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -11,9 +11,8 @@
 
 from re import match
 from shlex import quote
-from sos.report.plugins import (Plugin, RedHatPlugin, SCLPlugin,
-                                DebianPlugin, UbuntuPlugin, PluginOpt)
-from sos.utilities import is_executable
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, PluginOpt)
 
 
 class Foreman(Plugin):
@@ -324,7 +323,7 @@ class Foreman(Plugin):
 # attr so we can keep all log definitions centralized in the main class
 
 
-class RedHatForeman(Foreman, SCLPlugin, RedHatPlugin):
+class RedHatForeman(Foreman, RedHatPlugin):
 
     apachepkg = 'httpd'
 
@@ -333,10 +332,6 @@ class RedHatForeman(Foreman, SCLPlugin, RedHatPlugin):
         self.add_file_tags({
             '/usr/share/foreman/.ssh/ssh_config': 'ssh_foreman_config',
         })
-        # if we are on RHEL7 with scl, wrap some Puma commands by
-        # scl enable tfm 'command'
-        if self.policy.dist_version() == 7 and is_executable('scl'):
-            self.pumactl = "scl enable tfm '%s'" % self.pumactl
 
         super().setup()
         self.add_cmd_output('gem list')

--- a/sos/report/plugins/jars.py
+++ b/sos/report/plugins/jars.py
@@ -41,7 +41,7 @@ class Jars(Plugin, RedHatPlugin):
     # Following paths can be optionally scanned as well. Note the scan can take
     # *very* long time.
     extra_jar_locations = (
-        "/opt",             # location for RHSCL and 3rd party software
+        "/opt",             # location for 3rd party software
         "/usr/local",       # used by sysadmins when installing SW locally
         "/var/lib"          # Java services commonly explode WARs there
     )

--- a/sos/report/plugins/redis.py
+++ b/sos/report/plugins/redis.py
@@ -9,17 +9,17 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, SCLPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Redis(Plugin, SCLPlugin):
+class Redis(Plugin, IndependentPlugin):
 
     short_desc = 'Redis, in-memory data structure store'
 
     plugin_name = 'redis'
     profiles = ('services',)
 
-    packages = ('redis', 'rh-redis32', 'rh-redis5')
+    packages = ('redis',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/redis"
 
@@ -30,17 +30,6 @@ class Redis(Plugin, SCLPlugin):
             self.var_puppet_gen + "/etc/redis/",
             self.var_puppet_gen + "/etc/security/limits.d/"
         ])
-
-        for pkg in self.packages[1:]:
-            scl = pkg.split('rh-redis*-')[0]
-            self.add_copy_spec_scl(scl, [
-                '/etc/redis.conf',
-                '/etc/redis.conf.puppet',
-                '/etc/redis-sentinel.conf',
-                '/etc/redis-sentinel.conf.puppet',
-                '/var/log/redis/sentinel.log',
-                '/var/log/redis/redis.log'
-            ])
 
         self.add_cmd_output("redis-cli info")
         if self.get_option("all_logs"):
@@ -53,10 +42,7 @@ class Redis(Plugin, SCLPlugin):
             ])
 
     def postproc(self):
-        for path in ["/etc/",
-                     self.var_puppet_gen + "/etc/",
-                     "/etc/opt/rh/rh-redis32/",
-                     "/etc/opt/rh/rh-redis5/"]:
+        for path in ["/etc/", self.var_puppet_gen + "/etc/"]:
             self.do_file_sub(
                 path + "redis.conf",
                 r"(masterauth|requirepass)\s.*",


### PR DESCRIPTION
SCL is not used in RHEL past RHEL 7, and sos has not directly supported RHEL 7 for some years now due to the switch to python3 that came along with sos-4.0.

Drop SCLPlugin, as it will never be used in modern sos. Cleanup any references to it in existing plugins as well.

Resolves: #3559

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?