### PR TITLE
[networking] Update ss predicate for Ubuntu

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -289,15 +289,14 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
 
     def setup(self):
 
-        ubuntu_ss_kmods = dict.fromkeys([22.04, 23.10],
-                                        ['tcp_diag', 'udp_diag',
-                                         'inet_diag', 'unix_diag',
-                                         'netlink_diag',
-                                         'af_packet_diag', 'xsk_diag',
-                                         'mptcp_diag', 'raw_diag'])
+        ubuntu_jammy_and_after_ss_kmods = ['tcp_diag', 'udp_diag',
+                                           'inet_diag', 'unix_diag',
+                                           'netlink_diag', 'af_packet_diag',
+                                           'xsk_diag', 'mptcp_diag',
+                                           'raw_diag']
 
-        if self.policy.dist_version() in ubuntu_ss_kmods:
-            self.ss_kmods = ubuntu_ss_kmods[self.policy.dist_version()]
+        if self.policy.dist_version() >= 22.04:
+            self.ss_kmods = ubuntu_jammy_and_after_ss_kmods
 
         super().setup()
 


### PR DESCRIPTION
We see that the predicate is replicated among all Ubuntu distros after 22.04, so we simplify the check to ensure all distros are covered in the future.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
