### PR TITLE
[linting] Fix linting issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,21 +59,18 @@ flake8_task:
     alias: "flake8_test"
     name: "Flake8 linting test"
     container:
-        image: alpine/flake8:latest
-    setup_script: |
-        apk update
-        apk add --upgrade py3-tox
+        image: "python:latest"
+    setup_script: &tox-lint-setup |
+        apt update
+        apt -y install tox
     flake_script: tox -e flake8
 
 pylint_task:
     alias: "pylint_test"
     name: "pylint linting test"
-    allow_failures: true
     container:
         image: "python:latest"
-    setup_script: |
-        apt update
-        apt -y install tox
+    setup_script: *tox-lint-setup
     pylint_script: tox -e pylint
 
 # Run a check on newer upstream python versions to check for possible

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -455,7 +455,7 @@ support representative.
         try:
             if self.get_upload_url().startswith(RH_API_HOST):
                 self.upload_url = self.check_file_too_big(archive)
-            uploaded = super(RHELPolicy, self).upload_archive(archive)
+            uploaded = super().upload_archive(archive)
         except Exception as e:
             uploaded = False
             if not self.upload_url.startswith(RH_API_HOST):


### PR DESCRIPTION
Update the super() lint isuse that crept in while linitng work was being done

Generalise the linting to use python:latest rather than alpine image

Enfore pylint now, as that will catch stuff with all the disabled plugins

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
