### PR TITLE
[kernel] Add plain 'dmesg' command to plugin

### DIFF
--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -75,6 +75,7 @@ class Kernel(Plugin, IndependentPlugin):
             self.add_cmd_output(f"find {' '.join(extra_mod_paths)} -ls")
 
         self.add_cmd_output([
+            "dmesg",
             "dmesg -T",
             "dkms status"
         ], cmd_as_tag=True)


### PR DESCRIPTION
PR #3657 added human readable timestamps to the dmesg command, but the command can be unreliable. This PR adds the plain 'dmesg' command capture again, to make sure that we still have an output with reliable
timestamps that can be easily converted to human readable in these cases where 'dmesg -T' could not be trusted.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
