### PR TITLE
[samba] Capture wbinfo --online-status

### DIFF
--- a/sos/report/plugins/samba.py
+++ b/sos/report/plugins/samba.py
@@ -39,6 +39,7 @@ class Samba(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
             "wbinfo --domain='.' --domain-groups",
             "wbinfo --trusted-domains --verbose",
             "wbinfo --check-secret",
+            "wbinfo --online-status",
             "net primarytrust dumpinfo",
             "net ads info",
             "net ads testjoin",


### PR DESCRIPTION
Capturing this command output can help find the domain status, specially in these cases where having multiple domains in the same forest/cross forest, or in cases where there is sssd and samba_winbind. This output complements that of 'net ads testjoin'.

Related: RH: RHEL-30958

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
