### PR TITLE
[cloudlinux] Revert license header change

### DIFF
--- a/sos/policies/distros/cloudlinux.py
+++ b/sos/policies/distros/cloudlinux.py
@@ -4,7 +4,7 @@
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
-# version 2 or later of the GNU General Public License.
+# version 2 of the GNU General Public License.
 #
 # See the LICENSE file in the source distribution for further information.
 

--- a/sos/policies/distros/cloudlinux.py
+++ b/sos/policies/distros/cloudlinux.py
@@ -35,7 +35,7 @@ class CloudLinuxPolicy(RedHatPolicy):
             return False
 
         if os.path.exists(OS_RELEASE):
-            with open(OS_RELEASE, 'r') as f:
+            with open(OS_RELEASE, 'r', encoding='utf-8') as f:
                 for line in f:
                     if line.startswith('NAME'):
                         if 'CloudLinux' in line:


### PR DESCRIPTION
Previous merge included a preemptive "or later" addition to the license header pending the early discussion in #3705. Revert that to be consistent with the "GPLv2 only" stance of the project.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
