### PR TITLE
[networking] List contents of netplan configuration dirs

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -349,6 +349,14 @@ class UbuntuNetworking(Networking, UbuntuPlugin, DebianPlugin):
             "/run/systemd/network"
         ])
 
+        # Netplan only consumes files with the `.yaml` extension (LP#1815734),
+        # so give visibility on other files that might be present.
+        self.add_dir_listing([
+            "/etc/netplan",
+            "/lib/netplan",
+            "/run/netplan",
+        ])
+
     def postproc(self):
 
         self.do_path_regex_sub(


### PR DESCRIPTION
If a user uses `.yml` for a netplan configuration file, netplan silently ignores it. I've engaged with upstream since that behavior isn't ideal, but it isn't likely that it will change soon.

This at least gives us better visibility without needing to worry about obfuscating the contents of other (possibly malformatted) files.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
