### PR TITLE
[system] List env_var names

### DIFF
--- a/sos/report/plugins/system.py
+++ b/sos/report/plugins/system.py
@@ -6,6 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import os
 from sos.report.plugins import Plugin, IndependentPlugin
 
 
@@ -39,6 +40,12 @@ class System(Plugin, IndependentPlugin):
             "ld.so --list-diagnostics",
             "ld.so --list-tunables"
         ])
+
+        var_names = list(os.environ.keys())
+        var_names.sort()
+        self.add_string_as_file('\n'.join(var_names),
+                                "environment_varnames",
+                                plug_dir=True)
 
     def postproc(self):
         self.do_paths_http_sub([


### PR DESCRIPTION
This code gets the environment Names (without values) and saves them to `environment_varnames`.

Inspired by: #3792
Resolves: #3792

Signed-off-by: Pablo Fernández Rodríguez <pafernan@redhat.com>
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ x] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
