### PR TITLE
[heat] Obfuscate Add auth_encryption_key in config

### DIFF
--- a/sos/report/plugins/openstack_heat.py
+++ b/sos/report/plugins/openstack_heat.py
@@ -119,7 +119,7 @@ class OpenStackHeat(Plugin):
         protect_keys = [
             "admin_password", "memcache_secret_key", "password",
             "qpid_password", "rabbit_password", "stack_domain_admin_password",
-            "transport_url"
+            "transport_url", "auth_encryption_key",
         ]
         connection_keys = ["connection"]
 


### PR DESCRIPTION
This was discovered while verification of 4.7.2 to go into Ubuntu stable release

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
