### PR TITLE
[ansible] Forbid collecting /etc/ansible/files

### DIFF
--- a/sos/report/plugins/ansible.py
+++ b/sos/report/plugins/ansible.py
@@ -33,6 +33,7 @@ class Ansible(Plugin, RedHatPlugin, UbuntuPlugin):
         self.add_forbidden_path([
             "/etc/ansible/facts.d/",
             "/etc/ansible/roles/",
+            "/etc/ansible/files/",
             "/etc/ansible/hosts",
         ])
 


### PR DESCRIPTION
The directory contains random server's files to copy, potentially with sensitive data, not relevant to any troubleshooting.

Resolves: #3845

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
