### PR TITLE
[Global] Update strings to align with `sos` tooling names

### DIFF
--- a/bin/sos-collector
+++ b/bin/sos-collector
@@ -22,8 +22,9 @@ except KeyboardInterrupt:
     raise SystemExit()
 
 if __name__ == '__main__':
-    msg = ("Please note the 'sos-collector' command has been deprecated in "
-           " favor of the new 'sos' command, E.G. 'sos collect'.\n"
+    msg = ("WARNING: the 'sos-collector' command has been deprecated in "
+           " favor of the new 'sos' command, E.G. 'sos collect', and will be "
+           "removed in the upcoming sos-4.9 release.\n"
            "Redirecting to 'sos collect %s'" % (' '.join(sys.argv[1:]) or ''))
     print(msg)
     time.sleep(0.5)

--- a/bin/sosreport
+++ b/bin/sosreport
@@ -22,8 +22,9 @@ except KeyboardInterrupt:
     raise SystemExit()
 
 if __name__ == '__main__':
-    msg = ("Please note the 'sosreport' command has been deprecated in favor "
-           "of the new 'sos' command, E.G. 'sos report'.\n"
+    msg = ("WARNING: the 'sosreport' command has been deprecated in favor "
+           "of the new 'sos' command, E.G. 'sos report', and will be removed "
+           "in the upcoming sos-4.9 release.\n"
            "Redirecting to 'sos report %s'" % (' '.join(sys.argv[1:]) or ''))
     print(msg)
     time.sleep(0.5)

--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -1,6 +1,6 @@
 .TH SOS CLEAN 1 "Thu May 21 2020"
 .SH NAME
-sos clean - Obfuscate sensitive data from one or more sosreports
+sos clean - Obfuscate sensitive data from one or more sos reports
 .SH SYNOPSIS
 .B sos clean TARGET [options]
     [\-\-domains]
@@ -16,11 +16,11 @@ sos clean - Obfuscate sensitive data from one or more sosreports
 
 .SH DESCRIPTION
 \fBsos clean\fR or \fBsos mask\fR is an sos subcommand used to obfuscate sensitive information from
-previously generated sosreports that is not covered by the standard plugin-based post
+previously generated sos reports that is not covered by the standard plugin-based post
 processing executed during report generation, for example IP addresses.
 .LP
 Data obfuscated via this utility is done so consistently, meaning for example an IP address of
-192.168.1.1 in an unprocessed sosreport that gets obfuscated to, for example, 100.0.0.1, will be
+192.168.1.1 in an unprocessed sos report that gets obfuscated to, for example, 100.0.0.1, will be
 changed to 100.0.0.1 in all occurrences found in the report.
 
 Additionally, by default all such obfuscations are stored in "maps" that will be persistently
@@ -47,7 +47,7 @@ using the same compression method as the original.
 .TP
 .B \-\-domains DOMAINS
 Provide a comma-delimited list of domain names to obfuscate, in addition to those
-matching the hostname of the system that created the sosreport. Subdomains that
+matching the hostname of the system that created the sos report. Subdomains that
 match a domain given via this option will also be obfuscated.
 
 For example, if \fB\-\-domains redhat.com\fR is specified, then 'redhat.com' will

--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -1,7 +1,7 @@
 .TH SOS COLLECT 1 "April 2020"
 
 .SH NAME
-sos collect \- Collect sosreports from multiple (cluster) nodes
+sos collect \- Collect sos reports from multiple (cluster) nodes
 .SH SYNOPSIS
 .B sos collect
     [\-a|\-\-all\-options]
@@ -51,20 +51,22 @@ sos collect \- Collect sosreports from multiple (cluster) nodes
 
 .PP
 .SH DESCRIPTION
-collect is an sos subcommand to collect sosreports from multiple nodes and package
+collect is an sos subcommand to collect sos reports from multiple nodes and package
 them in a single useful tar archive. 
 
 sos collect can be run either on a workstation that has SSH key authentication setup
 for the nodes in a given cluster, or from a "primary" node in a cluster that has SSH
 keys configured for the other nodes.
 
-Some sosreport options are supported by sos-collect and are passed directly to 
-the sosreport command run on each node.
-
+Some sos report options are supported by sos-collect and are passed directly to
+the sos report command run on each node.
+.LP
+\fBNote:\fR the \fBsos-collector\fR command has been deprecated and will be removed in
+sos-4.9. Use the new \fBsos collect\fR syntax instead.
 .SH OPTIONS
 .TP
 \fB\-a\fR, \fB\-\-alloptions\fR
-Enables all sosreport options. 
+Enables all sos report options.
 
 This does NOT enable all sos collect options.
 .TP
@@ -76,7 +78,7 @@ Run in non-interactive mode. This will skip prompts for user input, with the
 exception of a prompt for the SSH password.
 .TP
 \fB\-\-all\-logs\fR
-Sosreport option. Collects all logs regardless of size. 
+Report option. Collects all logs regardless of size. 
 
 Default: no
 .TP
@@ -89,13 +91,13 @@ a specific cluster you would use \fB'-c ovirt.cluster=example_cluster'\fR.
 Available cluster options can be listed by running \fB'sos collect -l'\fR.
 .TP
 \fB\-\-chroot\fR CHROOT
-Sosreport option. Set the chroot mode. When \fB\-\-sysroot\fR is used commands default
+Report option. Set the chroot mode. When \fB\-\-sysroot\fR is used commands default
 to executing with SYSROOT as the root directory. This can be overridden by setting
 \fB\-\-chroot\fR to "always" (always chroot) or "never" (always run in the host
 namespace).
 .TP
 \fB\-\-case\-id\fR CASE_ID
-Sosreport option. Specifies a case number identifier.
+Report option. Specifies a case number identifier.
 .TP
 \fB\-\-cluster\-type\fR CLUSTER_TYPE
 When run by itself, sos collect will attempt to identify the type of cluster at play.
@@ -110,7 +112,7 @@ specified by the \fB--nodes\fR option. Note that in this scenario, regex string(
 for node names will be ignored.
 
 Example: \fBsos collect --cluster-type=kubernetes\fR will force the kubernetes profile
-to be run, and thus set sosreport options and attempt to determine a list of nodes using
+to be run, and thus set sos report options and attempt to determine a list of nodes using
 that profile. 
 .TP
 \fB\-\-container\-runtime\fR RUNTIME
@@ -119,7 +121,7 @@ to nodes with sos version 4.3 or later. This option controls the default contain
 runtime plugins will use for collections. See \fBman sos-report\fR.
 .TP
 \fB\-e\fR ENABLE_PLUGINS, \fB\-\-enable\-plugins\fR ENABLE_PLUGINS
-Sosreport option. Use this to enable a plugin that would otherwise not be run.
+Report option. Use this to enable a plugin that would otherwise not be run.
 
 This option supports providing a comma-delimited list of plugins.
 .TP
@@ -186,7 +188,7 @@ Specify the number of concurrent node collections that should be run.
 
 If the number of nodes enumerated exceeds the number of JOBS, then sos collect
 will start collecting from the first X number of nodes and then continue to iterate
-through the remaining nodes as sosreport collection finishes.
+through the remaining nodes as sos report collection finishes.
 
 Defaults to 4.
 .TP
@@ -195,17 +197,17 @@ Use this option when connecting as a non-root user that has passwordless sudo
 configured.
 
 If this option is omitted and a bogus sudo password is supplied, collection of
-sosreports may exhibit unexpected behavior and/or fail entirely.
+sos reports may exhibit unexpected behavior and/or fail entirely.
 .TP
 \fB\-k\fR PLUGIN_OPTION, \fB\-\-plugin\-option\fR PLUGIN_OPTION
-Sosreport option. Set a plugin option to a particular value. This takes the form of
+Report option. Set a plugin option to a particular value. This takes the form of
 plugin_name.option_name=value.
 
-Example: To enable the kubernetes "all" option in sosreport use \fB-k kubernetes.all=on\fR.
+Example: To enable the kubernetes "all" option in sos report use \fB-k kubernetes.all=on\fR.
 .TP
 \fB\-\-label\fR LABEL
 Specify a label to be added to the archive names. This label will be applied to
-both the sos collect archive and the sosreport archives.
+both the sos collect archive and the sos report archives.
 
 If a cluster sets a default label, the user-provided label will be appended to
 that cluster default.
@@ -223,13 +225,13 @@ size of the final sos report tarball and the memory usage of sos during collecti
 of commands, such as very large journals that may be several GiB in size.
 .TP
 \fB\-n\fR SKIP_PLUGINS, \fB\-\-skip\-plugins\fR SKIP_PLUGINS
-Sosreport option. Disable (skip) a particular plugin that would otherwise run.
+Report option. Disable (skip) a particular plugin that would otherwise run.
 This is useful if a particular plugin is prone to hanging for one reason or another.
 
 This option supports providing a comma-delimited list of plugins.
 .TP
 \fB\-\-nodes\fR NODES
-Provide a comma-delimited list of nodes to collect sosreports from, or a regex string to
+Provide a comma-delimited list of nodes to collect sos reports from, or a regex string to
 be used to compare discovered node names against. If using a regex, only nodes matching the regex
 will be used - i.e. it can be used as a whitelist but not a blacklist.
 
@@ -243,10 +245,10 @@ if the cluster profile should be applied or not.
 Use this with \fB\-\-cluster-type\fR if there are rpm or apt issues on the primary/local node.
 .TP
 \fB\-\-no\-local\fR
-Do not collect a sosreport from the local system. 
+Do not collect a sos report from the local system. 
 
-If \fB--primary\fR is not supplied, it is assumed that the host running sosreport is part of
-the cluster that is to be collected. Use this option to skip collection of a local sosreport.
+If \fB--primary\fR is not supplied, it is assumed that the host running sos report is part of
+the cluster that is to be collected. Use this option to skip collection of a local sos report.
 
 This option is NOT needed if \fB--primary\fR is provided.
 .TP
@@ -288,9 +290,9 @@ Note that this file must exist on the node(s) performing the pull operations, no
 node from which \fBsos collect\fR was run.
 .TP
 \fB\-o\fR ONLY_PLUGINS, \fB\-\-only\-plugins\fR ONLY_PLUGINS
-Sosreport option. Run ONLY the plugins listed.
+Report option. Run ONLY the plugins listed.
 
-Note that a cluster profile will NOT override this option. This may cause the sosreports
+Note that a cluster profile will NOT override this option. This may cause the sos reports
 generated to not contain the relevant output for a given type of cluster.
 
 This option supports providing a comma-delimited list of plugins.
@@ -304,7 +306,7 @@ ideally deploy SSH keys, but the \-\-password\-per\-node option is also availabl
 .TP
 \fB\-\-password\-per\-node\fR
 When using this option, sos collect will prompt the user for the SSH password for
-each node that will have an sosreport collected from it individually before attempting
+each node that will have an sos report collected from it individually before attempting
 to connect to the nodes.
 .TP
 \fB\-\-preset\fR PRESET
@@ -336,7 +338,7 @@ Specify an SSH user for sos collect to connect to nodes with. Default is root.
 sos collect will prompt for a sudo password for non-root users.
 .TP
 \fB\-s\fR SYSROOT, \fB\-\-sysroot\fR SYSROOT
-Sosreport option. Specify an alternate root file system path.
+Report option. Specify an alternate root file system path.
 .TP
 \fB\-t\fR THREADS \fB\-\-threads\fR THREADS
 Report option. Specify the number of collection threads to run.
@@ -347,9 +349,9 @@ during the collection process.
 Defaults to 4.
 .TP
 \fB\-\-timeout\fR TIMEOUT
-Timeout for sosreport generation on each node, in seconds.
+Timeout for sos report generation on each node, in seconds.
 
-Note that sosreports are collected in parallel, so you can approximate the total
+Note that sos reports are collected in parallel, so you can approximate the total
 runtime of sos collect via timeout*(number of nodes/jobs).
 
 Default is 180 seconds.
@@ -373,20 +375,20 @@ The types of transports supported are currently as follows:
 Specify a temporary directory to save sos archives to. By default one will be created in
 /tmp and then removed after sos collect has finished running.
 
-This is NOT the same as specifying a temporary directory for sosreport on the remote nodes.
+This is NOT the same as specifying a temporary directory for sos report on the remote nodes.
 .TP
 \fB\-v\fR \fB\-\-verbose\fR
 Print debug information to screen.
 .TP
 \fB\-\-verify\fR
-Sosreport option. Passes the "--verify" option to sosreport on the nodes which 
-causes sosreport to validate plugin-specific data during collection.
+Report option. Passes the "--verify" option to sos report on the nodes which 
+causes sos report to validate plugin-specific data during collection.
 
-Note that this option may considerably extend the time it takes sosreport to run on
+Note that this option may considerably extend the time it takes sos report to run on
 the nodes. Consider increasing \fB\-\-timeout\fR when using this option.
 .TP
 \fB\-z\fR COMPRESSION, \fB\-\-compression-type\fR COMPRESSION
-Sosreport option. Override the default compression type.
+Report option. Override the default compression type.
 
 .SH SEE ALSO
 .BR sos (1)

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -57,6 +57,9 @@ Sos is modular in design and is able to collect data from a wide
 range of subsystems and packages that may be installed. An
 HTML report summarizing the collected information is optionally
 generated and stored within the archive.
+.LP
+\fBNote:\fR the \fBsosreport\fR command has been deprecated and will be removed in
+sos-4.9. Use the new \fBsos report\fR syntax instead.
 .SH OPTIONS
 .TP
 .B \-l, \--list-plugins
@@ -260,13 +263,13 @@ See the sections on \fB--encrypt-key\fR and \fB--encrypt-pass\fR below for more
 information.
 .TP
 .B \--encrypt-key KEY
-Encrypts the resulting archive that sosreport produces using GPG. KEY must be
+Encrypts the resulting archive that sos report produces using GPG. KEY must be
 an existing key in the user's keyring as GPG does not allow for keyfiles.
 KEY can be any value accepted by gpg's 'recipient' option.
 
-Note that the user running sosreport must match the user owning the keyring
+Note that the user running sos report must match the user owning the keyring
 from which keys will be obtained. In particular this means that if sudo is
-used to run sosreport, the keyring must also be set up using sudo
+used to run sos report, the keyring must also be set up using sudo
 (or direct shell access to the account).
 
 Users should be aware that encrypting the final archive will result in sos
@@ -298,7 +301,7 @@ Labels will be appended after the system's short hostname and may contain
 alphanumeric characters.
 .TP
 .B \--threads THREADS
-Specify the number of threads sosreport will use for concurrency. Defaults to 4.
+Specify the number of threads sos report will use for concurrency. Defaults to 4.
 .TP
 .B \--plugin-timeout TIMEOUT
 Specify a timeout in seconds to allow each plugin to run for. A value of 0
@@ -360,7 +363,7 @@ Specify a case identifier to associate with the archive.
 Identifiers may include alphanumeric characters, commas and periods ('.').
 .TP
 .B \--build
-Do not archive copied data. Causes sosreport to leave an uncompressed
+Do not archive copied data. Causes sos report to leave an uncompressed
 archive as a temporary file or directory tree.
 .TP
 .B \--debug
@@ -375,7 +378,7 @@ option.
 .TP
 .B \--estimate-only
 Estimate disk space requirements when running sos report. This can be valuable
-to prevent sosreport working dir to consume all free disk space. No plugin data
+to prevent sos report working dir to consume all free disk space. No plugin data
 is available at the end.
 
 Plugins will be collected sequentially, size of collected files and commands outputs
@@ -398,7 +401,7 @@ as well. If these credentials are not provided, sos will still run and create an
 but will not attempt an automatic upload, instead relying on the end user to upload it
 as needed.
 
-The sosreport archive will still remain on the local filesystem even after a successful
+The sos report archive will still remain on the local filesystem even after a successful
 upload.
 
 Note that depending on the distribution sos is being run on, or the vendor policy detected during

--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -10,7 +10,7 @@ sos \- A unified tool for collecting system logs and other debug information
 support representatives, and the like to assist in troubleshooting issues with
 a system or group of systems.
 
-The most well known function is \fB sos report\fR or \fBsosreport\fR as it was
+The most well known function is \fB sos report\fR or \fBsos report\fR as it was
 previously known.
 
 An sos archive is typically requested by support organizations to collect baseline
@@ -31,7 +31,7 @@ services, or system architecture is detected.
 
 See \fBsos report --help\fR and \fBman sos-report\fR for more information.
 
-May also be invoked via the alias \fBrep\fR or the deprecated command \fBsosreport\fR.
+May also be invoked via the alias \fBrep\fR or the deprecated command \fBsos report\fR.
 
 .TP
 .B collect
@@ -51,9 +51,9 @@ May also be invoked via the alias \fBsos collector\fR or the deprecated command
 
 .TP
 .B clean|cleaner|mask
-This subcommand takes input of either 1) an sosreport tarball, 2) a collection
-of sosreport tarballs such as from \fBcollect\fR, or 3) the unpackaged
-directory of an sosreport and obfuscates potentially sensitive system information
+This subcommand takes input of either 1) an sos report tarball, 2) a collection
+of sos report tarballs such as from \fBcollect\fR, or 3) the unpackaged
+directory of an sos report and obfuscates potentially sensitive system information
 that is not covered by the standard postprocessing of \fBsos report\fR.
 
 Such data includes IP addresses, networks, MAC addresses, and more. Data obfuscated
