### PR TITLE
[archive] Fix get_archive_root after files reordering

### DIFF
--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -104,7 +104,7 @@ class SoSObfuscationArchive():
             if toplevel.isdir():
                 return toplevel.name
             else:
-                return os.sep
+                return os.path.dirname(toplevel.name) or os.sep
         return os.path.abspath(self.archive_path)
 
     def report_msg(self, msg):


### PR DESCRIPTION
Commit d5d8c21 reordered files in the archive, such that the first member is not the archive root directory further more. Let change the get_archive_root method accordingly to prevent self.archive_root being empty.

Resolves: #3616

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
