### PR TITLE
[ssh,cups] Dont set val_type=str for bool PluginOpt

### DIFF
--- a/sos/report/plugins/cups.py
+++ b/sos/report/plugins/cups.py
@@ -22,7 +22,7 @@ class Cups(Plugin, IndependentPlugin):
     packages = ('cups',)
 
     option_list = [
-        PluginOpt('userconfs', default=False, val_type=str,
+        PluginOpt('userconfs', default=False,
                   desc=('Changes whether plugin will '
                         'collect user .cups configs'))
     ]

--- a/sos/report/plugins/ssh.py
+++ b/sos/report/plugins/ssh.py
@@ -21,7 +21,7 @@ class Ssh(Plugin, IndependentPlugin):
     profiles = ('services', 'security', 'system', 'identity')
 
     option_list = [
-        PluginOpt('userconfs', default=True, val_type=str,
+        PluginOpt('userconfs', default=True,
                   desc=('Changes whether module will '
                         'collect user .ssh configs'))
     ]


### PR DESCRIPTION
.. otherwise self.get_option(..) returns string that can be wrongly evaluated as a bool statement. That namely affects ssh plugin where overriding default True to False/off/0 has no real effect.

Resolves: #3973

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?