### PR TITLE
[leapp] improve plugin enablement and add more collected files

### DIFF
--- a/sos/report/plugins/leapp.py
+++ b/sos/report/plugins/leapp.py
@@ -16,10 +16,13 @@ class Leapp(Plugin, RedHatPlugin):
     short_desc = 'Leapp upgrade handling tool'
 
     plugin_name = 'leapp'
-    packages = ('leapp', 'leapp-repository')
+    packages = ('leapp',)
+    files = ('/var/lib/leapp',)
 
     def setup(self):
         self.add_copy_spec([
+            '/etc/migration-results',
+            '/var/log/leapp/answerfile',
             '/var/log/leapp/dnf-debugdata/',
             '/var/log/leapp/leapp-preupgrade.log',
             '/var/log/leapp/leapp-upgrade.log',


### PR DESCRIPTION
The `leapp-repository` package was renamed to `leapp-upgrade-elXtoY`
in [1], and while we could list all possible combinations here,
the main `leapp` package should be enough to trigger this plugin

While at it, also enable plugin when /var/lib/leapp exists, as
after an upgrade is performed, users often uninstall the leapp packages,
but it can still be beneficial for SOS to collect data about the fact
that this is a system that was upgraded (and data about the upgrade) and
/var/lib/leapp shows exactly that.
    
Also include /etc/migration-results and /var/log/leapp/answerfile in
collected files.
    
[1] https://github.com/oamg/leapp-repository/commit/924c398a003f8ada079f2819fa3305adda7dfcda
    
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
