### PR TITLE
[cleaner] Stop obfuscation of gz files when using --keep-binary-files

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -693,6 +693,10 @@ third party.
                         archive.should_remove_file(short_name)):
                     archive.remove_file(short_name)
                     continue
+                if (self.opts.keep_binary_files and
+                        archive.should_remove_file(short_name)):
+                    archive.should_skip_file(short_name)
+                    continue
                 try:
                     count = self.obfuscate_file(fname, short_name,
                                                 archive.archive_name)


### PR DESCRIPTION
This commit tries to honour option --keep-binary-files when using cleaner by making sure that these files are skipped so the cleaner doesn't attempt
to apply substitutions directly on them.

Related: #3884

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
