### PR TITLE
[process] Capture information about sched_ext

### DIFF
--- a/sos/report/plugins/process.py
+++ b/sos/report/plugins/process.py
@@ -41,7 +41,8 @@ class Process(Plugin, IndependentPlugin):
             "/proc/sched_debug",
             "/proc/stat",
             "/sys/kernel/debug/sched/debug",
-            "/sys/kernel/debug/sched/features"
+            "/sys/kernel/debug/sched/features",
+            "/sys/kernel/sched_ext/",
         ])
 
         procs = [p for p in self.listdir("/proc") if re.match("[0-9]", p)]


### PR DESCRIPTION
Sched_ext is an extensible scheduler class which
allows a BPF program to hook into core scheduler
code paths to implement a custom scheduler.
This patch captures some initial information about sched_ext from sysfs.

Related: RHEL-70330

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