@@ -103,13 +103,13 @@ See the sections on \fB--encrypt-key\fR and \fB--encrypt-pass\fR below for more
 information.
 .TP
 .B \--encrypt-key KEY
-Encrypts the resulting archive that sosreport produces using GPG. KEY must be
+Encrypts the resulting archive that sos report produces using GPG. KEY must be
 an existing key in the user's keyring as GPG does not allow for keyfiles.
 KEY can be any value accepted by gpg's 'recipient' option.
 
-Note that the user running sosreport must match the user owning the keyring
+Note that the user running sos report must match the user owning the keyring
 from which keys will be obtained. In particular this means that if sudo is
-used to run sosreport, the keyring must also be set up using sudo
+used to run sos report, the keyring must also be set up using sudo
 (or direct shell access to the account).
 
 Users should be aware that encrypting the final archive will result in sos
@@ -139,7 +139,7 @@ Specify an alternate root file system path.
 Specify alternate temporary directory to copy data during execution.
 .TP
 .B \--threads THREADS
-Specify the number of threads sosreport will use for concurrency. Defaults to 4. 
+Specify the number of threads sos report will use for concurrency. Defaults to 4. 
 .TP
 .B \-v, \--verbose
 Increase logging verbosity. May be specified multiple times to enable
@@ -165,7 +165,7 @@ Display usage message.
 .BR sos.conf (5)
 .SH MAINTAINER
 .nf
