### PR TITLE
[testing] Add debian to standard testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,8 @@ env:
     FEDORA_NAME: "fedora-38"
     FEDORA_PRIOR_NAME: "fedora-37"
 
-    DEBIAN_NAME: "debian-11"
+    DEBIAN_12_NAME: "debian-12"
+    DEBIAN_11_NAME: "debian-11"
 
     UBUNTU_DEVEL_NAME: "ubuntu-25.04"
     UBUNTU_LATEST_NAME: "ubuntu-24.10"
@@ -135,22 +136,36 @@ rpm_build_task:
 deb_build_task:
     skip: *man-changes-include
     alias: "deb_build"
-    name: "deb Build From Checkout"
+    name: "deb Build From Checkout - ${BUILD_NAME}"
     gce_instance:
-        image_project: "${UBUNTU_PROJECT}"
-        image_family: "${UBUNTU_DEB_FAMILY_NAME}"
+        image_project: "${PROJECT}"
+        image_family: "${VM_FAMILY_NAME}"
         type: e2-medium
+    matrix:
+        - env: &debian-11-deb-pkg
+            PROJECT: ${DEBIAN_PROJECT}
+            BUILD_NAME: ${DEBIAN_11_NAME}
+            VM_FAMILY_NAME: ${DEBIAN_FAMILY_NAME}
+        - env: &debian-12-deb-pkg
+            PROJECT: ${DEBIAN_PROJECT}
+            BUILD_NAME: ${DEBIAN_12_NAME}
+            VM_FAMILY_NAME: ${DEBIAN_FAMILY_NAME}
+        - env: &ubuntu-latest-deb-pkg
+            PROJECT: ${UBUNTU_PROJECT}
+            BUILD_NAME: ${UBUNTU_LATEST_NAME}
+            VM_FAMILY_NAME: ${UBUNTU_DEB_FAMILY_NAME}
     setup_script: |
         apt update --allow-releaseinfo-change
         apt -y install devscripts equivs python3-pip
         mk-build-deps
         apt -y install ./sosreport-build-deps*.deb
-        pip3 install -r test-requirements.txt --break-system-packages
+        [[ $(pip3 install --help | grep break-system) ]] && PIP_EXTRA="--break-system-packages"
+        pip3 install -r test-requirements.txt ${PIP_EXTRA}
     main_script: |
         dpkg-buildpackage -b -us -uc -rfakeroot -m --build-by="noreply@canonical.com"
