### PR TITLE
[tests] Allow tests to restrict OS version

### DIFF
--- a/tests/report_tests/plugin_tests/teamd.py
+++ b/tests/report_tests/plugin_tests/teamd.py
@@ -25,6 +25,9 @@ class TeamdPluginTest(StageTwoReportTest):
     sos_cmd = '-o teamd'
     redhat_only = True
 
+    # teaming has been deprecated from RHEL 9
+    only_os_versions = ['8']
+
     def pre_sos_setup(self):
         # restart NetworkManager to account for the new package
         nmout = process.run('systemctl restart NetworkManager', timeout=30)


### PR DESCRIPTION
Add a new `versions` class attribute that allows test classes to specify which version(s) are allowed/designed to execute on. If the test is attempted to be executed on a version that's not specified, the test will be skipped and a message will be printed.

By default, the list of versions will be empty, which means that the test should run in all versions of the OS.

This patch contains a change to restrict the execution of Teamd to RHEL 8, because it was deprecated for RHEL 9 and later.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
