### PR TITLE
[policies|auth] Move away from deprecated datetime.utcnow

### DIFF
--- a/sos/policies/auth/__init__.py
+++ b/sos/policies/auth/__init__.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     REQUESTS_LOADED = False
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sos.utilities import TIMEOUT_DEFAULT
 
@@ -128,14 +128,14 @@ class DeviceAuthorizationClass:
         and their expiry etc.
         """
         self._access_token = token_data.get("access_token")
-        self._access_expires_at = datetime.utcnow() + \
+        self._access_expires_at = datetime.now(timezone.utc) + \
             timedelta(seconds=token_data.get("expires_in"))
         self._refresh_token = token_data.get("refresh_token")
         self._refresh_expires_in = token_data.get("refresh_expires_in")
         if self._refresh_expires_in == 0:
             self._refresh_expires_at = datetime.max
         else:
-            self._refresh_expires_at = datetime.utcnow() + \
+            self._refresh_expires_at = datetime.now(timezone.utc) + \
                 timedelta(seconds=self._refresh_expires_in)
 
     def get_access_token(self):
@@ -161,7 +161,7 @@ class DeviceAuthorizationClass:
         """
         return self._access_token and self._access_expires_at and \
             self._access_expires_at - timedelta(seconds=180) > \
-            datetime.utcnow()
+            datetime.now(timezone.utc)
 
     def is_refresh_token_valid(self):
         """
@@ -173,7 +173,7 @@ class DeviceAuthorizationClass:
         """
         return self._refresh_token and self._refresh_expires_at and \
             self._refresh_expires_at - timedelta(seconds=180) > \
-            datetime.utcnow()
+            datetime.now(timezone.utc)
 
     def _use_refresh_token_grant(self, refresh_token=None):
         """


### PR DESCRIPTION
Change calls to deprecated datetime.utcnow to datetime.now.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
