### PR TITLE
[nginx] Implementing files exclusions from AAP for nginx

### DIFF
--- a/sos/report/plugins/nginx.py
+++ b/sos/report/plugins/nginx.py
@@ -33,6 +33,18 @@ class Nginx(Plugin, IndependentPlugin):
             "/var/log/nginx/access.log",
             "/var/log/nginx/error.log",
         ])
+
+        # Other plugins collect these files;
+        # do not collect them here to avoid collisions in the archive paths.
+        altconf = [
+            'automationcontroller',
+            'automationhub',
+            'automationedacontroller'
+        ]
+        self.add_forbidden_path([
+            f"/var/log/nginx/{alt}*" for alt in altconf
+        ])
+
         if self.get_option("log") or self.get_option("all_logs"):
             self.add_copy_spec("/var/log/nginx/*")
 


### PR DESCRIPTION
Implementing the exclusion of AAP nginx log files
The AAP configuration creates nginx logs with non-standard names

Related: RH AAP-19782, RH AAP-18409

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?