### PR TITLE
[ceph_mds] Add required path parameter to `dump tree`

### DIFF
--- a/sos/report/plugins/ceph_mds.py
+++ b/sos/report/plugins/ceph_mds.py
@@ -75,7 +75,7 @@ class CephMDS(Plugin, RedHatPlugin, UbuntuPlugin):
             "counter schema",
             "damage ls",
             "dump loads",
-            "dump tree",
+            "dump tree /",
             "dump_blocked_ops",
             "dump_historic_ops",
             "dump_historic_ops_by_duration",


### PR DESCRIPTION
Current output of this command without a path is:

```
Invalid command: missing required parameter root(<string>)
dump tree <root> [<depth:int>] :  dump metadata cache for subtree
admin_socket: invalid command
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
