### PR TITLE
[openshift] Capture ls long listing for /mnt

### DIFF
--- a/sos/report/plugins/openshift_lso.py
+++ b/sos/report/plugins/openshift_lso.py
@@ -1,0 +1,41 @@
+# openshift_lso.py
+# Copyright (C) 2007-2025 Red Hat, Inc., Jon Magrini <jmagrini@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+from sos.report.plugins import (Plugin, RedHatPlugin)
+
+class OpenshiftLSO(Plugin, RedHatPlugin):
+    """
+    This plugin is used to collect Openshift LSO details. This expands 
+    the ceph_osd plugin since storage nodes by default are not setup for
+    ceph access. When gathering data from an OpenShift node when LSO is in use, 
+    we currently do not collect the symlink data location for LSO, 
+    which is always under /mnt (basically two layers lower, 
+    but the names can change). This is useful in determining if LSO 
+    is setup correctly when also having a must-gather output.  
+    Many times the LSO directory has pointers to paths instead of devices. 
+    This can cause issues with lost access to the OCP backend storage 
+    used by OpenShift.
+    """
+
+    short_desc = 'Openshift LSO'
+    
+    plugin_name = "openshift_lso"
+    profiles = ('storage', 'openshift', 'ceph')    
+    # Each node runs the ceph-osd daemon, 
+    # which interacts with logical disks attached to the node.
+    files = ('/run/ceph/**/ceph-osd*')
+    
+    def setup(self): 
+        self.add_cmd_output([
+            'ls -lanR /mnt'
+        ])
+


### PR DESCRIPTION
This plugin is used to collect Openshift LSO details. This expands the 
ceph_osd plugin since storage nodes by default are not setup for 
ceph access. When gathering data from an OpenShift node when 
LSO is in use, we currently do not collect the symlink data location 
for LSO, which is always under /mnt. Many times this directory has 
pointers/symlinks to paths instead of devices.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ x] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
