### PR TITLE
[scsi] Capture the WWN for disks in the output of lsscsi

### DIFF
--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -58,7 +58,8 @@ class Scsi(Plugin, IndependentPlugin):
             "lsscsi -H",
             "lsscsi -d",
             "lsscsi -s",
-            "lsscsi -L"
+            "lsscsi -L",
+            "lsscsi -iw",
         ])
 
         scsi_hosts = glob("/sys/class/scsi_host/*")


### PR DESCRIPTION
Capture the WWN for disks via lsscsi.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
