### PR TITLE
[logs] Add all auth.log, syslog and kerne.log as standard

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -41,16 +41,18 @@ class LogsBase(Plugin):
                 self.add_copy_spec(i)
 
         self.add_copy_spec([
-            "/etc/syslog.conf",
-            "/etc/rsyslog.conf",
-            "/etc/rsyslog.d",
+            "/var/log/auth.log*",
             "/var/log/boot.log",
+            "/var/log/dist-upgrade",
             "/var/log/installer",
+            "/var/log/kern.log*",
             "/var/log/messages*",
             "/var/log/secure*",
+            "/var/log/syslog*",
             "/var/log/udev",
-            "/var/log/dist-upgrade",
-            "/var/log/auth.log",
+            "/etc/rsyslog.conf",
+            "/etc/rsyslog.d",
+            "/etc/syslog.conf",
         ])
 
         self.add_cmd_output("journalctl --disk-usage")
@@ -71,25 +73,6 @@ class LogsBase(Plugin):
                 self.add_copy_spec([
                     "/var/log/journal/*",
                     "/run/log/journal/*"
-                ])
-        else:  # If not using journal
-            if not self.get_option("all_logs"):
-                self.add_copy_spec([
-                    "/var/log/syslog",
-                    "/var/log/syslog.1",
-                    "/var/log/syslog.2*",
-                    "/var/log/kern.log",
-                    "/var/log/kern.log.1",
-                    "/var/log/kern.log.2*",
-                    "/var/log/auth.log",
-                    "/var/log/auth.log.1",
-                    "/var/log/auth.log.2*",
-                ])
-            else:
-                self.add_copy_spec([
-                    "/var/log/syslog*",
-                    "/var/log/kern.log*",
-                    "/var/log/auth.log*",
                 ])
 
     def postproc(self):


### PR DESCRIPTION
The RH based systems already collect this type of logs, and Ubuntu systems was lacking this. This will allow to debug issue better and easier to consume.

Re-order the file set to be in alphabetical order.

The else for the syslog, auth.log and syslog us now redundant, as we collect all of these files now.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
