### PR TITLE
[common] Standardise snap package checks

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -541,6 +541,7 @@ class Plugin():
     cmdtags = {}
     filetags = {}
     option_list = []
+    is_snap = False
 
     # Default predicates
     predicate = None
@@ -580,6 +581,11 @@ class Plugin():
         for opt in self.option_list:
             opt.plugin = self.name()
             self.options[opt.name] = opt
+
+        # Check if any of the packages tuple is a snap
+        self.is_snap = any(
+            self.is_snap_installed(pkg) for pkg in list(self.packages)
+        )
 
         # Initialise the default --dry-run predicate
         self.set_predicate(SoSPredicate(self))
@@ -998,6 +1004,18 @@ class Plugin():
         return (
             len(self.policy.package_manager.all_pkgs_by_name(package_name)) > 0
         )
+
+    def is_snap_installed(self, package_name):
+        """Is the snap package $package_name installed?
+
+        :param package_name:    The name of the package to check
+        :type package_name:     ``str``
+
+        :returns: ``True`` if the snap package is installed, else ``False``
+        :rtype: ``bool``
+        """
+        pkg = self.policy.package_manager.pkg_by_name(package_name)
+        return pkg is not None and pkg['pkg_manager'] == 'snap'
 
     def is_service(self, name):
         """Does the service $name exist on the system?

--- a/sos/report/plugins/grafana.py
+++ b/sos/report/plugins/grafana.py
@@ -18,16 +18,8 @@ class Grafana(Plugin, IndependentPlugin):
     profiles = ('services', 'openstack', 'openstack_controller')
 
     packages = ('grafana',)
-    is_snap = False
-
-    def _is_snap_installed(self):
-        grafana_pkg = self.policy.package_manager.pkg_by_name('grafana')
-        if grafana_pkg:
-            return grafana_pkg['pkg_manager'] == 'snap'
-        return False
 
     def setup(self):
-        self.is_snap = self._is_snap_installed()
         if self.is_snap:
             grafana_cli = "grafana.grafana-cli"
             log_path = "/var/snap/grafana/common/data/log/"

--- a/sos/report/plugins/kafka.py
+++ b/sos/report/plugins/kafka.py
@@ -23,16 +23,8 @@ class Kafka(Plugin, UbuntuPlugin):
     profiles = ('services',)
     packages = ('charmed-kafka',)
     services = ('kafka',)
-    is_snap = False
-
-    def _is_snap_installed(self):
-        kafka_pkg = self.policy.package_manager.pkg_by_name('charmed-kafka')
-        if kafka_pkg:
-            return kafka_pkg['pkg_manager'] == 'snap'
-        return False
 
     def setup(self):
-        self.is_snap = self._is_snap_installed()
         log_file_pattern = "*.log*" if self.get_option("all_logs") else "*.log"
 
         if self.is_snap:

--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -21,9 +21,7 @@ class LXD(Plugin, UbuntuPlugin):
     services = ('snap.lxd.daemon', 'snap.lxd.activate')
 
     def setup(self):
-
-        lxd_pkg = self.policy.package_manager.pkg_by_name('lxd')
-        if lxd_pkg and lxd_pkg['pkg_manager'] == 'snap':
+        if self.is_snap:
 
             lxd_pred = SoSPredicate(self, services=['snap.lxd.daemon'],
                                     required={'services': 'all'})

--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -47,8 +47,6 @@ class Maas(Plugin, UbuntuPlugin):
                   desc='Credentials, or the API key')
     ]
 
-    is_snap = False
-
     def _has_login_options(self):
         return self.get_option("url") and self.get_option("credentials") \
             and self.get_option("profile-name")
@@ -61,14 +59,7 @@ class Maas(Plugin, UbuntuPlugin):
 
         return ret['status'] == 0
 
-    def _is_snap_installed(self):
-        maas_pkg = self.policy.package_manager.pkg_by_name('maas')
-        if maas_pkg:
-            return maas_pkg['pkg_manager'] == 'snap'
-        return False
-
     def setup(self):
-        self.is_snap = self._is_snap_installed()
         if self.is_snap:
             self.add_cmd_output([
                 'snap info maas',


### PR DESCRIPTION
* Add function is_snap_installed, so that this can be used more widely
* This also reduces duplicate code in plugins.
* Add is_snap variable, that can be used if any of the packages is a snap; typically it's one of the other.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
