### PR TITLE
[tox] Use posargs for the tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -148,7 +148,7 @@ deb_build_task:
         apt -y install devscripts equivs python3-pip
         mk-build-deps
         apt -y install ./sosreport-build-deps*.deb
-        pip3 install "avocado-framework<104.0" --break-system-packages
+        pip3 install -r test-requirements.txt --break-system-packages
     main_script: |
         dpkg-buildpackage -b -us -uc -rfakeroot -m --build-by="noreply@canonical.com"
     prep_artifacts_script: mv ../*.deb ./sos_cirrus.deb
@@ -240,7 +240,7 @@ report_stageone_task:
         fi
         PIP_EXTRA=""
         [[ $(pip3 install --help | grep break-system) ]] && PIP_EXTRA="--break-system-packages"
-        pip3 install "avocado-framework<104.0" ${PIP_EXTRA}
+        pip3 install -r test-requirements.txt ${PIP_EXTRA}
     # run the unittests separately as they require a different PYTHONPATH in
     # order for the imports to work properly under avocado
     unittest_script: &unit_test |

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+avocado-framework<104.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = flake8
 [testenv]
 deps =
     -r{toxinidir}/requirements.txt
-    avocado-framework<104.0
+    -r{toxinidir}/test-requirements.txt
     python_magic
 setenv =
     PYTHONPATH = {toxinidir}/tests
@@ -15,6 +15,8 @@ stage_tests =
     tests/collect_tests \
     tests/report_tests \
     tests/vendor_tests
+foreman_tests =
+    tests/product_tests/foreman
 
 [testenv:flake8]
 deps = flake8
@@ -29,22 +31,23 @@ basepython = python3
 setenv =
     PYTHONPATH = .
 commands =
-    avocado run tests/unittests/
+    avocado run tests/unittests
 
 [testenv:stageone_tests]
 basepython = python3
 commands =
-    {[testenv]avocado_cmd} -t stageone {[testenv]stage_tests}
+    {[testenv]avocado_cmd} -t stageone {posargs:[testenv]stage_tests}
 
 [testenv:stagetwo_tests]
 basepython = python3
+sitepackages = True
 commands =
-    {[testenv]avocado_cmd} -t stagetwo {[testenv]stage_tests}
+    {[testenv]avocado_cmd} -t stagetwo {posargs:[testenv]stage_tests}
 
 [testenv:foreman_tests]
 basepython = python3
 commands =
-    {[testenv]avocado_cmd} -t foreman tests/product_tests/foreman/
+    {[testenv]avocado_cmd} -t foreman {posargs:[testenv]foreman_tests}
 
 [testenv:nosetests]
 basepython = python3


### PR DESCRIPTION
This allows to run specific tests, and not all the tests in one go. This is especially useful if you're writing a plugin or creating a test for a specific scenario. Below an example of what would be possible

```
sudo tox -e stagetwo_tests -- tests/report_tests/plugin_tests/openstack/openstack.py
```

This will run stagetwo tests for the specific test, i.e. openstack in this case

This also fixes the stagetwo tests, so that it picks up the systemd python libs from the distro environment

Update the installation of avocado-framework from one place, so that we don't need to change the version in many places. Adding `test-requirements.txt` to handle this and integrate this with both tox and Cirrus CI

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
