### PR TITLE
[process] Collect process stat files

### DIFF
--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -50,6 +50,7 @@ class Process(Plugin, IndependentPlugin):
 
         for proc in procs:
             self.add_copy_spec([
+                f"/proc/{proc}/stat",
                 f"/proc/{proc}/status",
                 f"/proc/{proc}/cpuset",
                 f"/proc/{proc}/oom_*",


### PR DESCRIPTION
The /proc/<PID> subdirectory for a process contains many files, most of which the report doesn't capture. One of those files is stat, which contains, among other pieces of information, the CPU on which the process is running. This information is not contained in any of the files that the report currently collects, and is important for troubleshooting, e.g., isolcpus or other scheduling issues.  The status file contains the field Cpus_allowed and Cpus_allowed_list, but this is not the same information. The underlying task_struct has separate members for the current CPU and the allowed CPU mask (list). The stat file is quite small and should be included in the report since it contains important information not contained elsewhere.

Signed-off-by: Jesse Hester <jhester@redhat.com>
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
