### PR TITLE
[juju] Fix juju agent introspect commands

### DIFF
--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -10,6 +10,7 @@
 
 import pwd
 import json
+import re
 from sos.report.plugins import Plugin, UbuntuPlugin, PluginOpt
 
 
@@ -76,6 +77,8 @@ class Juju(Plugin, UbuntuPlugin):
         ),
     ]
 
+    agent_name = ""
+
     def setup(self):
         # Juju service names are not consistent through deployments,
         # so we need to use a wildcard to get the correct service names.
@@ -83,18 +86,25 @@ class Juju(Plugin, UbuntuPlugin):
             self.add_journal(service)
             self.add_service_status(service)
 
-        self.add_cmd_output([
-            'juju_engine_report',
-            'juju_goroutines',
-            'juju_heap_profile',
-            'juju_leases',
-            'juju_metrics',
-            'juju_pubsub_report',
-            'juju_presence_report',
-            'juju_statepool_report',
-            'juju_statetracker_report',
-            'juju_unit_status',
-        ])
+        juju_agent_cmds = {
+            'juju_engine_report': 'depengine',
+            'juju_goroutines': 'debug/pprof/goroutine?debug=1',
+            'juju_heap_profile': 'debug/pprof/heap?debug=1',
+            'juju_metrics': 'metrics',
+            'juju_pubsub_report': 'pubsub',
+            'juju_presence_report': 'presence',
+            'juju_statepool_report': 'statepool',
+            'juju_statetracker_report': ('debug/pprof/juju/state/tracker?'
+                                         'debug=1'),
+            'juju_unit_status': 'units?action=status',
+        }
+
+        if self.path_exists("/var/lib/juju/agents"):
+            for cmd, agent_cmd in juju_agent_cmds.items():
+                self.add_cmd_output(
+                    self._juju_agent(agent_cmd),
+                    suggest_filename=cmd
+                )
 
         # Get agent configs for each agent.
         self.add_copy_spec("/var/lib/juju/agents/*/agent.conf")
@@ -185,6 +195,15 @@ class Juju(Plugin, UbuntuPlugin):
                             f"--format=json"
                         )
                         self.add_cmd_output(command, runas=juju_user)
+
+    def _juju_agent(self, command):
+        if self.agent_name == "":
+            for dir_name in self.listdir("/var/lib/juju/agents"):
+                if re.search('machine-*|controller-*|application-*', dir_name):
+                    self.agent_name = dir_name
+                    break
+
+        return f"juju-introspect --agent={self.agent_name} {command}"
 
     def postproc(self):
         agents_path = "/var/lib/juju/agents/*"


### PR DESCRIPTION
By default the introspect commands are aliases in the bash login profile, so these won't be available via sos. This extraplotes the commands that are available and passes it to juju-introspect.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
