### PR TITLE
[Plugin] Standardize directory listings with new method

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2011,6 +2011,45 @@ class Plugin():
         else:
             self.log_skipped_cmd(soscmd.cmd, pred, changes=soscmd.changes)
 
+    def add_dir_listing(self, paths, tree=False, recursive=False, chroot=True,
+                        env=None, sizelimit=None, pred=None, subdir=None,
+                        tags=[], runas=None, container=None,
+                        suggest_filename=None):
+        """
+        Used as a way to standardize our collections of directory listings,
+        either as an output of `ls` or `tree` depending on if the `tree`
+        parameter is set to `True`.
+
+        This is ultimately a wrapper around `add_cmd_output()` and supports
+        several, but not all, of the options for that method.
+
+        :param paths:   The path(s) to collect a listing for
+        :type paths:     ``str`` or a ``list`` of ``str``s
+
+        :param tree:    Collect output with `tree` instead of `ls`
+        :type tree:     ``bool`` (default: False)
+
+        :param recursive:   Recursively list directory contents with `ls`
+        :type recursive:    ``bool`` (default: False)
+        """
+        if isinstance(paths, str):
+            paths = [paths]
+
+        paths = [p for p in paths if self.path_exists(p)]
+
+        if not tree:
+            options = f"alhZ{'R' if recursive else ''}"
+        else:
+            options = 'lhp'
+
+        for path in paths:
+            self.add_cmd_output(
+                f"{'tree' if tree else 'ls'} -{options} {path}",
+                chroot=chroot, env=env, sizelimit=sizelimit, pred=pred,
+                subdir=subdir, tags=tags, container=container, runas=runas,
+                suggest_filename=suggest_filename
+            )
+
     def add_cmd_output(self, cmds, suggest_filename=None,
                        root_symlink=None, timeout=None, stderr=True,
                        chroot=True, runat=None, env=None, binary=False,

--- a/sos/report/plugins/aap_controller.py
+++ b/sos/report/plugins/aap_controller.py
@@ -56,12 +56,15 @@ class AAPControllerPlugin(Plugin, RedHatPlugin):
             "/var/lib/awx/venv/awx/bin/pip freeze -l",
             "/var/lib/awx/venv/ansible/bin/pip freeze",
             "/var/lib/awx/venv/ansible/bin/pip freeze -l",
-            "tree -d /var/lib/awx",
-            "ls -ll /var/lib/awx",
-            "ls -ll /var/lib/awx/venv",
-            "ls -ll /etc/tower",
             "umask -p",
         ])
+
+        self.add_dir_listing([
+            '/var/lib/awx',
+            '/var/lib/awx/venv',
+            '/etc/tower',
+        ])
+        self.add_dir_listing('/var/lib/awx', tree=True)
 
     def postproc(self):
         # remove database password

--- a/sos/report/plugins/aap_eda.py
+++ b/sos/report/plugins/aap_eda.py
@@ -35,11 +35,11 @@ class AAPEDAControllerPlugin(Plugin, RedHatPlugin):
             "/etc/ansible-automation-platform/eda/server.key",
         ])
 
-        self.add_cmd_output([
-            "aap-eda-manage --version",  # eda version
-            "ls -alhR /etc/ansible-automation-platform/",
-            "ls -alhR /var/log/ansible-automation-platform/",
-        ])
+        self.add_cmd_output("aap-eda-manage --version")
+        self.add_dir_listing([
+            "/etc/ansible-automation-platform/",
+            "/var/log/ansible-automation-platform/",
+        ], recursive=True)
 
         self.add_cmd_output("su - eda -c 'export'",
                             suggest_filename="eda_export")

--- a/sos/report/plugins/aap_gateway.py
+++ b/sos/report/plugins/aap_gateway.py
@@ -35,11 +35,9 @@ class AAPGatewayPlugin(Plugin, RedHatPlugin):
             "/etc/ansible-automation-platform/gateway/*.cert",
         ])
 
