### PR TITLE
[global] Remove empty except warnings highlighted by CodeQL

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -26,6 +26,9 @@ from sos.utilities import sos_get_command_output
 try:
     import selinux
 except ImportError:
+    # not on a distro that uses selinux most likely, but for distros that
+    # use selinux this import failure simply means we won't match context in
+    # the sos archive
     pass
 
 P_FILE = "file"

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -546,7 +546,7 @@ class SoSCollector(SoSComponent):
         try:
             self.close_all_connections()
         except Exception:
-            pass
+            self.log_warn("Warning: Failed to close all remote connections")
         if error != 130:
             # keep the tempdir around when a user issues a keyboard interrupt
             # like we do for report
@@ -703,8 +703,8 @@ class SoSCollector(SoSComponent):
 
         try:
             string.lowercase = string.ascii_lowercase
-        except NameError:
-            pass
+        except NameError as err:
+            self.log_debug(f"Could not cast to ascii_lowercase: {err}")
 
         rand = ''.join(random.choice(string.lowercase) for x in range(5))
         return '%s-%s-%s' % (nstr, dt, rand)
@@ -1133,8 +1133,8 @@ class SoSCollector(SoSComponent):
         try:
             _node_max = len(max(self.node_list, key=len))
             self.commons['hostlen'] = max(_node_max, self.commons['hostlen'])
-        except (TypeError, ValueError):
-            pass
+        except (TypeError, ValueError) as err:
+            self.log_debug(f"Could not set UI spacing: {err}")
 
     def _connect_to_node(self, node):
         """Try to connect to the node, and if we can add to the client list to

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -440,5 +440,6 @@ class Cluster():
                     if 'sosreport' in extra_file:
                         files.append(extra_file + '.md5')
         except AttributeError:
+            # run_extra_cmd() not defined for cluster profile
             pass
         return files

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -256,8 +256,8 @@ class LinuxPolicy(Policy):
                 for line in mfile:
                     kmod = line.split('/')[-1].split('.ko')[0]
                     self.kernel_mods.append(kmod)
-        except IOError:
-            pass
+        except IOError as err:
+            self.soslog.warning(f"Unable to read kernel builtins: {err}")
 
         # finally, parse kconfig looking for specific kconfig strings that
         # have been verified to not appear in either lsmod or modules.builtin
@@ -274,8 +274,8 @@ class LinuxPolicy(Policy):
                 for line in kfile:
                     if '=y' in line:
                         kconfigs.append(line.split('=y')[0])
-        except IOError:
-            pass
+        except IOError as err:
+            self.soslog.warning(f"Unable to read booted kernel config: {err}")
 
         for builtin in config_strings:
             if config_strings[builtin] in kconfigs:

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -922,6 +922,7 @@ class SoSReport(SoSComponent):
                         try:
                             val = int(val)
                         except ValueError:
+                            # not a number to convert back to int from argparse
                             pass
 
                 try:
@@ -1375,11 +1376,16 @@ class SoSReport(SoSComponent):
             try:
                 self.pluglist.remove(plugin)
             except ValueError:
-                pass
+                self.soslog.debug(
+                    f"Could not remove {plugin} from plugin list, ignoring..."
+                )
             try:
                 self.running_plugs.remove(plugname)
             except ValueError:
-                pass
+                self.soslog.debug(
+                    f"Could not remove {plugin} from running plugin list, "
+                    f"ignoring..."
+                )
             status = ''
             if (len(self.pluglist) <= int(self.opts.threads) and
                     self.running_plugs):


### PR DESCRIPTION
This commit is a first pass at addressing a number of the `Empty Except` warnings flagged by CodeQL. These are for try/except blocks whose except statement simply contains a `pass`, and to address these we add a log message in almost all cases. Where we don't log, there is an added comment for context as to why we're passing without further action.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?