### PR TITLE
[lustre] lnetctl net show more verbose

### DIFF
--- a/sos/report/plugins/lustre.py
+++ b/sos/report/plugins/lustre.py
@@ -33,7 +33,7 @@ class Lustre(Plugin, RedHatPlugin):
             "lctl device_list",
             "lctl list_nids",
             "lctl route_list",
-            "lnetctl net show -v"
+            "lnetctl net show -v 4"
         ])
 
         # Grab almost everything


### PR DESCRIPTION
This dumps more stats for net show:

old:
```
    - net type: tcp
      local NI(s):
        - nid: 10.73.20.11@tcp
          status: up
          interfaces:
              0: bond0
          statistics:
              send_count: 2682857
              recv_count: 2682851
              drop_count: 11
          tunables:
              peer_timeout: 180
              peer_credits: 8
              peer_buffer_credits: 0
              credits: 256
          lnd tunables:
              conns_per_peer: 1
          dev cpt: -1
          CPT: "[0]"
```

NEW:
```
    - net type: tcp
      local NI(s):
        - nid: 10.73.20.11@tcp
          status: up
          interfaces:
              0: bond0
          statistics:
              send_count: 2682864
              recv_count: 2682858
              drop_count: 11
          sent_stats:
              put: 2485192
              get: 197672
              reply: 0
              ack: 0
              hello: 0
          received_stats:
              put: 2485045
              get: 98837
              reply: 98835
              ack: 141
              hello: 0
          dropped_stats:
              put: 11
              get: 0
              reply: 0
              ack: 0
              hello: 0
          health stats:
              fatal_error: 0
              health value: 1000
              interrupts: 0
              dropped: 0
              aborted: 0
              no route: 0
              timeouts: 0
              error: 0
              ping_count: 0
              next_ping: 0
          tunables:
              peer_timeout: 180
              peer_credits: 8
              peer_buffer_credits: 0
              credits: 256
          lnd tunables:
              conns_per_peer: 1
          dev cpt: -1
          CPT: "[0]"
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