-        self.add_cmd_output([
-            "aap-gateway-manage list_services",
-            "ls -ll /etc/ansible-automation-platform/",
-            "ls -ll /etc/ansible-automation-platform/gateway/",
-        ])
+        self.add_cmd_output("aap-gateway-manage list_services")
+        self.add_dir_listing("/etc/ansible-automation-platform/",
+                             recursive=True)
 
     def postproc(self):
         # remove database password

--- a/sos/report/plugins/aap_hub.py
+++ b/sos/report/plugins/aap_hub.py
@@ -29,9 +29,9 @@ class AAPAutomationHub(Plugin, RedHatPlugin):
 
         ])
 
-        self.add_cmd_output([
-            "ls -alhR /etc/ansible-automation-platform/",
-            "ls -alhR /var/log/ansible-automation-platform/",
-        ])
+        self.add_dir_listing([
+            "/etc/ansible-automation-platform/",
+            "/var/log/ansible-automation-platform/",
+        ], recursive=True)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/aap_receptor.py
+++ b/sos/report/plugins/aap_receptor.py
@@ -40,10 +40,10 @@ class AAPreceptorPlugin(Plugin, RedHatPlugin):
             "/etc/receptor/*key.pem"
         ])
 
-        self.add_cmd_output([
-            "ls -llZ /etc/receptor",
-            "ls -llZ /var/run/receptor",
-            "ls -llZ /var/run/awx-receptor"
+        self.add_dir_listing([
+            "/etc/receptor",
+            "/var/run/receptor",
+            "/var/run/awx-receptor"
         ])
 
         for s in glob.glob('/var/run/*receptor/*.sock'):

--- a/sos/report/plugins/apparmor.py
+++ b/sos/report/plugins/apparmor.py
@@ -29,10 +29,11 @@ class Apparmor(Plugin, UbuntuPlugin):
             "/etc/apparmor.d/abstractions"
         ])
 
-        self.add_cmd_output([
-            "apparmor_status",
-            "ls -alh /etc/apparmor.d/abstractions",
-            "ls -alh /etc/apparmor.d/libvirt",
+        self.add_cmd_output("apparmor_status")
+
+        self.add_dir_listing([
+            '/etc/apparmor.d/abstractions',
+            '/etc/apparmor.d/libvirt'
         ])
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/apport.py
+++ b/sos/report/plugins/apport.py
@@ -33,7 +33,7 @@ class Apport(Plugin, DebianPlugin, UbuntuPlugin):
             "gdbus call -y -d com.ubuntu.WhoopsiePreferences \
             -o /com/ubuntu/WhoopsiePreferences \
             -m com.ubuntu.WhoopsiePreferences.GetIdentifier")
-        self.add_cmd_output("ls -alhR /var/crash/")
+        self.add_dir_listing('/var/crash', recursive=True)
         self.add_cmd_output("bash -c 'grep -B 50 -m 1 ProcMaps /var/crash/*'")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -25,15 +25,16 @@ class Block(Plugin, IndependentPlugin):
             '/sys/block/.*/queue/scheduler': 'scheduler'
         })
 
+        self.add_dir_listing('/dev', tags=['ls_dev'], recursive=True)
+        self.add_dir_listing('/sys/block', recursive=True)
+
         self.add_cmd_output("blkid -c /dev/null", tags="blkid")
-        self.add_cmd_output("ls -lanR /dev", tags="ls_dev")
         self.add_cmd_output("lsblk", tags="lsblk")
         self.add_cmd_output("lsblk -O -P", tags="lsblk_pairs")
         self.add_cmd_output([
             "lsblk -t",
             "lsblk -D",
             "blockdev --report",
-            "ls -lanR /sys/block",
             "losetup -a",
         ])
 

--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -33,16 +33,17 @@ class Boot(Plugin, IndependentPlugin):
             "/boot/yaboot.conf"
         ])
 
