### PR TITLE
[aap_hub] Implementing AAP Automation Hub Plugin

### DIFF
--- a/sos/report/plugins/aap_hub.py
+++ b/sos/report/plugins/aap_hub.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2024 Mike Silmser <msilmser@redhat.com>
+# Copyright (c) 2024 Lucas Benedito <lbenedit@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class AAPAutomationHub(Plugin, RedHatPlugin):
+    short_desc = 'AAP Automation Hub plugin'
+    plugin_name = 'aap_hub'
+    profiles = ('sysmgmt', 'ansible',)
+    packages = ('automation-hub',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/ansible-automation-platform/",
+            "/var/log/ansible-automation-platform/hub/worker.log*",
+            "/var/log/ansible-automation-platform/hub/pulpcore-api.log*",
+            "/var/log/ansible-automation-platform/hub/pulpcore-content.log*",
+            "/var/log/nginx/automationhub.access.log*",
+            "/var/log/nginx/automationhub.error.log*",
+
+        ])
+
+        self.add_cmd_output([
+            "ls -alhR /etc/ansible-automation-platform/",
+            "ls -alhR /var/log/ansible-automation-platform/",
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Adding the file 'aap_hub.py' for the sos report collects 
the files used for troubleshooting issues at
Ansible Automation Platform Automation Hub

Related: RH AAP-19782

Signed-off-by: Lucas Benedito <lbenedit@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?