### PR TITLE
[plugins] maxage and all_logs on all plugins

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -940,13 +940,17 @@ class SoSReport(SoSComponent):
 
             for plugname, plug in self.loaded_plugins:
                 if plugname in opts:
-                    for opt in opts[plugname]:
-                        if opt not in plug.options:
-                            self.soslog.error(f'no such option "{opt}" for '
+                    # Map from parameter names to internal option names
+                    plug_param_map = {o.param_name: o.name
+                                      for o in plug.options.values()}
+                    for param in opts[plugname]:
+                        opt = plug_param_map.get(param)
+                        if not opt:
+                            self.soslog.error(f'no such option "{param}" for '
                                               f'plugin ({plugname})')
                             self._exit(1)
                         try:
-                            plug.options[opt].set_value(opts[plugname][opt])
+                            plug.options[opt].set_value(opts[plugname][param])
                             self.soslog.debug(
                                 f"Set {plugname} plugin option to "
                                 f"{plug.options[opt]}")
@@ -1059,7 +1063,7 @@ class SoSReport(SoSComponent):
                         val = TIMEOUT_DEFAULT
                 if opt.name == 'postproc':
                     val = not self.opts.no_postproc
-                self.ui_log.info(f"{opt.name:<25} {val:<15} {opt.desc}")
+                self.ui_log.info(f"{opt.param_name:<25} {val:<15} {opt.desc}")
             self.ui_log.info("")
 
             self.ui_log.info(_("The following plugin options are available:"))
@@ -1079,7 +1083,7 @@ class SoSReport(SoSComponent):
                 if tmpopt is None:
                     tmpopt = 0
 
-                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<25} "
+                self.ui_log.info(f" {f'{opt.plugin}.{opt.param_name}':<25} "
                                  f"{tmpopt:<15} {opt.desc}")
         else:
             self.ui_log.info(_("No plugin options available."))

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -401,7 +401,8 @@ class PluginOpt():
     to define options alongside their distro-specific classes in order to add
     support for user-controlled changes in Plugin behavior.
 
-    :param name:        The name of the plugin option
+    :param name:        The name of the plugin option as used by the code.
+                        Equivalent to the `dest` in arg parser terminology.
     :type name:         ``str``
 
     :param default:     The default value of the option
@@ -417,9 +418,15 @@ class PluginOpt():
     :param val_type:    The type of object the option accepts for values. If
                         not provided, auto-detect from the type of ``default``
     :type val_type:     A single type or a ``list`` of types
+
+    :param param_name:  The name of the parameter in the command line. Defaults
+                        to ``name`` if unset.
+    :type param_name:   ``str``
+
     """
 
     name = ''
+    param_name = ''
     default = None
     enabled = False
     desc = ''
@@ -429,8 +436,9 @@ class PluginOpt():
     plugin = ''
 
     def __init__(self, name='undefined', default=None, desc='', long_desc='',
-                 val_type=None):
+                 val_type=None, param_name=None):
         self.name = name
+        self.param_name = param_name or name
         self.default = default
         self.desc = desc
         self.long_desc = long_desc
@@ -445,6 +453,7 @@ class PluginOpt():
     def __str__(self):
         items = [
             f'name={self.name}',
+            f'param_name={self.param_name}',
             f'desc=\'{self.desc}\'',
             f'value={self.value}',
             f'default={self.default}'
@@ -861,7 +870,7 @@ class Plugin():
                     _def = "True/On"
                 else:
                     _def = "False/Off"
-            _ln = f"{' ':<4}{opt.name:<20}{_def:<30}{opt.desc:<20}"
+            _ln = f"{' ':<4}{opt.param_name:<20}{_def:<30}{opt.desc:<20}"
             optsec.add_text(
                 textwrap.fill(_ln, width=TERMSIZE,
                               subsequent_indent=opt_indent),

--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -100,7 +100,7 @@ class RedHatKDump(KDump, RedHatPlugin):
 
         # collect the latest vmcore created in the last 24hrs <= 2GB
         if self.get_option("get-vm-core"):
-            self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxage=24)
+            self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxhours=24)
 
 
 class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
@@ -178,6 +178,6 @@ class AzureKDump(KDump, AzurePlugin):
 
         # collect the latest vmcore created in the last 24hrs <= 2GB
         if self.get_option("get-vm-core"):
-            self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxage=24)
+            self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxhours=24)
 
 # vim: set et ts=4 sw=4 :

--- a/tests/report_tests/options_tests/options_tests.py
+++ b/tests/report_tests/options_tests/options_tests.py
@@ -28,11 +28,12 @@ class OptionsFromConfigTest(StageTwoReportTest):
     def test_plugopts_logged_from_config(self):
         self.assertSosLogContains(
             r"Set kernel plugin option to \(name=with-timer, "
+            r"param_name=with-timer, "
             r"desc='gather /proc/timer\* statistics', value=True, "
             r"default=False\)"
         )
         self.assertSosLogContains(
-            r"Set kernel plugin option to \(name=trace, "
+            r"Set kernel plugin option to \(name=trace, param_name=trace, "
             "desc='gather /sys/kernel/debug/tracing/trace file', "
             r"value=True, default=False\)"
         )


### PR DESCRIPTION
This patch makes 2 options settable globally and per-plugin: `maxage` and `all_logs`.

Examples:

```
sos report --all-logs --maxage=1
sos report -k container_log.all-logs=on,container_log.maxage=1
sos report --all-logs --maxage=1 -k container_log.all-logs=off,container_log.maxage=2
```

This adds flexibility to what users want to retrieve.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