-        self.add_cmd_output("ls -lanR /boot", tags="ls_boot")
-        self.add_cmd_output("ls -lanR /sys/firmware",
-                            tags="ls_sys_firmware")
+        self.add_dir_listing('/boot', tags=['ls_boot'], recursive=True)
+        self.add_dir_listing('/sys/firmware/', tags=['ls_sys_firmware'],
+                             recursive=True)
+        self.add_dir_listing(['/initrd.img', '/boot/initrd.img'])
+
         self.add_cmd_output("lsinitrd", tags="lsinitrd")
         self.add_cmd_output("mokutil --sb-state",
                             tags="mokutil_sbstate")
 
         self.add_cmd_output([
             "efibootmgr -v",
-            "ls -l /initrd.img /boot/initrd.img",
             "lsinitramfs -l /initrd.img",
             "lsinitramfs -l /boot/initrd.img"
         ])

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -46,9 +46,10 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
         ])
 
         self.add_cmd_output([
-            "ls -alhR /etc/cni",
             "crio config"
         ])
+
+        self.add_dir_listing('/etc/cni', recursive=True)
 
         # base cri-o installation does not require cri-tools, which is what
         # supplies the crictl utility

--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -44,7 +44,7 @@ class Docker(Plugin, CosPlugin):
         ])
 
         self.add_journal(units="docker")
-        self.add_cmd_output("ls -alhR /etc/docker")
+        self.add_dir_listing('/etc/docker', recursive=True)
 
         self.set_cmd_predicate(SoSPredicate(self, services=["docker"]))
 

--- a/sos/report/plugins/docker_distribution.py
+++ b/sos/report/plugins/docker_distribution.py
@@ -25,7 +25,7 @@ class DockerDistribution(Plugin):
                 for line in file:
                     if 'rootdirectory' in line:
                         loc = line.split()[1]
-                        self.add_cmd_output('tree ' + loc)
+                        self.add_dir_listing(loc, tree=True)
 
 
 class RedHatDockerDistribution(DockerDistribution, RedHatPlugin):

--- a/sos/report/plugins/ds.py
+++ b/sos/report/plugins/ds.py
@@ -77,7 +77,7 @@ class DirectoryServer(Plugin, RedHatPlugin):
                 "/opt/redhat-ds/slapd-*/logs"
             ])
 
-        self.add_cmd_output("ls -l /var/lib/dirsrv/slapd-*/db/*")
+        self.add_dir_listing("/var/lib/dirsrv/slapd-*/db/*")
 
     def postproc(self):
         # Example for scrubbing rootpw hash

--- a/sos/report/plugins/etcd.py
+++ b/sos/report/plugins/etcd.py
@@ -51,7 +51,8 @@ class Etcd(Plugin, RedHatPlugin):
             '/etc/etcd/*.key'
         ])
 
-        self.add_cmd_output('ls -lR /var/lib/etcd/', container=etcd_con)
+        self.add_dir_listing('/var/lib/etcd/', container=etcd_con,
+                             recursive=True)
         self.add_copy_spec('/etc/etcd', container=etcd_con)
 
         subcmds = [

--- a/sos/report/plugins/filesys.py
+++ b/sos/report/plugins/filesys.py
@@ -108,6 +108,6 @@ class RedHatFilesys(Filesys, RedHatPlugin):
 
     def setup(self):
         super().setup()
-        self.add_cmd_output("ls -ltradZ /tmp")
+        self.add_cmd_output('ls -ldZ /tmp')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -127,12 +127,16 @@ class Foreman(Plugin):
             'passenger-status --show requests',
             'passenger-status --show backtraces',
             'passenger-memory-stats',
-            'ls -lanR /root/ssl-build',
-            'ls -lanR /usr/share/foreman/config/hooks',
             f'ping -c1 -W1 {_hostname}',
             f'ping -c1 -W1 {_host_f}',
             'ping -c1 -W1 localhost'
         ])
