### PR TITLE
[policies] Fix bug in distro identification

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -164,7 +164,10 @@ class LinuxPolicy(Policy):
         if remote:
             return _check_release(remote)
         # use the os-specific file primarily
-        if os.path.isfile(cls.os_release_file):
+        # also check the symlink destination
+        if (os.path.isfile(cls.os_release_file) and
+            os.path.basename(cls.os_release_file)
+                == os.path.basename(os.path.realpath(cls.os_release_file))):
             return True
         # next check os-release for a NAME or ID value we expect
         with open(OS_RELEASE, "r", encoding='utf-8') as f:


### PR DESCRIPTION
Fixes a bug in #3764.

A bug in the distro-identifying logic caused incorrect identification of the distro as CentOS, Fedora, or RHEL under the following conditions:

1. Distro inherits RedHatPolicy
2. Distro has either of /etc/{centos,fedora,redhat}-release
3. Policy file appears earlier than redhat.py in dictionary order

The issue occurs because the distro-identifying logic relies on the existence of the above os_release_file without examining its contents, more than checking NAME or ID in the /etc/os-release file. As a result, once /etc/{centos,fedora,redhat}-release is found, the contents of /etc/os-release are never checked, leading to distro misidentification.

At least AlmaLinux is affected by this bug.

---

## Steps to reproduce

### AlmaLinux 9

#### On the container host
```shell
$ git clone https://github.com/sosreport/sos
$ podman run -it --rm -v .//sos:/sos quay.io/almalinuxorg/almalinux:9 /bin/bash
```

#### Inside the container
```
# ls -l /etc/*-release
-rw-r--r--. 1 root root 36 Nov 12 09:29 /etc/almalinux-release
lrwxrwxrwx. 1 root root 21 Nov 12 09:29 /etc/os-release -> ../usr/lib/os-release
lrwxrwxrwx. 1 root root 17 Nov 12 09:29 /etc/redhat-release -> almalinux-release
lrwxrwxrwx. 1 root root 17 Nov 12 09:29 /etc/system-release -> almalinux-release
# cat /etc/almalinux-release
AlmaLinux release 9.5 (Teal Serval)
# dnf install -y python3-setuptools
# cd sos
# python3 -m venv env && source env/bin/activate
# pip install -r requirements.txt
# bin/sos rep

(snip)

sos report (version 4.8.1)

(snip)

This command will collect diagnostic and configuration information from
this Red Hat Enterprise Linux system and installed applications.

An archive containing the collected information will be generated in
/var/tmp/sos.khtjjzfz and may be provided to a Red Hat support
representative.

Any information provided to Red Hat will be treated in accordance with
the published support policies at:

        Distribution Website : https://www.redhat.com/
        Commercial Support   : https://access.redhat.com/

The generated archive may contain data considered sensitive and its
content should be reviewed by the originating organization before being
passed to any third party.

No changes will be made to system configuration.

Press ENTER to continue, or CTRL-C to quit.
```

### AlmaLinux 8
#### On the container host
```shell
$ git clone https://github.com/sosreport/sos
$ podman run -it --rm -v .//sos:/sos quay.io/almalinuxorg/almalinux:8 /bin/bash
```

#### Inside the container
```
# ls -l /etc/*-release
-rw-r--r--. 1 root root 42 May 22  2024 /etc/almalinux-release
lrwxrwxrwx. 1 root root 17 May 22  2024 /etc/centos-release -> almalinux-release
lrwxrwxrwx. 1 root root 21 May 22  2024 /etc/os-release -> ../usr/lib/os-release
lrwxrwxrwx. 1 root root 17 May 22  2024 /etc/redhat-release -> almalinux-release
lrwxrwxrwx. 1 root root 17 May 22  2024 /etc/system-release -> almalinux-release
# cat /etc/almalinux-release
AlmaLinux release 8.10 (Cerulean Leopard)
# dnf install -y python3.11 python3.11-setuptools
# cd sos
# python3.11 -m venv env && source env/bin/activate
# pip3.11 install -r requirements.txt
# bin/sos rep

WARNING: Failed to load 'magic' module version >= 0.4.20 which sos aims
to use for detecting binary files. A less effective method will be used.
It is recommended to install proper python3-magic package with the
module.

(snip)

sos report (version 4.8.1)

(snip)

This command will collect diagnostic and configuration information from
this CentOS Linux system and installed applications.

An archive containing the collected information will be generated in
/var/tmp/sos.az9ho1x4 and may be provided to a CentOS support
representative.

Any information provided to CentOS will be treated in accordance with
the published support policies at:

        Community Website : https://www.centos.org/

The generated archive may contain data considered sensitive and its
content should be reviewed by the originating organization before being
passed to any third party.

No changes will be made to system configuration.

Press ENTER to continue, or CTRL-C to quit.
```

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
