### PR TITLE
[rear] add recover log

### DIFF
--- a/sos/report/plugins/rear.py
+++ b/sos/report/plugins/rear.py
@@ -28,7 +28,9 @@ class Rear(Plugin, RedHatPlugin):
             '/etc/rear/mappings/*',
             '/var/lib/rear/layout/*',
             '/var/lib/rear/recovery/*',
-            '/var/log/rear/*log*'
+            '/var/log/rear/*log*',
+            '/var/log/rear/recover/*log*',
+            '/var/log/rear/recover/restore/*log*'
         ])
 
         self.add_cmd_output([


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

There are some useful troubleshoot logs for recover, so add it to sos.
```
# ll /var/log/rear/recover/
total 560
drwxr-xr-x. 5 root root    207 May  6 20:24 layout
-rw-r--r--. 1 root root 573312 May  6 20:24 rear-xxx.log  <<---
drwxr-xr-x. 2 root root    197 May  6 20:24 recovery
drwxr-xr-x. 2 root root     51 May  6 20:24 restore

# ll /var/log/rear/recover/restore/
total 13656
-rw-r--r--. 1 root root 13981562 May  6 20:22 recover.backup.tar.gz.xxx.restore.log <<---
```

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
