### PR TITLE
[Plugins, Options] Standardized PluginOpt names to use dashes

### DIFF
--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -29,7 +29,7 @@ RHOSP = "rhosp"
 RHOSP_DESC = "Red Hat OpenStack Platform"
 RHOSP_OPTS = SoSOptions(plugopts=[
                              'process.lsof=off',
-                             'networking.ethtool_namespaces=False',
+                             'networking.ethtool-namespaces=False',
                              'networking.namespaces=200'])
 
 RHOCP = "ocp"
@@ -40,7 +40,7 @@ RHOCP_OPTS = SoSOptions(
     plugopts=[
         'crio.timeout=600',
         'networking.timeout=600',
-        'networking.ethtool_namespaces=False',
+        'networking.ethtool-namespaces=False',
         'networking.namespaces=200'
     ])
 

--- a/sos/report/plugins/jars.py
+++ b/sos/report/plugins/jars.py
@@ -24,9 +24,9 @@ class Jars(Plugin, RedHatPlugin):
     plugin_name = "jars"
     profiles = ("java",)
     option_list = [
-        PluginOpt('append_locations', default="", val_type=str,
+        PluginOpt('append-locations', default="", val_type=str,
                   desc='colon-delimited list of additional JAR paths'),
-        PluginOpt('all_known_locations', default=False,
+        PluginOpt('all-known-locations', default=False,
                   desc='scan all known paths')
     ]
 
@@ -51,11 +51,11 @@ class Jars(Plugin, RedHatPlugin):
         jar_paths = []
 
         locations = list(Jars.jar_locations)
-        if self.get_option("all_known_locations"):
+        if self.get_option("all-known-locations"):
             locations += list(Jars.extra_jar_locations)
 
         # append also user-defined locations, if any
-        user_locations = self.get_option("append_locations")
+        user_locations = self.get_option("append-locations")
         if user_locations:
             locations += user_locations.split(":")
 

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -131,7 +131,7 @@ class AzureKDump(KDump, AzurePlugin):
     packages = ('kexec-tools',)
 
     option_list = [
-        PluginOpt("get_vm_core", default=False, val_type=bool,
+        PluginOpt("get-vm-core", default=False, val_type=bool,
                   desc="collect vm core")
     ]
 
@@ -166,7 +166,7 @@ class AzureKDump(KDump, AzurePlugin):
         self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
 
         # collect the latest vmcore created in the last 24hrs <= 2GB
-        if self.get_option("get_vm_core"):
+        if self.get_option("get-vm-core"):
             self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxage=24)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -118,7 +118,7 @@ class IndependentLogs(LogsBase, IndependentPlugin):
 
 class CosLogs(LogsBase, CosPlugin):
     option_list = [
-        PluginOpt(name="log_days", default=3,
+        PluginOpt(name="log-days", default=3,
                   desc="the number of days logs to collect")
     ]
 
@@ -127,7 +127,7 @@ class CosLogs(LogsBase, CosPlugin):
         if self.get_option("all_logs"):
             self.add_cmd_output("journalctl -o export")
         else:
-            days = self.get_option("log_days", 3)
+            days = self.get_option("log-days", 3)
             self.add_journal(since=f"-{days}days")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/mssql.py
+++ b/sos/report/plugins/mssql.py
@@ -20,12 +20,12 @@ class MsSQL(Plugin, RedHatPlugin):
     packages = ('mssql-server',)
 
     option_list = [
-        PluginOpt('mssql_conf', default='/var/opt/mssql/mssql.conf',
+        PluginOpt('mssql-conf', default='/var/opt/mssql/mssql.conf',
                   desc='SQL server configuration file')
     ]
 
     def setup(self):
-        mssql_conf = self.get_option('mssql_conf')
+        mssql_conf = self.get_option('mssql-conf')
 
         # Pick error log file from mssql_conf.
         # Expecting the following format

--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -21,12 +21,12 @@ class Networking(Plugin):
     option_list = [
         PluginOpt("traceroute", default=False,
                   desc=f"collect a traceroute to {trace_host}"),
-        PluginOpt("namespace_pattern", default="", val_type=str,
+        PluginOpt("namespace-pattern", default="", val_type=str,
                   desc=("Specific namespace names or patterns to collect, "
                         "whitespace delimited.")),
         PluginOpt("namespaces", default=None, val_type=int,
                   desc="Number of namespaces to collect, 0 for unlimited"),
-        PluginOpt("ethtool_namespaces", default=True,
+        PluginOpt("ethtool-namespaces", default=True,
                   desc=("Toggle if ethtool commands should be run for each "
                         "namespace")),
         PluginOpt("eepromdump", default=False,
@@ -203,7 +203,7 @@ class Networking(Plugin):
         self.add_cmd_output("ip netns")
         cmd_prefix = "ip netns exec "
         namespaces = self.get_network_namespaces(
-                self.get_option("namespace_pattern"),
+                self.get_option("namespace-pattern"),
                 self.get_option("namespaces"))
         if namespaces:
             # 'ip netns exec <foo> iptables-save' must be guarded by nf_tables
@@ -254,7 +254,7 @@ class Networking(Plugin):
 
                 # Collect ethtool commands only when ethtool_namespaces
                 # is set to true.
-                if self.get_option("ethtool_namespaces"):
+                if self.get_option("ethtool-namespaces"):
                     # Devices that exist in a namespace use less ethtool
                     # parameters. Run this per namespace.
                     self.add_device_cmd([

--- a/sos/report/plugins/npm.py
+++ b/sos/report/plugins/npm.py
@@ -18,7 +18,7 @@ class Npm(Plugin, IndependentPlugin):
     plugin_name = 'npm'
     profiles = ('system',)
     option_list = [
-        PluginOpt('project_path', default='', val_type=str,
+        PluginOpt('project-path', default='', val_type=str,
                   desc='Collect npm modules of project at this path')
     ]
 
@@ -35,9 +35,9 @@ class Npm(Plugin, IndependentPlugin):
         )
 
     def setup(self):
-        if self.get_option("project_path"):
+        if self.get_option("project-path"):
             project_path = os.path.abspath(os.path.expanduser(
-                self.get_option("project_path")))
+                self.get_option("project-path")))
             self._get_npm_output("npm ls --json", "npm_ls_project",
                                  working_directory=project_path)
             self._get_npm_output("npm config list -l",

--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -57,7 +57,7 @@ class Ovirt(Plugin, RedHatPlugin):
     option_list = [
         PluginOpt('jbosstrace', default=True,
                   desc='Enable oVirt Engine JBoss stack trace collection'),
-        PluginOpt('sensitive_keys', default=DEFAULT_SENSITIVE_KEYS,
+        PluginOpt('sensitive-keys', default=DEFAULT_SENSITIVE_KEYS,
                   desc='Sensitive keys to be masked in post-processing'),
         PluginOpt('heapdump', default=False,
                   desc='Collect heap dumps from /var/log/ovirt-engine/dump/')
@@ -231,7 +231,7 @@ class Ovirt(Plugin, RedHatPlugin):
 
         sensitive_keys = self.DEFAULT_SENSITIVE_KEYS
         # Handle --alloptions case which set this to True.
-        keys_opt = self.get_option('sensitive_keys')
+        keys_opt = self.get_option('sensitive-keys')
         if keys_opt and keys_opt is not True:
             sensitive_keys = keys_opt
         key_list = [x for x in sensitive_keys.split(':') if x]

--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -25,9 +25,9 @@ class Pacemaker(Plugin):
     )
 
     option_list = [
-        PluginOpt('crm_from', default='', val_type=str,
+        PluginOpt('crm-from', default='', val_type=str,
                   desc='specfiy the start time for crm_report'),
-        PluginOpt('crm_scrub', default=True,
+        PluginOpt('crm-scrub', default=True,
                   desc='enable crm_report password scrubbing')
     ]
 
@@ -105,17 +105,17 @@ class Pacemaker(Plugin):
         # time in order to collect data.
         crm_from = (datetime.today() -
                     timedelta(hours=72)).strftime("%Y-%m-%d %H:%m:%S")
-        if self.get_option("crm_from"):
+        if self.get_option("crm-from"):
             if re.match(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}',
-                        str(self.get_option("crm_from"))):
-                crm_from = self.get_option("crm_from")
+                        str(self.get_option("crm-from"))):
+                crm_from = self.get_option("crm-from")
             else:
                 self._log_error(
-                    f"crm_from parameter '{self.get_option('crm_from')}' is "
+                    f"crm_from parameter '{self.get_option('crm-from')}' is "
                     "not a valid date: using default")
 
         crm_dest = self.get_cmd_output_path(name="crm_report", make=False)
-        if self.get_option("crm_scrub"):
+        if self.get_option("crm-scrub"):
             crm_scrub = '-p "passw.*"'
         else:
             crm_scrub = ""

--- a/sos/report/plugins/proxmox.py
+++ b/sos/report/plugins/proxmox.py
@@ -26,7 +26,7 @@ class Proxmox(Plugin, DebianPlugin):
     packages = ('proxmox-ve',)
 
     option_list = [
-        PluginOpt('output_formats',
+        PluginOpt('output-formats',
                   desc='List of output formats to use '
                        'for the commands separated by ":".',
                   default='text',
@@ -34,7 +34,7 @@ class Proxmox(Plugin, DebianPlugin):
     ]
 
     def setup(self):
-        output_formats = self.get_option('output_formats').split(':')
+        output_formats = self.get_option('output-formats').split(':')
 
         commands = [
             'cluster/resources',

--- a/sos/report/plugins/sar.py
+++ b/sos/report/plugins/sar.py
@@ -25,7 +25,7 @@ class Sar(Plugin):
     for the current day-of data being collected at the time of report
     generation).
 
-    Using the 'all_sar' plugin option will not only cause the plugin to capture
+    Using the 'all-sar' plugin option will not only cause the plugin to capture
     _all_ 'saX' files present on the host, but further perform the 'sar'
     conversion on all files, not just those produced within the last week.
 
@@ -46,13 +46,13 @@ class Sar(Plugin):
     packages = ('sysstat',)
     sa_path = '/var/log/sa'
     option_list = [
-        PluginOpt('all_sar', default=False,
+        PluginOpt('all-sar', default=False,
                   desc="gather all system activity records")
     ]
 
     def setup(self):
         self.add_copy_spec(self.path_join(self.sa_path, '*'),
-                           sizelimit=0 if self.get_option("all_sar") else None,
+                           sizelimit=0 if self.get_option("all-sar") else None,
                            tailit=False)
 
         try:
@@ -72,7 +72,7 @@ class Sar(Plugin):
                 sar_filename = 'sar' + fname[2:]
                 if sar_filename not in dir_list:
                     # only collect sar output for the last 7 days by default
-                    if not self.get_option('all_sar') and \
+                    if not self.get_option('all-sar') and \
                        self.is_older_than_7days(sa_data_path):
                         continue
                     sar_cmd = f"sar -A -f {sa_data_path}"

--- a/sos/report/plugins/watchdog.py
+++ b/sos/report/plugins/watchdog.py
@@ -20,7 +20,7 @@ class Watchdog(Plugin, RedHatPlugin):
     packages = ('watchdog',)
 
     option_list = [
-        PluginOpt('conf_file', default='/etc/watchdog.conf',
+        PluginOpt('conf-file', default='/etc/watchdog.conf',
                   desc='watchdog config file')
     ]
 
@@ -55,7 +55,7 @@ class Watchdog(Plugin, RedHatPlugin):
             Collect configuration files, custom executables for test-binary
             and repair-binary, and stdout/stderr logs.
         """
-        conf_file = self.path_join(self.get_option('conf_file'))
+        conf_file = self.path_join(self.get_option('conf-file'))
         log_dir = self.path_join('/var/log/watchdog')
 
         # Get service configuration and sysconfig files


### PR DESCRIPTION
This commit standardizes the use of dashes/hypens (`-`) for the names of PluginOpts. This is done to conform with argparse formatting so that the formating of options names is consistent across sos global options, component options, and now plugin options.

For example, the `networking` plugin's `namespace_pattern` option is now `namespace-pattern` and should now be specified via the `--plugin-option networking.namespace-pattern=foo` syntax. Similarly, developers will now need to use `Plugin.get_option('namespace-pattern')` in order to reference it.

Note that the use of global options within plugins (for example `--all-logs`) is unchanged, meaning that users will continue to use `--all-logs` and due to how these options get stored, developers would still use `Plugin.get_option('all_logs')`.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
