### PR TITLE
[cirrus] Update Fedora GCP image family name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,8 @@ env:
     # Images exist on GCP already
     CENTOS_9_FAMILY_NAME: "centos-stream-9"
     DEBIAN_FAMILY_NAME: "debian-11"
-    FEDORA_FAMILY_NAME: "fedora-cloud-41"
-    FEDORA_PRIOR_FAMILY_NAME: "fedora-cloud-40"
+    FEDORA_FAMILY_NAME: "fedora-cloud-41-x86-64"
+    FEDORA_PRIOR_FAMILY_NAME: "fedora-cloud-40-x86-64"
 
     UBUNTU_DEB_FAMILY_NAME: "ubuntu-minimal-2410-amd64"
     UBUNTU_LATEST_FAMILY_NAME: "ubuntu-2410-amd64"


### PR DESCRIPTION
The family name for the GCP images for Fedora have been updated to include the arch, so we need to update our cirrus config accordingly.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