-Maintained on GitHub at https://github.com/sosreport/sos
+Maintained on GitHub at https://github.com/sos report/sos
 .fi
 .SH AUTHORS & CONTRIBUTORS
 See \fBAUTHORS\fR file in the package documentation.

--- a/man/en/sos.conf.5
+++ b/man/en/sos.conf.5
@@ -1,9 +1,9 @@
-.TH "sos.conf" "5" "SOSREPORT" "sosreport configuration file"
+.TH "sos.conf" "5" "SOS" "sos configuration file"
 .SH NAME
-sos.conf \- sosreport configuration
+sos.conf \- sos report configuration
 .SH DESCRIPTION
 .sp
-sosreport uses a configuration file at /etc/sos/sos.conf, and there are
+sos report uses a configuration file at /etc/sos/sos.conf, and there are
 subdirectories under /etc/sos that are used for specific purposes.
 
 Note that non-root users may override options set in /etc/sos/sos.conf by creating

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -13,7 +13,7 @@ from sos.cleaner.mappings.username_map import SoSUsernameMap
 
 
 class SoSUsernameParser(SoSCleanerParser):
-    """Parser for obfuscating usernames within an sosreport archive.
+    """Parser for obfuscating usernames within an sos report archive.
 
     Note that this parser does not rely on regex matching directly, like most
     other parsers do. Instead, usernames are discovered via scraping the

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -306,7 +306,7 @@ class SoSCollector(SoSComponent):
                              help='Collect logs regardless of size')
         sos_grp.add_argument('--allow-system-changes', action='store_true',
                              default=False,
-                             help=('Allow sosreport to run commands that may '
+                             help=('Allow sos report to run commands that may '
                                    'alter system state'))
         sos_grp.add_argument('--chroot', default='',
                              choices=['auto', 'always', 'never'],
@@ -315,7 +315,7 @@ class SoSCollector(SoSComponent):
                              help="Default container runtime to use for "
                                   "collections. 'auto' for policy control.")
         sos_grp.add_argument('-e', '--enable-plugins', action="extend",
-                             help='Enable specific plugins for sosreport')
+                             help='Enable specific plugins for sos report')
         sos_grp.add_argument('--journal-size', type=int, default=0,
                              help='Limit the size of journals in MiB')
         sos_grp.add_argument('-k', '--plugin-option', '--plugopts',
@@ -336,7 +336,7 @@ class SoSCollector(SoSComponent):
                                   'output for - 0 means unlimited')
         sos_grp.add_argument('--no-env-vars', action='store_true',
                              default=False,
-                             help='Do not collect env vars in sosreports')
+                             help='Do not collect env vars in sos reports')
         sos_grp.add_argument('--plugin-timeout', type=int, default=None,
                              help='Set the global plugin timeout value')
         sos_grp.add_argument('--cmd-timeout', type=int, default=None,
@@ -427,7 +427,7 @@ class SoSCollector(SoSComponent):
         collect_grp.add_argument('--ssh-user',
                                  help='Specify an SSH user. Default root')
         collect_grp.add_argument('--timeout', type=int, required=False,
-                                 help='Timeout for sosreport on each node.')
+                                 help='Timeout for sos report on each node.')
         collect_grp.add_argument('--transport', default='auto', type=str,
                                  help='Remote connection transport to use')
         collect_grp.add_argument("--upload", action="store_true",
@@ -691,7 +691,7 @@ class SoSCollector(SoSComponent):
                          '"pacemaker.offline=False"\n')
 
     def delete_tmp_dir(self):
