### PR TITLE
[cleaner] Make cleaner concurrent inside one archive

### DIFF
--- a/sos/cleaner/archives/sos.py
+++ b/sos/cleaner/archives/sos.py
@@ -69,7 +69,8 @@ class SoSCollectorArchive(SoSObfuscationArchive):
         for fname in os.listdir(_path):
             arc_name = os.path.join(_path, fname)
             if 'sosreport-' in fname and tarfile.is_tarfile(arc_name):
-                archives.append(SoSReportArchive(arc_name, self.tmpdir))
+                archives.append(SoSReportArchive(arc_name, self.tmpdir,
+                                                 self.keep_binary_files))
         return archives
 
 

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -55,6 +55,9 @@ class SoSCleanerParser():
         self.skip_cleaning_files = skip_cleaning_files
         self._generate_skip_regexes()
 
+    def load_map_entries(self):
+        self.mapping.load_entries()
+
     def _generate_skip_regexes(self):
         """Generate the regexes for the parser's configured parser_skip_files
         or global skip_cleaning_files, so that we don't regenerate them on

--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -21,8 +21,8 @@ class SoSHostnameParser(SoSCleanerParser):
         r'(((\b|_)[a-zA-Z0-9-\.]{1,200}\.[a-zA-Z]{1,63}(\b|_)))'
     ]
 
-    def __init__(self, config, skip_cleaning_files=[]):
-        self.mapping = SoSHostnameMap()
+    def __init__(self, config, workdir, skip_cleaning_files=[]):
+        self.mapping = SoSHostnameMap(workdir)
         super().__init__(config, skip_cleaning_files)
 
     def parse_line(self, line):

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -45,6 +45,6 @@ class SoSIPParser(SoSCleanerParser):
     map_file_key = 'ip_map'
     compile_regexes = False
 
-    def __init__(self, config, skip_cleaning_files=[]):
-        self.mapping = SoSIPMap()
+    def __init__(self, config, workdir, skip_cleaning_files=[]):
+        self.mapping = SoSIPMap(workdir)
         super().__init__(config, skip_cleaning_files)

--- a/sos/cleaner/parsers/ipv6_parser.py
+++ b/sos/cleaner/parsers/ipv6_parser.py
@@ -35,8 +35,8 @@ class SoSIPv6Parser(SoSCleanerParser):
     ]
     compile_regexes = False
 
-    def __init__(self, config, skip_cleaning_files=[]):
-        self.mapping = SoSIPv6Map()
+    def __init__(self, config, workdir, skip_cleaning_files=[]):
+        self.mapping = SoSIPv6Map(workdir)
         super().__init__(config, skip_cleaning_files)
 
     def get_map_contents(self):

--- a/sos/cleaner/parsers/keyword_parser.py
+++ b/sos/cleaner/parsers/keyword_parser.py
@@ -20,8 +20,8 @@ class SoSKeywordParser(SoSCleanerParser):
     name = 'Keyword Parser'
     map_file_key = 'keyword_map'
 
-    def __init__(self, config, skip_cleaning_files=[]):
-        self.mapping = SoSKeywordMap()
+    def __init__(self, config, workdir, skip_cleaning_files=[]):
+        self.mapping = SoSKeywordMap(workdir)
         super().__init__(config, skip_cleaning_files)
 
     def _parse_line(self, line):

--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -53,8 +53,8 @@ class SoSMacParser(SoSCleanerParser):
     map_file_key = 'mac_map'
     compile_regexes = False
 
-    def __init__(self, config, skip_cleaning_files=[]):
-        self.mapping = SoSMacMap()
+    def __init__(self, config, workdir, skip_cleaning_files=[]):
+        self.mapping = SoSMacMap(workdir)
         super().__init__(config, skip_cleaning_files)
 
     def reduce_mac_match(self, match):

--- a/sos/cleaner/parsers/username_parser.py
+++ b/sos/cleaner/parsers/username_parser.py
@@ -26,8 +26,8 @@ class SoSUsernameParser(SoSCleanerParser):
     map_file_key = 'username_map'
     regex_patterns = []
 
-    def __init__(self, config, skip_cleaning_files=[]):
-        self.mapping = SoSUsernameMap()
+    def __init__(self, config, workdir, skip_cleaning_files=[]):
+        self.mapping = SoSUsernameMap(workdir)
         super().__init__(config, skip_cleaning_files)
 
     def _parse_line(self, line):

--- a/tests/cleaner_tests/existing_archive.py
+++ b/tests/cleaner_tests/existing_archive.py
@@ -124,13 +124,16 @@ class ExistingArchiveCleanTmpTest(StageTwoReportTest):
     :avocado: tags=stagetwo
     """
 
-    sos_cmd = f'--keywords var,tmp,avocado --disable-parsers \
-        ip,ipv6,mac,username --no-update tests/test_data/{ARCHIVE}.tar.xz'
+    sos_cmd = f'--keywords avocado,ExistingArchiveCleanTmpTest --no-update \
+                --disable-parsers ip,ipv6,mac,username \
+                tests/test_data/{ARCHIVE}.tar.xz'
     sos_component = 'clean'
 
     def test_sys_tmp_not_obfuscated(self):
