### PR TITLE
[policies] Add CloudLinux policy

### DIFF
--- a/sos/policies/distros/cloudlinux.py
+++ b/sos/policies/distros/cloudlinux.py
@@ -1,0 +1,46 @@
+# Copyright (C) Eduard Abdullin <eabdullin@cloudlinux.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+from sos.policies.distros.redhat import RedHatPolicy, OS_RELEASE
+
+
+class CloudLinuxPolicy(RedHatPolicy):
+    distro = "CloudLinux"
+    vendor = "CloudLinux"
+    vendor_urls = [
+        ('Distribution Website', 'https://www.cloudlinux.com/'),
+        ('Commercial Support', 'https://www.cloudlinux.com/')
+    ]
+
+    def __init__(self, sysroot=None, init=None, probe_runtime=True,
+                 remote_exec=None):
+        super().__init__(sysroot=sysroot, init=init,
+                         probe_runtime=probe_runtime,
+                         remote_exec=remote_exec)
+
+    @classmethod
+    def check(cls, remote=''):
+        if remote:
+            return cls.distro in remote
+
+        if not os.path.isfile('/etc/cloudlinux-release'):
+            return False
+
+        if os.path.exists(OS_RELEASE):
+            with open(OS_RELEASE, 'r') as f:
+                for line in f:
+                    if line.startswith('NAME'):
+                        if 'CloudLinux' in line:
+                            return True
+
+        return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/policies/distros/cloudlinux.py
+++ b/sos/policies/distros/cloudlinux.py
@@ -4,7 +4,7 @@
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
-# version 2 of the GNU General Public License.
+# version 2 or later of the GNU General Public License.
 #
 # See the LICENSE file in the source distribution for further information.
 


### PR DESCRIPTION
CloudLinux OS is an Enterprise Linux distro, binary compatible with RHEL.
This commit adds a CloudLinux policy, which inherits the RedHatPolicy base.

Signed-off-by: Eduard Abdullin eabdullin@almalinux.org

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
