### PR TITLE
[vmware] Enable vmware plugin support on Ubuntu

### DIFF
--- a/sos/report/plugins/vmware.py
+++ b/sos/report/plugins/vmware.py
@@ -6,10 +6,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class VMWare(Plugin, RedHatPlugin):
+class VMWare(Plugin, IndependentPlugin):
 
     short_desc = 'VMWare client information'
 


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?

Howdy! In a recent case it came to my attention that this plugin wasn't triggering on Ubuntu systems on vmware estates. Since all the config files, commands, etc are all the same on Ubuntu as they are for RHEL, I gave it a quick test with these minor adjustments and found it to work swimmingly.

Let me know thoughts/opinions on this!