### PR TITLE
[tests] Disable verbose stdout killing avocado performance

### DIFF
--- a/tests/cleaner_tests/existing_archive.py
+++ b/tests/cleaner_tests/existing_archive.py
@@ -23,7 +23,7 @@ class ExistingArchiveCleanTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = '-v tests/test_data/%s.tar.xz' % ARCHIVE
+    sos_cmd = 'tests/test_data/%s.tar.xz' % ARCHIVE
     sos_component = 'clean'
 
     def test_obfuscation_log_created(self):
@@ -124,7 +124,7 @@ class ExistingArchiveCleanTmpTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = f'-v --keywords var,tmp,avocado --disable-parsers \
+    sos_cmd = f'--keywords var,tmp,avocado --disable-parsers \
         ip,ipv6,mac,username --no-update tests/test_data/{ARCHIVE}.tar.xz'
     sos_component = 'clean'
 

--- a/tests/cleaner_tests/full_report/full_report_run.py
+++ b/tests/cleaner_tests/full_report/full_report_run.py
@@ -20,7 +20,7 @@ class FullCleanTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = '-v --clean'
+    sos_cmd = '--clean'
     sos_timeout = 600
     # replace with an empty placeholder, make sure that this test case is not
     # influenced by previous clean runs

--- a/tests/cleaner_tests/ipv6_test/ipv6_test.py
+++ b/tests/cleaner_tests/ipv6_test/ipv6_test.py
@@ -20,7 +20,7 @@ class IPv6Test(StageTwoReportTest):
     """
 
     install_plugins = ['ipv6']
-    sos_cmd = '-v --clean -o ipv6'
+    sos_cmd = '--clean -o ipv6'
     sos_timeout = 600
     # replace default mapping to avoid being influenced by previous runs
     # place mock file with crafted address used by mocked plugin

--- a/tests/report_tests/options_tests/options_tests.py
+++ b/tests/report_tests/options_tests/options_tests.py
@@ -17,7 +17,7 @@ class OptionsFromConfigTest(StageTwoReportTest):
     """
 
     files = [('options_tests_sos.conf', '/etc/sos/sos.conf')]
-    sos_cmd = '-v '
+    sos_cmd = ''
 
     def test_case_id_from_config(self):
         self.assertTrue('8675309' in self.archive)


### PR DESCRIPTION
To prevent avocado hiccups that slow down sos execution, let disable debug logs to stdout.

Resolves: #3693

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?