### PR TITLE
[bootc] Do not capture /usr/lib/bootc/storage directory

### DIFF
--- a/sos/report/plugins/bootc.py
+++ b/sos/report/plugins/bootc.py
@@ -29,4 +29,6 @@ class Bootc(Plugin, RedHatPlugin):
             "bootc status",
         )
 
+        self.add_forbidden_path("/usr/lib/bootc/storage")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add this directory to the forbidden path list
so we don't gather the images that could be
stored inside.

Related: SUPDEV-177

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
