### PR TITLE
[designate] fix to include configs files

### DIFF
--- a/sos/report/plugins/openstack_designate.py
+++ b/sos/report/plugins/openstack_designate.py
@@ -33,8 +33,8 @@ class OpenStackDesignate(Plugin):
             "/etc/designate/*",
             self.var_puppet_gen + "/etc/designate/designate.conf",
             self.var_puppet_gen + "/etc/designate/pools.yaml",
-            self.var_ansible_gen + "/designate/etc/designate/named.conf",
-            self.var_ansible_gen + "/designate/etc/designate/named/*",
+            self.var_ansible_gen + "/designate/etc/named.conf",
+            self.var_ansible_gen + "/designate/etc/named/*",
             self.var_ansible_gen + "/unbound/*"
         ])
 


### PR DESCRIPTION
From [1] Designate ansible generate configuration files were added to
 the list folder/files to be collected. An additional /designate/ was added
to the path where the files are retrieved. 

This patch removes that extra level.

[1] https://github.com/sosreport/sos/pull/3356

Signed-off-by: Fernando Royo <froyo@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
