### PR TITLE
[ceph_common]: Add New Microceph Commands

### DIFF
--- a/sos/report/plugins/ceph_common.py
+++ b/sos/report/plugins/ceph_common.py
@@ -109,6 +109,9 @@ class CephCommon(Plugin, RedHatPlugin, UbuntuPlugin):
                 'disk list',
                 'log get-level',
                 'status',
+                'pool list',
+                'remote list',
+                'replication list rbd',
             ]
 
             self.add_cmd_output([f"microceph {cmd}" for cmd in cmds],


### PR DESCRIPTION
Since the last update to the ceph_common plugin, microceph has added
new features and commands such as microceph pool list, microceph remote
list, and microceph replication list rbd. This commit collects the output of
those commands

Signed-off-by: Bryan Fraschetti <bryan.fraschetti@canonical.com>