### PR TITLE
[global][utilities] Move the chdir after the runas

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -231,12 +231,12 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
     def _child_prep_fn():
         if chroot and chroot != '/':
             os.chroot(chroot)
-        if (chdir):
-            os.chdir(chdir)
         if runas:
             os.setgid(pwd.getpwnam(runas).pw_gid)
             os.setuid(pwd.getpwnam(runas).pw_uid)
             os.chdir(pwd.getpwnam(runas).pw_dir)
+        if (chdir):
+            os.chdir(chdir)
 
     def _check_poller(proc):
         if poller() or proc.poll() == 124:


### PR DESCRIPTION
If the chdir would have been set as well as runas, the chdir would not have taken effect, so updating to reflect the correct behaviour

Related: #3648 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
