### PR TITLE
[tomcat] skip collecting keystore

### DIFF
--- a/sos/report/plugins/tomcat.py
+++ b/sos/report/plugins/tomcat.py
@@ -26,6 +26,7 @@ class Tomcat(Plugin, RedHatPlugin):
             "/etc/tomcat7",
             "/etc/tomcat8"
         ])
+        self.add_forbidden_path("/etc/tomcat*/keystore")
 
         if not self.get_option("all_logs"):
             log_glob = "/var/log/tomcat*/catalina.out"


### PR DESCRIPTION
`/etc/tomcat/keystore` is assumed to contain just keystores to application's data - let preventively don't collect it.

Closes: #3991

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
