### PR TITLE
[cirrus] Start testing on new devel ubuntu daily

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,11 +34,11 @@ env:
     UBUNTU_DEB_IMAGE_NAME: "ubuntu-minimal-2404-noble-amd64-v20240423"
     UBUNTU_LATEST_IMAGE_NAME: "ubuntu-2404-noble-amd64-v20240423"
     UBUNTU_IMAGE_NAME: "ubuntu-2404-noble-amd64-v20240423"
-    UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2204-jammy-v20240319"
-    UBUNTU_PRIOR2_IMAGE_NAME: "ubuntu-2004-focal-v20240307b"
+    UBUNTU_PRIOR_IMAGE_NAME: "ubuntu-2204-jammy-v20240501"
+    UBUNTU_PRIOR2_IMAGE_NAME: "ubuntu-2004-focal-v20240426"
     UBUNTU_PRIOR3_IMAGE_NAME: "ubuntu-1804-bionic-v20240116a"
-    UBUNTU_SNAP_IMAGE_NAME: "ubuntu-2204-jammy-v20240319"
-    UBUNTU_DEVEL_FAMILY_NAME: "ubuntu-2404-lts-amd64"
+    UBUNTU_SNAP_IMAGE_NAME: "ubuntu-2204-jammy-v20240501"
+    UBUNTU_DEVEL_FAMILY_NAME: "ubuntu-2410-amd64"
 
     # Curl-command prefix for downloading task artifacts, simply add the
     # the url-encoded task name, artifact name, and path as a suffix.

--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -57,7 +57,7 @@ class Processor(Plugin, IndependentPlugin):
         ], cmd_as_tag=True)
 
         if (isinstance(self.policy, UbuntuPolicy) and
-                self.policy.dist_version() == 24.04):
+                self.policy.dist_version() >= 24.04):
             self.cpu_kmods = ['msr']
 
         cpupower_pred = SoSPredicate(self, kmods=self.cpu_kmods)


### PR DESCRIPTION
Ubuntu 24.10 release cycle has new started with the daily builds, so
we start testing on these to uncover any issues

Also update to latest GCE images for any new ubuntu images

Fix the `msr` predicate, such that it is caught on 24.04 and newer
releases of ubuntu

Related: https://github.com/sosreport/sos/issues/3610

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
