### PR TITLE
[tests] Scrub tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,17 @@ against the `flake8` linter, the unit tests, and the stage one avocado test suit
 $ flake8 sos
 $ nosetests -v tests/unittests/
 
-# as root
-# PYTHONPATH=tests/ avocado run --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
+# sudo PYTHONPATH=tests/ avocado run --test-runner=runner -t stageone tests/{cleaner,collect,report,vendor}_tests
+```
+
+For further test run stagetwo tests
+```
+# sudo PYTHONPATH=tests/ avocado run --test-runner=runner -t stagetwo tests/{cleaner,collect,report,vendor}_tests
+```
+
+If you want to check basic scrub tests
+```
+# sudo PYTHONPATH=tests/ avocado run --test-runner=runner -t scrub tests/{cleaner,collect,report,vendor}_tests
 ```
 
 Note that the avocado test suite will generate and remove several reports over its

--- a/tests/report_tests/plugin_tests/apt/apt.py
+++ b/tests/report_tests/plugin_tests/apt/apt.py
@@ -15,7 +15,7 @@ class AptConfScrubTest(StageTwoReportTest):
     """Ensure that sources.list and apt conf are picked up and properly
     scrubbed
 
-    :avocado: tags=stagetwo
+    :avocado: tags=stagetwo,scrub
     """
 
     sos_cmd = '-o apt'

--- a/tests/report_tests/plugin_tests/curtin/curtin.py
+++ b/tests/report_tests/plugin_tests/curtin/curtin.py
@@ -12,7 +12,7 @@ from sos_tests import StageTwoReportTest
 class CurtinScrubbedTest(StageTwoReportTest):
     """Ensure that curtin conf is picked up and properly scrubbed
 
-    :avocado: tags=stagetwo
+    :avocado: tags=stagetwo,scrub
     """
 
     sos_cmd = '-o curtin'

--- a/tests/report_tests/plugin_tests/juju/juju.py
+++ b/tests/report_tests/plugin_tests/juju/juju.py
@@ -12,7 +12,7 @@ from sos_tests import StageTwoReportTest
 class JujuAgentConfScrubbedTest(StageTwoReportTest):
     """Ensure that agent conf is picked up and properly scrubbed
 
-    :avocado: tags=stagetwo
+    :avocado: tags=stagetwo,scrub
     """
 
     sos_cmd = '-o juju'

--- a/tests/report_tests/plugin_tests/networking/networking.py
+++ b/tests/report_tests/plugin_tests/networking/networking.py
@@ -46,7 +46,7 @@ class NetplanScrubTest(StageTwoReportTest):
     ensure that netplan configuration is collected and then the wifi password
     is scrubbed correctly
 
-    :avocado: tags=stagetwo
+    :avocado: tags=stagetwo,scrub
     """
 
     sos_cmd = '-o networking'

--- a/tests/report_tests/plugin_tests/sudo/sudo.py
+++ b/tests/report_tests/plugin_tests/sudo/sudo.py
@@ -10,7 +10,7 @@ from sos_tests import StageOneReportTest, StageTwoReportTest
 
 
 class SudoPluginTest(StageOneReportTest):
-    """Basic sanity check to make sure ocmmon config files are collected
+    """Basic sanity check to make sure common config files are collected
 
     :avocado: tags=stageone
     """
@@ -25,7 +25,7 @@ class SudoPluginTest(StageOneReportTest):
 class SudoLdapScrubbedTest(StageTwoReportTest):
     """Ensure that sudo conf is picked up and properly scrubbed
 
-    :avocado: tags=stagetwo
+    :avocado: tags=stagetwo,scrub
     """
 
     sos_cmd = '-o sudo'

--- a/tests/report_tests/plugin_tests/system/system.py
+++ b/tests/report_tests/plugin_tests/system/system.py
@@ -1,0 +1,90 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageOneReportTest, StageTwoReportTest, redhat_only
+
+
+class SystemPluginTest(StageOneReportTest):
+    """Basic sanity check to make sure common config files are collected
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o system'
+
+    def test_system_files_collected(self):
+        self.assertFileCollected("/proc/sys")
+        self.assertFileCollected("/etc/default")
+        self.assertFileCollected("/etc/environment")
+
+    @redhat_only
+    def test_system_files_collected_RH(self):
+        self.assertFileGlobInArchive("/etc/sysconfig")
+
+    def test_system_files_forbidden(self):
+        self.assertFileGlobNotInArchive("/proc/sys/net/ipv4/route/flush")
+        self.assertFileGlobNotInArchive("/proc/sys/net/ipv6/route/flush")
+        self.assertFileGlobNotInArchive("/proc/sys/net/ipv6/neigh/" +
+                                        "*/retrans_time")
+        self.assertFileGlobNotInArchive("/proc/sys/net/ipv6/neigh/" +
+                                        "*/base_reachable_time")
+        self.assertFileCollected("/etc/default/grub.d/" +
+                                 "50-curtin-settings.cfg")
+
+    def test_system_cmd_collected(self):
+        self.assertFileGlobInArchive("ld.so_--help")
+        self.assertFileGlobInArchive("ld.so_--list-diagnostics")
+        self.assertFileGlobInArchive("ld.so_--list-tunables")
+
+
+class SystemScrubTest(StageTwoReportTest):
+    """Ensure that environment, default and sysconfig are picked up
+    and properly scrubbed
+
+    :avocado: tags=stagetwo,scrub
+    """
+    sos_cmd = '-o system'
+    files = [
+        ('system_test_data', '/etc/environment'),
+        ('system_test_data', '/etc/default/proxy'),
+        ('system_test_data', '/etc/default/proxy1'),
+    ]
+    secrets_list = [
+        'foouser',
+        'somesecretpassword'
+    ]
+
+    def test_system_scrub(self):
+        for file in self.files:
+            for secret in self.secrets_list:
+                self.assertFileNotHasContent(file[1], secret)
+
+
+class SystemScrubTestRH(StageTwoReportTest):
+    """Ensure that environment, default and sysconfig are picked up
+    and properly scrubbed
+
+    :avocado: tags=stagetwo,scrub
+    """
+    redhat_only = True
+    sos_cmd = '-o system'
+    files = [
+        ('system_test_data', '/etc/sysconfig/proxy'),
+        ('system_test_data', '/etc/sysconfig/proxy1'),
+    ]
+    secrets_list = [
+        'foouser',
+        'somesecretpassword'
+    ]
+
+    def test_system_scrub(self):
+        for file in self.files:
+            for secret in self.secrets_list:
+                self.assertFileNotHasContent(file[1], secret)
+
+# vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/system/system_test_data
+++ b/tests/report_tests/plugin_tests/system/system_test_data
@@ -1,0 +1,4 @@
+HTTP_PROXY=http://foouser:somesecretpassword@proxyurl:8080
+HTTPS_PROXY=https://foouser:somesecretpassword@proxyurl:8080
+http_proxy=http://foouser:somesecretpassword@proxyurl:8080
+https_proxy=https://foouser:somesecretpassword@proxyurl:8080

--- a/tests/report_tests/plugin_tests/systemd/systemd.py
+++ b/tests/report_tests/plugin_tests/systemd/systemd.py
@@ -1,0 +1,87 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageOneReportTest, StageTwoReportTest
+
+
+class SystemdPluginTest(StageOneReportTest):
+    """Basic sanity check to make sure common config files are collected
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o systemd'
+
+    def test_systemd_files_collected(self):
+        self.assertFileCollected("/etc/systemd")
+        self.assertFileCollected("/lib/systemd/system")
+        self.assertFileCollected("/lib/systemd/user")
+        self.assertFileCollected("/etc/vconsole.conf")
+        self.assertFileCollected("/run/systemd/generator*")
+        self.assertFileCollected("/run/systemd/seats")
+        self.assertFileCollected("/run/systemd/sessions")
+        self.assertFileCollected("/run/systemd/system")
+        self.assertFileCollected("/run/systemd/users")
+        self.assertFileCollected("/etc/modules-load.d/*.conf")
+        self.assertFileCollected("/etc/yum/protected.d/systemd.conf")
+        self.assertFileCollected("/etc/tmpfiles.d/*.conf")
+        self.assertFileCollected("/run/tmpfiles.d/*.conf")
+        self.assertFileCollected("/usr/lib/tmpfiles.d/*.conf")
+
+    def test_systemd_files_forbidden(self):
+        self.assertFileGlobNotInArchive("/dev/null")
+
+    def test_systemd_cmd_collected(self):
+        self.assertFileCollected("journalctl_--list-boots")
+        self.assertFileCollected("ls_-alZR_.lib.systemd")
+        self.assertFileCollected("resolvectl_statistics")
+        self.assertFileCollected("resolvectl_status")
+        self.assertFileCollected("systemctl_list-dependencies")
+        self.assertFileCollected("systemctl_list-jobs")
+        self.assertFileCollected("systemctl_list-machines")
+        self.assertFileCollected("systemctl_list-timers_--all")
+        self.assertFileCollected("systemctl_list-unit-files")
+        self.assertFileCollected("systemctl_list-units")
+        self.assertFileCollected("systemctl_list-units_--all")
+        self.assertFileCollected("systemctl_list-units_--failed")
+        self.assertFileCollected("systemctl_show_--all")
+        self.assertFileCollected("systemctl_show-environment")
+        self.assertFileCollected("systemctl_show_service_--all")
+        self.assertFileCollected("systemctl_status_--all")
+        self.assertFileCollected("systemd-analyze")
+        self.assertFileCollected("systemd-analyze_blame")
+        self.assertFileCollected("systemd-analyze_dump")
+        self.assertFileCollected("systemd-analyze_plot.svg")
+        self.assertFileCollected("systemd-delta")
+        self.assertFileCollected("systemd-inhibit_--list")
+        self.assertFileCollected("timedatectl")
+
+
+class SystemdScrubTest(StageTwoReportTest):
+    """Ensure that system files are picked up
+    and properly scrubbed
+
+    :avocado: tags=stagetwo,scrub
+    """
+    sos_cmd = '-o systemd'
+    files = [
+        ('systemd_test_data', '/etc/systemd/system'),
+        ('systemd_test_data', '/lib/systemd/system'),
+        ('systemd_test_data', '/run/systemd/system'),
+    ]
+    secrets_list = [
+        'foouser',
+        'somesecretpassword'
+    ]
+
+    def test_systemd_scrub(self):
+        for file in self.files:
+            for secret in self.secrets_list:
+                self.assertFileNotHasContent(file[1], secret)
+
+# vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/systemd/systemd_test_data
+++ b/tests/report_tests/plugin_tests/systemd/systemd_test_data
@@ -1,0 +1,4 @@
+HTTP_PROXY=http://foouser:somesecretpassword@proxyurl:8080
+HTTPS_PROXY=https://foouser:somesecretpassword@proxyurl:8080
+http_proxy=http://foouser:somesecretpassword@proxyurl:8080
+https_proxy=https://foouser:somesecretpassword@proxyurl:8080

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -809,7 +809,7 @@ class StageTwoReportTest(BaseSoSReportTest):
                       tests/test_data/fake_plugins
 
     :avocado: disable
-    :avocado: tags=stagetwo,foreman2
+    :avocado: tags=stagetwo,scrub,foreman2
     """
 
     sos_cmd = ''


### PR DESCRIPTION
Adding stageone and stagetwo tests for [system] plugin.

Also adding tag scrub for only testing scrub of sensitive data.

And updating README with how to call scrub and stagetwo tests.

Related: #3788
Related: #3789
Resolves: #3798

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
