### PR TITLE
[sunbeam] Forbid pki folder & manifest inclusion

### DIFF
--- a/sos/report/plugins/sunbeam.py
+++ b/sos/report/plugins/sunbeam.py
@@ -10,6 +10,7 @@
 
 import json
 import pwd
+import yaml
 from sos.report.plugins import Plugin, UbuntuPlugin, PluginOpt
 
 
@@ -46,7 +47,17 @@ class Sunbeam(Plugin, UbuntuPlugin):
         self.add_cmd_output([
             'sunbeam cluster list',
             'sunbeam cluster list --format yaml',
+            'sunbeam manifest list',
         ], snap_cmd=True)
+
+        manifest_raw = self.collect_cmd_output(
+            'sunbeam manifest list --format yaml')
+
+        if manifest_raw['status'] == 0:
+            manifests = yaml.safe_load(manifest_raw['output'])
+            for manifest in manifests:
+                self.add_cmd_output(
+                    f'sunbeam manifest show --id {manifest["manifestid"]}')
 
         sunbeam_user = self.get_option("sunbeam-user")
         try:

--- a/sos/report/plugins/sunbeam_hypervisor.py
+++ b/sos/report/plugins/sunbeam_hypervisor.py
@@ -39,6 +39,7 @@ class SunbeamHypervisor(Plugin, UbuntuPlugin):
             f'{self.common_dir}/etc/libvirt/passwd.db',
             f'{self.common_dir}/etc/libvirt/krb5.tab',
             f'{self.common_dir}/var/log/ovn/',
+            f'{self.common_dir}/etc/pki/',
         ])
 
     def postproc(self):


### PR DESCRIPTION
* Forbid the pki folder collection newly added recently
* Add manifest collection from sunbeam

Related: SET-813

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
