### PR TITLE
[redhat] Enhance OCP preset

### DIFF
--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -40,10 +40,14 @@ RHOCP_OPTS = SoSOptions(
     skip_plugins=['cgroups'], container_runtime='crio', no_report=True,
     log_size=100,
     plugopts=[
+        'crio.all=on',
+        'crio.logs=on',
         'crio.timeout=600',
         'networking.timeout=600',
         'networking.ethtool_namespaces=False',
-        'networking.namespaces=200'
+        'networking.namespaces=200',
+        'podman.all=on',
+        'podman.logs=on',
     ])
 
 RH_CFME = "cfme"


### PR DESCRIPTION
Support engineers always call sos report with

-k crio.all=on -k crio.logs=on  -k podman.all=on -k podman.logs=on

options on OCP so let make it part of the preset by default.

Relevant: RHEL-28547
Closes: #3565


(it is even in OCP upstream doc: https://docs.openshift.com/container-platform/4.14/support/gathering-cluster-data.html)

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?