### PR TITLE
[cleaner] Skip obfuscation of substrings for hostnames properly

### DIFF
--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -99,7 +99,7 @@ class SoSMap():
         :rtype:         ``re.Pattern``
         """
         if self.match_full_words_only:
-            item = rf'(?=\b|_|-){re.escape(item)}(?=\b|_|-)'
+            item = rf'(?<![a-z0-9]){re.escape(item)}(?=\b|_|-)'
         else:
             item = re.escape(item)
         return re.compile(item, re.I)

--- a/sos/cleaner/mappings/hostname_map.py
+++ b/sos/cleaner/mappings/hostname_map.py
@@ -87,7 +87,7 @@ class SoSHostnameMap(SoSMap):
         """
         if '.' in item:
             item = item.replace('.', '(\\.|_)')
-        return re.compile(item, re.I)
+        return super().get_regex_result(item)
 
     def set_initial_counts(self):
         """Set the initial counter for host and domain obfuscation numbers

--- a/tests/cleaner_tests/full_report/full_report_run.py
+++ b/tests/cleaner_tests/full_report/full_report_run.py
@@ -64,7 +64,10 @@ class FullCleanTest(StageTwoReportTest):
         host = self.sysinfo['pre']['networking']['hostname']
         short = host.split('.')[0]
         # much faster to just use grep here
-        content = self.grep_for_content(host) + self.grep_for_content(short)
+        host = rf'(?<![a-z0-9]){re.escape(host)}(?=\b|_|-)'
+        short = rf'(?<![a-z0-9]){re.escape(short)}(?=\b|_|-)'
+        content = self.grep_for_content(host, regexp=True) + \
+            self.grep_for_content(short, regexp=True)
         if not content:
             assert True
         else:


### PR DESCRIPTION
Leftover from #3403 / #3496 where match_full_words_only is ignored for hostname mapping due to own get_regex_result method.

Resolves: #3593

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