+
+        self.add_dir_listing([
+            '/root/ssl-build',
+            '/usr/share/foreman/config/hooks'
+        ], recursive=True)
+
         self.add_cmd_output(
             'qpid-stat -b amqps://localhost:5671 -q \
                     --ssl-certificate=/etc/pki/katello/qpid_router_client.crt \

--- a/sos/report/plugins/grub2.py
+++ b/sos/report/plugins/grub2.py
@@ -39,7 +39,6 @@ class Grub2(Plugin, IndependentPlugin):
             "/etc/grub2-efi.cfg"
         ])
 
-        self.add_cmd_output("ls -lanR /boot", tags="ls_boot")
         # call grub2-mkconfig with GRUB_DISABLE_OS_PROBER=true to prevent
         # possible unwanted loading of some kernel modules
         # further, check if the command supports --no-grubenv-update option

--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -52,8 +52,8 @@ class RedHatInsights(Plugin, RedHatPlugin):
             timeout=30
         )
 
-        for _dir in ["/etc/rhsm", "/sys/kernel", "/var/lib/sss"]:
-            self.add_cmd_output(f"/bin/ls -lanR {_dir}", cmd_as_tag=True)
+        self.add_dir_listing(["/etc/rhsm", "/sys/kernel", "/var/lib/sss"],
+                             recursive=True)
 
     def postproc(self):
         for conf in self.config_and_status:

--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -164,7 +164,6 @@ class Ipa(Plugin, RedHatPlugin):
         ])
 
         self.add_cmd_output([
-            "ls -la /etc/dirsrv/slapd-*/schema/",
             "certutil -L -d /etc/httpd/alias/",
             "pki-server cert-find --show-all",
             "pki-server subsystem-cert-validate ca",
@@ -172,6 +171,8 @@ class Ipa(Plugin, RedHatPlugin):
             "klist -ket /etc/httpd/conf/ipa.keytab",
             "klist -ket /var/lib/ipa/gssproxy/http.keytab"
         ])
+
+        self.add_dir_listing("/etc/dirsrv/slapd-*/schema/")
 
         getcert_pred = SoSPredicate(self,
                                     services=['certmonger'])

--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -33,10 +33,10 @@ class Juju(Plugin, UbuntuPlugin):
         self.add_copy_spec("/var/lib/juju/agents/*/agent.conf")
 
         # Get a directory listing of /var/log/juju and /var/lib/juju
-        self.add_cmd_output([
-            "ls -alRh /var/log/juju*",
-            "ls -alRh /var/lib/juju*"
-        ])
+        self.add_dir_listing([
+            '/var/log/juju*',
+            '/var/lib/juju*'
+        ], recursive=True)
 
         if self.get_option("all_logs"):
             # /var/lib/juju used to be in the default capture moving here

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -94,7 +94,7 @@ class RedHatKDump(KDump, RedHatPlugin):
             # set no filesystem and default path
             path = "/var/crash"
 
-        self.add_cmd_output(f"ls -alhR {path}")
+        self.add_dir_listing(path, recursive=True)
         self.add_copy_spec(f"{path}/*/vmcore-dmesg.txt")
         self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
 
@@ -131,7 +131,7 @@ class CosKDump(KDump, CosPlugin):
 
     def setup(self):
         super().setup()
-        self.add_cmd_output('ls -alRh /var/kdump*')
+        self.add_dir_listing('/var/kdump*', recursive=True)
         if self.get_option("collect-kdumps"):
             self.add_copy_spec(["/var/kdump-*"])
 
@@ -172,7 +172,7 @@ class AzureKDump(KDump, AzurePlugin):
             # set no filesystem and default path
             path = "/var/crash"
 
-        self.add_cmd_output(f"ls -alhR {path}")
+        self.add_dir_listing(path, recursive=True)
         self.add_copy_spec(f"{path}/*/vmcore-dmesg.txt")
         self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
 

--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -51,7 +51,7 @@ class Kernel(Plugin, IndependentPlugin):
         # compat
         self.add_cmd_output("uname -a", root_symlink="uname", tags="uname")
         self.add_cmd_output("lsmod", root_symlink="lsmod", tags="lsmod")
