### PR TITLE
[kdump] Capture vmcore-creation.status file

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -82,7 +82,8 @@ class RedHatKDump(KDump, RedHatPlugin):
             "/etc/udev/rules.d/*kexec.rules",
             "/usr/lib/udev/rules.d/*kexec.rules",
             "/var/crash/*/kexec-dmesg.log",
-            "/var/log/kdump.log"
+            "/var/log/kdump.log",
+            "/var/crash/*/vmcore-creation.status",
         ])
         self.add_copy_spec("/var/crash/*/vmcore-dmesg.txt",
                            tags="vmcore_dmesg")
@@ -95,6 +96,7 @@ class RedHatKDump(KDump, RedHatPlugin):
         self.add_dir_listing(path, recursive=True)
         self.add_copy_spec(f"{path}/*/vmcore-dmesg.txt")
         self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
+        self.add_copy_spec(f"{path}/*/vmcore-creation.status")
 
         # collect the latest vmcore created in the last 24hrs <= 2GB
         if self.get_option("get-vm-core"):
@@ -173,6 +175,7 @@ class AzureKDump(KDump, AzurePlugin):
         self.add_dir_listing(path, recursive=True)
         self.add_copy_spec(f"{path}/*/vmcore-dmesg.txt")
         self.add_copy_spec(f"{path}/*/kexec-dmesg.log")
+        self.add_copy_spec(f"{path}/*/vmcore-creation.status")
 
         # collect the latest vmcore created in the last 24hrs <= 2GB
         if self.get_option("get-vm-core"):


### PR DESCRIPTION
Capture the newly added vmcore-creation.status
under var/crash/<vmcore-dir>/

Related: RHEL-91178, RHEL-29941

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
