### PR TITLE
[tests] Rework journal size calculation for tests

### DIFF
--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -41,7 +41,7 @@ class JournalSizeLimitTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = '-o logs --journal-size=20 --log-size=10'
+    sos_cmd = '-o logs --journal-size=10 --log-size=5'
     sos_timeout = 500
     packages = {
         'rhel': ['python3-systemd'],
@@ -54,7 +54,7 @@ class JournalSizeLimitTest(StageTwoReportTest):
         from systemd import journal  # pylint: disable=import-error
         _reader = journal.Reader()
         _size = _reader.get_usage() / 1024 / 1024
-        if _size > 20:
+        if _size > 30:
             return
         # write 20MB at a time to side-step rate/size limiting on some distros
         # write over 20MB to ensure we will actually size limit inside sos,


### PR DESCRIPTION
In 3853 it was discovered that size calculations via get_usage() were not corresponding to the expected size, and the tests were failing sometimes.
This commit tries to fix the problem by calling
'journalctl' directly and then calculating the size on the output.

Related: #3853

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
