### PR TITLE
[kubernetes] add kube-system-log-files option, collect some kubelet files

### DIFF
--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -46,6 +46,12 @@ class Kubernetes(Plugin):
     config_files = [
         "/etc/kubernetes",
         "/run/flannel",
+        "/var/lib/kubelet/config.yaml",
+        "/var/lib/kubelet/kubeadm-flags.env",
+        "/var/lib/kubelet/*_manager_state",
+    ]
+    forbidden_paths = [
+        "/etc/kubernetes/pki",
     ]
     resources = [
         'events',
@@ -105,7 +111,7 @@ class Kubernetes(Plugin):
     def setup(self):
         self.add_copy_spec(self.config_files)
 
-        self.add_forbidden_path("/etc/kubernetes/pki")
+        self.add_forbidden_path(self.forbidden_paths)
 
         self.add_env_var([
             'KUBECONFIG',

--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -53,6 +53,12 @@ class Kubernetes(Plugin):
     forbidden_paths = [
         "/etc/kubernetes/pki",
     ]
+    kube_system_logs = [
+        "/var/log/pods/kube-system_etcd-*",
+        "/var/log/pods/kube-system_kube-apiserver-*",
+        "/var/log/pods/kube-system_kube-controller-manager-*",
+        "/var/log/pods/kube-system_kube-scheduler-*",
+    ]
     resources = [
         'events',
         'deployments',
@@ -88,8 +94,10 @@ class Kubernetes(Plugin):
                   desc='collect all namespace output separately'),
         PluginOpt('describe', default=False,
                   desc='collect describe output of all resources'),
+        PluginOpt('kubelogs', default=False,
+                  desc='copy some kube-system pod logs without using the API'),
         PluginOpt('podlogs', default=False,
-                  desc='capture stdout/stderr logs from pods'),
+                  desc='capture stdout/stderr logs from pods using the API'),
         PluginOpt('podlogs-filter', default='', val_type=str,
                   desc='only collect logs from pods matching this pattern')
     ]
@@ -112,6 +120,9 @@ class Kubernetes(Plugin):
         self.add_copy_spec(self.config_files)
 
         self.add_forbidden_path(self.forbidden_paths)
+
+        if self.get_option('kubelogs'):
+            self.add_copy_spec(self.kube_system_logs)
 
         self.add_env_var([
             'KUBECONFIG',


### PR DESCRIPTION
2 small enhancements to the kubernetes plugin

I'm open to proposal for another name than `kube-system-log-files`:
```
The following plugin options are available:
 kubernetes.all            on              collect all namespace output separately
 kubernetes.describe       on              collect describe output of all resources
 kubernetes.podlogs        on              capture stdout/stderr logs from pods
 kubernetes.podlogs-filter                 only collect logs from pods matching this pattern
 kubernetes.kube-system-log-files off             copy some kube-system pod logs without using the API
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
