### PR TITLE
[cifs] Capture missing files from /proc/fs/cifs

### DIFF
--- a/sos/report/plugins/cifs.py
+++ b/sos/report/plugins/cifs.py
@@ -17,14 +17,16 @@ class Cifs(Plugin, IndependentPlugin):
     packages = ('cifs-utils',)
 
     def setup(self):
+        self.add_forbidden_path([
+            "/proc/fs/cifs/traceSMB",
+            "/proc/fs/cifs/cifsFYI",
+        ])
+
         self.add_copy_spec([
             "/etc/request-key.d/cifs.spnego.conf",
             "/etc/request-key.d/cifs.idmap.conf",
             "/proc/keys",
-            "/proc/fs/cifs/LinuxExtensionsEnabled",
-            "/proc/fs/cifs/SecurityFlags",
-            "/proc/fs/cifs/Stats",
-            "/proc/fs/cifs/DebugData",
+            "/proc/fs/cifs/*",
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Added some missing files from /proc/fs/cifs and blacklist some files that we don't need to capture.

Related: RH: RHEL-29707

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?