### PR TITLE
[foreman] Obfuscate http_proxy passwords

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -327,6 +327,23 @@ class Foreman(Plugin):
             r"/etc/foreman/(.*)((yaml|yml)(.*)?)",
             r"((\:|\s*)(passw|cred|token|secret|key).*(\:\s|=))(.*)",
             r'\1"********"')
+        # hide proxy credentials..
+        self.do_paths_http_sub([
+            '/var/log/foreman/production.log*',
+        ])
+        # .. even those appearing TWICE in the logfile, in format (one-line):
+        # Setting (7) update event on value --- https://USER:PASS@foobar:443,\
+        # --- https://USER:PASS@foobar:3128
+        self.do_path_regex_sub(
+            '/var/log/foreman/production.log*',
+            r", --- (http(s)?://)\S+:\S+(@.*)",
+            r"\1******:******\3"
+        )
+        # hide proxy credentials from http_proxy setting
+        self.do_cmd_output_sub(
+            "from settings where",
+            r"(http(s)?://)\S+:\S+(@.*)",
+            r"\1******:******\3")
 
 # Let the base Foreman class handle the string substitution of the apachepkg
 # attr so we can keep all log definitions centralized in the main class


### PR DESCRIPTION
production.log can (unintentionally) contain http_proxy URL including credentials. Since the URL can appear on one logline twice, obfuscating the 2nd instance is more tricky than usual.

Also, obfuscate the same password in settings table.

Related: SAT-30137
Closes: #3878

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
