### PR TITLE
[ssh] Collect sshd_config.d directory

### DIFF
--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -8,6 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+from glob import glob
 from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
@@ -33,7 +34,8 @@ class Ssh(Plugin, IndependentPlugin):
 
         sshcfgs = [
             "/etc/ssh/ssh_config",
-            "/etc/ssh/sshd_config"
+            "/etc/ssh/sshd_config",
+            "/etc/ssh/sshd_config.d/*",
             ]
 
         # Include main config files
@@ -49,7 +51,12 @@ class Ssh(Plugin, IndependentPlugin):
         """ Include subconfig files """
         # Read configs for any includes and copy those
         try:
-            for sshcfg in sshcfgs:
+            cfgfiles = [
+                f for files in [
+                    glob(copyspec, recursive=True) for copyspec in sshcfgs
+                ] for f in files
+            ]
+            for sshcfg in cfgfiles:
                 tag = sshcfg.split('/')[-1]
                 with open(self.path_join(sshcfg), 'r',
                           encoding='UTF-8') as cfgfile:


### PR DESCRIPTION
Collect sshd config files in its dedicated sshd_config.d directory, as well as config files included from them.

Resolves: #3595

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
