### PR TITLE
[foreman] Obfuscate http_proxy passwords. PR-3878 improvement

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1317,9 +1317,9 @@ class Plugin():
         return replacements
 
     def do_paths_http_sub(self, pathspecs):
-        """ Obfuscate credentials in *_PROXY variables in all files in the
-        given list. Proxy setting without protocol is ignored, since that
-        is not recommended setting and obfuscating that one can hit false
+        """ Obfuscate Basic_AUTH URL credentials in all files in the given
+        list. Proxy setting without protocol is ignored, since that is
+        not recommended setting and obfuscating that one can hit false
         positives.
 
         :param pathspecs: A filepath to obfuscate credentials in
@@ -1329,7 +1329,7 @@ class Plugin():
             pathspecs = [pathspecs]
         for path in pathspecs:
             self.do_path_regex_sub(
-                path, r"(http(s)?://)\S+:\S+(@.*)", r"\1******:******\3")
+                path, r"http(s)?://\S+:\S+@", r"http\1://******:******@")
 
     def do_path_regex_sub(self, pathexp, regexp, subst):
         """Apply a regexp substituation to a set of files archived by

--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -331,14 +331,6 @@ class Foreman(Plugin):
         self.do_paths_http_sub([
             '/var/log/foreman/production.log*',
         ])
-        # .. even those appearing TWICE in the logfile, in format (one-line):
-        # Setting (7) update event on value --- https://USER:PASS@foobar:443,\
-        # --- https://USER:PASS@foobar:3128
-        self.do_path_regex_sub(
-            '/var/log/foreman/production.log*',
-            r", --- (http(s)?://)\S+:\S+(@.*)",
-            r"\1******:******\3"
-        )
         # hide proxy credentials from http_proxy setting
         self.do_cmd_output_sub(
             "from settings where",


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
