### PR TITLE
[livepatch] Add config output and bring out service

### DIFF
--- a/sos/report/plugins/canonical_livepatch.py
+++ b/sos/report/plugins/canonical_livepatch.py
@@ -18,13 +18,16 @@ class CanonicaLivepatch(Plugin, UbuntuPlugin):
     plugin_name = 'canonical_livepatch'
     profiles = ('system', 'kernel')
     commands = ('canonical-livepatch',)
+    services = ('snap.canonical-livepatch.canonical-livepatchd',)
 
     def setup(self):
         self.add_cmd_output([
             "canonical-livepatch status --verbose",
-            "canonical-livepatch --version"
+            "canonical-livepatch --version",
+            "canonical-livepatch config",
         ])
-        self.add_service_status(
-            "snap.canonical-livepatch.canonical-livepatchd")
+
+    def postproc(self):
+        self.do_cmd_private_sub("canonical-livepatch config")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add the service in the service dict so that we collect the journal for the corresponding service. Also acts as an extra trigger.

Obfuscate the certs that the config outputs

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
