### PR TITLE
[sunbeam_hypervisor] Fix obfuscation for ceilometer and hooks.log

### DIFF
--- a/sos/report/plugins/sunbeam_hypervisor.py
+++ b/sos/report/plugins/sunbeam_hypervisor.py
@@ -66,15 +66,33 @@ class SunbeamHypervisor(Plugin, UbuntuPlugin):
         connection_keys = ["connection", "sql_connection"]
 
         self.do_path_regex_sub(
-            fr"{self.common_dir}/etc/(nova|neutron)/*",
+            fr"{self.common_dir}/etc/(nova|neutron|ceilometer)/*",
             fr'(^\s*({"|".join(protect_keys)})\s*=\s*)(.*)',
             r"\1*********"
         )
         self.do_path_regex_sub(
-            fr"{self.common_dir}/etc/(nova|neutron)/*",
+            fr"{self.common_dir}/etc/(nova|neutron|ceilometer)/*",
             fr'(^\s*({"|".join(connection_keys)})\s*=\s*(.*)'
             r'://(\w*):)(.*)(@(.*))',
             r"\1*********\6"
+        )
+
+        # hooks.log
+        protect_hook_keys = [
+            "password",
+            "ovn_metadata_proxy_shared_secret",
+            "cacert",
+            "cert",
+            "key",
+            "ovn_cacert",
+            "ovn_cert",
+            "ovn_key",
+        ]
+
+        self.do_file_sub(
+            f'{self.common_dir}/hooks.log',
+            fr'(\'({"|".join(protect_hook_keys)})\'):\s?\'(.+?)\'',
+            r"\1: **********"
         )
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Previous environment tests did not have ceilometer, and testing on new version brought out this issue.

Also solved the hooks.log obfuscation

Resolves: #3713

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
