### PR TITLE
[pulseaudio]: Created new plugin for pulseaudio

### DIFF
--- a/sos/report/plugins/pulseaudio.py
+++ b/sos/report/plugins/pulseaudio.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2025 Canonical Ltd.,
+#                    Bryan Fraschetti <bryan.fraschetti@canonical.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class PulseAudio(Plugin, IndependentPlugin):
+    """The PulseAudio plugin collects information about the system's inputs
+    sources, output sinks, detected sound cards, and pulse audio's
+    configuration
+    """
+
+    short_desc = 'The sound server audio middleware'
+    plugin_name = "pulseaudio"
+    profiles = ('system', 'desktop', 'hardware')
+
+    packages = ('pulseaudio-utils', 'pulseaudio')
+
+    pactl_cmd = "pactl"
+    pulseaudio_cmd = "pulseaudio"
+
+    def setup(self):
+        pactl_subcmds = [
+            'list sinks',
+            'list sources',
+            'list cards',
+            'info',
+            'stat',
+            '--version'
+        ]
+
+        pulseaudio_subcmds = [
+            '--dump-conf',
+            '--dump-modules',
+            '--check'
+        ]
+
+        self.add_cmd_output([
+            f"{self.pactl_cmd} {subcmd}" for subcmd in pactl_subcmds
+        ])
+        self.add_cmd_output([
+            f"{self.pulseaudio_cmd} {subcmd}" for subcmd in pulseaudio_subcmds
+        ])
+
+        self.add_copy_spec("/etc/pulse/*")
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/soundcard.py
+++ b/sos/report/plugins/soundcard.py
@@ -9,7 +9,7 @@
 from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
-class Soundcard(Plugin):
+class Soundcard(Plugin, DebianPlugin, UbuntuPlugin):
 
     short_desc = 'Sound devices'
 
@@ -33,12 +33,5 @@ class RedHatSoundcard(Soundcard, RedHatPlugin):
             "/etc/alsa/*",
             "/etc/asound.*"
         ])
-
-
-class DebianSoundcard(Soundcard, DebianPlugin, UbuntuPlugin):
-
-    def setup(self):
-        super().setup()
-        self.add_copy_spec("/etc/pulse/*")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This commit adds a new plugin for pulseaudio, which is the default sound server middleware package in Ubuntu LTSes up to and including Jammy as well as RedHat up to and including RHEL 9. The plugin collects the output of commands that list the detected sinks, sources, and soundcards, which helps determine the available input and output audio devices. The other commands included aid in determining any applied configurations which may affect the prioritization of device selection.

It seemed appropriate to move the add_copy_spec of the pulseaudio directory from the soundcard plugin to the new pulseaudio plugin for organizational structure, grouping it with the rest of the package's collection. Especially as Ubuntu LTSes will be using Pipewire by default from Noble onwards, so PulseAudio is no longer representative of the default audio/soundcard configuration

Signed-off-by: Bryan Fraschetti bryan.fraschetti@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
