### PR TITLE
[ceph_mon] Add json output for 'ceph config dump'

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -102,7 +102,6 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
             # The ceph_mon plugin will collect all the "ceph ..." commands
             # which typically require the keyring.
 
-            "ceph config dump",
             "ceph config generate-minimal-conf",
             "ceph config log",
             "ceph config-key dump",
@@ -145,6 +144,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
                     self.add_cmd_output(f"ceph crash info {cid}")
 
         ceph_cmds = [
+            "config dump",
             "device ls",
             "df detail",
             "df",


### PR DESCRIPTION
Related: RHEL-70689

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
