### PR TITLE
[tests] Fix issue with 127.0.1.1 IP being detected

### DIFF
--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -136,7 +136,10 @@ class BaseSoSTest(Test):
 
         # get networking info
         hostname = socket.gethostname()
-        ip_addr = socket.gethostbyname(hostname)
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # This doesn't send any data
+        s.connect(('10.255.255.255', 1))
+        ip_addr = s.getsockname()[0]
         sysinfo['networking'] = {}
         sysinfo['networking']['hostname'] = hostname
         sysinfo['networking']['ip_addr'] = ip_addr


### PR DESCRIPTION
Running stageone tests in some environments sees the hostname of the
machine to have an IP of 127.0.1.1 but the host is never set up in a
way that this address is configured on the host. We use socket.connect
to connect to a dummy address, which ensure to go via a default route
and therefore not track the loopbak address. Then grabbing the IP of
the socket give you a proper local IP address.

Closes: #3975

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
