### PR TITLE
[pylint] Re-enable useless-return

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -53,7 +53,6 @@ disable=
     R1714, # consider-using-in
     C0206, # consider-using-dict-items
     W0221, # arguments-differ
-    R1711, # useless-return
     R1720, # no-else-raise
     R0205, # useless-object-inheritance
     W3101, # missing-timeout

--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -360,8 +360,6 @@ class LinuxPolicy(Policy):
             except KeyboardInterrupt:
                 raise
 
-        return
-
     def _configure_low_priority(self):
         """Used to constrain sos to a 'low priority' execution, potentially
         letting individual policies set their own definition of what that is.

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -288,7 +288,6 @@ support representative.
                 _("The option --upload-pass has been deprecated in favour"
                   " of device authorization in RHEL")
             )
-        return
 
     def get_upload_url(self):
         if self.upload_url:


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
