### PR TITLE
[plugins] apply --since to all journal collection

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2959,6 +2959,7 @@ class Plugin():
                 boot = "-1"
             journal_cmd += boot_opt % boot
 
+        since = since or self.get_option('since')
         if since:
             journal_cmd += since_opt % since
 

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -22,8 +22,6 @@ class LogsBase(Plugin):
         confs = ['/etc/syslog.conf', rsyslog]
         logs = []
 
-        since = self.get_option("since")
-
         if self.path_exists(rsyslog):
             with open(self.path_join(rsyslog), 'r', encoding='UTF-8') as conf:
                 for line in conf.readlines():
@@ -65,12 +63,10 @@ class LogsBase(Plugin):
         journal = any(self.path_exists(self.path_join(p, "log/journal/"))
                       for p in ["/var", "/run"])
         if journal and self.is_service("systemd-journald"):
-            self.add_journal(since=since, tags=['journal_full', 'journal_all'],
+            self.add_journal(tags=['journal_full', 'journal_all'],
                              priority=100)
-            self.add_journal(boot="this", since=since,
-                             tags='journal_since_boot')
-            self.add_journal(boot="last", since=since,
-                             tags='journal_last_boot')
+            self.add_journal(boot="this", tags='journal_since_boot')
+            self.add_journal(boot="last", tags='journal_last_boot')
             if self.get_option("all_logs"):
                 self.add_copy_spec([
                     "/var/log/journal/*",


### PR DESCRIPTION
If user limit logs with --since, there is no reasons to have logs older than the limit.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