-        self.add_cmd_output("ls -lt /sys/kernel/slab")
+        self.add_dir_listing('/sys/kernel/slab')
 
         try:
             modules = self.listdir(self.sys_module)

--- a/sos/report/plugins/libraries.py
+++ b/sos/report/plugins/libraries.py
@@ -44,7 +44,9 @@ class Libraries(Plugin, IndependentPlugin):
                 dirs.add(fqlib[1].rsplit('/', 1)[0])
 
             if dirs:
-                self.add_cmd_output(f"ls -lanH {' '.join(dirs)}",
-                                    suggest_filename="ld_so_cache")
+                self.add_dir_listing(
+                    f"{' '.join(dirs)}",
+                    suggest_filename='ld_so_cache'
+                )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -74,7 +74,7 @@ class Libvirt(Plugin, IndependentPlugin):
         if self.path_exists(self.path_join(libvirt_keytab)):
             self.add_cmd_output(f"klist -ket {libvirt_keytab}")
 
-        self.add_cmd_output("ls -lR /var/lib/libvirt/qemu")
+        self.add_dir_listing("/var/lib/libvirt/qemu", recursive=True)
 
         # get details of processes of KVM hosts
         for pidfile in glob.glob("/run/libvirt/*/*.pid"):

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -54,7 +54,7 @@ class LogsBase(Plugin):
         ])
 
         self.add_cmd_output("journalctl --disk-usage")
-        self.add_cmd_output('ls -alRh /var/log/')
+        self.add_dir_listing('/var/log', recursive=True)
 
         # collect journal logs if:
         # - there is some data present, either persistent or runtime only

--- a/sos/report/plugins/mssql.py
+++ b/sos/report/plugins/mssql.py
@@ -66,7 +66,7 @@ class MsSQL(Plugin, RedHatPlugin):
                       f' but not found in {kerberoskeytabfile}')
         if kerberoskeytabfile is not None:
             if self.path_isfile(kerberoskeytabfile):
-                self.add_cmd_output(f'ls -l {kerberoskeytabfile}')
+                self.add_dir_listing(kerberoskeytabfile)
                 self.add_cmd_output(f'klist -e -k {kerberoskeytabfile}')
             else:
                 self._log_error(keytab_err)

--- a/sos/report/plugins/openstack_ironic.py
+++ b/sos/report/plugins/openstack_ironic.py
@@ -71,8 +71,10 @@ class OpenStackIronic(Plugin):
             for path in ['/var/lib/ironic', '/httpboot', '/tftpboot',
                          self.ins_puppet_gen + '/var/lib/httpboot/',
                          self.ins_puppet_gen + '/var/lib/tftpboot/']:
-                self.add_cmd_output(f'ls -laRt {path}')
-                self.add_cmd_output(f'ls -laRt {self.var_puppet_gen + path}')
+                self.add_dir_listing([
+                    path,
+                    f"{self.var_puppet_gen}{path}"
+                ], recursive=True)
 
             # Let's get the packages from the containers, always helpful when
             # troubleshooting.
@@ -108,8 +110,8 @@ class OpenStackIronic(Plugin):
                     "/var/log/ironic-inspector/*.log",
                 ])
 
