### PR TITLE
[kernel] Print human-readable timestamps with dmesg command in kernel

### DIFF
--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -75,7 +75,7 @@ class Kernel(Plugin, IndependentPlugin):
             self.add_cmd_output(f"find {' '.join(extra_mod_paths)} -ls")
 
         self.add_cmd_output([
-            "dmesg",
+            "dmesg -T",
             "dkms status"
         ], cmd_as_tag=True)
         self.add_cmd_output("sysctl -a", tags="sysctl")


### PR DESCRIPTION
plugin

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X ] Is the subject and message clear and concise?
- [X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