-    prep_artifacts_script: mv ../*.deb ./sos_cirrus.deb
+    prep_artifacts_script: mv ../*.deb ./sos_${BUILD_NAME}.deb
     packages_artifacts:
-        path: ./sos_cirrus.deb
+        path: ./sos_${BUILD_NAME}.deb
         type: application/octet-stream
 
 # Make sure a user can manually build a snap from the checkout
@@ -213,25 +228,36 @@ report_stageone_task:
             BUILD_NAME: "${UBUNTU_LATEST_NAME} - ${PKG}"
             VM_FAMILY_NAME: ${UBUNTU_LATEST_FAMILY_NAME}
         - env: &ubuntu-latest-deb
+            <<: *ubuntu-latest-deb-pkg
             PKG: "deb"
-            PROJECT: ${UBUNTU_PROJECT}
             BUILD_NAME: "${UBUNTU_LATEST_NAME} - ${PKG}"
+            DEB_BUILD_NAME: ${UBUNTU_LATEST_NAME}
             VM_FAMILY_NAME: ${UBUNTU_LATEST_FAMILY_NAME}
+        - env: &debian-12
+            <<: *debian-12-deb-pkg
+            PKG: "deb"
+            DEB_BUILD_NAME: ${BUILD_NAME}
+        - env: &debian-11
+            <<: *debian-11-deb-pkg
+            PKG: "deb"
+            DEB_BUILD_NAME: ${BUILD_NAME}
     setup_script: &setup |
         if [ $(command -v apt) ]; then
             apt -y purge sosreport
             apt update --allow-releaseinfo-change
-            apt -y install python3-pip snapd
+            apt -y install python3-pip ethtool python3-systemd
             if [ ${PKG} == "snap" ] ; then
+                apt -y install snapd
                 echo "$ARTCURL/snap%20Build%20From%20Checkout/packages/sosreport_test_amd64.snap"
                 $ARTCURL/snap%20Build%20From%20Checkout/packages/sosreport_test_amd64.snap
                 systemctl start snapd
                 snap install ./sosreport_test_amd64.snap --classic --dangerous
                 snap alias sosreport.sos sos
             elif [ ${PKG} == "deb" ]; then
-                echo "$ARTCURL/deb%20Build%20From%20Checkout/packages/sos_cirrus.deb"
-                $ARTCURL/deb%20Build%20From%20Checkout/packages/sos_cirrus.deb
-                apt -y install ./sos_cirrus.deb
+                echo "$ARTCURL/deb%20Build%20From%20Checkout%20-%20${DEB_BUILD_NAME}/packages/sos_${DEB_BUILD_NAME}.deb"
+                $ARTCURL/deb%20Build%20From%20Checkout%20-%20${DEB_BUILD_NAME}/packages/sos_${DEB_BUILD_NAME}.deb
+                apt -y install ./sos_${DEB_BUILD_NAME}.deb
+                sed -i 's/\(127.0.1.1\)/#\1/g' /etc/hosts
             fi
         fi
         if [ $(command -v dnf) ]; then
@@ -290,6 +316,7 @@ report_stagetwo_task:
         - env: *ubuntu
         - env: *ubuntu-latest-snap
         - env: *ubuntu-latest-deb
+        - env: *debian-12
     setup_script: *setup
     install_pexpect_script: |
         if [ $(command -v apt) ]; then
@@ -330,9 +357,7 @@ report_foreman_task:
         type: e2-standard-2
     matrix:
         - env:
-            PROJECT: ${DEBIAN_PROJECT}
-            VM_FAMILY_NAME: ${DEBIAN_FAMILY_NAME}
-            BUILD_NAME: ${DEBIAN_NAME}
+            <<: *debian-11
             FOREMAN_VER: "3.7"
     setup_script: *setup
     foreman_setup_script: ./tests/test_data/foreman_setup.sh

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ X-Python3-Version: >= 3.6
 
 Package: sosreport
 Architecture: any
-Depends: ${python3:Depends}, ${misc:Depends}, python3-pexpect, python3-magic, python3-packaging, python3-boto3
+Depends: ${python3:Depends}, ${misc:Depends}, python3-pexpect, python3-magic, python3-packaging, python3-boto3, python3-yaml
 Description: Set of tools to gather troubleshooting data from a system
  Sos is a set of tools that gathers information about system
  hardware and configuration. The information can then be used for

--- a/tests/product_tests/foreman/foreman_tests.py
+++ b/tests/product_tests/foreman/foreman_tests.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-from sos_tests import StageOneReportTest, redhat_only, ubuntu_only
+from sos_tests import StageOneReportTest, redhat_only, debian_only
 
 # known values in our CI test images
 FOREMAN_DB_PASSWORD = r'S0Sdb=p@ssw0rd!'
@@ -104,7 +104,7 @@ class ForemanBasicTest(StageOneReportTest):
     def test_foreman_httpd_collected(self):
         self.assertFileGlobInArchive("/var/log/httpd*/foreman-ssl_*_ssl*log*")
 
-    @ubuntu_only
+    @debian_only
     def test_foreman_apache_collected(self):
         self.assertFileGlobInArchive("/var/log/apache2/foreman-ssl_*_ssl*log*")
 

