### PR TITLE
[containerd] record deprecation warnings

### DIFF
--- a/sos/report/plugins/containerd.py
+++ b/sos/report/plugins/containerd.py
@@ -23,6 +23,7 @@ class Containerd(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
         ])
 
         self.add_cmd_output('containerd config dump')
+        self.add_cmd_output('ctr deprecations list')
 
         # collect the containerd logs.
         self.add_journal(units='containerd')


### PR DESCRIPTION
Starting with containerd 1.6.27 and 1.7.12, warnings are issued for the use of deprecated features.  The new `ctr deprecations list` command can be used to retrieve warnings.

Closes https://github.com/sosreport/sos/issues/3786
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
