### PR TITLE
[openvswitch] Dump meter configuration and stats.

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -383,6 +383,8 @@ class OpenVSwitch(Plugin):
                     f"{self.ofctl} -O {flow} dump-flows {bridge}",
                     f"{self.ofctl} -O {flow} dump-tlv-map {bridge}",
                     f"{self.ofctl} -O {flow} dump-ports-desc {bridge}",
+                    f"{self.ofctl} -O {flow} dump-meters {bridge}",
+                    f"{self.ofctl} -O {flow} meter-stats {bridge}",
                 ])
 
     def get_port_list(self, bridge):


### PR DESCRIPTION
Without meters, we lack complete visibility into OpenFlow, which 
means we cannot fully monitor the networking activities in 
OCP/OSP that rely on meters through OVN.

This change adds both necessary outputs.

Signed-off-by: Flavio Leitner <fbl@redhat.com>


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
