### PR TITLE
[FedoraPolicy] Update sos binary path for collect

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -376,6 +376,7 @@ class FedoraPolicy(RedHatPolicy):
     os_release_file = '/etc/fedora-release'
     os_release_name = 'Fedora Linux'
     os_release_id = 'fedora'
+    sos_bin_path = '/usr/bin'
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):


### PR DESCRIPTION
At some point, Fedora packaging switched to placing `sos` into `/usr/bin` instead of `/usr/sbin` like RHEL does. Update this in policy so that `sos collect` calls the proper location on remote Fedora hosts.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
