### PR TITLE
[report] Increase column size for plugin options

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1082,7 +1082,7 @@ class SoSReport(SoSComponent):
                 if tmpopt is None:
                     tmpopt = 0
 
-                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<25} "
+                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<30} "
                                  f"{tmpopt:<15} {opt.desc}")
         else:
             self.ui_log.info(_("No plugin options available."))


### PR DESCRIPTION
With the current size, we have some misaligned options:

 lvm2.metadata             off             attempt to collect headers
	and metadata via pvck
 networking.traceroute     off             collect a traceroute to
	www.example.com
 networking.namespace-pattern                 Specific namespace names
	or patterns to collect, whitespace delimited.
 networking.namespaces     0               Number of namespaces
	to collect, 0 for unlimited
 networking.ethtool-namespaces on              Toggle if ethtool
	commands should be run for each namespace
 networking.eepromdump     off             Toggle collection
	of 'ethtool -e' for NICs
 ostree.fsck               off             collect ostree fsck

Increasing it from 25 from 30 seems to cover all options.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
