### PR TITLE
[common] Fix a bug in f-string usage

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -121,18 +121,13 @@ def fileobj(path_or_file, mode='r'):
         return closing(path_or_file)
 
 
-def convert_bytes(bytes_, K=1 << 10, M=1 << 20, G=1 << 30, T=1 << 40):
+def convert_bytes(num_bytes):
     """Converts a number of bytes to a shorter, more human friendly format"""
-    fn = float(bytes_)
-    if bytes_ >= T:
-        return f'{(fn / T):.1fT}'
-    if bytes_ >= G:
-        return f'{(fn / G):.1fG}'
-    if bytes_ >= M:
-        return f'{(fn / M):.1fM}'
-    if bytes_ >= K:
-        return f'{(fn / K):.1fK}'
-    return f'{bytes_}'
+    sizes = {'T': 1 << 40, 'G': 1 << 30, 'M': 1 << 20, 'K': 1 << 10}
+    for symbol, size in sizes.items():
+        if num_bytes >= size:
+            return f"{float(num_bytes) / size:.1f}{symbol}"
+    return f"{num_bytes}"
 
 
 def file_is_binary(fname):


### PR DESCRIPTION
The commit d65e135c8 appears to have introduced a bug when converting formats to use f-strings. This apparently broke the `convert_bytes()` function.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
