### PR TITLE
[apt] Obfuscate passwords for configs/sources

### DIFF
--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -47,16 +47,20 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
 
     def postproc(self):
         super().postproc()
-        self.do_file_sub(
-            "/etc/apt/sources.list",
-            r"(deb\shttp(s)?://)\S+:\S+(@.*)",
-            r"\1******:******\3"
-        )
-        self.do_path_regex_sub(
-            "/etc/apt/sources.list.d/",
-            r"(deb\shttp(s)?://)\S+:\S+(@.*)",
-            r"\1******:******\3"
-        )
 
+        common_regex = r"(http(s)?://)\S+:\S+(@.*)"
+        common_replace = r"\1******:******\3"
+
+        files_to_sub = [
+            "/etc/apt/sources.list",
+            "/etc/apt/sources.list.d/",
+            "/etc/apt/apt.conf",
+            "/etc/apt/apt.conf.d/",
+        ]
+
+        for file in files_to_sub:
+            self.do_path_regex_sub(
+                file, common_regex, common_replace
+            )
 
 # vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/apt/apt-proxy.conf
+++ b/tests/report_tests/plugin_tests/apt/apt-proxy.conf
@@ -1,0 +1,3 @@
+Acquire::http::proxy "http://username:somesecretpassword@10.0.0.254:80";
+Acquire::https::proxy "http://username:somesecretpassword@10.0.0.254:80";
+Acquire::ftp::proxy "http://username:somesecretpassword@10.0.0.254:80";

--- a/tests/report_tests/plugin_tests/apt/apt-sources.list
+++ b/tests/report_tests/plugin_tests/apt/apt-sources.list
@@ -1,0 +1,1 @@
+deb http://username:somesecretpassword@archive.example.com/ubuntu jammy main

--- a/tests/report_tests/plugin_tests/apt/apt-sources.sources
+++ b/tests/report_tests/plugin_tests/apt/apt-sources.sources
@@ -1,0 +1,4 @@
+Types: deb
+URIs: http://username:somesecretpassword@archive.example.com/ubuntu
+Suites: jammy
+Components: main

--- a/tests/report_tests/plugin_tests/apt/apt.py
+++ b/tests/report_tests/plugin_tests/apt/apt.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2024 Canonical Ltd., Arif Ali <arif.ali@canonical.com>
+#
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+
+class AptConfScrubTest(StageTwoReportTest):
+    """Ensure that sources.list and apt conf are picked up and properly
+    scrubbed
+
+    :avocado: tags=stagetwo
+    """
+
+    sos_cmd = '-o apt'
+    ubuntu_only = True
+    files = [
+        ('apt-proxy.conf', '/etc/apt/apt.conf.d/50-apt-proxy'),
+        ('apt-sources.list', '/etc/apt/sources.list'),
+        ('apt-sources.sources', '/etc/apt/sources.list.d/ubuntu.sources'),
+    ]
+
+    def test_apt_sources_and_apt_confs_collected(self):
+        self.assertFileCollected('/etc/apt/apt.conf.d/50-apt-proxy')
+        self.assertFileCollected('/etc/apt/sources.list')
+        self.assertFileCollected('/etc/apt/ubuntu.sources')
+
+    def test_apt_sources_and_proxy_scrubbed(self):
+        # Ensure that we scrubbed all passwords
+        files_to_check = [
+            '/etc/apt/apt.conf.d/50-apt-proxy',
+            '/etc/apt/sources.list',
+            '/etc/apt/sources.list.d/ubuntu.sources',
+        ]
+        password = 'somesecretpassword'
+        for file in files_to_check:
+            self.assertFileNotHasContent(file, password)
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The configuration of apt was not being obfuscated if any of the URLs had a password; one example was the proxy. There is also a new format for the deb sources, so ensuring that would be obfuscated in the same way. Add some tests to ensure that this is always being obfuscated.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
