### PR TITLE
[pylint] Fix deprecated warnings

### DIFF
--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -292,6 +292,7 @@ class SoSObfuscationArchive():
             else:
                 shutil.rmtree(name)
         self.log_debug("Removing %s" % self.extracted_path)
+        # pylint: disable-next=deprecated-argument
         shutil.rmtree(self.extracted_path, onerror=force_delete_file)
 
     def extract_self(self):

--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -241,7 +241,7 @@ class ocp(Cluster):
             return 'oc'
         self.log_info("Local installation of 'oc' not found or is not "
                       "correctly configured. Will use ControlPersist.")
-        self.ui_log.warn(
+        self.ui_log.warning(
             "Preferred transport 'oc' not available, will fallback to SSH."
         )
         if not self.opts.batch:


### PR DESCRIPTION
* W4903: deprecated-argument
* W4902: deprecated-method

```
sos/collector/clusters/ocp.py:244:8: W4902: Using deprecated method warn() (deprecated-method)
sos/collector/clusters/ocp.py:244:8: W4902: Using deprecated method warn() (deprecated-method)
sos/cleaner/archives/__init__.py:295:8: W4903: Using deprecated argument onerror of method rmtree() (deprecated-argument)
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
