### PR TITLE
[selinux] Add "boolean list" option to "semanage" command

### DIFF
--- a/sos/report/plugins/selinux.py
+++ b/sos/report/plugins/selinux.py
@@ -51,6 +51,7 @@ class SELinux(Plugin, RedHatPlugin, UbuntuPlugin):
                 'login',
                 'node',
                 'interface',
+                'boolean',
                 'module'
             ]
 


### PR DESCRIPTION
`semanage` command with `boolean` and `-l` will collect all the list of booleans and put it in
`sos_commands/selinux/semanage_boolean_-l` file. It is helpful on many occasions to see if
particular boolean is enabled or not.

Signed-off-by: Shreyas Mahangade [smahanga@redhat.com](mailto:smahnaga@redhat.com)

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
