### PR TITLE
[policies] Fallback to /lib/modules/*/config

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -269,7 +269,19 @@ class LinuxPolicy(Policy):
             'dm_mod': 'CONFIG_BLK_DEV_DM'
         }
 
-        booted_config = self.join_sysroot(f"/boot/config-{release}")
+        kconfigs = (
+            f"/boot/config-{release}",
+            f"/lib/modules/{release}/config",
+        )
+        for kconfig in kconfigs:
+            kconfig = self.join_sysroot(kconfig)
+            if os.path.exists(kconfig):
+                booted_config = kconfig
+                break
+        else:
+            self.soslog.warning("Unable to find booted kernel config")
+            return
+
         kconfigs = []
         try:
             with open(booted_config, "r") as kfile:


### PR DESCRIPTION
When using rpm-ostree, /boot/config-{release} doesn't exists but RHEL/Fedora family also ship the kernel config file in /lib/modules/{release}/config, so try that as fallback.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
