### PR TITLE
[tomcat] Enable the plugin by pki-servlet-engine package

### DIFF
--- a/sos/report/plugins/tomcat.py
+++ b/sos/report/plugins/tomcat.py
@@ -16,7 +16,8 @@ class Tomcat(Plugin, RedHatPlugin):
     plugin_name = 'tomcat'
     profiles = ('webserver', 'java', 'services', 'sysmgmt')
 
-    packages = ('tomcat', 'tomcat6', 'tomcat7', 'tomcat8')
+    packages = ('tomcat', 'tomcat6', 'tomcat7', 'tomcat8',
+                'pki-servlet-engine')
 
     def setup(self):
         self.add_copy_spec([


### PR DESCRIPTION
pki-servlet-engine implements Tomcat as well, let add the package to the plugin's triggers.

Resolves: #3640

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
