### PR TITLE
[pkg] Don't initialize _packages to empty set

### DIFF
--- a/sos/policies/package_managers/__init__.py
+++ b/sos/policies/package_managers/__init__.py
@@ -54,7 +54,7 @@ class PackageManager():
     files = None
 
     def __init__(self, chroot=None, remote_exec=None):
-        self._packages = {}
+        self._packages = None
         self.files = []
         self.remote_exec = remote_exec
 
@@ -63,7 +63,7 @@ class PackageManager():
 
     @property
     def packages(self):
-        if not self._packages:
+        if self._packages is None:
             self._generate_pkg_list()
         return self._packages
 
@@ -181,6 +181,9 @@ class PackageManager():
                               'pkg_manager': 'package manager name'}}
 
         """
+        if self._packages is None:
+            self._packages = {}
+
         if self.query_command:
             cmd = self.query_command
             pkg_list = self.exec_cmd(cmd, timeout=30, chroot=self.chroot)
@@ -340,6 +343,9 @@ class MultiPackageManager(PackageManager):
         return self.files
 
     def _generate_pkg_list(self):
+        if self._packages is None:
+            self._packages = {}
+
         self._packages.update(self.primary.packages)
         for pm in self.fallbacks:
             _pkgs = pm.packages


### PR DESCRIPTION
When initializing _packages, a distinction must be made between not having any package and not being initialized at all. Otherwise, if a package manager returns no package, the query command will execute hundreds of times.

This can reproduce with 'flatpak' on RHEL when no package is returned:

```
# flatpak list
--> no output

# strace -fttTvyy -s 128 -e execve -o sos.strace -- ./bin/sos report
[...]
Press ENTER to continue, or CTRL-C to quit.
^C

# grep -c ' execve("/usr/sbin/flatpak"' sos.strace
350
```
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
