### PR TITLE
[coredump] Add sizelimit for coredump

### DIFF
--- a/sos/report/plugins/coredump.py
+++ b/sos/report/plugins/coredump.py
@@ -32,7 +32,7 @@ class Coredump(Plugin, IndependentPlugin):
             "/usr/lib/systemd/coredump.conf.d/"
         ])
 
-        self.add_cmd_output("coredumpctl dump")
+        self.add_cmd_output("coredumpctl dump", sizelimit=100)
 
         coredump_list = self.collect_cmd_output("coredumpctl list")
         if self.get_option("detailed") and coredump_list['status'] == 0:


### PR DESCRIPTION
While most coredumps could be relatively small,
in certain environments, like Ceph, these can be
as big as 5GB. This change adds a limit of 100MB
to the latest core collection.

Related: RHEL-62972

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
