### PR TITLE
[redhat] Fix return of function check_file_too_big()

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -441,8 +441,7 @@ support representative.
                   f"{convert_bytes(self._max_size_request)} "
                   " via sos http upload. \n")
                   )
-            return RH_SFTP_HOST
-        return RH_API_HOST
+            self.upload_url = RH_SFTP_HOST
 
     def upload_archive(self, archive):
         """Override the base upload_archive to provide for automatic failover
@@ -450,7 +449,7 @@ support representative.
         """
         try:
             if self.get_upload_url().startswith(RH_API_HOST):
-                self.upload_url = self.check_file_too_big(archive)
+                self.check_file_too_big(archive)
             uploaded = super().upload_archive(archive)
         except Exception as e:
             uploaded = False


### PR DESCRIPTION
Fix the return of the size checks for Red Hat uploads to customer portal. Without this fix, uploads were failing silently.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
