### PR TITLE
[redhat] Fix NoneType return when checking file size limit

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -22,7 +22,7 @@ from sos.policies.distros import LinuxPolicy, ENV_HOST_SYSROOT
 from sos.policies.package_managers.rpm import RpmPackageManager
 from sos.policies.package_managers.flatpak import FlatpakPackageManager
 from sos.policies.package_managers import MultiPackageManager
-from sos.utilities import bold, convert_bytes
+from sos.utilities import bold
 from sos import _sos as _
 
 try:
@@ -436,9 +436,7 @@ support representative.
         if size >= self._max_size_request:
             self.ui_log.warning(
                 _("Size of archive is bigger than Red Hat Customer Portal "
-                  "limit for uploads of "
-                  f"{convert_bytes(self._max_size_request)} "
-                  " via sos http upload. \n")
+                  "limit for uploads of 1Gb via sos http upload. \n")
                   )
             return RH_SFTP_HOST
         return RH_API_HOST


### PR DESCRIPTION
The new fuction check_file_too_big() was returning None when the file size was bigger than the max limit for Red Hat Customer Portal uploads. By removing the f-string that converted the size limit via convert_bytes() the function returned RH_SFTP_HOST as expected.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
