### PR TITLE
[login,clean] Update login plugin and use for clean

### DIFF
--- a/sos/cleaner/preppers/usernames.py
+++ b/sos/cleaner/preppers/usernames.py
@@ -28,6 +28,7 @@ class UsernamePrepper(SoSPrepper):
         'stack',
         'reboot',
         'root',
+        'timeout:',
         'ubuntu',
         'username',
         'wtmp'
@@ -39,10 +40,12 @@ class UsernamePrepper(SoSPrepper):
             'sos_commands/login/lastlog_-u_1000-60000',
             'sos_commands/login/lastlog_-u_60001-65536',
             'sos_commands/login/lastlog_-u_65537-4294967295',
+            'sos_commands/login/lastlog2',
             # AD users will be reported here, but favor the lastlog files since
             # those will include local users who have not logged in
             'sos_commands/login/last',
             'sos_commands/login/last_-F',
+            'sos_commands/login/lslogins',
             'etc/cron.allow',
             'etc/cron.deny'
         ]
@@ -53,6 +56,11 @@ class UsernamePrepper(SoSPrepper):
             for line in content.splitlines():
                 try:
                     user = line.split()[0].lower()
+                    if "lslogins" in _file:
+                        if int(line.split()[0]) >= 1000:
+                            user = line.split()[1].lower()
+                        else:
+                            continue
                     if user and user not in self.skip_list:
                         items.add(user)
                         if '\\' in user:

--- a/sos/report/plugins/login.py
+++ b/sos/report/plugins/login.py
@@ -25,7 +25,9 @@ class Login(Plugin, IndependentPlugin):
             "lastlog -u 0-999",
             "lastlog -u 1000-60000",
             "lastlog -u 60001-65536",
-            "lastlog -u 65537-4294967295"
+            "lastlog -u 65537-4294967295",
+            "lastlog2",
+            "lslogins",
         ])
 
         self.add_copy_spec([


### PR DESCRIPTION
Add lslogin and lastlog2 output. Then use these for username obfuscations for clean. New distros don't have lastlogin anymore and last is not always installed by default.

timout: is excluded as well. When the command is run, it runs with timout command, and if the command doesn't exist, it parses that as the username.

Related: #3960

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
