### PR TITLE
[Plugin,Policy] Make an AzurePlugin class, Update the vendor url, Update the check function

### DIFF
--- a/sos/policies/distros/azure.py
+++ b/sos/policies/distros/azure.py
@@ -8,6 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+from sos.report.plugins import AzurePlugin
 from sos.policies.distros.redhat import RedHatPolicy, OS_RELEASE
 import os
 
@@ -17,7 +18,7 @@ class AzurePolicy(RedHatPolicy):
     distro = "Azure Linux"
     vendor = "Microsoft"
     vendor_urls = [
-        ('Distribution Website', 'https://github.com/microsoft/CBL-Mariner')
+        ('Distribution Website', 'https://github.com/microsoft/azurelinux')
     ]
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
@@ -25,6 +26,7 @@ class AzurePolicy(RedHatPolicy):
         super(AzurePolicy, self).__init__(sysroot=sysroot, init=init,
                                           probe_runtime=probe_runtime,
                                           remote_exec=remote_exec)
+        self.valid_subclasses += [AzurePlugin]
 
     @classmethod
     def check(cls, remote=''):
@@ -39,6 +41,8 @@ class AzurePolicy(RedHatPolicy):
             for line in f:
                 if line.startswith('NAME'):
                     if 'Common Base Linux Mariner' in line:
+                        return True
+                    if 'Microsoft Azure Linux' in line:
                         return True
         return False
 

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3528,6 +3528,11 @@ class ExperimentalPlugin(PluginDistroTag):
     pass
 
 
+class AzurePlugin(PluginDistroTag):
+    """Tagging class for Azure Linux"""
+    pass
+
+
 def import_plugin(name, superclasses=None):
     """Import name as a module and return a list of all classes defined in that
     module. superclasses should be a tuple of valid superclasses to import,


### PR DESCRIPTION
This commit creates an AzurePlugin class, adds the AzurePlugin as a valid subclass in the Azure Policy, updates the vendor url and updates the check method due to a product rebranding for Microsoft Azure Linux 3.0

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?