### PR TITLE
[report] Fix traceback when running plugins_overview.py

### DIFF
--- a/plugins_overview.py
+++ b/plugins_overview.py
@@ -90,25 +90,29 @@ for plugfile in sorted(os.listdir(PLUGDIR)):
             'env': [],
     }
     with open(os.path.join(PLUGDIR, plugfile),
-              encoding='utf-8').read().replace('\n', '') as pfd:
+              encoding='utf-8') as pfd:
+        pfd_content = pfd.read().replace('\n', '')
         add_all_items(
             "from sos.report.plugins import ", plugs_data[plugname]['distros'],
-            pfd, wrapopen='', wrapclose='(class|from|import)'
+            pfd_content, wrapopen='', wrapclose='(class|from|import)'
         )
         add_all_items("profiles = ", plugs_data[plugname]['profiles'],
-                      pfd, wrapopen='')
+                      pfd_content, wrapopen='')
         add_all_items("packages = ", plugs_data[plugname]['packages'],
-                      pfd, wrapopen='')
-        add_all_items("add_copy_spec", plugs_data[plugname]['copyspecs'], pfd)
+                      pfd_content, wrapopen='')
+        add_all_items("add_copy_spec", plugs_data[plugname]['copyspecs'],
+                      pfd_content)
         add_all_items("add_forbidden_path",
-                      plugs_data[plugname]['forbidden'], pfd)
-        add_all_items("add_cmd_output", plugs_data[plugname]['commands'], pfd)
+                      plugs_data[plugname]['forbidden'], pfd_content)
+        add_all_items("add_cmd_output", plugs_data[plugname]['commands'],
+                      pfd_content)
         add_all_items("collect_cmd_output",
-                      plugs_data[plugname]['commands'], pfd)
+                      plugs_data[plugname]['commands'], pfd_content)
         add_all_items("add_service_status",
-                      plugs_data[plugname]['service_status'], pfd)
-        add_all_items("add_journal", plugs_data[plugname]['journals'], pfd)
-        add_all_items("add_env_var", plugs_data[plugname]['env'], pfd)
+                      plugs_data[plugname]['service_status'], pfd_content)
+        add_all_items("add_journal", plugs_data[plugname]['journals'],
+                      pfd_content)
+        add_all_items("add_env_var", plugs_data[plugname]['env'], pfd_content)
 
 # print output; if "csv" is cmdline argument, print in CSV format, else JSON
 if (len(sys.argv) > 1) and (sys.argv[1] == "csv"):


### PR DESCRIPTION
Running plugins_overview.py after commit be1ad32a7 resulted in the following traceback:

Traceback (most recent call last):
  File "/sos_plugin_overview_fix/plugins_overview.py", line 92, in <module>
with open(os.path.join(PLUGDIR, plugfile),
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'str' object does not support the context manager protocol

This is because the call to read() returns a str and it was
 happening within the 'with' statement. This fix separates the
action of opening the file via 'with' and the action of reading its content via 'read()'.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
