### PR TITLE
[pylint] Re-enable inconsistent-return-statements

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -69,7 +69,6 @@ disable=
     W0622, # redefined-builtin
     W0212, # protected-access
     R1728, # consider-using-generator
-    R1710, # inconsistent-return-statements
     C1802, # use-implicit-booleaness-not-len
     W0706, # try-except-raise
     C1803, # use-implicit-booleaness-not-comparison

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1427,3 +1427,5 @@ this utility or remote systems that it connects to.
             msg = (f"Could not finalize archive: {err}\n\nData may still be "
                    f"available uncompressed at {self.archive_path}")
             self.exit(msg, 2)
+            # Never gets here. This is to fix "inconsistent-return-statements
+            return "Archive error"

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -106,6 +106,7 @@ class SosNode():
             if self.host.containerized:
                 self.create_sos_container()
             self._load_sos_info()
+        return None
 
     @property
     def connected(self):

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1869,5 +1869,7 @@ class SoSReport(SoSComponent):
             sys.exit(e.code)
 
         self._exit(1)
+        # Never gets here. This is to fix "inconsistent-return-statements
+        return False
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
