### PR TITLE
[squid] updated Debian and Ubuntu paths in Squid plugin

### DIFF
--- a/sos/report/plugins/squid.py
+++ b/sos/report/plugins/squid.py
@@ -34,13 +34,15 @@ class RedHatSquid(Squid, RedHatPlugin):
 class DebianSquid(Squid, DebianPlugin, UbuntuPlugin):
 
     plugin_name = 'squid'
-    files = ('/etc/squid3/squid.conf',)
-    packages = ('squid3',)
+    files = ('/etc/squid/squid.conf',)
+    packages = ('squid',)
 
     def setup(self):
-        self.add_copy_spec("/etc/squid3/squid.conf")
-        self.add_copy_spec("/var/log/squid3/*")
-        self.add_copy_spec('/etc/squid-deb-proxy')
-        self.add_copy_spec("/var/log/squid-deb-proxy/*")
+        self.add_copy_spec([
+            "/etc/squid/squid.conf",
+            "/var/log/squid/*",
+            "/etc/squid-deb-proxy",
+            "/var/log/squid-deb-proxy/*",
+        ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
The Squid plugin was using squid3 paths for all Debian and Ubuntu versions, but this path has not been correct since Debian 9 Stretch and Ubuntu 18.04 Bionic Beaver. The result is that no Squid data is recorded in current OS releases.

This fixes the paths for both distros and cleans up the self.add_copy_spec() line to be consistent with style guidelines.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
