### PR TITLE
[boot] add default kernel show

### DIFF
--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -45,7 +45,8 @@ class Boot(Plugin, IndependentPlugin):
         self.add_cmd_output([
             "efibootmgr -v",
             "lsinitramfs -l /initrd.img",
-            "lsinitramfs -l /boot/initrd.img"
+            "lsinitramfs -l /boot/initrd.img",
+            "grubby --default-kernel"
         ])
 
         if self.get_option("all-images"):


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

It is very often to check the default kernel set for the boot case(always set one kernel version, but boot with different kernel version, or forget to set). so add it:

```
# grubby --default-kernel
/boot/vmlinuz-5.14.0-427.35.1.el9_4.x86_64
```

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
