### PR TITLE
[coverage] Add coverage tests with avocado and replace nosetests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,6 +73,18 @@ pylint_task:
     setup_script: *tox-lint-setup
     pylint_script: tox -e pylint
 
+coverage_task:
+    alias: "unit_coverage_test"
+    name: "unit and coverage test"
+    container:
+        image: "python:latest"
+    setup_script: *tox-lint-setup
+    coverage_script: tox -e coverage
+    prep_artefacts_script: |
+        ls -d ./cover 2> /dev/null | xargs tar cf coverage-html.tar
+    packages_artifacts:
+        path: "coverage-html.tar"
+
 # Run a check on newer upstream python versions to check for possible
 # breaks/changes in common modules. This is not meant to check any of the actual
 # collections or archive integrity.

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+concurrency = multiprocessing
+source = sos
+parallel = true

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ setenv =
     PYTHONPATH = {toxinidir}/tests:{toxinidir}
 avocado_cmd =
     avocado run -p TESTLOCAL=true --max-parallel-tasks=1
+unit_tests =
+    {toxinidir}/tests/unittests
 stage_tests =
     {toxinidir}/tests/cleaner_tests \
     {toxinidir}/tests/collect_tests \
@@ -33,7 +35,7 @@ commands = pylint -v --rcfile={toxinidir}/pylintrc {posargs:{[testenv]py_files}}
 [testenv:unit_tests]
 basepython = python3
 commands =
-    avocado run tests/unittests
+    avocado run {posargs:{[testenv]unit_tests}}
 
 [testenv:stageone_tests]
 basepython = python3
@@ -51,10 +53,17 @@ basepython = python3
 commands =
     {[testenv]avocado_cmd} -t foreman {posargs:{[testenv]foreman_tests}}
 
-[testenv:nosetests]
+[testenv:coverage]
 basepython = python3
+setenv =
+    {[testenv]setenv}
+    COVERAGE_RUN = "true"
 deps =
     {[testenv]deps}
-    nose3
+    coverage
 commands =
-    nosetests -v --with-coverage --cover-package=sos tests/unittests --cover-html
+    coverage erase
+    coverage run -m avocado run {posargs:{[testenv]unit_tests}}
+    coverage combine
+    coverage html -d cover
+    coverage report


### PR DESCRIPTION
Replacing nosetests with avocado coverage.

Adding it as a separate test for latest python also helps with testing new versions of python, which we didn't pick up in the past

There was a bug in avocado that wouldn't work and was discussed in https://github.com/avocado-framework/avocado/discussions/5610 and resolved. It is due to be back-ported to the LTS we are using, so adding this a sa draft to get it going and others to review

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
