### PR TITLE
[packaging] address fedora-review issues

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -74,12 +74,14 @@ rm -rf %{buildroot}/usr/config/
 %else
 %{_sbindir}/sos
 %endif
+%dir /etc/sos
 %dir /etc/sos/cleaner
 %dir /etc/sos/presets.d
 %dir /etc/sos/extras.d
 %dir /etc/sos/groups.d
 %{_tmpfilesdir}/%{name}.conf
-%{python3_sitelib}/*
+%{python3_sitelib}/sos/
+%{python3_sitelib}/sos-*info/
 %{_mandir}/man1/*
 %{_mandir}/man5/*
 %doc AUTHORS README.md
@@ -178,10 +180,10 @@ rm -rf %{buildroot}/usr/config/
 
 * Wed Sep 17 2014 Bryn M. Reeves <bmr@redhat.com> = 3.2-beta1
 - New upstream beta release
- 
+
 * Thu Jun 12 2014 Bryn M. Reeves <bmr@redhat.com> = 3.2-alpha1
 - New upstream alpha release
- 
+
 * Mon Jan 27 2014 Bryn M. Reeves <bmr@redhat.com> = 3.1-1
 - New upstream release
 
@@ -310,7 +312,7 @@ rm -rf %{buildroot}/usr/config/
 - Improve sanitization of RHN user and case number in report name
   Resolves: bz771393
 - Fix verbose output and debug logging
-  Resolves: bz782339 
+  Resolves: bz782339
 - Add basic support for CloudForms data collection
   Resolves: bz752666
 - Add support for Subscription Asset Manager diagnostics
@@ -355,7 +357,7 @@ rm -rf %{buildroot}/usr/config/
 * Tue Nov  1 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-17
 - Do not collect subscription manager keys in general plugin
   Resolves: bz750607
- 
+
 * Fri Sep 23 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-16
 - Fix execution of RHN hardware.py from hardware plugin
   Resolves: bz736718
@@ -413,7 +415,7 @@ rm -rf %{buildroot}/usr/config/
 * Thu Apr 07 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-8
 - Use sha256 for report digest when operating in FIPS mode
   Resolves: bz689387
- 
+
 * Tue Apr 05 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-7
 - Fix parted and dumpe2fs output on s390
   Resolves: bz622784
@@ -782,4 +784,3 @@ rm -rf %{buildroot}/usr/config/
 
 * Mon May 22 2006 John Berninger <jwb at redhat dot com> - 0.1-1
 - initial package build
-


### PR DESCRIPTION
- add /etc/sos which was unowned
- address forbidden `%{pythonX_site(lib|arch)}/*` in `%files` See <https://pagure.io/packaging-committee/issue/782>
- trimmed trailing whitespaces

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