--- a/tests/report_tests/plugin_tests/apt/apt.py
+++ b/tests/report_tests/plugin_tests/apt/apt.py
@@ -19,7 +19,7 @@ class AptConfScrubTest(StageTwoReportTest):
     """
 
     sos_cmd = '-o apt'
-    ubuntu_only = True
+    debian_only = True
     files = [
         ('apt-proxy.conf', '/etc/apt/apt.conf.d/50-apt-proxy'),
         ('apt-sources.list', '/etc/apt/sources.list'),

--- a/tests/report_tests/plugin_tests/defaults.py
+++ b/tests/report_tests/plugin_tests/defaults.py
@@ -16,8 +16,11 @@ class DefaultCollectionsTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    packages = {'rhel': 'cups',
-                'Ubuntu': 'cups'}
+    packages = {
+        'rhel': 'cups',
+        'Ubuntu': 'cups',
+        'debian': 'cups',
+    }
 
     sos_cmd = '-o cups'
 

--- a/tests/report_tests/plugin_tests/krb5.py
+++ b/tests/report_tests/plugin_tests/krb5.py
@@ -7,7 +7,7 @@
 # See the LICENSE file in the source distribution for further information.
 
 
-from sos_tests import StageTwoReportTest, redhat_only, ubuntu_only
+from sos_tests import StageTwoReportTest, redhat_only, debian_only
 
 
 class Krb5PluginTest(StageTwoReportTest):
@@ -22,7 +22,8 @@ class Krb5PluginTest(StageTwoReportTest):
     sos_cmd = '-o krb5'
     packages = {
         'rhel': ['krb5-libs', 'krb5-server'],
-        'Ubuntu': ['krb5-user', 'krb5-kdc']
+        'Ubuntu': ['krb5-user', 'krb5-kdc'],
+        'debian': ['krb5-user', 'krb5-kdc'],
     }
 
     def test_plugin_ran(self):
@@ -31,7 +32,7 @@ class Krb5PluginTest(StageTwoReportTest):
     def test_conf_collected(self):
         self.assertFileCollected('/etc/krb5.conf')
 
-    @ubuntu_only
+    @debian_only
     def test_ubuntu_kdcdir_collected(self):
         self.assertFileGlobInArchive('/var/lib/krb5kdc/*')
 

--- a/tests/report_tests/smoke_tests.py
+++ b/tests/report_tests/smoke_tests.py
@@ -10,7 +10,7 @@ import re
 
 
 from avocado.utils import process
-from sos_tests import StageOneReportTest, redhat_only, ubuntu_only
+from sos_tests import StageOneReportTest, redhat_only, debian_only
 
 
 # These are the header strings in --list-plugins output
@@ -105,7 +105,7 @@ class ExpectedDefaultPluginsTest(StageOneReportTest):
             'yum'
         ])
 
-    @ubuntu_only
+    @debian_only
     def test_ubuntu_default_plugins(self):
         """Plugins expected to always run on a Ubuntu (-like) system
         """

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -32,7 +32,8 @@ SOS_TEST_DATA_DIR = os.path.realpath(os.path.join(SOS_TEST_DIR, 'test_data'))
 SOS_TEST_BIN = os.path.realpath(os.path.join(SOS_TEST_DIR, '../bin/sos'))
 
 RH_DIST = ['rhel', 'centos', 'fedora', 'centos-stream']
-UBUNTU_DIST = ['Ubuntu', 'debian']
+UBUNTU_DIST = ['Ubuntu']
+DEBIAN_DIST = ['Ubuntu', 'debian']
 
 _distro = distro.detect()
 
@@ -62,7 +63,15 @@ def redhat_only(tst):
 def ubuntu_only(tst):
     def wrapper(func):
         if _distro.name not in UBUNTU_DIST:
-            raise TestSkipError('Not running on a Ubuntu or Debian distro')
+            raise TestSkipError('Not running on a Ubuntu distro')
+    return wrapper
+
+
+# pylint: disable=unused-argument
+def debian_only(tst):
+    def wrapper(func):
+        if _distro.name not in DEBIAN_DIST:
+            raise TestSkipError('Not running on a Debian or Ubuntu distro')
     return wrapper
 
 
@@ -82,6 +91,7 @@ class BaseSoSTest(Test):
     sos_timeout = 600
     redhat_only = False
     ubuntu_only = False
+    debian_only = False
     end_of_test_case = False
     arch = []
     only_os_versions = []
@@ -247,7 +257,10 @@ class BaseSoSTest(Test):
                 raise TestSkipError('Not running on a Red Hat distro')
         elif self.ubuntu_only:
             if self.local_distro not in UBUNTU_DIST:
-                raise TestSkipError("Not running on a Ubuntu or Debian distro")
+                raise TestSkipError("Not running on a Ubuntu distro")
+        elif self.debian_only:
+            if self.local_distro not in DEBIAN_DIST:
+                raise TestSkipError("Not running on a Debian or Ubuntu distro")
 
     def check_arch_for_enablement(self):
         """


### PR DESCRIPTION
* Add new debian_only to replace current ubuntu_only.
* ubuntu_only now only tests true for only Ubuntu distros.
* Add extra packages to install for Debian ditsros, as these are not installed by default.

As per discussions in the maintainer call, wanted to start testing more on Debian, and this is a first start on testing debian regularly

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
