### PR TITLE
[memory] Collect all sysfs THP files

### DIFF
--- a/sos/report/plugins/memory.py
+++ b/sos/report/plugins/memory.py
@@ -26,7 +26,7 @@ class Memory(Plugin, IndependentPlugin):
             "/proc/pagetypeinfo",
             "/proc/vmallocinfo",
             "/sys/kernel/mm/ksm",
-            "/sys/kernel/mm/transparent_hugepage/enabled",
+            "/sys/kernel/mm/transparent_hugepage",
             "/sys/kernel/mm/hugepages",
             "/sys/kernel/mm/lru_gen/enabled",
             "/sys/kernel/mm/lru_gen/min_ttl_ms",


### PR DESCRIPTION
Changes to THP result in sysfs `enabled` file alone (and the kernel parameter) are now insuffiecient to know if THP is enabled or not. For example, `shmem_enabled` can be set to `[always]` while `enabled` can be set to `[never]` and THP will still be enabled but only for shmem segments. As such, to better know if and how THP is enabled, collect all files under `/sys/kernel/mm/transparent_hugepage/` rather than just `enabled`.

Fixes #3945 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line? _N/A_?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)? _N/A_?
