### PR TITLE
[cleaner] Check if keyword exists in dataset before obfuscation

### DIFF
--- a/sos/cleaner/mappings/keyword_map.py
+++ b/sos/cleaner/mappings/keyword_map.py
@@ -25,6 +25,8 @@ class SoSKeywordMap(SoSMap):
     word_count = 0
 
     def sanitize_item(self, item):
+        if item in self.dataset:
+            return self.dataset[item]
         _ob_item = f"obfuscatedword{self.word_count}"
         self.word_count += 1
         if _ob_item in self.dataset.values():


### PR DESCRIPTION
Check whether item keyword exists in dataset before obfuscation in sanitize_item(self, item) method. Resolves redundant increments when the same keyword is provided more than once, and the current obfuscation "obfuscatedwordX" is preserved.

Closes: #3745

Example stdout (using the example in the issue):
1. First run with keywords: 
    ```
    root@fedora:sos# ./bin/sos report --batch -o block --clean --map-file /etc/sos/cleaner/default_mapping --keywords supercalifragilisticexpialidocious,supersecret,topsecretstuff
    ...
    root@fedora:sos# jq '.keyword_map' /etc/sos/cleaner/default_mapping
    {
      "supercalifragilisticexpialidocious": "obfuscatedword0",
      "supersecret": "obfuscatedword1",
      "topsecretstuff": "obfuscatedword2"
    }
    ```
2. Obfuscations are preserved in the subsequent runs:
    ```
    root@fedora:sos# ./bin/sos report --batch -o block --clean --map-file /etc/sos/cleaner/default_mapping --keywords supersecret
    ...
    root@fedora:sos# jq '.keyword_map' /etc/sos/cleaner/default_mapping
    {
      "supercalifragilisticexpialidocious": "obfuscatedword0",
      "supersecret": "obfuscatedword1",
      "topsecretstuff": "obfuscatedword2"
    }
    
    root@fedora:sos# ./bin/sos report --batch -o block --clean --map-file /etc/sos/cleaner/default_mapping --keywords supersecret
    ...
    root@fedora:sos# jq '.keyword_map' /etc/sos/cleaner/default_mapping
    {
      "supercalifragilisticexpialidocious": "obfuscatedword0",
      "supersecret": "obfuscatedword1",
      "topsecretstuff": "obfuscatedword2"
    }
    ```
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
