### PR TITLE
[iscsi] Add /var/lib/iscsi/send_targets to the obfuscation list

### DIFF
--- a/sos/report/plugins/iscsi.py
+++ b/sos/report/plugins/iscsi.py
@@ -50,9 +50,9 @@ class Iscsi(Plugin):
         self.do_path_regex_sub('/etc/iscsi/iscsid.conf', nodesessionpwd, repl)
         self.do_path_regex_sub('/etc/iscsi/iscsid.conf', discoverypwd, repl)
         self.do_path_regex_sub(
-                '/var/lib/iscsi/nodes/*/*/*', nodesessionpwd, repl)
+                '/var/lib/iscsi/', nodesessionpwd, repl)
         self.do_path_regex_sub(
-                '/var/lib/iscsi/nodes/*/*/*', discoverypwd, repl)
+                '/var/lib/iscsi/', discoverypwd, repl)
 
 
 class RedHatIscsi(Iscsi, RedHatPlugin):


### PR DESCRIPTION
Obfuscate discovery and node seesion passwords that can be found in other files inside /var/lib/iscsi directory.

Related: RHEL-81187

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
