### PR TITLE
[component] Move _fmt_msg() to SoSComponent

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -19,7 +19,6 @@ import fnmatch
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pwd import getpwuid
-from textwrap import fill
 
 import sos.cleaner.preppers
 
@@ -177,13 +176,6 @@ class SoSCleaner(SoSComponent):
 
     def log_error(self, msg, caller=None):
         self.soslog.error(self._fmt_log_msg(msg, caller))
-
-    def _fmt_msg(self, msg):
-        width = 80
-        _fmt = ''
-        for line in msg.splitlines():
-            _fmt = _fmt + fill(line, width, replace_whitespace=False) + '\n'
-        return _fmt
 
     @classmethod
     def display_help(cls, section):

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -26,7 +26,6 @@ from concurrent.futures import ThreadPoolExecutor
 from getpass import getpass
 from pathlib import Path
 from shlex import quote
-from textwrap import fill
 from sos.cleaner import SoSCleaner
 from sos.collector.sosnode import SosNode
 from sos.options import ClusterOption, str_to_bool
@@ -723,13 +722,6 @@ class SoSCollector(SoSComponent):
         self.arc_name = self._get_archive_name()
         compr = 'gz'
         return self.tmpdir + '/' + self.arc_name + '.tar.' + compr
-
-    def _fmt_msg(self, msg):
-        width = 80
-        _fmt = ''
-        for line in msg.splitlines():
-            _fmt = _fmt + fill(line, width, replace_whitespace=False) + '\n'
-        return _fmt
 
     def _load_group_config(self):
         """

--- a/sos/component.py
+++ b/sos/component.py
@@ -16,6 +16,7 @@ import tempfile
 import sys
 import time
 
+from textwrap import fill
 from argparse import SUPPRESS
 from datetime import datetime
 from getpass import getpass
@@ -470,6 +471,13 @@ class SoSComponent():
 
     def get_temp_file(self):
         return self.tempfile_util.new()
+
+    def _fmt_msg(self, msg):
+        width = 80
+        _fmt = ''
+        for line in msg.splitlines():
+            _fmt = _fmt + fill(line, width, replace_whitespace=False) + '\n'
+        return _fmt
 
 
 class SoSMetadata():

--- a/sos/upload/__init__.py
+++ b/sos/upload/__init__.py
@@ -13,7 +13,6 @@ import sys
 import logging
 import inspect
 
-from textwrap import fill
 from sos.component import SoSComponent
 from sos import _sos as _
 from sos import __version__
@@ -136,13 +135,6 @@ class SoSUpload(SoSComponent):
             'sos reports, as well as other files like logs and vmcores '
             'to a distribution specific location.'
         )
-
-    def _fmt_msg(self, msg):
-        width = 80
-        _fmt = ''
-        for line in msg.splitlines():
-            _fmt = _fmt + fill(line, width, replace_whitespace=False) + '\n'
-        return _fmt
 
     def intro(self):
         """Print the intro message and prompts for a case ID if one is not


### PR DESCRIPTION
The function _fmt_msg() was in three different subsystems. This commit removes the code from collector, cleaner, and upload into SosComponent.

Related: #3746

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
