### PR TITLE
[processor] Add a timeout to turbostat collection

### DIFF
--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -66,8 +66,10 @@ class Processor(Plugin, IndependentPlugin):
             "cpupower frequency-info",
             "cpupower info",
             "cpupower idle-info",
-            "turbostat --debug sleep 10",
         ], cmd_as_tag=True, pred=cpupower_pred)
+
+        self.add_cmd_output("turbostat --debug sleep 10", cmd_as_tag=True,
+                            pred=cpupower_pred, timeout=15)
 
         if '86' in self.policy.get_arch():
             self.add_cmd_output("x86info -a")


### PR DESCRIPTION
The `turbostat` command has been seen to hit the default 5-minute timeout for reasons that are not immediately obvious. The behavior pattern is that the `turbostat --debug sleep 10` command this plugin captures may not exit until some form of input is received, at which point the command "fails successfully" with the following message:

`turbostat: get_rapl_counters: failed to read perf_data (8 1): Success`

Prevent this condition from holding up sos report execution by adding a timeout to this collection.

Resolves: #3753

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
