### PR TITLE
[openshift] Fix openshift plugin for 4.16+

### DIFF
--- a/sos/report/plugins/openshift.py
+++ b/sos/report/plugins/openshift.py
@@ -58,7 +58,7 @@ class Openshift(Plugin, RedHatPlugin):
     plugin_name = "openshift"
     plugin_timeout = 900
     profiles = ('openshift',)
-    packages = ('openshift-hyperkube',)
+    packages = ('openshift-hyperkube', 'openshift-kubelet')
 
     master_localhost_kubeconfig = (
         '/etc/kubernetes/static-pod-resources/'


### PR DESCRIPTION
Added "openshift-kubelet" to the list of packages for the "openshift" sos plugin, so that it works in 4.16+

Related: SUPDEV-161

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
