### PR TITLE
[global] Update use of pipes with shlex

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
 from getpass import getpass
 from pathlib import Path
-from pipes import quote
+from shlex import quote
 from textwrap import fill
 from sos.cleaner import SoSCleaner
 from sos.collector.sosnode import SosNode

--- a/sos/collector/clusters/kubernetes.py
+++ b/sos/collector/clusters/kubernetes.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from pipes import quote
+from shlex import quote
 from sos.collector.clusters import Cluster
 
 

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -10,7 +10,7 @@
 
 import os
 
-from pipes import quote
+from shlex import quote
 from sos.collector.clusters import Cluster
 from sos.utilities import is_executable
 

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -10,7 +10,7 @@
 
 import fnmatch
 
-from pipes import quote
+from shlex import quote
 from sos.collector.clusters import Cluster
 
 ENGINE_KEY = '/etc/pki/ovirt-engine/keys/engine_id_rsa'

--- a/sos/collector/clusters/satellite.py
+++ b/sos/collector/clusters/satellite.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from pipes import quote
+from shlex import quote
 from sos.collector.clusters import Cluster
 
 

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 
-from pipes import quote
+from shlex import quote
 from sos.policies import load
 from sos.policies.init_systems import InitSystem
 from sos.collector.transports.juju import JujuSSH

--- a/sos/collector/transports/__init__.py
+++ b/sos/collector/transports/__init__.py
@@ -13,7 +13,7 @@ import logging
 import pexpect
 import re
 
-from pipes import quote
+from shlex import quote
 from sos.collector.exceptions import (ConnectionException,
                                       CommandTimeoutException)
 from sos.utilities import bold

--- a/sos/policies/runtimes/__init__.py
+++ b/sos/policies/runtimes/__init__.py
@@ -10,7 +10,7 @@
 
 import re
 
-from pipes import quote
+from shlex import quote
 from sos.utilities import sos_get_command_output, is_executable
 
 

--- a/sos/policies/runtimes/crio.py
+++ b/sos/policies/runtimes/crio.py
@@ -11,7 +11,7 @@ import json
 
 from sos.policies.runtimes import ContainerRuntime
 from sos.utilities import sos_get_command_output
-from pipes import quote
+from shlex import quote
 
 
 class CrioContainerRuntime(ContainerRuntime):


### PR DESCRIPTION
`pipes` is deprecated and being removed from Python in 3.13. Our usage is exclusively `pipes.quote()`, which has actually been calling `shlex.quote()` behind the scenes for some time (at least since 3.6).

Update our usage of `quote` to directly import from `shlex`.

Resolves: #3310

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
