### PR TITLE
[cirrus] Update images, add noble to supported list

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,10 +8,11 @@ env:
 
     DEBIAN_NAME: "debian-11"
 
-    UBUNTU_LATEST_NAME: "ubuntu-23.10"
-    UBUNTU_NAME: "ubuntu-22.04"
-    UBUNTU_PRIOR_NAME: "ubuntu-20.04"
-    UBUNTU_PRIOR2_NAME: "ubuntu-18.04"
+    UBUNTU_LATEST_NAME: "ubuntu-24.04"
+    UBUNTU_NAME: "ubuntu-24.04"
+    UBUNTU_PRIOR_NAME: "ubuntu-22.04"
+    UBUNTU_PRIOR2_NAME: "ubuntu-20.04"
+    UBUNTU_PRIOR3_NAME: "ubuntu-18.04"
 
     CENTOS_9_NAME: "centos-stream-9"
     CENTOS_8_NAME: "centos-stream-8"
@@ -30,12 +31,13 @@ env:
     FEDORA_IMAGE_NAME: "fedora-cloud-base-gcp-38-1-6-x86-64"
     FEDORA_PRIOR_IMAGE_NAME: "fedora-cloud-base-gcp-37-1-7-x86-64"
 
-    UBUNTU_DEB_IMAGE_NAME: "ubuntu-minimal-2310-mantic-amd64-v20231030"
-    UBUNTU_LATEST_IMAGE_NAME: "ubuntu-2310-mantic-amd64-v20231031"
-    UBUNTU_IMAGE_NAME: "ubuntu-2204-jammy-v20231030"
-    UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2004-focal-v20231101"
-    UBUNTU_PRIOR2_IMAGE_NAME: "ubuntu-1804-bionic-v20230605"
-    UBUNTU_SNAP_IMAGE_NAME: "ubuntu-2204-jammy-v20231030"
+    UBUNTU_DEB_IMAGE_NAME: "ubuntu-minimal-2404-noble-amd64-v20240423"
+    UBUNTU_LATEST_IMAGE_NAME: "ubuntu-2404-noble-amd64-v20240423"
+    UBUNTU_IMAGE_NAME: "ubuntu-2404-noble-amd64-v20240423"
+    UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2204-jammy-v20240319"
+    UBUNTU_PRIOR2_IMAGE_NAME: "ubuntu-2004-focal-v20240307b"
+    UBUNTU_PRIOR3_IMAGE_NAME: "ubuntu-1804-bionic-v20240116a"
+    UBUNTU_SNAP_IMAGE_NAME: "ubuntu-2204-jammy-v20240319"
     UBUNTU_DEVEL_FAMILY_NAME: "ubuntu-2404-lts-amd64"
 
     # Curl-command prefix for downloading task artifacts, simply add the
@@ -195,25 +197,30 @@ report_stageone_task:
         - env: *fedora
         - env: *fedoraprior
         - env: &ubuntu
+            PKG: "snap"
             PROJECT: ${UBUNTU_PROJECT}
-            BUILD_NAME: ${UBUNTU_NAME}
+            BUILD_NAME: "${UBUNTU_NAME} - ${PKG}"
             VM_IMAGE_NAME: ${UBUNTU_IMAGE_NAME}
-            PKG: "snap"
         - env: &ubuntuprior
+            PKG: "snap"
             PROJECT: ${UBUNTU_PROJECT}
-            BUILD_NAME: ${UBUNTU_PRIOR_NAME}
+            BUILD_NAME: "${UBUNTU_PRIOR_NAME} - ${PKG}"
             VM_IMAGE_NAME: ${UBUNTU_PRIOR_IMAGE_NAME}
-            PKG: "snap"
         - env: &ubuntuprior2
-            PROJECT: ${UBUNTU_PROJECT}
-            BUILD_NAME: ${UBUNTU_PRIOR2_NAME}
-            VM_IMAGE_NAME: ${UBUNTU_PRIOR2_IMAGE_NAME}
             PKG: "snap"
-        - env: &ubuntu-latest
             PROJECT: ${UBUNTU_PROJECT}
-            BUILD_NAME: ${UBUNTU_LATEST_NAME}
-            VM_IMAGE_NAME: ${UBUNTU_LATEST_IMAGE_NAME}
+            BUILD_NAME: "${UBUNTU_PRIOR2_NAME} - ${PKG}"
+            VM_IMAGE_NAME: ${UBUNTU_PRIOR2_IMAGE_NAME}
+        - env: &ubuntuprior3
+            PKG: "snap"
+            PROJECT: ${UBUNTU_PROJECT}
+            BUILD_NAME: "${UBUNTU_PRIOR3_NAME} - ${PKG}"
+            VM_IMAGE_NAME: ${UBUNTU_PRIOR3_IMAGE_NAME}
+        - env: &ubuntu-latest
             PKG: "deb"
+            PROJECT: ${UBUNTU_PROJECT}
+            BUILD_NAME: "${UBUNTU_LATEST_NAME} - ${PKG}"
+            VM_IMAGE_NAME: ${UBUNTU_LATEST_IMAGE_NAME}
     setup_script: &setup |
         if [ $(command -v apt) ]; then
             apt -y purge sosreport


### PR DESCRIPTION
Update the ubuntu images to the newest available.

`noble`(24.04) was released yesterday, and the new GCE image is available in the project, so we can officially start testing on that

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
