### PR TITLE
[common] handle all_logs when snap package is installed

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2007,8 +2007,11 @@ class Plugin():
             kwargs['priority'] = 10
         if 'changes' not in kwargs:
             kwargs['changes'] = False
-        if self.get_option('all_logs') or kwargs['sizelimit'] == 0:
+        if (not getattr(SoSCommand(**kwargs), "snap_cmd", False) and
+           (self.get_option('all_logs') or kwargs['sizelimit'] == 0)):
             kwargs['to_file'] = True
+        if "snap_cmd" in kwargs:
+            kwargs.pop("snap_cmd")
         soscmd = SoSCommand(**kwargs)
         self._log_debug("packed command: " + soscmd.__str__())
         for _skip_cmd in self.skip_commands:
@@ -2073,7 +2076,7 @@ class Plugin():
                        sizelimit=None, pred=None, subdir=None,
                        changes=False, foreground=False, tags=[],
                        priority=10, cmd_as_tag=False, container=None,
-                       to_file=False, runas=None):
+                       to_file=False, runas=None, snap_cmd=False):
         """Run a program or a list of programs and collect the output
 
         Output will be limited to `sizelimit`, collecting the last X amount
@@ -2149,6 +2152,9 @@ class Plugin():
 
         :param runas: Run the `cmd` as the `runas` user
         :type runas: ``str``
+
+        :param snap_cmd: Are the commands being run from a snap?
+        :type snap_cmd: ``bool``
         """
         if isinstance(cmds, str):
             cmds = [cmds]
@@ -2177,7 +2183,7 @@ class Plugin():
                                  changes=changes, foreground=foreground,
                                  priority=priority, cmd_as_tag=cmd_as_tag,
                                  to_file=to_file, container_cmd=container_cmd,
-                                 runas=runas)
+                                 runas=runas, snap_cmd=snap_cmd)
 
     def add_cmd_tags(self, tagdict):
         """Retroactively add tags to any commands that have been run by this

--- a/sos/report/plugins/grafana.py
+++ b/sos/report/plugins/grafana.py
@@ -25,7 +25,7 @@ class Grafana(Plugin, IndependentPlugin):
             log_path = "/var/snap/grafana/common/data/log/"
             config_path = "/var/snap/grafana/current/conf/grafana.ini"
 
-            self.add_cmd_output("snap info grafana")
+            self.add_cmd_output("snap info grafana", snap_cmd=True)
         else:
             grafana_cli = "grafana-cli"
             log_path = "/var/log/grafana/"
@@ -36,7 +36,7 @@ class Grafana(Plugin, IndependentPlugin):
             f'{grafana_cli} plugins list-remote',
             f'{grafana_cli} -v',
             'grafana-server -v',
-        ])
+        ], snap_cmd=self.is_snap)
 
         log_file_pattern = "*.log*" if self.get_option("all_logs") else "*.log"
 

--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -26,7 +26,7 @@ class LXD(Plugin, UbuntuPlugin):
             lxd_pred = SoSPredicate(self, services=['snap.lxd.daemon'],
                                     required={'services': 'all'})
 
-            self.add_cmd_output("lxd.buginfo", pred=lxd_pred)
+            self.add_cmd_output("lxd.buginfo", pred=lxd_pred, snap_cmd=True)
 
             self.add_copy_spec([
                 '/var/snap/lxd/common/config',

--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -88,7 +88,7 @@ class MAAS(Plugin, UbuntuPlugin):
         self.add_cmd_output([
             'snap info maas',
             'maas status',
-        ])
+        ], snap_cmd=True)
 
         self.add_forbidden_path([
             "/var/snap/maas/**/*.key",

--- a/sos/report/plugins/sunbeam.py
+++ b/sos/report/plugins/sunbeam.py
@@ -46,7 +46,7 @@ class Sunbeam(Plugin, UbuntuPlugin):
         self.add_cmd_output([
             'sunbeam cluster list',
             'sunbeam cluster list --format yaml',
-        ])
+        ], snap_cmd=True)
 
         sunbeam_user = self.get_option("sunbeam-user")
         try:
@@ -100,7 +100,7 @@ class Sunbeam(Plugin, UbuntuPlugin):
                     "login")
 
     def _get_juju_cmd_details(self, user):
-        self.add_cmd_output("juju controllers", runas=user)
+        self.add_cmd_output("juju controllers", runas=user, snap_cmd=True)
         juju_controllers = self.collect_cmd_output(
             "juju controllers --format json", runas=user)
 
@@ -113,7 +113,7 @@ class Sunbeam(Plugin, UbuntuPlugin):
                     f'juju model-defaults -c {controller}',
                     f'juju controller-config -c {controller}',
                     f'juju controller-config -c {controller} --format json',
-                ], runas=user)
+                ], runas=user, snap_cmd=True)
 
                 juju_models = self.collect_cmd_output(
                     f'juju models -c {controller} --format json',
@@ -131,7 +131,7 @@ class Sunbeam(Plugin, UbuntuPlugin):
                             f'juju status -m {model_name} --format json',
                             f'juju model-config -m {model_name}',
                             f'juju model-config -m {model_name} --format json',
-                        ], runas=user)
+                        ], runas=user, snap_cmd=True)
 
     def postproc(self):
 


### PR DESCRIPTION
Add a new flag to add_cmd_output to suggest a snap_cmd, so that sos
does not direct the command directly to a file.

Resolves: #3683

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
