### PR TITLE
[docker,podman] Collect container image layers

### DIFF
--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -97,6 +97,11 @@ class Docker(Plugin, CosPlugin):
             insp = name if 'none' not in name else img_id
             self.add_cmd_output(f"docker inspect {insp}", subdir='images',
                                 tags="docker_image_inspect")
+            self.add_cmd_output(
+                f"docker image history {insp}",
+                subdir='images/history',
+                tags='docker_image_tree'
+            )
 
         for vol in volumes:
             self.add_cmd_output(f"docker volume inspect {vol}",

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -62,6 +62,7 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
 
         subcmds = [
             'info',
+            'image trust show',
             'images',
             'images --digests',
             'pod ps',
@@ -109,6 +110,11 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
             insp = name if 'none' not in name else img_id
             self.add_cmd_output(f"podman inspect {insp}", subdir='images',
                                 tags='podman_image_inspect')
+            self.add_cmd_output(
+                f"podman image tree {insp}",
+                subdir='images/tree',
+                tags='podman_image_tree'
+            )
 
         for vol in volumes:
             self.add_cmd_output(f"podman volume inspect {vol}",


### PR DESCRIPTION
Adds collection of container image layers for the docker and podman plugins via the `history` and `tree` subcommands repsectively.

Resolves: #3796

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
