### PR TITLE
[containerd] Add option to collect stack dump files

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3551,7 +3551,7 @@ class Plugin():
     def get_process_pids(self, process):
         """Get a list of all PIDs that match a specified name
 
-        :param process:     The name of the process the get PIDs for
+        :param process:     The name or regex of the process the get PIDs for
         :type process:  ``str``
 
         :returns: A list of PIDs
@@ -3563,8 +3563,8 @@ class Plugin():
         for path in cmd_line_paths:
             try:
                 with open(path, 'r', encoding='utf-8') as f:
-                    cmd_line = f.read().strip()
-                    if process in cmd_line:
+                    cmd_line = f.read().strip('\x00')
+                    if re.match(process, cmd_line):
                         pids.append(path.split("/")[2])
             except IOError:
                 continue

--- a/sos/report/plugins/containerd.py
+++ b/sos/report/plugins/containerd.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Containerd(Plugin, IndependentPlugin):
@@ -15,6 +15,9 @@ class Containerd(Plugin, IndependentPlugin):
     plugin_name = 'containerd'
     profiles = ('container',)
     packages = ('containerd', 'containerd.io',)
+    option_list = [
+        PluginOpt('stackdump', False, desc='collect containerd stack dump(s)')
+    ]
 
     def setup(self):
         self.add_copy_spec([
@@ -34,5 +37,9 @@ class Containerd(Plugin, IndependentPlugin):
 
         # collect the containerd logs.
         self.add_journal(units='containerd')
+
+        if self.get_option('stackdump'):
+            for pid in self.signal_process_usr1(r'^/usr/bin/containerd$'):
+                self.add_copy_spec(f"/tmp/containerd.{pid}.stacks.log")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/crio.py
+++ b/sos/report/plugins/crio.py
@@ -107,12 +107,7 @@ class CRIO(Plugin, RedHatPlugin, UbuntuPlugin, CosPlugin):
         return ret
 
     def _get_crio_goroutine_stacks(self):
-        result = self.exec_cmd("pidof crio")
-        if result['status'] != 0:
-            return
-        pid = result['output'].strip()
-        result = self.exec_cmd("kill -USR1 " + pid)
-        if result['status'] == 0:
+        if self.signal_process_usr1(r'^/usr/bin/crio$'):
             self.add_copy_spec("/tmp/crio-goroutine-stacks*.log")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Two patchset that:

First, updates `Plugin.get_process_pids()` with a new `exact` argument that, if `True`, will only return PIDs that exactly match the given string, which is necessary to capture the "root"/"main" `containerd` process(es) for the second patch.

Second, adds a `containerd.stackdump` option that, if enabled, will send `SIGUSR1` to the containerd process(es) to trigger writing stack dumps to disk, then marking them for collection.

Resolves: #3918 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
