### PR TITLE
[os-net-config] Include the os-net-config logfile

### DIFF
--- a/sos/report/plugins/os_net_config.py
+++ b/sos/report/plugins/os_net_config.py
@@ -20,6 +20,7 @@ class OsNetConfig(Plugin, IndependentPlugin):
     def setup(self):
         self.add_copy_spec("/etc/os-net-config")
         self.add_copy_spec("/var/lib/os-net-config")
+        self.add_copy_spec("/var/log/os-net-config.log")
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Issues with os-net-config can cause major problems with hypervisor provisioning and configuration, but the logfile is not currently captured.  Explicitly capture it.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
