### PR TITLE
[kubernetes] remove old openshift support

### DIFF
--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -15,7 +15,6 @@ import json
 import os
 from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
                                 UbuntuPlugin, PluginOpt)
-from sos.utilities import is_executable
 
 
 KUBE_PACKAGES = (
@@ -276,15 +275,9 @@ class Kubernetes(Plugin):
 
 class RedHatKubernetes(Kubernetes, RedHatPlugin):
 
-    packages = KUBE_PACKAGES + (
-        'kubernetes-master',
-        'atomic-openshift-master',
-    )
+    packages = KUBE_PACKAGES
 
-    files = KUBECONFIGS + (
-        '/etc/origin/master/admin.kubeconfig',
-        '/etc/origin/node/pods/master-config.yaml',
-    )
+    files = KUBECONFIGS
 
     services = KUBE_SVCS
 
@@ -296,18 +289,6 @@ class RedHatKubernetes(Kubernetes, RedHatPlugin):
 
     def setup(self):
         self.set_kubeconfig()
-
-        # if present, use `oc` command and add some OCP specific ressources
-        if is_executable('oc'):
-            self.kube_cmd = 'oc'
-            self.resources.extend([
-                'policies',
-                'routes'
-            ])
-            self.global_resources.extend([
-                'projects',
-                'pvs'
-            ])
         super().setup()
 
 


### PR DESCRIPTION
PR as promised here https://github.com/sosreport/sos/pull/3630#issuecomment-2113294101

Looking on https://access.redhat.com/downloads/content/package-browser latest version of
- kubernetes-master is from 2017-06-06
- atomic-openshift-master is from 2022-08-30

The first versions of openshift-hyperkube are
4.1.0-201905191700.git.0.cb455d6.el{7,8}, so it's
safe to drop openshift bits from kubernetes plugin.

We keep the "not openshift-hyperkube" check_enabled() as we might have files in common in the future.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
