### PR TITLE
[report] print plugname instead of plugin tuple

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1372,13 +1372,14 @@ class SoSReport(SoSComponent):
                 self.pluglist.remove(plugin)
             except ValueError:
                 self.soslog.debug(
-                    f"Could not remove {plugin} from plugin list, ignoring..."
+                    f"Could not remove {plugname} from plugin list, "
+                    f"ignoring..."
                 )
             try:
                 self.running_plugs.remove(plugname)
             except ValueError:
                 self.soslog.debug(
-                    f"Could not remove {plugin} from running plugin list, "
+                    f"Could not remove {plugname} from running plugin list, "
                     f"ignoring..."
                 )
             status = ''


### PR DESCRIPTION
Replace (count, plugname) by pure plugname in two debug logs - the int is misleading rather than helping.

Resolves: #3778

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
