### PR TITLE
[tests] Add report output format tests

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1041,7 +1041,7 @@ class SoSReport(SoSComponent):
                                "disabled:"))
             self.ui_log.info("")
             for (plugname, plugclass, reason) in self.skipped_plugins:
-                self.ui_log.info(f" {plugname:<20} {reason:<14} "
+                self.ui_log.info(f" {plugname:<30} {reason:<14} "
                                  f"{plugclass.get_description()}")
 
         self.ui_log.info("")
@@ -1082,7 +1082,7 @@ class SoSReport(SoSComponent):
                 if tmpopt is None:
                     tmpopt = 0
 
-                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<30} "
+                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<35} "
                                  f"{tmpopt:<15} {opt.desc}")
         else:
             self.ui_log.info(_("No plugin options available."))

--- a/tests/report_tests/help_output_tests.py
+++ b/tests/report_tests/help_output_tests.py
@@ -71,7 +71,7 @@ class ReportListPluginsTest(StageOneOutputTest):
         for plug in disabled_plugins:
             if not plug.strip():
                 continue
-            self.assertRegex(plug, r' ([\S ]){20} (inactive[ ]{6}) ([\S ])*')
+            self.assertRegex(plug, r' ([\S ]){30} (inactive[ ]{6}) ([\S ])*')
         for opt in options:
             if not opt.strip():
                 continue
@@ -79,7 +79,7 @@ class ReportListPluginsTest(StageOneOutputTest):
         for opt in plugin_options:
             if not opt.strip():
                 continue
-            self.assertRegex(opt, r' ([\S ]){30} ([\S ]{15}) ([\S ])*')
+            self.assertRegex(opt, r' ([\S ]){35} ([\S ]{15}) ([\S ])*')
 
 
 class ReportListPresetsTest(StageOneOutputTest):


### PR DESCRIPTION
Adds a few tests to check the output format of "--list-presets" and "--list-plugins" related to the changes in https://github.com/sosreport/sos/pull/3762 and a fix to an existing test (which seemed to be just testing whether a line contains more than a single character instead of checking whether a description is missing).

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
