### PR TITLE
[rhc] Collect information related to rhc-worker-playbook

### DIFF
--- a/sos/report/plugins/rhc.py
+++ b/sos/report/plugins/rhc.py
@@ -27,6 +27,7 @@ class Rhc(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/rhc/*",
+            "/var/log/rhc-worker-playbook",
         ])
 
         self.add_cmd_output([
@@ -46,4 +47,19 @@ class Rhc(Plugin, RedHatPlugin):
         self.do_path_regex_sub("/etc/rhc/workers/foreman_rh_cloud.toml",
                                r"(FORWARDER_PASSWORD\s*=\s*)(.+)(\"\,)",
                                r"\1********\3")
+
+        # hide ssh host keys from rhc-worker ansible playbooks
+        # Example for scrubbing one of the ssh keys
+        #
+        # "ansible_ssh_host_key_ecdsa_public": "ABCDEFGHIJ",
+        #
+        # to
+        #
+        # "ansible_ssh_host_key_ecdsa_public": ********,
+
+        path = "/var/log/rhc-worker-playbook/ansible/*"
+        regexp = r"(\s*\"ansible_ssh_host_key_)(.+)(_public\":\s*)(.+)(\,|$)"
+        self.do_path_regex_sub(path, regexp,
+                               r"\1\2\3********\5")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Capture information from rhc worker playbooks, and obfuscate public ssh keys.

Related: RH: RHEL-27555

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
