### PR TITLE
[collect] Fix exception when using collect with batch and password

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -74,8 +74,7 @@ This does NOT enable all sos collect options.
 Become the root user on the remote node when connecting as a non-root user.
 .TP
 \fB\-\-batch\fR
-Run in non-interactive mode. This will skip prompts for user input, with the
-exception of a prompt for the SSH password.
+Run in non-interactive mode. This will skip prompts for user input.
 .TP
 \fB\-\-all\-logs\fR
 Report option. Collects all logs regardless of size. 

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1194,6 +1194,14 @@ this utility or remote systems that it connects to.
 
         self.intro()
 
+        if self.opts.batch and self.opts.password:
+            self.exit(
+                "\nsos-collector was called with incompatible options --batch "
+                "and --password.\nIf you need to use --password,"
+                " please omit batch mode.\n",
+                1
+            )
+
         self.configure_sos_cmd()
         self.prep()
         self.display_nodes()


### PR DESCRIPTION
Using --batch --password together in sos-collect leads to an error:

Unable to open remote session:
unsupported operand type(s) for +: 'bool' and 'str'

This PR removes the check for the batch option, enabling
the prompt for password as specified in the man page:

  --batch
	  Run in non-interactive mode.
	 This will skip prompts for user input,  with  the
	 exception  of  a prompt for the SSH password.

Related: #3839

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
