### PR TITLE
[AAP EDA] Adding aap eda nginx log files to be collected

### DIFF
--- a/sos/report/plugins/aap_eda.py
+++ b/sos/report/plugins/aap_eda.py
@@ -25,6 +25,8 @@ class AAPEDAControllerPlugin(Plugin, RedHatPlugin):
             "/var/log/ansible-automation-platform/eda/scheduler.log*",
             "/var/log/ansible-automation-platform/eda/gunicorn.log*",
             "/var/log/ansible-automation-platform/eda/activation.log*",
+            "/var/log/nginx/automationedacontroller.access.log*",
+            "/var/log/nginx/automationedacontroller.error.log*",
         ])
 
         self.add_forbidden_path([


### PR DESCRIPTION
Adding the line to collect the nginx log files for the AAP EDA 
sos report used for troubleshooting issues at 
Ansible Automation Platform Event Driven Controller

Related: RH AAP-12898

Signed-off-by: Rudnei Bertol Junior <rudnei@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
