### PR TITLE
[Plugin] Collect exact filesizes in add_dir_listing

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2058,9 +2058,9 @@ class Plugin():
         paths = [p for p in paths if self.path_exists(p)]
 
         if not tree:
-            options = f"alhZ{'R' if recursive else ''}"
+            options = f"alZ{'R' if recursive else ''}"
         else:
-            options = 'lhp'
+            options = 'lp'
 
         for path in paths:
             self.add_cmd_output(

--- a/tests/report_tests/basic_report_tests.py
+++ b/tests/report_tests/basic_report_tests.py
@@ -48,8 +48,8 @@ class NormalSoSReport(StageOneReportTest):
         )
 
     def test_dir_listing_works(self):
-        self.assertFileCollected('sos_commands/boot/ls_-alhZR_.boot')
-        boot_ls = self.get_name_in_archive('sos_commands/boot/ls_-alhZR_.boot')
+        self.assertFileCollected('sos_commands/boot/ls_-alZR_.boot')
+        boot_ls = self.get_name_in_archive('sos_commands/boot/ls_-alZR_.boot')
         with open(boot_ls, 'r', encoding='utf-8') as ls_file:
             # make sure we actually got ls output
             ln = ls_file.readline().strip()


### PR DESCRIPTION
`add_dir_listing` method in #3664 hid exact filesizes in "`ls -l`" like outputs in favour of human readable output. That has two drawbacks:

1) It provides less precise information, while particular filesizes for some files can be essential to know. E.g. `3.1K` can mean `3075` or `3174` bytes and the difference can matter for some well known files with well known default sizes.
2) It makes it difficult to parse the size by various analytical tools

`sos` tool should be data collectio tool rather than interpreting them. So let replace human readable filesize by exact one.

Resolves: #3758

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
