### PR TITLE
[collect] Fix exception while parsing sos help

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -367,7 +367,8 @@ class SosNode():
             for line in result.splitlines():
                 if not is_list:
                     try:
-                        res.append(line.split()[0])
+                        if ls := line.split():
+                            res.append(ls[0])
                     except Exception as err:
                         self.log_debug(f"Error parsing sos help: {err}")
                 else:


### PR DESCRIPTION
While parsing the output of 'sos report -l', we
were attempting to split an empty line, and
getting the following exception:

[<ip address>:_regex_sos_help] Error parsing sos help: list index out of range

Related: #3827

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