-        """Removes the temp directory and all collected sosreports"""
+        """Removes the temp directory and all collected sos reports"""
         shutil.rmtree(self.tmpdir)
 
     def _get_archive_name(self):
@@ -713,7 +713,7 @@ class SoSCollector(SoSComponent):
 
     def _get_archive_path(self):
         """Returns the path, including filename, of the tarball we build
-        that contains the collected sosreports
+        that contains the collected sos reports
         """
         self.arc_name = self._get_archive_name()
         compr = 'gz'
@@ -766,11 +766,11 @@ class SoSCollector(SoSComponent):
 
     def write_host_group(self):
         """
-        Saves the results of this run of sos-collector to a host group file
+        Saves the results of this run of sos collect to a host group file
         on the system so it can be used later on.
 
         The host group will save the options primary, cluster_type, and nodes
-        as determined by sos-collector prior to execution of sosreports.
+        as determined by sos collect prior to execution of sos reports.
         """
         cfg = {
             'name': self.opts.save_group,
@@ -795,7 +795,7 @@ class SoSCollector(SoSComponent):
         if (not self.opts.password and not
                 self.opts.password_per_node):
             self.log_debug('password not specified, assuming SSH keys')
-            msg = ('sos-collector ASSUMES that SSH keys are installed on all '
+            msg = ('sos collect ASSUMES that SSH keys are installed on all '
                    'nodes unless the --password option is provided.\n')
             self.ui_log.info(self._fmt_msg(msg))
 
@@ -972,7 +972,7 @@ class SoSCollector(SoSComponent):
                 self.exit(repr(e), 1)
 
     def configure_sos_cmd(self):
-        """Configures the sosreport command that is run on the nodes"""
+        """Configures the sos report command that is run on the nodes"""
         sos_cmd = 'sosreport --batch '
 
         sos_options = {}
@@ -1092,7 +1092,7 @@ class SoSCollector(SoSComponent):
         return False
 
     def get_nodes(self):
-        """ Sets the list of nodes to collect sosreports from """
+        """ Sets the list of nodes to collect sos reports from """
         if not self.primary and not self.cluster:
             msg = ('Could not determine a cluster type and no list of '
                    'nodes or primary node was provided.\nAborting...'
@@ -1141,7 +1141,7 @@ class SoSCollector(SoSComponent):
 
     def _connect_to_node(self, node):
         """Try to connect to the node, and if we can add to the client list to
-        run sosreport on
+        run sos report on
 
         Positional arguments
             node - a tuple specifying (address, password). If no password, set
@@ -1180,7 +1180,7 @@ organization before being passed to any third party.
 No configuration changes will be made to the system running \
 this utility or remote systems that it connects to.
 """)
-        self.ui_log.info(f"\nsos-collector (version {__version__})\n")
+        self.ui_log.info(f"\nsos collect (version {__version__})\n")
         intro_msg = self._fmt_msg(disclaimer % self.tmpdir)
         self.ui_log.info(intro_msg)
 
@@ -1215,7 +1215,7 @@ this utility or remote systems that it connects to.
 
     def collect(self):
         """ For each node, start a collection thread and then tar all
-        collected sosreports """
+        collected sos reports """
         filters = set([self.primary.address, self.primary.hostname])
         # add primary if:
         # - we are connected to it and
@@ -1262,7 +1262,7 @@ this utility or remote systems that it connects to.
                         "Aborting...", 1
                     )
 
-            self.ui_log.info("\nBeginning collection of sosreports from "
+            self.ui_log.info("\nBeginning collection of sos reports from "
                              f"{self.report_num} nodes, collecting a maximum "
                              f"of {self.opts.jobs} concurrently\n")
 
@@ -1284,13 +1284,13 @@ this utility or remote systems that it connects to.
             files = self.cluster._run_extra_cmd()
             if files:
                 self.primary.collect_extra_cmd(files)
-        msg = '\nSuccessfully captured %s of %s sosreports'
+        msg = '\nSuccessfully captured %s of %s sos reports'
         self.log_info(msg % (self.retrieved, self.report_num))
         self.close_all_connections()
         if self.retrieved > 0:
             arc_name = self.create_cluster_archive()
         else:
-            msg = 'No sosreports were collected, nothing to archive...'
+            msg = 'No sos reports were collected, nothing to archive...'
             self.exit(msg, 1)
 
         if (self.opts.upload and self.policy.get_upload_url()) or \
@@ -1312,7 +1312,7 @@ this utility or remote systems that it connects to.
                            f"{client.address}: {err}")
 
     def _collect(self, client):
-        """Runs sosreport on each node"""
+        """Runs sos report on each node"""
         try:
             if not client.local:
                 client.sosreport()
@@ -1322,7 +1322,7 @@ this utility or remote systems that it connects to.
             if client.retrieved:
                 self.retrieved += 1
         except Exception as err:
-            self.log_error(f"Error running sosreport: {err}")
+            self.log_error(f"Error running sos report: {err}")
 
     def close_all_connections(self):
         """Close all sessions for nodes"""
@@ -1333,7 +1333,7 @@ this utility or remote systems that it connects to.
 
     def create_cluster_archive(self):
         """Calls for creation of tar archive then cleans up the temporary
-        files created by sos-collector"""
+        files created by sos collect"""
         map_file = None
         arc_paths = []
         for host in self.client_list:
@@ -1360,7 +1360,7 @@ this utility or remote systems that it connects to.
                 self.ui_log.error(f"ERROR: unable to obfuscate reports: {err}")
 
         try:
-            self.log_info('Creating archive of sosreports...')
+            self.log_info('Creating archive of sos reports...')
             for fname in arc_paths:
                 dest = fname.split('/')[-1]
                 if do_clean:

--- a/sos/collector/clusters/__init__.py
+++ b/sos/collector/clusters/__init__.py
@@ -18,7 +18,7 @@ from sos.utilities import bold
 class Cluster():
     """This is the class that cluster profiles should subclass in order to
     add support for different clustering technologies and environments to
-    sos-collector.
+    sos collect.
 
     A profile should at minimum define a package that indicates the node is
     configured for the type of cluster the profile is intended to serve and
@@ -392,7 +392,7 @@ class Cluster():
         """This may be overridden by clusters profiles subclassing this class
 
         If there is a distinction between primaries and nodes, or types of
-        nodes, then this can be used to label the sosreport archive differently
+        nodes, then this can be used to label the sos report archives as needed
         """
         return ''
 
@@ -424,7 +424,7 @@ class Cluster():
         """
         Ensures that any files returned by a cluster's run_extra_cmd()
         method are properly typed as a list for iterative collection. If any
-        of the files are an additional sosreport (e.g. the ovirt db dump) then
+        of the files are an additional sos report (e.g. the ovirt db dump) then
         the md5 sum file is automatically added to the list
         """
         files = []

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -839,7 +839,7 @@ class SosNode():
             return False
 
     def retrieve_sosreport(self):
-        """Collect the sosreport archive from the node"""
+        """Collect the sos report archive from the node"""
         if self.need_sudo or self.opts.become_root:
             try:
                 self.make_archive_readable(self.sos_path)
@@ -862,7 +862,7 @@ class SosNode():
             return False
 
     def remove_sos_archive(self):
-        """Remove the sosreport archive from the node, since we have
+        """Remove the sos report archive from the node, since we have
         collected it and it would be wasted space otherwise"""
         if self.sos_path is None or self.local:
             # local transport moves the archive rather than copies it, so there

--- a/sos/collector/transports/control_persist.py
+++ b/sos/collector/transports/control_persist.py
@@ -48,14 +48,14 @@ class SSHControlPersist(RemoteTransport):
         ControlPersist allows OpenSSH to keep a single open connection to a
         remote host rather than building a new session each time. This is the
         same feature that Ansible uses in place of paramiko, which we have a
-        need to drop in sos-collector.
+        need to drop in sos collect.
 
         This check relies on feedback from the ssh binary. The command being
         run should always generate stderr output, but depending on what that
         output reads we can determine if ControlPersist is supported or not.
 
         For our purposes, a host that does not support ControlPersist is not
-        able to run sos-collector.
+        able to run sos collect.
 
         Returns
             True if ControlPersist is supported, else raise Exception.
@@ -74,7 +74,7 @@ class SSHControlPersist(RemoteTransport):
         Using ControlPersist, create the initial connection to the node.
 
         This will generate an OpenSSH ControlPersist socket within the tmp
-        directory created or specified for sos-collector to use.
+        directory created or specified for sos collect to use.
 
         At most, we will wait 30 seconds for a connection. This involves a 15
         second wait for the initial connection attempt, and a subsequent 15

--- a/sos/collector/transports/saltstack.py
+++ b/sos/collector/transports/saltstack.py
@@ -72,7 +72,7 @@ class SaltStackMaster(RemoteTransport):
         output reads we can determine if SaltStack Master is supported or not.
 
         For our purposes, a host that does not support SaltStack Master is not
-        able to run sos-collector.
+        able to run sos collect.
 
         Returns
             True if SaltStack Master is supported, else raise Exception

--- a/sos/missing.py
+++ b/sos/missing.py
@@ -16,14 +16,14 @@ class MissingCollect(SoSComponent):
     desc = '(unavailable) Collect an sos report from multiple nodes'
     missing_msg = (
         'It appears likely that your distribution separately ships a package '
-        'called sos-collector. Please install it to enable this function'
+        'called sos collect. Please install it to enable this function'
     )
 
     def execute(self):
         sys.stderr.write(
             "The collect command is unavailable as it appears to be packaged "
             "separately for your distribution.\n\nPlease install the latest "
-            "sos-collector package to enable this functionality.\n"
+            "sos collect package to enable this functionality.\n"
         )
 
     def load_options(self):

--- a/sos/options.py
+++ b/sos/options.py
@@ -279,7 +279,7 @@ class SoSOptions():
         """Return command arguments for this object.
 
             Return a list of the non-default options of this ``SoSOptions``
-            object in ``sosreport`` command line argument notation:
+            object in ``sos report`` command line argument notation:
 
                 ``["--all-logs", "-vvv"]``
 

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -311,7 +311,7 @@ any third party.
 
     def post_work(self):
         """
-        This function is called after the sosreport has been generated.
+        This function is called after the sos report has been generated.
         """
         pass
 
@@ -441,7 +441,7 @@ any third party.
 
         if archive:
             self.ui_log.info(
-                _(f"\nYour sosreport has been generated and saved in:"
+                _(f"\nYour sos report has been generated and saved in:"
                   f"\n\t{archive}\n")
             )
             self.ui_log.info(
@@ -452,7 +452,7 @@ any third party.
             )
         else:
             self.ui_log.info(
-                _(f"Your sosreport build tree has been generated in:"
+                _(f"Your sos report build tree has been generated in:"
                   f"\n\t{directory}\n")
             )
         if checksum:

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -982,7 +982,7 @@ class LinuxPolicy(Policy):
             raise Exception(f"Failed to upload to S3: {str(e)}") from e
 
     def set_sos_prefix(self):
-        """If sosreport commands need to always be prefixed with something,
+        """If sos report commands need to always be prefixed with something,
         for example running in a specific container image, then it should be
         defined here.
 

--- a/sos/policies/init_systems/__init__.py
+++ b/sos/policies/init_systems/__init__.py
@@ -100,7 +100,7 @@ class InitSystem():
         # This is going to be primarily used in gating if service related
         # commands are going to be run or not. Default to always returning
         # True when an actual init system is not specified by policy so that
-        # we don't inadvertantly restrict sosreports on those systems
+        # we don't inadvertantly restrict sos reports on those systems
         return default
 
     def load_all_services(self):

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -444,7 +444,7 @@ class SoSReport(SoSComponent):
         ssec.add_text(helpln)
 
     def print_header(self):
-        print(f"\n{_(f'sosreport (version {__version__})')}\n")
+        print(f"\n{_(f'sos report (version {__version__})')}\n")
 
     def _get_hardware_devices(self):
         self.devices = {
@@ -1273,7 +1273,7 @@ class SoSReport(SoSComponent):
         version file"""
 
         versions = []
-        versions.append(f"sosreport: {__version__}")
+        versions.append(f"sos report: {__version__}")
 
         self.archive.add_string(content="\n".join(versions),
                                 dest='version.txt')

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -478,7 +478,7 @@ class PluginOpt():
 
 
 class Plugin():
-    """This is the base class for sosreport plugins. Plugins should subclass
+    """This is the base class for sos report plugins. Plugins should subclass
     this and set the class variables where applicable.
 
     :param commons:     A set of information that is shared internally so that
@@ -1176,7 +1176,7 @@ class Plugin():
         return self.do_cmd_output_sub(cmd, _certmatch, replace)
 
     def do_cmd_output_sub(self, cmd, regexp, subst):
-        """Apply a regexp substitution to command output archived by sosreport.
+        """Apply a regexp substitution to command output archived by sos
 
         This is used to obfuscate sensitive information captured by command
         output collection via plugins.
@@ -1259,7 +1259,7 @@ class Plugin():
             self.do_file_sub(path, _certmatch, replace)
 
     def do_file_sub(self, srcpath, regexp, subst):
-        """Apply a regexp substitution to a file archived by sosreport.
+        """Apply a regexp substitution to a file archived by sos report.
 
         :param srcpath: Path in the archive where the file can be found
         :type srcpath: ``str``

--- a/sos/report/plugins/arcconf.py
+++ b/sos/report/plugins/arcconf.py
@@ -7,15 +7,16 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-# This sosreport plugin is meant for sas adapters.
-# This plugin logs inforamtion on each adapter it finds.
-
 import re
 
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class ArcConf(Plugin, IndependentPlugin):
+    """
+    The ArcConf plugin is meant for sas adapters, and will collect logs and
+    information for each RAID adapter discovered on the system.
+    """
 
     short_desc = 'arcconf Integrated RAID adapter information'
 

--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -31,7 +31,7 @@ class Azure(Plugin, UbuntuPlugin):
             "/var/lib/AzureEnhancedMonitor"
         ])
 
