### PR TITLE
[component] Apply plugopts from cmdline gently

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -243,7 +243,20 @@ class SoSComponent():
                         setattr(opts, oopt, [x for x in getattr(opts, oopt)
                                 if x not in common])
 
-            if val != opts.arg_defaults[opt]:
+            # plugin options as a list should be concatenated, not overriden
+            # BUT if cmdline plugoption overrides same option in opts, we must
+            # drop the opts's value; since the items are in form
+            # 'apache.log=on', we must separate the *name* of each option
+            if opt == 'plugopts':
+                oplugopts = getattr(opts, opt)
+                valnames = [v.split('=')[0] for v in val]
+                ovalnames = [v.split('=')[0] for v in oplugopts]
+                for common in set(valnames) & set(ovalnames):
+                    cstring = f"{common}="
+                    oplugopts = [oopt for oopt in oplugopts
+                                 if not oopt.startswith(cstring)]
+                setattr(opts, opt, list(set(val) | set(oplugopts)))
+            elif val != opts.arg_defaults[opt]:
                 setattr(opts, opt, val)
 
         return opts


### PR DESCRIPTION
When plugopts are set both in a loaded preset and in cmdline, we should merge the options instead of blindly using cmdline ones.

This means preset plugopt options not present in cmdline are added, while preset plugopt options also present in cmdline are ignored.

Closes: #3855

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
