### PR TITLE
[AAP CONTROLLER] Add new preset

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -16,7 +16,8 @@ from sos.policies.auth import DeviceAuthorizationClass
 
 from sos.report.plugins import RedHatPlugin
 from sos.presets.redhat import (RHEL_PRESETS, RHV, RHEL, CB, RHOSP,
-                                RHOCP, RH_CFME, RH_SATELLITE, AAPEDA)
+                                RHOCP, RH_CFME, RH_SATELLITE, AAPEDA,
+                                AAPCONTROLLER)
 from sos.policies.distros import LinuxPolicy, ENV_HOST_SYSROOT
 from sos.policies.package_managers.rpm import RpmPackageManager
 from sos.policies.package_managers.flatpak import FlatpakPackageManager
@@ -479,6 +480,8 @@ support representative.
         if self.pkg_by_name("ovirt-engine") is not None or \
                 self.pkg_by_name("vdsm") is not None:
             return self.find_preset(RHV)
+        if self.pkg_by_name("automation-controller-server") is not None:
+            return self.find_preset(AAPCONTROLLER)
         for pkg in ['automation-eda-controller',
                     'automation-eda-controller-server']:
             if self.pkg_by_name(pkg) is not None:

--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -64,6 +64,18 @@ AAPEDA_NOTE = ('Collects \'eda\' user output for the containers_common plugin.'
                ' If you need more users, do not forget to add \'eda\' '
                'to your own list for the \'rootlessusers\' option.')
 
+AAPCONTROLLER = 'aap_controller'
+AAPCONTROLLER_DESC = 'Ansible Automation Platform Controller'
+AAPCONTROLLER_OPTS = SoSOptions(
+    enable_plugins=['containers_common'],
+    plugopts=[
+        'containers_common.rootlessusers=awx'
+    ])
+AAPCONTROLLER_NOTE = ('Collects \'awx\' user output for the containers_common'
+                      'pluging. If you need more users, do not forget to add'
+                      '\'awx\' to your own list for the \'rootlessusers\' '
+                      'option.')
+
 CB = "cantboot"
 CB_DESC = "For use when normal system startup fails"
 CB_OPTS = SoSOptions(
@@ -79,6 +91,9 @@ NOTE_SIZE_TIME = "This preset may increase report size and run time"
 RHEL_PRESETS = {
     AAPEDA: PresetDefaults(name=AAPEDA, desc=AAPEDA_DESC, opts=AAPEDA_OPTS,
                            note=AAPEDA_NOTE),
+    AAPCONTROLLER: PresetDefaults(name=AAPCONTROLLER, desc=AAPCONTROLLER_DESC,
+                                  opts=AAPCONTROLLER_OPTS,
+                                  note=AAPCONTROLLER_NOTE),
     RHV: PresetDefaults(name=RHV, desc=RHV_DESC, note=NOTE_TIME,
                         opts=_opts_verify),
     RHEL: PresetDefaults(name=RHEL, desc=RHEL_DESC),


### PR DESCRIPTION
Adds a new preset for `aap_controller`, or Ansible Automation Controller.

This preset will set the `containers_common` plugin to collect output for the `awx` user.

Related: #3561

Signed-off-by: Rudnei Bertol Junior <rudnei@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
