### PR TITLE
[Global] Resolve empty except alerts from CodeQL

### DIFF
--- a/sos/collector/clusters/ocp.py
+++ b/sos/collector/clusters/ocp.py
@@ -226,6 +226,8 @@ class ocp(Cluster):
                 try:
                     idx[state] = statline.index(state.upper())
                 except Exception:
+                    # label is not available, which is not fatal for our dict
+                    # construction here
                     pass
             for node in nodelist:
                 _node = node.split()

--- a/sos/collector/clusters/ovirt.py
+++ b/sos/collector/clusters/ovirt.py
@@ -148,6 +148,7 @@ class ovirt(Cluster):
                     v = str(line.split('=')[1].replace('"', ''))
                     conf[k] = v
                 except IndexError:
+                    # not a valid line to parse config values from, ignore
                     pass
             return conf
         return False

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -367,8 +367,8 @@ class SosNode():
                 if not is_list:
                     try:
                         res.append(line.split()[0])
-                    except Exception:
-                        pass
+                    except Exception as err:
+                        self.log_debug(f"Error parsing sos help: {err}")
                 else:
                     r = line.split(',')
                     res.extend(p.strip() for p in r if p.strip())
@@ -475,8 +475,8 @@ class SosNode():
                 self.log_error('Unable to determine path of sos archive')
             if self.sos_path:
                 self.retrieved = self.retrieve_sosreport()
-        except Exception:
-            pass
+        except Exception as err:
+            self.log_error(f"Error during sos execution: {err}")
         self.cleanup()
 
     def _preset_exists(self, preset):

--- a/sos/component.py
+++ b/sos/component.py
@@ -91,8 +91,8 @@ class SoSComponent():
         try:
             import signal
             signal.signal(signal.SIGTERM, self.get_exit_handler())
-        except Exception:
-            pass
+        except Exception as err:
+            sys.stdout.write(f"Notice: Could not set SIGTERM handler: {err}\n")
 
         self.opts = SoSOptions(arg_defaults=self._arg_defaults)
         if self.load_policy:

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -556,6 +556,7 @@ support representative.
                 for line in hfile.read().splitlines():
                     coreos |= 'Red Hat Enterprise Linux CoreOS' in line
         except IOError:
+            # host release file not present, will fallback to RHEL policy check
             pass
         return coreos
 

--- a/sos/policies/init_systems/systemd.py
+++ b/sos/policies/init_systems/systemd.py
@@ -41,6 +41,7 @@ class SystemdInit(InitSystem):
                     'config': config
                 }
             except IndexError:
+                # not a valid line to extract status info from
                 pass
 
     def is_running(self, name, default=False):

--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -113,6 +113,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
                         transactions = int(line.split('|')[0].strip())
                         break
                     except ValueError:
+                        # not a valid line to extract transactions from, ignore
                         pass
             for tr_id in range(1, min(transactions+1, 50)):
                 self.add_cmd_output(f"dnf history info {tr_id}",

--- a/sos/report/plugins/gluster.py
+++ b/sos/report/plugins/gluster.py
@@ -52,8 +52,8 @@ class Gluster(Plugin, RedHatPlugin):
                                     '/glusterd_state_[0-9]*_[0-9]*'))
                 for name in remove_files:
                     os.remove(name)
-            except OSError:
-                pass
+            except OSError as err:
+                self._log_error(f"Could not remove statedump files: {err}")
 
     def setup(self):
         self.add_forbidden_path("/var/lib/glusterd/geo-replication/secret.pem")

--- a/sos/report/plugins/pcp.py
+++ b/sos/report/plugins/pcp.py
@@ -51,6 +51,7 @@ class Pcp(Plugin, RedHatPlugin, DebianPlugin):
                 (key, value) = line.strip().split('=')
                 env_vars[key] = value
             except (ValueError, KeyError):
+                # not a line for a key, value pair. Ignore the line.
                 pass
 
         try:

--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -95,8 +95,8 @@ class SubscriptionManager(Plugin, RedHatPlugin):
             if no_proxy:
                 env = {'NO_PROXY': no_proxy}
         except (ModuleNotFoundError, ImportError, NoOptionError,
-                NoSectionError):
-            pass
+                NoSectionError) as err:
+            self._log_debug(f"Error checking for RHSM cert/proxy issue: {err}")
         self.add_cmd_output(curlcmd, env=env, timeout=30)
 
     def postproc(self):

--- a/sos/report/plugins/watchdog.py
+++ b/sos/report/plugins/watchdog.py
@@ -44,6 +44,7 @@ class Watchdog(Plugin, RedHatPlugin):
                     if key.strip() == 'log-dir':
                         log_dir = value.strip()
                 except ValueError:
+                    # not a valid key, value line and we can safely ignore
                     pass
 
         return log_dir

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -616,10 +616,12 @@ class TempFileUtil():
                 f.flush()
                 f.close()
             except Exception:
+                # file already closed or potentially already removed, ignore
                 pass
             try:
                 os.unlink(fname)
             except Exception:
+                # if the above failed, this is also likely to fail, ignore
                 pass
         self.files = []
 


### PR DESCRIPTION
This commit resolves the remaining 'Empty except' alerts from CodeQL scanning.

Most of these involve logging something during exception handling when we were previously simply `pass`ing. Others, either when logging is unavailable or it makes no sense to log something for, are resolved by placing comments within the except block as the CodeQL alerts should be suppressed if the 'empty except' (`pass`ing) has an explanatory note.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
