### PR TITLE
[ceph_mds] Capture alternative mds file path

### DIFF
--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -16,7 +16,8 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'ceph_mds'
     profiles = ('storage', 'virt', 'container', 'ceph')
     containers = ('ceph-(.*-)?fs.*',)
-    files = ('/var/lib/ceph/mds/*', '/var/snap/microceph/common/data/mds/*')
+    files = ('/var/lib/ceph/mds/*', '/var/lib/ceph/*/mds.*',
+             '/var/snap/microceph/common/data/mds/*')
 
     def setup(self):
         all_logs = self.get_option("all_logs")
@@ -48,6 +49,7 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
             self.add_copy_spec([
                 "/var/lib/ceph/bootstrap-mds/",
                 "/var/lib/ceph/mds/",
+                "/var/lib/ceph/*/mds.*",
                 "/run/ceph/ceph-mds*",
             ])
 


### PR DESCRIPTION
Newer versions of Ceph place information in
/var/lib/ceph/<fsid>/mds* instead of
/var/lib/ceph/mds/*, so we need to capture
the new path as well.

Related: RH: SUPDEV-154

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