-        # Adds all files under /var/log/azure to the sosreport
+        # Adds all files under /var/log/azure to the sos report
         # os.walk is used because /var/log/azure is used by multiple Azure
         # extensions and there is no standard log filename format
         limit = self.get_option("log_size")

--- a/sos/report/plugins/candlepin.py
+++ b/sos/report/plugins/candlepin.py
@@ -79,7 +79,7 @@ class Candlepin(Plugin, RedHatPlugin):
             "/var/log/candlepin/error.log[.-]*",
             # Specific to candlepin, ALL catalina logs are relevant. Adding it
             # here rather than the tomcat plugin to ease maintenance and not
-            # pollute non-candlepin sosreports that enable the tomcat plugin
+            # pollute non-candlepin sos reports that enable the tomcat plugin
             "/var/log/tomcat*/catalina*log*",
             "/var/log/tomcat*/host-manager*log*",
             "/var/log/tomcat*/localhost*log*",

--- a/sos/report/plugins/mvcli.py
+++ b/sos/report/plugins/mvcli.py
@@ -7,13 +7,14 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-# This sosreport plugin is meant for sas adapters.
-# This plugin logs inforamtion on each adapter it finds.
-
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class MvCLI(Plugin, IndependentPlugin):
+    """
+    The mvCLI plugin is meant for sas adapters, and collects information for
+    each adapter discovered on the system.
+    """
 
     short_desc = 'mvCLI Integrated RAID adapter information'
 

