### PR TITLE
[ceph_mon] Capture ceph health detail in plain text

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -92,6 +92,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "ceph config-key dump",
             "ceph crash stat",
             "ceph features",
+            "ceph health detail",
             "ceph insights",
             "ceph log last 10000 debug audit",
             "ceph log last 10000 debug cluster",


### PR DESCRIPTION
Currently we capture the output of 'ceph health detail' in json format only, but we need plain text output as well.

Related: RH RHEL-27525

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?