### PR TITLE
[container_log] Get rotated logs

### DIFF
--- a/sos/report/plugins/container_log.py
+++ b/sos/report/plugins/container_log.py
@@ -9,7 +9,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 import os
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class ContainerLog(Plugin, IndependentPlugin):
@@ -17,18 +17,29 @@ class ContainerLog(Plugin, IndependentPlugin):
     short_desc = 'All logs under /var/log/containers'
     plugin_name = 'container_log'
     logdir = '/var/log/containers/'
+    poddir = '/var/log/pods/'
+    rotated_dirs = [poddir + '*/*.log.*', poddir + '*/*/*.log.*']
     files = (logdir, )
+
+    option_list = [
+        PluginOpt('rotated', default=False, val_type=bool,
+                  desc='also get rotated logs from /var/log/pods'),
+    ]
 
     def setup(self):
         if self.get_option('all_logs'):
             self.add_copy_spec(self.logdir)
+            if self.get_option('rotated'):
+                self.add_copy_spec(self.rotated_dirs)
         else:
-            self.collect_subdirs()
+            self.collect_subdirs(self.logdir, '*.log')
+            if self.get_option('rotated'):
+                self.collect_subdirs(self.poddir, '*.log.*')
 
-    def collect_subdirs(self, root=logdir):
+    def collect_subdirs(self, root, glob):
         """Collect *.log files from subdirs of passed root path
         """
         for dir_name, _, _ in os.walk(root):
-            self.add_copy_spec(self.path_join(dir_name, '*.log'))
+            self.add_copy_spec(self.path_join(dir_name, glob))
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
In Kubernetes/OpenShift rotated logs have no symbolic link in /var/log/containers and they cannot be retrieved using `oc logs` either, so there is no way to get these rotated logs in a SOS report.

This patch proposes a new functionality for the `container_log` plugin to retrieve rotated logs for the containers.

Since there may be lots of rotated logs we also add the `maxage` option.

The plugin will not only download the `/var/log/pods` files but also the `/var/log/container` symlinks.

Closes #3677
Signed-off-by: Gorka Eguileor <geguileo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
