### PR TITLE
[login] Capture 'last -F' output

### DIFF
--- a/sos/report/plugins/login.py
+++ b/sos/report/plugins/login.py
@@ -17,10 +17,10 @@ class Login(Plugin, IndependentPlugin):
     profiles = ('system', 'identity')
 
     def setup(self):
-        self.add_cmd_output("last", root_symlink="last")
+        self.add_cmd_output("last -F", root_symlink="last")
         self.add_cmd_output([
-            "last reboot",
-            "last shutdown",
+            "last -F reboot",
+            "last -F shutdown",
             "lastlog",
             "lastlog -u 0-999",
             "lastlog -u 1000-60000",


### PR DESCRIPTION
Invoking the command `last` with the `-F` flag will give all timestamps expanded so that they are human-readable

Related: RHEL-68128

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
