### PR TITLE
[clean,options] Correct skip-clean-files in sos.conf and skipping logic

### DIFF
--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -45,23 +45,23 @@ class SoSCleanerParser():
     regex_patterns = []
     skip_line_patterns = []
     parser_skip_files = []  # list of skip files relevant to a parser
-    skip_clean_files = []   # list of global skip files from cmdline arguments
+    skip_cleaning_files = []   # list of global skip files from cmdline args
     map_file_key = 'unset'
     compile_regexes = True
 
-    def __init__(self, config={}, skip_clean_files=[]):
+    def __init__(self, config={}, skip_cleaning_files=[]):
         if self.map_file_key in config:
             self.mapping.conf_update(config[self.map_file_key])
-        self.skip_clean_files = skip_clean_files
+        self.skip_cleaning_files = skip_cleaning_files
         self._generate_skip_regexes()
 
     def _generate_skip_regexes(self):
         """Generate the regexes for the parser's configured parser_skip_files
-        or global skip_clean_files, so that we don't regenerate them on every
-        file being examined for if the parser should skip a given file.
+        or global skip_cleaning_files, so that we don't regenerate them on
+        every file being examined for if the parser should skip a given file.
         """
         self.skip_patterns = []
-        for p in self.parser_skip_files + self.skip_clean_files:
+        for p in self.parser_skip_files + self.skip_cleaning_files:
             self.skip_patterns.append(re.compile(p))
 
     def generate_item_regexes(self):

--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -21,9 +21,9 @@ class SoSHostnameParser(SoSCleanerParser):
         r'(((\b|_)[a-zA-Z0-9-\.]{1,200}\.[a-zA-Z]{1,63}(\b|_)))'
     ]
 
-    def __init__(self, config, skip_clean_files=[]):
+    def __init__(self, config, skip_cleaning_files=[]):
         self.mapping = SoSHostnameMap()
-        super().__init__(config, skip_clean_files)
+        super().__init__(config, skip_cleaning_files)
 
     def parse_line(self, line):
         """This will be called for every line in every file we process, so that

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -44,6 +44,6 @@ class SoSIPParser(SoSCleanerParser):
     map_file_key = 'ip_map'
     compile_regexes = False
 
-    def __init__(self, config, skip_clean_files=[]):
+    def __init__(self, config, skip_cleaning_files=[]):
         self.mapping = SoSIPMap()
-        super().__init__(config, skip_clean_files)
+        super().__init__(config, skip_cleaning_files)

--- a/sos/cleaner/parsers/ipv6_parser.py
+++ b/sos/cleaner/parsers/ipv6_parser.py
@@ -35,9 +35,9 @@ class SoSIPv6Parser(SoSCleanerParser):
     ]
     compile_regexes = False
 
-    def __init__(self, config, skip_clean_files=[]):
+    def __init__(self, config, skip_cleaning_files=[]):
         self.mapping = SoSIPv6Map()
-        super().__init__(config, skip_clean_files)
+        super().__init__(config, skip_cleaning_files)
 
     def get_map_contents(self):
         """Structure the dataset contents properly so that they can be reloaded

--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -20,9 +20,9 @@ class SoSKeywordParser(SoSCleanerParser):
     name = 'Keyword Parser'
     map_file_key = 'keyword_map'
 
-    def __init__(self, config, skip_clean_files=[]):
+    def __init__(self, config, skip_cleaning_files=[]):
         self.mapping = SoSKeywordMap()
-        super().__init__(config, skip_clean_files)
+        super().__init__(config, skip_cleaning_files)
 
     def _parse_line(self, line):
         return line, 0

--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -50,9 +50,9 @@ class SoSMacParser(SoSCleanerParser):
     map_file_key = 'mac_map'
     compile_regexes = False
 
-    def __init__(self, config, skip_clean_files=[]):
+    def __init__(self, config, skip_cleaning_files=[]):
         self.mapping = SoSMacMap()
-        super().__init__(config, skip_clean_files)
+        super().__init__(config, skip_cleaning_files)
 
     def reduce_mac_match(self, match):
         """Strips away leading and trailing non-alphanum characters from any

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -26,9 +26,9 @@ class SoSUsernameParser(SoSCleanerParser):
     map_file_key = 'username_map'
     regex_patterns = []
 
-    def __init__(self, config, skip_clean_files=[]):
+    def __init__(self, config, skip_cleaning_files=[]):
         self.mapping = SoSUsernameMap()
-        super().__init__(config, skip_clean_files)
+        super().__init__(config, skip_cleaning_files)
 
     def _parse_line(self, line):
         return line, 0

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -89,7 +89,7 @@ class SoSCollector(SoSComponent):
         'group': None,
         'image': '',
         'force_pull_image': True,
-        'skip_clean_files': [],
+        'skip_cleaning_files': [],
         'jobs': 4,
         'journal_size': 0,
         'keywords': [],
@@ -488,7 +488,7 @@ class SoSCollector(SoSComponent):
                                        'those elements are not obfuscated'))
         cleaner_grp.add_argument('--skip-cleaning-files',
                                  '--skip-masking-files', action='extend',
-                                 default=[], dest='skip_clean_files',
+                                 default=[], dest='skip_cleaning_files',
                                  help=('List of files to skip/ignore during '
                                        'cleaning. Globs are supported.'))
         cleaner_grp.add_argument('--keywords', action='extend', default=[],

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -91,7 +91,7 @@ class SoSReport(SoSComponent):
         'desc': '',
         'domains': [],
         'disable_parsers': [],
-        'skip_clean_files': [],
+        'skip_cleaning_files': [],
         'dry_run': False,
         'estimate_only': False,
         'experimental': False,
@@ -363,7 +363,7 @@ class SoSReport(SoSComponent):
                                        'those elements are not obfuscated'))
         cleaner_grp.add_argument('--skip-cleaning-files',
                                  '--skip-masking-files', action='extend',
-                                 default=[], dest='skip_clean_files',
+                                 default=[], dest='skip_cleaning_files',
                                  help=('List of files to skip/ignore during '
                                        'cleaning. Globs are supported.'))
         cleaner_grp.add_argument('--keywords', action='extend', default=[],


### PR DESCRIPTION
First, fix the issue raised in #3671 for the `--skip-cleaning-files` option, which would need to be written to `sos.conf` as `skip-clean-files` due to the internal variable naming.

Second, noticed as part of the reproducer for this issue when `--skip-cleaning-files` would be seti, that we were inadvertantly still going through the motions of creating a temporary file and scanning the file even if we weren't intending to do any obfuscations to it. Correct this by bailing out after determining there are no parsers for which we want to do an obfuscation. Apply the same update to symlink paths so that we don't create broken symlinks.

Resolves: #3671

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
