### PR TITLE
[policies] Obfuscate upload password in `get_upload_url_string()`

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -643,11 +643,16 @@ class LinuxPolicy(Policy):
             self._upload_url = f"s3://{bucket}/{prefix}"
         return self.upload_url or self._upload_url
 
+    def _get_obfuscated_upload_url(self, url):
+        pattern = r"([^:]+://[^:]+:)([^@]+)(@.+)"
+        obfuscated_url = re.sub(pattern, r'\1********\3', url)
+        return obfuscated_url
+
     def get_upload_url_string(self):
         """Used by distro policies to potentially change the string used to
         report upload location from the URL to a more human-friendly string
         """
-        return self.get_upload_url()
+        return self._get_obfuscated_upload_url(self.get_upload_url())
 
     def get_upload_user(self):
         """Helper function to determine if we should use the policy default

--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -339,7 +339,7 @@ support representative.
             return "Red Hat Customer Portal"
         if self.get_upload_url().startswith(RH_SFTP_HOST):
             return "Red Hat Secure FTP"
-        return self.upload_url
+        return self._get_obfuscated_upload_url(self.upload_url)
 
     def _get_sftp_upload_name(self):
         """The RH SFTP server will only automatically connect file uploads to

--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -87,7 +87,7 @@ class UbuntuPolicy(DebianPolicy):
     def get_upload_url_string(self):
         if self.upload_url.startswith(self._upload_url):
             return "Canonical Support File Server"
-        return self.get_upload_url()
+        return self._get_obfuscated_upload_url(self.get_upload_url())
 
     def get_upload_url(self):
         if not self.upload_url or self.upload_url.startswith(self._upload_url):


### PR DESCRIPTION
Adds _get_obfuscated_upload_url(self, url) method in LinuxPolicy class to be used when passwords in upload urls are needed to be obfuscated. The same is used in RedHatPolicy and UbuntuPolicy classes.

Closes: #3465

Example stdout:
```
$ sos report --upload-url https://user:PASSWORD@URL --batch

...

Creating compressed archive...

Your sos report has been generated and saved in:
	/var/tmp/sosreport-fedora-2024-08-23-yxxrsqh.tar.xz

 Size	21.50MiB
 Owner	root
 sha256	896cce985997729a8107635b5aa7e9b51ad79f03b39e65b1445ebb77fb655252

Please send this file to your support representative.

Attempting upload to https://user:********@URL
...
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
