### PR TITLE
[man] List --plugopts variant of -k/--plugin-option

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -8,7 +8,7 @@ sos_report \- Collect and package diagnostic and support data
           [-e|--enable-plugins plugin-names]\fR
           [-o|--only-plugins plugin-names]\fR
           [-a|--alloptions] [-v|--verbose]\fR
-          [-k plug.opt|--plugin-option plug.opt]\fR
+          [-k plug.opt|--plugin-option plug.opt]|--plugopts plug.opt\fR
           [--no-report] [--config-file conf]\fR
           [--no-postproc]\fR
           [--preset preset] [--add-preset add_preset]\fR
@@ -84,7 +84,8 @@ Enable the specified plugin(s) only (all other plugins should be
 disabled). Multiple plugins may be specified by repeating the option
 or as a comma-separated list.
 .TP
-.B \-k PLUGNAME.PLUGOPT[=VALUE], \--plugin-option=PLUGNAME.PLUGOPT[=VALUE]
+.B \-k PLUGNAME.PLUGOPT[=VALUE], \--plugin-option=PLUGNAME.PLUGOPT[=VALUE], \
+\--plugopts=PLUGNAME.PLUGOPT[=VALUE]
 Specify plug-in options. The option PLUGOPT is enabled, or set to the
 specified value in the plug-in PLUGNAME.
 .TP


### PR DESCRIPTION
`--plugopts` is yet another alternative to `-k`/`--plugin-option` that sos report accepts. Let list it in man pages.

Resolves: #3865

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
