### PR TITLE
[cups] Expand captures in cups plugin

### DIFF
--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -6,7 +6,9 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+import pwd
+
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Cups(Plugin, IndependentPlugin):
@@ -15,22 +17,36 @@ class Cups(Plugin, IndependentPlugin):
 
     plugin_name = 'cups'
     profiles = ('hardware',)
-    services = ('cups', 'cups-browsed')
+    services = ('cups', 'cups-browsed',
+                'lprint', 'legacy-printer-app')
     packages = ('cups',)
+
+    option_list = [
+        PluginOpt('userconfs', default=False, val_type=str,
+                  desc=('Changes whether plugin will '
+                        'collect user .cups configs'))
+    ]
 
     def setup(self):
         if not self.get_option("all_logs"):
             self.add_copy_spec("/var/log/cups/access_log")
             self.add_copy_spec("/var/log/cups/error_log")
             self.add_copy_spec("/var/log/cups/page_log")
+            self.add_copy_spec("/var/log/ipp-usb/main.log")
         else:
             self.add_copy_spec("/var/log/cups")
+            self.add_copy_spec("/var/log/ipp-usb")
 
         self.add_copy_spec([
             "/etc/cups/*.conf",
             "/etc/cups/*.types",
             "/etc/cups/lpoptions",
-            "/etc/cups/ppd/*.ppd"
+            "/etc/cups/ppd/*.ppd",
+            "/etc/ipp-usb/",
+            "/etc/lprint.conf",
+            "/etc/legacy-printer-app.conf",
+            "/var/lib/lprint.state",
+            "/var/lib/legacy-printer-app.state",
         ])
 
         self.add_cmd_output([
@@ -38,5 +54,42 @@ class Cups(Plugin, IndependentPlugin):
             "lpstat -s",
             "lpstat -d"
         ])
+
+        if self.get_option('userconfs'):
+            self.get_user_configs()
+
+    def get_user_configs(self):
+        """
+        Iterate over .cups folders in user homes to capture config files.
+        """
+        users_data = pwd.getpwall()
+        config_files = [
+            "client.conf",
+            "lpoptions",
+        ]
+        fs_mount_info = {}
+        try:
+            with open('/proc/mounts', "r", encoding='UTF-8') as mounts_file:
+                for line in mounts_file:
+                    (fs_file, fs_vstype) = line.split()[1:3]
+                    fs_mount_info[fs_file] = fs_vstype
+        except Exception:
+            self._log_error("Couldn't read /proc/mounts")
+            return
+        non_local_fs = {'nfs', 'nfs4', 'autofs'}
+        # Read the home paths of users in the system and
+        # config files from .cups
+        for user in users_data:
+            if user.pw_dir in fs_mount_info and \
+                    fs_mount_info[user.pw_dir] in non_local_fs:
+                self._log_info(
+                    f"Skipping capture in {user.pw_dir}"
+                    " because it's a remote directory"
+                )
+                continue
+            home_dir = self.path_join(user.pw_dir, '.cups')
+            self.add_copy_spec(
+                [f"{home_dir}/{config_file}" for config_file in config_files]
+            )
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add new command captures to the cups plugin.
Also, add a new option, 'userconfs', that when enabled is used to capture config files inside .cups in users' home directories.

Related: SUPDEV-171

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
