### PR TITLE
[pylint] Fix redefined-builtin in maas plugin

### DIFF
--- a/sos/report/plugins/maas.py
+++ b/sos/report/plugins/maas.py
@@ -44,8 +44,8 @@ class MAAS(Plugin, UbuntuPlugin):
         'snap.maas.pebble',
     )
 
-    def _get_machines_syslog(self, dir):
-        if not self.path_exists(dir):
+    def _get_machines_syslog(self, directory):
+        if not self.path_exists(directory):
             return []
 
         # Machine messages are collected with syslog and are stored under:
@@ -53,8 +53,8 @@ class MAAS(Plugin, UbuntuPlugin):
         # Collect only the most recent "%$YEAR%-%$MONTH%-%$DAY%"
         # for each "%HOSTNAME%".
         recent = []
-        for host_dir in self.listdir(dir):
-            host_path = self.path_join(dir, host_dir)
+        for host_dir in self.listdir(directory):
+            host_path = self.path_join(directory, host_dir)
             if not self.path_isdir(host_path):
                 continue
 


### PR DESCRIPTION
The commit 992fda9440891000e1b1cf783b829a4e722e2a84 reintroduced one of the pylints checks (`redefined-builtin`) that was already removed. Fixing it here.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
