### PR TITLE
[manpages] Add note about deprecation of options for RHEL

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -430,6 +430,7 @@ variable. If this variable is set, then no username prompt will occur and --batc
 may be used provided all other required values (case number, upload password)
 are provided.
 
+This option is ignored when uploading to the Red Customer Portal or Red Hat Secure FTP server in favour of web token authentication.
 .TP
 .B \-\-upload-pass PASS
 Specify the password to use for authentication with the destination server.
@@ -448,6 +449,7 @@ You also have the option of providing this value via the SOSUPLOADPASSWORD envir
 variable. If this variable is set, then no password prompt will occur and --batch may
 be used provided all other required values (case number, upload user) are provided.
 
+This option is ignored when uploading to the Red Customer Portal or Red Hat Secure FTP server in favour of web token authentication.
 .TP
 .B \--upload-directory DIR
 Specify a directory to upload to, if one is not specified by a vendor default location


### PR DESCRIPTION
Add a note to the entries for --upload-user and --upload-pass clarifying that these options have been deprecated in RHEL systems.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?