### PR TITLE
[presets] Adjust OCP preset options

### DIFF
--- a/sos/presets/redhat/__init__.py
+++ b/sos/presets/redhat/__init__.py
@@ -36,9 +36,13 @@ RHOCP = "ocp"
 RHOCP_DESC = "OpenShift Container Platform by Red Hat"
 RHOCP_OPTS = SoSOptions(
     skip_plugins=['cgroups'], container_runtime='crio', no_report=True,
-    log_size=100,
+    log_size=100, enable_plugins=['openshift', 'openshift_ovn'],
     plugopts=[
         'crio.timeout=600',
+        'crio.all=on',
+        'crio.logs=on',
+        'podman.all=on',
+        'podman.logs=on',
         'networking.timeout=600',
         'networking.ethtool-namespaces=False',
         'networking.namespaces=200'


### PR DESCRIPTION
Change the options used in the OCP preset based
on current use by support engineers and
documentation for OCP 4. Basically:
- Enable crio options crio.all and crio.logs.
- Enable podman options podman.all and podman.logs.
- Explicitly enable the 'openshift' plugin to cover old sos installations where commit a379ab3d2a is not present.

Related: RHEL-86516

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