-            for path in ['/var/lib/ironic', '/httpboot', '/tftpboot']:
-                self.add_cmd_output(f'ls -laRt {path}')
+            self.add_dir_listing(['/var/lib/ironic', '/httpboot', '/tftpboot'],
+                                 recursive=True)
 
         self.add_file_tags({
             ".*/etc/ironic/ironic.conf": "ironic_conf"

--- a/sos/report/plugins/openstack_neutron.py
+++ b/sos/report/plugins/openstack_neutron.py
@@ -42,7 +42,7 @@ class OpenStackNeutron(Plugin):
         # rather take a list of files in the dir only
         self.add_copy_spec("/var/lib/neutron/")
         self.add_forbidden_path("/var/lib/neutron/lock")
-        self.add_cmd_output("ls -laZR /var/lib/neutron/lock")
+        self.add_dir_listing('/var/lib/neutron/lock', recursive=True)
 
         if self.path_exists(self.var_puppet_gen):
             ml2_pre = self.var_puppet_gen

--- a/sos/report/plugins/opensvc.py
+++ b/sos/report/plugins/opensvc.py
@@ -49,7 +49,6 @@ class Opensvc(Plugin, IndependentPlugin):
             "/var/lib/opensvc/vol/*",
         ])
         self.add_cmd_output([
-            "ls -laRt /var/lib/opensvc",
             "om pool status --verbose --color=no",
             "om net status --verbose --color=no",
             "om mon --color=no",
@@ -57,6 +56,7 @@ class Opensvc(Plugin, IndependentPlugin):
             "om daemon relay status --color=no",
             "om daemon status --format flat_json --color=no"
         ])
+        self.add_dir_listing('/var/lib/opensvc', recursive=True)
         self.get_status('vol')
         self.get_status('svc')
 

--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -73,12 +73,14 @@ class OpenVSwitch(Plugin):
                 "openvswitch_server_log"
         })
 
+        self.add_dir_listing([
+            '/run/openvswitch',
+            '/dev/hugepages/',
+            '/dev/vfio',
+            '/var/lib/vhost_sockets',
+        ])
+
         self.add_cmd_output([
-            # List the contents of important runtime directories
-            "ls -laZ /run/openvswitch",
-            "ls -laZ /dev/hugepages/",
-            "ls -laZ /dev/vfio",
-            "ls -laZ /var/lib/vhost_sockets",
             # List devices and their drivers
             "dpdk_nic_bind --status",
             "dpdk-devbind.py --status",

--- a/sos/report/plugins/ovirt.py
+++ b/sos/report/plugins/ovirt.py
@@ -86,7 +86,7 @@ class Ovirt(Plugin, RedHatPlugin):
 
         if not self.get_option('heapdump'):
             self.add_forbidden_path('/var/log/ovirt-engine/dump')
-            self.add_cmd_output('ls -l /var/log/ovirt-engine/dump/')
+            self.add_dir_listing('/var/log/ovirt-engine/dump/')
 
         certificates = [
             '/etc/pki/ovirt-engine/ca.pem',

--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -209,8 +209,8 @@ class OVNCentral(Plugin):
                 dbfilepath = self.path_join(path, dbfile)
                 if self.path_exists(dbfilepath):
                     self.add_copy_spec(dbfilepath)
-                    self.add_cmd_output(
-                        f"ls -lan {dbfilepath}", foreground=True)
+                    self.add_dir_listing(dbfilepath)
+
             if ovs_dbdir:
                 self.add_copy_spec(self.path_join(ovs_dbdir, dbfile))
 

--- a/sos/report/plugins/pam.py
+++ b/sos/report/plugins/pam.py
@@ -30,10 +30,11 @@ class Pam(Plugin):
             "/etc/security"
         ])
         self.add_cmd_output([
-            f"ls -lanF {self.security_libs}",
             "pam_tally2",
             "faillock"
         ])
+
+        self.add_dir_listing(self.security_libs)
 
 
 class RedHatPam(Pam, RedHatPlugin):

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -79,10 +79,10 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
         if self.get_option('size'):
             self.add_cmd_output('podman ps -as', priority=100)
 
-        self.add_cmd_output([
-            "ls -alhR /etc/cni",
-            "ls -alhR /etc/containers"
-        ])
+        self.add_dir_listing([
+            '/etc/cni',
+            '/etc/containers'
+        ], recursive=True)
 
         pnets = self.collect_cmd_output('podman network ls',
                                         tags='podman_list_networks')

--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -121,8 +121,6 @@ class PowerPC(Plugin, IndependentPlugin):
             self.add_cmd_output([
                 "opal-prd --expert-mode run nvdimm_info"
             ])
-            if self.path_isdir("/var/log/dump"):
-                self.add_cmd_output("ls -l /var/log/dump")
-
+            self.add_dir_listing('/var/log/dump')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -100,7 +100,7 @@ class PulpCore(Plugin, IndependentPlugin):
                         "DJANGO_SETTINGS_MODULE": "pulpcore.app.settings"}
         self.add_cmd_output("dynaconf list", env=dynaconf_env)
         for _dir in [self.staticroot, self.uploaddir]:
