### PR TITLE
[helm] Created new sos report plugin for Helm

### DIFF
--- a/sos/report/plugins/helm.py
+++ b/sos/report/plugins/helm.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2025 Canonical Ltd.,
+#                    Bryan Fraschetti <bryan.fraschetti@canonical.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Helm(Plugin, IndependentPlugin):
+    """The Helm plugin collects information about the currently installed
+    Helm charts, plugins, and repositories used in delpoyments
+    """
+
+    short_desc = 'The k8s templating and deployment manager'
+    plugin_name = "helm"
+    profiles = ('container', 'packagemanager')
+
+    packages = ('helm',)
+
+    helm_cmd = "helm"
+
+    def setup(self):
+        helm_subcmds = [
+            'repo list',
+            'plugin list',
+            'list -a',
+            'version',
+        ]
+
+        self.add_cmd_output([
+            f"{self.helm_cmd} {subcmd}" for subcmd in helm_subcmds
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This commit adds a new sos report plugin that performs some basic output
collection from several helm commands to view the installed
repositories, plugins, and charts.

Closes #3504

Signed-off-by: Bryan Fraschetti <bryan.fraschetti@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
