### PR TITLE
[python] Collect verbose output via pip

### DIFF
--- a/sos/report/plugins/python.py
+++ b/sos/report/plugins/python.py
@@ -40,7 +40,7 @@ class Python(Plugin):
             # pip: /usr/bin/pip2.7 /usr/bin/pip3.6
             # where we must skip the first word
             for pip in pips['output'].split()[1:]:
-                self.add_cmd_output(f"{pip} list installed")
+                self.add_cmd_output(f"{pip} -v list installed")
 
 
 class UbuntuPython(Python, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
The idea is to be able to see the path where the module is installed. So I would prefer to having 
```
# pip3.9 -v list installed
Package                         Version   Location                               Installer
------------------------------- --------- -------------------------------------- ---------
aiodns                          3.0.0     /usr/lib/python3.9/site-packages
aiofiles                        22.1.0    /usr/lib/python3.9/site-packages
aiohttp                         3.9.2     /usr/lib64/python3.9/site-packages
```

Over
```
# pip3.9 list installed
Package                         Version
------------------------------- ---------
aiodns                          3.0.0
aiofiles                        22.1.0
aiohttp                         3.9.2
```

to ease my troubleshooting of support-cases, where we suspect the module is being picked up from the wrong path. 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
