### PR TITLE
Include manager table in ovs captured data

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -108,6 +108,8 @@ class OpenVSwitch(Plugin):
             f"{self.actl} upcall/show",
             # Capture OVS list
             f"{self.vctl} -t 5 list Open_vSwitch",
+            # Capture OVS manager
+            f"{self.vctl} -t 5 list manager",
             # Capture OVS interface list
             f"{self.vctl} -t 5 list interface",
             # Capture OVS detailed information from all the bridges


### PR DESCRIPTION
OpenvSwitch stores important settings in the manager table so we should include it in the table we capture.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x ] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
