### PR TITLE
[pylint] re-enable W0105: pointless-string-statement

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -86,7 +86,6 @@ disable=
     R1718, # consider-using-set-comprehension
     R1721, # unnecessary-comprehension
     R1722, # consider-using-sys-exit
-    W0105, # pointless-string-statement
     W0108, # unnecessary-lambda
     W0222, # signature-differs
     W0223, # abstract-method

--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -504,9 +504,8 @@ third party.
         """
         if self.opts.map_file and not self.opts.no_update:
             cleaner_dir = os.path.dirname(self.opts.map_file)
-            """ Attempt to create the directory /etc/sos/cleaner
-            just in case it didn't exist previously
-            """
+            # Attempt to create the directory /etc/sos/cleaner
+            # just in case it didn't exist previously
             try:
                 os.makedirs(cleaner_dir, exist_ok=True)
                 self.write_map_to_file(_map, self.opts.map_file)


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