-        """ Ensure that keywords var, tmp and avocado remains in the final
-        archive path despite they are parts of the --tmp-dir
+        """ Ensure that keywords avocado and ExistingArchiveCleanTmpTest
+        remains in the final archive path despite they are parts of the
+        --tmp-dir (set like
+        /var/tmp/avocado_1m9g7qt1sos_tests.py.ExistingArchiveCleanTmpTest )
         """
         self.assertTrue(
             self.archive.startswith(os.getenv('AVOCADO_TESTS_COMMON_TMPDIR'))


### PR DESCRIPTION
Draft version adding to the traditional sequential backend also sqlite3 and file based concurrent ones.

TL;DR: please review the idea, test it and comment or ack or nack the approach. Then I will fix the TODOs.

Let me explain various factors and reasons that affected the chosen implementation.

As very very first, I implemented both sqlite3 and files based approaches, see reasoning below. And left the original behaviour just for (performance) comparison (it must be run with `-j 1`).

First, mappings are very independent objects that do maintain their dataset on their own. Even adding an item to obfuscate (say, FQDN) means the dataset is updated a few times (by the host, FQDN and/or domain). I tried to respect this as I like that independency (and also changing it would require a lot of changes).

Also, the dataset is growing in time (as we discover more domains or IP networks) , which means some instances of lately discovered domain might not be obfuscated or that changing ordering of files to obfuscate result in *different* final mapping (also in the size of the final map). You can check it by yourself if you reorder the list from `get_file_list`. So running cleaner concurrently - which means dataset being populated non-deterministically - can end up in different final map. Dont be confused by this as I was.

I chose individual processes to sync over the pieces of information "we obfuscate item X as the first one, and item Y as the next". An option to exchange or sync on the whole mapping/datasets would mean 1) more data to sync and 2) altering the mapping classes "independent" behaviour.

This also means there are gaps in numbers and it is fine. The ordering number is the size of the dataset, which can be incremented more than by one when adding just one item. This is fine, as each and every process replays the same and adds the same stuff into its dataset. And also this allows a smart replay of the whole "how was the dataset created?" process at the end - see the `archive.load_parser_entries()` call.

Then, ProcessPoolExecutor has two limitations for us that I described directly in the code, plus one substantial one: passing the whole `SoSCleaner` class is not easily feasible. Doing so would prevent some code movement among classes and would be nicer to hook new code in, but it does not work easily. Trying that, I hit issues like "oh, cloning `SoSCleaner` into a child process means cloning there sos arguments parsing that overrides some __* method that blocks successful process spawn and iteration over a list". It is possible to fix or hack those traps in our code, but after iteratively doing that for five such traps, I gave up this rabbit hole journey.

Please, consider this as a draft only - see the number of TODO points, plus various methods need a better name. Anyway the code is functionally ready, works well(*) and scales fairly well.

(*) the only concern is that sqlite DB can lock itself. I did a few changes there, but still I seldomly hit a live-lock behaviour over locked DB on some artificial test cases (have 8 identical files each with 100 unique IP addresses inside a sosreport, and run cleaner with `-j 8` is my "favourite" one).

While I like the sqlite approach more (it looks so professional!), we cant choose it until we fix these live-locks / DB locks.
Gladly, the file-based approach works smoothly and provides comparable (or even slightly better) performance.


When speaking about performance, some benchmark tests are running. Results from 8cores RHEL10 beta, median time from 3 runs each:

a small, 11MB packed sosreport:
- current cleaner run 0m59.799s
- sqlite-based cleaner run 0m59.956s (j=1), 0m34.710s (j=2), 0m22.761s (j=4) and 0m14.137s (j=8)
- files-based cleaner run 0m59.760s (j=1), 0m34.594s (j=2), 0m22.650s (j=4) and 0m14.111s (j=8)

220MB packed sosreport:
- current cleaner run 42m2.282s
- sqlite-based cleaner run 42m4.665s (j=1), 23m17.864s (j=2), 19m17.219s (j=4) and 10m26.143s (j=8)
- files-based cleaner run 42m0.994s (j=1), 23m12.987s (j=2), 19m23.130s (j=4) and 10m26.608s (j=8)

350MB packed sosreport:
- current cleaner run 65m30.090s
- sqlite-based cleaner run 66m59.097s (j=1), 42m5.778s (j=2), 29m3.550s (j=4) and 25m45.191s (j=8)
- files-based cleaner run 66m51.753s (j=1), 41m39.086s (j=2), 28m21.102s (j=4) and 24m20.798s (j=8)

770MB packed sosreport:
- current cleaner run 794m0.238s - yes, over 12 hours
- sqlite-based cleaner run 794m47.511s (j=1), 436m9.563s (j=2), 219m25.159s (j=4) and 164m10.205s (j=8) - speeded up from 12h to 2.5h
- files-based cleaner run 793m45.589s (j=1), 432m25.081s (j=2), 218m22.004s (j=4) and 165m10.775s (j=8) - again speeded up from 12h to 2.5h

1GB packed sosreport:
- current cleaner run 66m17.037s
- sqlite-based cleaner run 66m14.740s (j=1), 48m7.181s (j=2), 26m5.231s (j=4) and 23m20.612s (j=8)
- files-based cleaner run 65m56.254s (j=1), 47m57.850s (j=2), 25m50.313s (j=4) and 23m19.893s (j=8)


Closes: #3097

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
