### PR TITLE
[sos] Fix typos in sos help

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -412,7 +412,7 @@ class SoSReport(SoSComponent):
 
         psec = section.add_section(title='How Collections Are Determined')
         psec.add_text(
-            'SoS report performs it\'s collections by way of \'plugins\' that '
+            'SoS report performs its collections by way of \'plugins\' that '
             'individually specify what files to copy and what commands to run.'
             ' Plugins typically map to specific components or software '
             'packages.'
@@ -421,9 +421,9 @@ class SoSReport(SoSComponent):
             'Plugins may specify different collections on different distribu'
             'tions, and some plugins may only be for specific distributions. '
             'Distributions are represented within SoS by \'policies\' and may '
-            'influence how other SoS commands or options function. For example'
-            'policies can alter where the --upload option defaults to or '
-            'functions.'
+            'influence how other SoS commands or options function. For '
+            'example policies can alter where the --upload option defaults '
+            'to or functions.'
         )
 
         ssec = section.add_section(title='See Also')


### PR DESCRIPTION
Related: RHELPLAN-170117

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
