### PR TITLE
[kea] New plugin for kea dhcp/ddns server

### DIFF
--- a/sos/report/plugins/kea.py
+++ b/sos/report/plugins/kea.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2024 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, IndependentPlugin)
+
+
+class Kea(Plugin, IndependentPlugin):
+    """
+    Kea is the next generation of DHCP software, developed by Internet
+    Systems Consortium (ISC). It supports both the DHCPv4 and DHCPv6 protocols
+    along with their extensions, e.g. prefix delegation and dynamic updates to
+    DNS.
+    """
+    short_desc = 'Kea DHCP and DDNS server from ISC'
+
+    plugin_name = "kea"
+    packages = ("kea", "kea-common",)
+    services = ('kea-ctrl-agent', 'kea-dhcp-ddns-server',
+                'kea-dhcp4-server', 'kea-dhcp6-server',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/kea/*",
+        ])
+        self.add_cmd_output([
+            "keactrl status",
+        ])
+
+    def postproc(self):
+        """ format is "password": "kea", """
+        self.do_path_regex_sub(
+            '/etc/kea/*',
+            r'(^\s*"password":\s*)(".*"),',
+            r'\1********'
+        )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This plugin captures config files and status of
the Kea DHCPv4/DHCPv6 and DDNS server by ISC.

Related:  RHEL-40285

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
