### PR TITLE
Fix duplicate-handler-exception in OSError exceptions

### DIFF
--- a/sos/options.py
+++ b/sos/options.py
@@ -218,7 +218,7 @@ class SoSOptions():
         try:
             with open(config_file, encoding='utf-8') as f:
                 config.read_file(f, config_file)
-        except (OSError, IOError) as e:
+        except OSError as e:
             print(
                 f'WARNING: Unable to read configuration file {config_file} : '
                 f'{e.args[1]}'

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1220,7 +1220,7 @@ class SoSReport(SoSComponent):
             self.setup_archive()
             self._make_archive_paths()
             return
-        except (OSError, IOError) as e:
+        except OSError as e:
             # we must not use the logging subsystem here as it is potentially
             # in an inconsistent or unreliable state (e.g. an EROFS for the
             # file system containing our temporary log files).
@@ -1258,7 +1258,7 @@ class SoSReport(SoSComponent):
                 plug.manifest.add_field('setup_time', end - start)
             except KeyboardInterrupt:
                 raise KeyboardInterrupt  # pylint: disable=raise-missing-from
-            except (OSError, IOError) as e:
+            except OSError as e:
                 if e.errno in fatal_fs_errors:
                     self.ui_log.error("")
                     self.ui_log.error(
@@ -1395,7 +1395,7 @@ class SoSReport(SoSComponent):
             # we already log and handle the plugin timeout in the nested thread
             # pool this is running in, so don't do anything here.
             pass
-        except (OSError, IOError) as e:
+        except OSError as e:
             if e.errno in fatal_fs_errors:
                 self.ui_log.error(
                     f"\n {e.strerror} while collecting plugin data")
@@ -1473,7 +1473,7 @@ class SoSReport(SoSComponent):
                 fd.flush()
                 self.archive.add_file(fd, dest=os.path.join('sos_reports',
                                                             filename))
-            except (OSError, IOError) as e:
+            except OSError as e:
                 if e.errno in fatal_fs_errors:
                     self.ui_log.error("")
                     self.ui_log.error(
@@ -1494,7 +1494,7 @@ class SoSReport(SoSComponent):
                 else:
                     self.soslog.info(
                         f"Skipping postproc for plugin {plugname}")
-            except (OSError, IOError) as e:
+            except OSError as e:
                 if e.errno in fatal_fs_errors:
                     self.ui_log.error("")
                     self.ui_log.error(
@@ -1616,7 +1616,7 @@ class SoSReport(SoSComponent):
                     self.archive.rename_archive_root(cleaner)
                 archive = self.archive.finalize(
                     self.opts.compression_type)
-            except (OSError, IOError) as e:
+            except OSError as e:
                 print("")
                 print(_(f" {e.strerror} while finalizing archive "
                         f"{self.archive.get_archive_path()}"))
@@ -1643,7 +1643,7 @@ class SoSReport(SoSComponent):
                 final_dir = os.path.join(self.sys_tmp, dir_name)
                 os.rename(directory, final_dir)
                 directory = final_dir
-            except (OSError, IOError):
+            except OSError:
                 print(_(f"Error moving directory: {directory}"))
                 return False
 
@@ -1665,7 +1665,7 @@ class SoSReport(SoSComponent):
                     return False
                 try:
                     self._write_checksum(archive, hash_name, checksum)
-                except (OSError, IOError):
+                except OSError:
                     print(_(f"Error writing checksum for file: {archive}"))
 
                 # output filename is in the private tmpdir - move it to the
@@ -1686,7 +1686,7 @@ class SoSReport(SoSComponent):
                 try:
                     os.rename(archive, final_name)
                     archive = final_name
-                except (OSError, IOError):
+                except OSError:
                     print(_(f"Error moving archive file: {archive}"))
                     return False
 
@@ -1704,7 +1704,7 @@ class SoSReport(SoSComponent):
                 # under the control of the user creating the link.
                 try:
                     os.rename(archive_hash, final_hash)
-                except (OSError, IOError):
+                except OSError:
                     print(_(f"Error moving checksum file: {archive_hash}"))
 
                 self.policy.display_results(archive, directory, checksum,

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1304,7 +1304,7 @@ class Plugin():
             if not path:
                 return 0
             replacements = self.archive.do_file_sub(path, regexp, subst)
-        except (OSError, IOError) as e:
+        except OSError as e:
             # if trying to regexp a nonexisting file, dont log it as an
             # error to stdout
             if e.errno == errno.ENOENT:
@@ -1499,7 +1499,7 @@ class Plugin():
 
         try:
             st = os.lstat(srcpath)
-        except (OSError, IOError):
+        except OSError:
             self._log_info(f"failed to stat '{srcpath}'")
             return None
 


### PR DESCRIPTION
IOError is covered by OSError since Python 3.3 so
lines like:

except (OSError, IOError) as e:

Were being marked with warning B014.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
