### PR TITLE
[aap_containerized] Check podman command for errors before using it

### DIFF
--- a/sos/report/plugins/aap_containerized.py
+++ b/sos/report/plugins/aap_containerized.py
@@ -112,7 +112,9 @@ class AAPContainerized(Plugin, RedHatPlugin):
         try:
             cmd = f"su - {username} -c 'podman ps -a --format {{{{.Names}}}}'"
             cmd_out = self.exec_cmd(cmd)
-            return cmd_out['output'].strip().split("\n")
+            if cmd_out['status'] == 0:
+                return cmd_out['output'].strip().split("\n")
+            return []
         except Exception:
             self._log_error("Error retrieving Podman containers")
             return []


### PR DESCRIPTION
This commit checks that the output of the command:

'podman ps -a --format {{{{.Names}}}}'

Ran without errors, so the container names returned is correct.

Resolves: RHEL-77339

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
