### PR TITLE
[foreman] Decrease hammer ping timeout

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -140,7 +140,7 @@ class Foreman(Plugin):
                     --sasl-mechanism=ANONYMOUS',
             suggest_filename='qpid-stat_-q'
         )
-        self.add_cmd_output("hammer ping", tags="hammer_ping")
+        self.add_cmd_output("hammer ping", tags="hammer_ping", timeout=120)
 
         # Dynflow Sidekiq
         self.add_cmd_output('systemctl list-units dynflow*',


### PR DESCRIPTION
hammer ping either finishes within a minute (or two), or never. Let decrease its timeout accordingly.

Resolves: #3639

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