-            self.add_cmd_output(f"ls -l {_dir}")
+            self.add_dir_listing(_dir)
 
         task_days = self.get_option('task-days')
         for table in ['core_task', 'core_taskgroup',

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -47,9 +47,12 @@ class Puppet(Plugin, IndependentPlugin):
         self.add_cmd_output([
             'facter',
             'puppet --version',
-            'ls -lanR /etc/puppet/modules',
-            'ls -lanR /etc/puppetlabs/code/modules'
         ])
+
+        self.add_dir_listing([
+            '/etc/puppet/modules',
+            '/etc/puppetlabs/code/modules'
+        ], recursive=True)
 
     def postproc(self):
         for device_conf in glob("/etc/puppet/device.conf*"):

--- a/sos/report/plugins/qpid.py
+++ b/sos/report/plugins/qpid.py
@@ -60,8 +60,9 @@ class Qpid(Plugin, RedHatPlugin):
             "qpid-route route list" + options,
             "qpid-cluster" + options,  # applies to pre-0.22 versions
             "qpid-ha query" + options,  # applies since 0.22 version
-            "ls -lanR /var/lib/qpidd"
         ])
+
+        self.add_dir_listing('/var/lib/qpidd', recursive=True)
 
         self.add_copy_spec([
             "/etc/qpidd.conf",  # applies to pre-0.22 versions

--- a/sos/report/plugins/rhui.py
+++ b/sos/report/plugins/rhui.py
@@ -39,8 +39,9 @@ class Rhui(Plugin, RedHatPlugin):
         self.add_cmd_output([
             "rhui-manager status",
             "rhui-manager cert info",
-            "ls -lR /var/lib/rhui/remote_share",
         ], timeout=60, env={'PYTHONUNBUFFERED': '1'})
+
+        self.add_dir_listing('/var/lib/rhui/remote_share', recursive=True)
 
     def postproc(self):
         # hide rhui_manager_password value in (also rotated) answers file

--- a/sos/report/plugins/rpm.py
+++ b/sos/report/plugins/rpm.py
@@ -27,7 +27,7 @@ class Rpm(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec("/var/log/rpmpkgs")
-        self.add_cmd_output("ls -lanR /var/lib/rpm")
+        self.add_dir_listing('/var/lib/rpm', recursive=True)
 
         if self.get_option("rpmq"):
             rpmq = "rpm --nodigest -qa --qf=%s"

--- a/sos/report/plugins/services.py
+++ b/sos/report/plugins/services.py
@@ -30,10 +30,9 @@ class Services(Plugin):
         ])
         if self.get_option('servicestatus'):
             self.add_cmd_output("service --status-all")
-        self.add_cmd_output([
-            "/sbin/runlevel",
-            "ls /var/lock/subsys"
-        ])
+        self.add_cmd_output("/sbin/runlevel")
+
+        self.add_dir_listing('/var/lock/subsys')
 
 
 class RedHatServices(Services, RedHatPlugin):

--- a/sos/report/plugins/smartcard.py
+++ b/sos/report/plugins/smartcard.py
@@ -34,13 +34,15 @@ class Smartcard(Plugin, RedHatPlugin):
         ])
         self.add_cmd_output([
             "pklogin_finder debug",
-            "ls -nl /usr/lib*/pam_pkcs11/",
             "pcsc_scan",
             "pkcs11-tool --show-info",
             "pkcs11-tool --list-mechanisms",
             "pkcs11-tool --list-slots",
             "pkcs11-tool --list-objects"
         ])
+
+        self.add_dir_listing('/usr/lib*/pam_pkcs11/')
+
         self.add_forbidden_path("/etc/pam_pkcs11/nssdb/key[3-4].db")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/snapper.py
