### PR TITLE
[ceph_mon] Fix capture of ceph json outputs

### DIFF
--- a/sos/report/plugins/ceph_mon.py
+++ b/sos/report/plugins/ceph_mon.py
@@ -97,7 +97,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
                 "/var/snap/microceph/current/conf/*",
             ])
 
-        self.add_cmd_output("ceph report", tags="ceph_report")
+        self.add_cmd_output("ceph report", tags="ceph_report", stderr=False)
         self.add_cmd_output([
             # The ceph_mon plugin will collect all the "ceph ..." commands
             # which typically require the keyring.
@@ -186,6 +186,7 @@ class CephMON(Plugin, RedHatPlugin, UbuntuPlugin):
         self.add_cmd_output(
             [f"ceph {cmd} --format json-pretty" for cmd in ceph_cmds],
             subdir="json_output",
+            stderr=False
         )
 
     def get_ceph_version(self):


### PR DESCRIPTION
Some ceph command captured with json output are
storing stderr at the end of the capture, and this can cause problems while parsing these outputs.
This commits disables stderr in add_cmd_output()
only for these captures that attempt to get json
outputs.

Related:RHEL-71127

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
