### PR TITLE
[o_horizon] Obfuscate credentials in local_settings.py

### DIFF
--- a/sos/report/plugins/openstack_horizon.py
+++ b/sos/report/plugins/openstack_horizon.py
@@ -47,12 +47,15 @@ class OpenStackHorizon(Plugin):
     def postproc(self):
         var_puppet_gen = self.var_puppet_gen + "/horizon"
         protect_keys = [
-            "SECRET_KEY", "EMAIL_HOST_PASSWORD"
+            "EMAIL_HOST_PASSWORD",
+            "PASSWORD",
+            "SECRET_KEY",
         ]
 
-        regexp = fr"(^\s*({'|'.join(protect_keys)})\s*=\s*)(.*)"
+        regexp = fr"(^\s*\'?({'|'.join(protect_keys)})\'?\s*(:|=)\s*)(.*)"
         for regpath in [r"/etc/openstack-dashboard/.*\.json",
-                        "/etc/openstack-dashboard/local_settings$"]:
+                        "/etc/openstack-dashboard/local_settings$",
+                        "/etc/openstack-dashboard/local_settings.py$"]:
             self.do_path_regex_sub(regpath, regexp, r"\1*********")
             self.do_path_regex_sub(var_puppet_gen + regpath,
                                    regexp, r"\1*********")


### PR DESCRIPTION
This file is present on Ubuntu based systems, and was not being obfuscated. Also potentially havd PASSWORD for the DB, which can be similar to below line

        'PASSWORD': 'q8GzrLk9bj9dt2RPqZZcgJMfGSmGhNLT',

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
