### PR TITLE
[authd] Implement authd plugin

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -453,7 +453,7 @@ class SoSReport(SoSComponent):
         ssec.add_text(helpln)
 
     def print_header(self):
-        print(f"\n{_(f'sos report (version {__version__})')}\n")
+        self.ui_log.info(f"\n{_(f'sos report (version {__version__})')}\n")
 
     def _get_hardware_devices(self):
         self.devices = {

--- a/sos/report/plugins/apparmor.py
+++ b/sos/report/plugins/apparmor.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, UbuntuPlugin
+from sos.report.plugins import Plugin, DebianPlugin
 
 
-class Apparmor(Plugin, UbuntuPlugin):
+class Apparmor(Plugin, DebianPlugin):
 
     short_desc = 'Apparmor mandatory access control'
 

--- a/sos/report/plugins/authd.py
+++ b/sos/report/plugins/authd.py
@@ -1,0 +1,74 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, UbuntuPlugin
+
+
+# See the docs: https://documentation.ubuntu.com/authd/
+class Authd(Plugin, UbuntuPlugin):
+
+    short_desc = 'Authd daemon & broker information'
+
+    plugin_name = 'authd'
+
+    apt_packages = (
+        'authd',
+    )
+
+    snap_packages = (
+        'authd-msentraid',
+        'authd-google',
+    )
+
+    packages = apt_packages + snap_packages
+
+    services = (
+        'authd',
+        'snap.authd-msentraid.authd-msentraid',
+        'snap.authd-google.authd-google',
+    )
+
+    def setup(self):
+        self.add_dir_listing([
+            "/etc/authd/brokers.d",
+        ])
+
+        self.add_copy_spec([
+            "/etc/authd/brokers.d/msentraid.conf",
+            "/etc/authd/brokers.d/google.conf",
+            "/var/snap/authd-google/current/broker.conf",
+            "/var/snap/authd-google/current/broker.conf.d/*",
+            "/var/snap/authd-msentraid/current/broker.conf",
+            "/var/snap/authd-msentraid/current/broker.conf.d/*",
+        ])
+
+        self.add_cmd_output([
+            f"apt-cache policy {' '.join(self.apt_packages)}",
+            f"snap list --all {' '.join(self.snap_packages)}",
+            "/usr/libexec/authd version",
+        ])
+
+    def postproc(self):
+        # Entra uses hex encoded IDs/secrets so just filter all hex data (with
+        # `-`) to be safe. These can be generated with uuidgen:
+        # $ uuidgen
+        # dd591ced-483e-4c47-beaf-ff46f68aab0a
+        self.do_path_regex_sub(
+            r".*",
+            r"[a-fA-F0-9-]{18,}",
+            r"******",
+        )
+
+        # Google's encoding is less clear, so we'll just filter out the values
+        # of the config fields (client_id and client_secret):
+        # client_secret = some.base64.stuff.with.domain
+        self.do_path_regex_sub(
+            r".*",
+            r"(.*_(id|secret)\s*=\s*)(.*)",
+            r"\1******",
+        )

--- a/tests/report_tests/plugin_tests/authd/authd.py
+++ b/tests/report_tests/plugin_tests/authd/authd.py
@@ -1,0 +1,49 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+ENTRA_BROKER_LOCATION = "/var/snap/authd-msentraid/current/broker.conf"
+
+ENTRA_BROKER_CONF_EXPECTED = """[oidc]
+issuer = https://login.microsoftonline.com/******/v2.0
+client_id = ******
+force_provider_authentication = false
+"""
+
+GOOGLE_BROKER_LOCATION = "/var/snap/authd-google/current/broker.conf"
+
+GOOGLE_BROKER_CONF_EXPECTED = """[oidc]
+issuer = https://accounts.google.com
+client_id = ******
+client_secret = ******
+force_provider_authentication = false
+"""
+
+
+class AuthdTest(StageTwoReportTest):
+
+    files = [
+        ("entra_broker.conf", ENTRA_BROKER_LOCATION),
+        ("google_broker.conf", GOOGLE_BROKER_LOCATION),
+    ]
+
+    ubuntu_only = True
+    sos_cmd = "-o authd"
+
+    def test_authd_scrubbed(self):
+        self.assertPluginIncluded("authd")
+
+        self.assertEqual(
+            self.get_file_content(ENTRA_BROKER_LOCATION),
+            ENTRA_BROKER_CONF_EXPECTED,
+        )
+        self.assertEqual(
+            self.get_file_content(GOOGLE_BROKER_LOCATION),
+            GOOGLE_BROKER_CONF_EXPECTED,
+        )

--- a/tests/report_tests/plugin_tests/authd/entra_broker.conf
+++ b/tests/report_tests/plugin_tests/authd/entra_broker.conf
@@ -1,0 +1,4 @@
+[oidc]
+issuer = https://login.microsoftonline.com/a24144fa-4c27-4094-b21a-77c8fc56554a/v2.0
+client_id = 82e3e7f7-a1a3-4483-b782-9db24b8edc71
+force_provider_authentication = false

--- a/tests/report_tests/plugin_tests/authd/google_broker.conf
+++ b/tests/report_tests/plugin_tests/authd/google_broker.conf
@@ -1,0 +1,5 @@
+[oidc]
+issuer = https://accounts.google.com
+client_id = 404081085900-ms7ohphjdnydamah1m0z0kr79297usyz.apps.googleusercontent.com
+client_secret = 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
+force_provider_authentication = false

--- a/tests/report_tests/smoke_tests.py
+++ b/tests/report_tests/smoke_tests.py
@@ -10,7 +10,7 @@ import re
 
 
 from avocado.utils import process
-from sos_tests import StageOneReportTest, redhat_only, debian_only
+from sos_tests import StageOneReportTest, redhat_only, debian_only, ubuntu_only
 
 
 # These are the header strings in --list-plugins output
@@ -52,9 +52,6 @@ class AllPluginSmokeTest(StageOneReportTest):
 
         Make sure our warnings are displayed
         """
-        self.assertOutputContains('Not logged in to OCP API, and no login '
-                                  'token provided. Will not collect `oc` '
-                                  'commands')
         self.assertOutputContains('Source the environment file for the user '
                                   'intended to connect to the OpenStack '
                                   'environment.')
@@ -97,20 +94,25 @@ class ExpectedDefaultPluginsTest(StageOneReportTest):
         """Plugins expected to always run on a RHEL (-like) system
         """
         self.assertPluginIncluded([
-            'anaconda',
             'dnf',
             'rpm',
             'selinux',
             'unpackaged',
-            'yum'
         ])
 
     @debian_only
-    def test_ubuntu_default_plugins(self):
-        """Plugins expected to always run on a Ubuntu (-like) system
+    def test_debian_default_plugins(self):
+        """Plugins expected to always run on a Debian (-like) system
         """
         self.assertPluginIncluded([
             'apparmor',
             'apt',
-            'ubuntu'
+        ])
+
+    @ubuntu_only
+    def test_ubuntu_default_plugins(self):
+        """Plugins expected to always run on a Ubuntu (-like) system
+        """
+        self.assertPluginIncluded([
+            'ubuntu',
         ])

--- a/tests/sos_tests.py
+++ b/tests/sos_tests.py
@@ -51,27 +51,27 @@ def skipIf(cond, message=None):
     return decorator
 
 
-# pylint: disable=unused-argument
 def redhat_only(tst):
-    def wrapper(func):
+    def wrapper(*args, **kwargs):
         if _distro.name not in RH_DIST:
             raise TestSkipError('Not running on a Red Hat distro')
+        tst(*args, *kwargs)
     return wrapper
 
 
-# pylint: disable=unused-argument
 def ubuntu_only(tst):
-    def wrapper(func):
+    def wrapper(*args, **kwargs):
         if _distro.name not in UBUNTU_DIST:
             raise TestSkipError('Not running on a Ubuntu distro')
+        tst(*args, **kwargs)
     return wrapper
 
 
-# pylint: disable=unused-argument
 def debian_only(tst):
-    def wrapper(func):
+    def wrapper(*args, **kwargs):
         if _distro.name not in DEBIAN_DIST:
             raise TestSkipError('Not running on a Debian or Ubuntu distro')
+        tst(*args, *kwargs)
     return wrapper
 
 


### PR DESCRIPTION
Fixes #3939

The secrets included in the tests are fake; I generated all the components locally. They are syntactically equivalent to the real secrets I was able to find online.

I've also included a commit to fix the `{debian,ubuntu,redhat}_only` test decorators. My first iteration of the tests passed even though the test called an assert function that didn't exist. The decorators were introduced in f2e99b89d and looking at that change it makes sense how this was missed.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
