### PR TITLE
[ceph_common] Capture cephadm.log file

### DIFF
--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -57,11 +57,13 @@ class CephCommon(Plugin, RedHatPlugin, UbuntuPlugin):
                 self.add_copy_spec([
                     "/var/log/calamari/*.log",
                     "/var/log/ceph/**/ceph.log",
+                    "/var/log/ceph/cephadm.log",
                 ])
             else:
                 self.add_copy_spec([
                     "/var/log/calamari",
                     "/var/log/ceph/**/ceph.log*",
+                    "/var/log/ceph/cephadm.log*",
                 ])
 
             self.add_copy_spec([


### PR DESCRIPTION
Capture log files /var/log/ceph/cephadm.log
via the ceph_common plugin.

Related: #3809

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
