### PR TITLE
[presets] Add new preset for RHEL AI

### DIFF
--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -86,6 +86,20 @@ NOTE_SIZE = "This preset may increase report size"
 NOTE_TIME = "This preset may increase report run time"
 NOTE_SIZE_TIME = "This preset may increase report size and run time"
 
+RHELAI = "rhelai"
+RHELAI_DESC = "Red Hat Enterprise Linux AI"
+RHELAI_OPTS = SoSOptions(
+                all_logs=True,
+                enable_plugins=[
+                    'instructlab',
+                    'nvidia',
+                    'bootc',
+                    'containers_common'
+                ])
+
+RHELAI_NOTE = ("Collects RHEL AI related data, like Instructlab containers,"
+               "nvidia and bootc plugins.")
+
 RHEL_PRESETS = {
     AAPEDA: PresetDefaults(name=AAPEDA, desc=AAPEDA_DESC, opts=AAPEDA_OPTS,
                            note=AAPEDA_NOTE),
@@ -102,7 +116,9 @@ RHEL_PRESETS = {
                             opts=_opts_verify),
     RH_SATELLITE: PresetDefaults(name=RH_SATELLITE, desc=RH_SATELLITE_DESC,
                                  note=NOTE_TIME, opts=SAT_OPTS),
-    CB: PresetDefaults(name=CB, desc=CB_DESC, note=CB_NOTE, opts=CB_OPTS)
+    CB: PresetDefaults(name=CB, desc=CB_DESC, note=CB_NOTE, opts=CB_OPTS),
+    RHELAI: PresetDefaults(name=RHELAI, desc=RHELAI_DESC, opts=RHELAI_OPTS,
+                           note=RHELAI_NOTE)
 }
 
 


### PR DESCRIPTION
Add a new preset for RHEL AI, that captures
the output of Instructlab plugin, as well as
related plugins like nvidia, bootc, 
and containers_common.

Related: RHEL-58169
Depends-on: #3804

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
