### PR TITLE
[Plugin] Check if a path exists inside a container in add_dir_listing()

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2075,7 +2075,11 @@ class Plugin():
         if isinstance(paths, str):
             paths = [paths]
 
-        paths = [p for p in paths if self.path_exists(p)]
+        if container:
+            paths = [p for p in paths if
+                     self.container_path_exists(p, container=container)]
+        else:
+            paths = [p for p in paths if self.path_exists(p)]
 
         if not tree:
             options = f"alZ{'R' if recursive else ''}"
@@ -3406,6 +3410,22 @@ class Plugin():
         verify_cmd = pm.build_verify_command(self.verify_packages)
         if verify_cmd:
             self.add_cmd_output(verify_cmd)
+
+    def container_path_exists(self, path, container):
+        """Check if a path exists inside a container before
+        collecting a dir listing
+
+        :param path:    The canonical path for a specific file/directory
+                        in a container
+        :type path:     ``str``
+
+        :param container: The container where to check for the path
+        :type container: ``str``
+
+        :returns:       True if the path exists in the container, else False
+        :rtype:         ``bool``
+        """
+        return self.exec_cmd(f"test -e {path}", container=container)
 
     def path_exists(self, path):
         """Helper to call the sos.utilities wrapper that allows the


### PR DESCRIPTION
Currently, add_dir_listing() checks if a path exists outside of a container, and when we call the command for a container, it fails to collect any listing. This patch adds a new function container_path_exists() that checks for the specified path in add_dir_listing() inside the container.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
