### PR TITLE
[plugin_ceph] adding the healthcheck history for more detailed view on alerts firing

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -141,6 +141,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             "df",
             "fs dump",
             "fs ls",
+            "healthcheck history ls",
             "mds stat",
             "mon dump",
             "osd blocked-by",


### PR DESCRIPTION
adding the `ceph healthcheck history ls` command will provide a detailed view of Healthchecks failing and or active

``` 
# ceph healthcheck history ls 
Healthcheck Name          First Seen (UTC)      Last seen (UTC)       Count  Active
CEPHADM_APPLY_SPEC_FAIL   2023/05/19 17:00:38   2024/03/21 14:52:58     637    No  
CEPHADM_DAEMON_PLACE_FAIL  2023/05/19 07:24:53   2024/01/12 19:18:23      66    No  
CEPHADM_FAILED_DAEMON     2023/05/19 07:04:08   2024/02/09 19:22:48      34    No  
CEPHADM_HOST_CHECK_FAILED  2023/05/19 06:19:06   2024/03/21 15:45:10     190    No  
CEPHADM_PAUSED            2023/05/19 16:42:23   2023/07/27 17:54:13       5    No  
CEPHADM_REFRESH_FAILED    2023/05/19 07:24:38   2024/03/20 07:48:15     971    No  
[..output omitted..]
```
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?