### PR TITLE
[cryptsetup] Collect information about Encrypted FileSystems

### DIFF
--- a/sos/report/plugins/cryptsetup.py
+++ b/sos/report/plugins/cryptsetup.py
@@ -1,0 +1,31 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class CryptSetup(Plugin, IndependentPlugin):
+    """
+    This plugin will capture infromation about the encrypted devices
+    that exist on this system.
+
+    Currently, it will only grab /etc/crypttab
+    """
+
+    short_desc = 'cryptsetup related files'
+
+    plugin_name = 'cryptsetup'
+    profiles = ('hardware', 'storage')
+    packages = ('cryptsetup',)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/crypttab",
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Cryptsetup is a tool to create an encrypted filesystems.
Certain information about these filesystems is located in /etc/crypttab.
This plugin will include the /etc/crypttab file to a sos report

**
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
