### PR TITLE
[memory] Capture content of /sys/kernel/memory/lru_gen

### DIFF
--- a/sos/report/plugins/memory.py
+++ b/sos/report/plugins/memory.py
@@ -27,7 +27,9 @@ class Memory(Plugin, IndependentPlugin):
             "/proc/vmallocinfo",
             "/sys/kernel/mm/ksm",
             "/sys/kernel/mm/transparent_hugepage/enabled",
-            "/sys/kernel/mm/hugepages"
+            "/sys/kernel/mm/hugepages",
+            "/sys/kernel/mm/lru_gen/enabled",
+            "/sys/kernel/mm/lru_gen/min_ttl_ms",
         ])
         self.add_cmd_output("free", root_symlink="free")
         self.add_cmd_output([


### PR DESCRIPTION
Capture two files from /sys/kernel/memory/lru_gen:
- enabled
- min_ttl_ms

Related: RHEL-50917

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
