### PR TITLE
[report] Revert changed formatting of plugin+presets lists

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1029,7 +1029,7 @@ class SoSReport(SoSComponent):
             self.ui_log.info(_("The following plugins are currently enabled:"))
             self.ui_log.info("")
             for (plugname, plug) in self.loaded_plugins:
-                self.ui_log.info(f"{plugname:<20} {plug.get_description()}")
+                self.ui_log.info(f" {plugname:<20} {plug.get_description()}")
         else:
             self.ui_log.info(_("No plugin enabled."))
         self.ui_log.info("")
@@ -1039,7 +1039,7 @@ class SoSReport(SoSComponent):
                                "disabled:"))
             self.ui_log.info("")
             for (plugname, plugclass, reason) in self.skipped_plugins:
-                self.ui_log.info(f"{plugname:<20} {reason:<14} "
+                self.ui_log.info(f" {plugname:<20} {reason:<14} "
                                  f"{plugclass.get_description()}")
 
         self.ui_log.info("")
@@ -1060,7 +1060,7 @@ class SoSReport(SoSComponent):
                         val = TIMEOUT_DEFAULT
                 if opt.name == 'postproc':
                     val = not self.opts.no_postproc
-                self.ui_log.info(f"{opt.name:<25} {val:<15} {opt.desc}")
+                self.ui_log.info(f" {opt.name:<25} {val:<15} {opt.desc}")
             self.ui_log.info("")
 
             self.ui_log.info(_("The following plugin options are available:"))
@@ -1126,14 +1126,14 @@ class SoSReport(SoSComponent):
             if not preset:
                 continue
             preset = self.policy.find_preset(preset)
-            self.ui_log.info(f"name: {preset.name:>14}")
-            self.ui_log.info(f"description: {preset.desc:>14}")
+            self.ui_log.info(f"{'name:':>14} {preset.name}")
+            self.ui_log.info(f"{'description:':>14} {preset.desc}")
             if preset.note:
-                self.ui_log.info(f"note: {preset.note:>14}")
+                self.ui_log.info(f"{'note:':>14} {preset.note}")
 
             if self.opts.verbosity > 0:
                 args = preset.opts.to_args()
-                options_str = f"{'options:':>14}"
+                options_str = f"{'options:':>14} "
                 lines = _format_list(options_str, args, indent=True, sep=' ')
                 for line in lines:
                     self.ui_log.info(line)


### PR DESCRIPTION
During conversion to f-strings in #3606, some changes in UI output happen. That makes some output less readable and could break some automated tests anticipating given preset or plugin output strings.

This commit reverts back tto the original output, using f-strings.

Resolves: #3762

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
