### PR TITLE
[collect] SosNode._format_cmd local node return without sudo/su when already root.

### DIFF
--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -277,6 +277,9 @@ class SosNode():
         """If we need to provide a sudo or root password to a command, then
         here we prefix the command with the correct bits
         """
+        is_root = self._env_vars.get("USER", os.environ.get("USER")) == 'root'
+        if self.local and is_root:
+            return cmd
         if self.opts.become_root:
             return f"su -c {quote(cmd)}"
         if self.need_sudo:


### PR DESCRIPTION
Resolves: #3827
Resolves: #3828

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?

----

## Passing Tests

1. `sudo sos collect --batch  --nopasswd-sudo --ssh-key ~/.ssh/id_setasside --ssh-user project-user --nodes 192.168.124.121`
2. `sos collect --batch  --nopasswd-sudo --ssh-key ~/.ssh/id_setasside --ssh-user project-user --nodes 192.168.124.121`
3. `sudo sos collect --batch --ssh-key ~/.ssh/id_setasside --ssh-user project-user --nodes 192.168.124.121`
4. `sudo sos collect --ssh-key ~/.ssh/id_setasside --ssh-user project-user --nodes 192.168.124.121`
5. `sos collect --ssh-key ~/.ssh/id_setasside --ssh-user project-user --nodes 192.168.124.121`
6. `sudo sos collect --password --ssh-user project-user --nodes 192.168.124.121`
7. `sudo sos collect --nopasswd-sudo --password --ssh-user project-user --nodes 192.168.124.121`
8. `sos collect --password --ssh-user project-user --nodes 192.168.124.121`
9. `sos collect --nopasswd-sudo --password --ssh-user project-user --nodes 192.168.124.121`

I did not think of any use cases that need/expect to run `sudo -S {cmd}` or `su -c {quote(cmd)}` when already the root user, or already running sudo etc.. However, this change would prevent that from happening on the local node executing `sos collect`.

I don't believe this introduces any unwanted changes. However, please let me know if there are any other test case combinations you would like performed to feel comfortable before merging.