### PR TITLE
[cleaner] Improve stripping raw MAC address

### DIFF
--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -57,9 +57,9 @@ class SoSMacParser(SoSCleanerParser):
         """Strips away leading and trailing non-alphanum characters from any
         matched string to leave us with just the bare MAC addr
         """
-        while not (match[0].isdigit() or match[0].isalpha()):
+        while not match[0] in '0123456789abcdefABCDEF':
             match = match[1:]
-        while not (match[-1].isdigit() or match[-1].isalpha()):
+        while not match[-1] in '0123456789abcdefABCDEF':
             match = match[0:-1]
         # just to be safe, call strip() to remove any padding
         return match.strip()


### PR DESCRIPTION
reduce_mac_match should strip all characters that cant appear in a MAC address string. Currently it forgets to strip e.g. from "mac:01:02:03:04:05" anything.

We should strip at least the 'm'. Ideally whole "mac" but that would be programatically difficult to describe proper condition for that.

Resolves: #3574

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?