### PR TITLE
[utilities,plugins] speedup journal collection (v2)

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3088,8 +3088,15 @@ class Plugin():
         if output:
             journal_cmd += output_opt % output
 
+        fname = journal_cmd
+        tac = False
+        if log_size > 0:
+            journal_cmd = f"{journal_cmd} --reverse"
+            tac = True
+
         self._log_debug(f"collecting journal: {journal_cmd}")
         self._add_cmd_output(cmd=journal_cmd, timeout=timeout,
+                             tac=tac, to_file=True, suggest_filename=fname,
                              sizelimit=log_size, pred=pred, tags=tags,
                              priority=priority)
 

--- a/tests/report_tests/plugin_tests/defaults.py
+++ b/tests/report_tests/plugin_tests/defaults.py
@@ -36,7 +36,7 @@ class DefaultCollectionsTest(StageTwoReportTest):
         _m = self.get_plugin_manifest('cups')
         ent = None
         for cmd in _m['commands']:
-            if cmd['exec'] == 'journalctl --no-pager  --unit cups':
+            if cmd['exec'] == 'journalctl --no-pager  --unit cups --reverse':
                 ent = cmd
         assert ent, "No manifest entry for journalctl cups"
 


### PR DESCRIPTION
Instead of generating all the logs and tailing the last 100M, we get the first 100M of 'journalctl --reverse' that we then reverse again using our own implementation of tac.

To handle multiline logs we would need to use "tac -brs '^[^ ]'" that takes ~30s on 100M of logs when plain 'tac' takes ~0.3s. Our simple implementation in python takes 0.7s, and avoid an extra dependency.

On journalctl timeout we now get the most recents logs.

During collection logs are now buffered on disk, so we use 2xsizelimit. While running our tac we could actually truncate the source file to limit disk usage. Previously buffering was in RAM (also 2xsizelimit).

On my test server, logs plugin runtime goes from 34s to 9.5s.

Fixes https://github.com/sosreport/sos/issues/3615

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
