### PR TITLE
[foreman] Add subnets table information

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -222,6 +222,14 @@ class Foreman(Plugin):
             f'foreman_tasks_tasks.started_at > NOW() - interval {interval} '
             'order by foreman_tasks_tasks.started_at asc')
 
+        subnetscmd = (
+            'SELECT id,network,mask,name,vlanid,gateway,'
+            'dns_primary,dns_secondary,boot_mode,ipam,type,description,'
+            'mtu,template_id,nic_delay,externalipam_id,'
+            'externalipam_group,dhcp_id,tftp_id,dns_id,discovery_id,'
+            'httpboot_id,externalipam_id FROM subnets ORDER BY id DESC'
+        )
+
         # counts of fact_names prefixes/types: much of one type suggests
         # performance issues
         factnamescmd = (
@@ -241,6 +249,7 @@ class Foreman(Plugin):
             'foreman_auth_table': 'select id,type,name,host,port,account,'
                                   'base_dn,attr_login,onthefly_register,tls '
                                   'from auth_sources',
+            'foreman_subnets_table': subnetscmd,
             'dynflow_schema_info': 'select * from dynflow_schema_info',
             'audits_table_count': 'select count(*) from audits',
             'logs_table_count': 'select count(*) from logs',


### PR DESCRIPTION
To know the configured subnets in Foreman is helpful for debugging issues because it provides critical network-related data that assists in troubleshooting deployment, provisioning, and communication problems.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X ] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
