### PR TITLE
[openstack_nova] Added the collection of console.log from Nova instances

### DIFF
--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -96,6 +96,7 @@ class OpenStackNova(Plugin):
             self.add_copy_spec([
                 "/var/log/nova/",
                 f"/var/log/{self.apachepkg}*/nova*",
+                f"/var/lib/nova/instances/*/console.log",
             ])
         else:
             novadir = '/var/log/nova/'

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -96,7 +96,7 @@ class OpenStackNova(Plugin):
             self.add_copy_spec([
                 "/var/log/nova/",
                 f"/var/log/{self.apachepkg}*/nova*",
-                f"/var/lib/nova/instances/*/console.log",
+                "/var/lib/nova/instances/*/console.log",
             ])
         else:
             novadir = '/var/log/nova/'


### PR DESCRIPTION
The console log files of Nova instances stored in /var/lib/nova/instances/*/console.log are collected when running sos with --all-logs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?