+++ b/sos/report/plugins/snapper.py
@@ -19,9 +19,10 @@ class Snapper(Plugin, IndependentPlugin):
     def setup(self):
 
         self.add_cmd_output([
-            "ls -la /usr/lib/snapper/",
             "snapper --version",
             "snapper list"
         ])
+
+        self.add_dir_listing('/usr/lib/snapper/')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -83,7 +83,6 @@ class Ssh(Plugin, IndependentPlugin):
         # Read the home paths of users in the system and check the ~/.ssh dirs
         for user in users_data:
             home_dir = self.path_join(user.pw_dir, '.ssh')
-            if self.path_isdir(home_dir):
-                self.add_cmd_output(f"ls -laZ {home_dir}")
+            self.add_dir_listing(home_dir)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -30,9 +30,10 @@ class Systemd(Plugin, IndependentPlugin):
             '/etc/systemd/logind.conf': 'systemd_logind_conf'
         })
 
+        self.add_dir_listing('/lib/systemd', recursive=True)
+
         self.add_cmd_output([
             "journalctl --list-boots",
-            "ls -lR /lib/systemd",
             "systemctl list-dependencies",
             "systemctl list-jobs",
             "systemctl list-machines",

--- a/sos/report/plugins/tftpserver.py
+++ b/sos/report/plugins/tftpserver.py
@@ -21,8 +21,6 @@ class TftpServer(Plugin, IndependentPlugin):
     packages = ('tftp-server',)
 
     def setup(self):
-        self.add_cmd_output("ls -lanR /tftpboot")
-        self.add_cmd_output('ls -lanR /srv/tftp')
-
+        self.add_dir_listing(['/tftpboot', '/sr/tftp'], recursive=True)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/vdsm.py
+++ b/sos/report/plugins/vdsm.py
@@ -98,11 +98,14 @@ class Vdsm(Plugin, RedHatPlugin):
                 for pid in qemu_pids
                 for name in files
             ])
-        self.add_cmd_output([
-            "ls -ldZ /etc/vdsm",
-            "su vdsm -s /bin/sh -c 'tree -l /rhev/data-center'",
-            "su vdsm -s /bin/sh -c 'ls -lR /rhev/data-center'"
-        ])
+
+        self.add_dir_listing(
+            ['/etc/vdsm', '/rhev/data-center'],
+            runas='vdsm', recursive=True
+        )
+
+        self.add_dir_listing('/rhev/data-center', tree=True)
+
         self.add_cmd_output([
             f"lvm vgs -v -o +tags --config \'{LVM_CONFIG}\'",
             f"lvm lvs -v -o +tags --config \'{LVM_CONFIG}\'",

--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -47,6 +47,16 @@ class NormalSoSReport(StageOneReportTest):
             "Tag summary malformed"
         )
 
+    def test_dir_listing_works(self):
+        self.assertFileCollected('sos_commands/boot/ls_-alhZR_.boot')
+        boot_ls = self.get_name_in_archive('sos_commands/boot/ls_-alhZR_.boot')
+        with open(boot_ls, 'r') as ls_file:
+            # make sure we actually got ls output
+            ln = ls_file.readline().strip()
+            self.assertEqual(
+                ln, '/boot:', f"dir listing first line looks incorrect: {ln}"
+            )
+
     @redhat_only
     def test_version_matches_package(self):
         if not self.params.get('TESTLOCAL') == 'true':


### PR DESCRIPTION
This commit adds a new `add_dir_listing()` wrapper method to standardize the collection of directory content listings across plugins. By default this will use the `ls` command, and will use `tree` if the `tree` parameter is set to `True`.

This wrapper is not intended to replace directory listing that are handlded by other components with their own `ls` functionality (e.g. `npm ls` in the `npm` plugin). Additionally this does not replace the direct calling of `ls` when used with `Plugin.exec_cmd()` to take some action based on the output of the `ls` command.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
