### PR TITLE
[Plugin] Don't log "None" as a user with `runas`

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2004,7 +2004,7 @@ class Plugin():
         if self.test_predicate(cmd=True, pred=pred):
             self.collect_cmds.append(soscmd)
             user = ""
-            if hasattr(soscmd, "runas"):
+            if getattr(soscmd, "runas", None) is not None:
                 user = f", as the {soscmd.runas} user"
             self._log_info(f"added cmd output '{soscmd.cmd}'{user}")
         else:
@@ -3096,7 +3096,7 @@ class Plugin():
         for soscmd in self.collect_cmds:
             self._log_debug("unpacked command: " + soscmd.__str__())
             user = ""
-            if hasattr(soscmd, "runas"):
+            if getattr(soscmd, "runas", None) is not None:
                 user = f", as the {soscmd.runas} user"
             self._log_info(f"collecting output of '{soscmd.cmd}'{user}")
             self._collect_cmd_output(**soscmd.__dict__)


### PR DESCRIPTION
Stops sos from logging ", as the None user" for command collections that do not specify a `runas` user (meaning when collections run as root).

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