--- a/sos/report/plugins/mysql.py
+++ b/sos/report/plugins/mysql.py
@@ -65,7 +65,7 @@ class Mysql(Plugin):
                 dbpass = os.environ['MYSQL_PWD']
 
             if dbuser is True or dbpass is True:
-                # sosreport -a or -k mysql.{dbuser,dbpass}
+                # sos report -a or -k mysql.{dbuser,dbpass}
                 self.soslog.warning(dbdump_err)
                 return
 

--- a/sos/report/plugins/sas3ircu.py
+++ b/sos/report/plugins/sas3ircu.py
@@ -7,13 +7,15 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-# This sosreport plugin is meant for sas adapters.
-# This plugin logs inforamtion on each adapter it finds.
-
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class SAS3ircu(Plugin, IndependentPlugin):
+    """
+    The sas3ircu plugin is intended to gather information for sas adapters,
+    particularly sas-3 RAID adapters, and will collect information on each
+    adapter discovered on the system.
+    """
 
     short_desc = 'SAS-3 Integrated RAID adapter information'
 

--- a/sos/report/reporting.py
+++ b/sos/report/reporting.py
@@ -9,7 +9,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-""" This provides a restricted tag language to define the sosreport
+""" This provides a restricted tag language to define the sos report
     index/report
 """
 

--- a/tests/cleaner_tests/basic_function_tests/report_with_mask.py
+++ b/tests/cleaner_tests/basic_function_tests/report_with_mask.py
@@ -101,7 +101,7 @@ class ReportWithUserCustomisations(StageOneReportTest):
     # Policy returning '/var/tmp' as temp.dir
     def test_keyword_in_tempdir_path(self):
         self.assertOutputContains(
-            'Your sosreport has been generated and saved in:'
+            'Your sos report has been generated and saved in:'
         )
         self.assertTrue('tmp/' in self.archive)
 


### PR DESCRIPTION
This commit serves to reinforce the typing of "sos (space) report" in place of the legacy "sosreport", and similarly updates items such as "sos-collector" to "sos collect". The tool is `sos` ("ess-oh-ess"), of which `report` and `collect` are sub-commands.

The most visible change is the update to the line printed before the path to a generate sos report, which may be significant for scripts and/or automation. To be clear, this commit changes this line:

`Your sosreport has been generated and saved in:`

to

`Your sos report has been generated and saved in:`

Note that this does not change the use of `sosreport` when used as part of method names, nor does it change the *filename* of the generated archive for either `report` or `collect`.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
