### PR TITLE
[Options] Add test of skip_plugins before referring it

### DIFF
--- a/sos/options.py
+++ b/sos/options.py
@@ -226,7 +226,8 @@ class SoSOptions():
 
         _update_from_section("global", config)
         _update_from_section(component, config)
-        if config.has_section("plugin_options") and hasattr(self, 'plugopts'):
+        if config.has_section("plugin_options") and hasattr(self, 'plugopts') \
+                and hasattr(self, 'skip_plugins'):
             # pylint: disable=no-member
             for key, val in config.items("plugin_options"):
                 if not key.split('.')[0] in self.skip_plugins:


### PR DESCRIPTION
When a component honours plugopts but not skip_plugins Option, dont update plugopts per skip_plugins.

This is rather theoretical scenario, though.

Resolves: #3904

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
