### PR TITLE
[dnf] Scrub passwords in repository URIs

### DIFF
--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -150,4 +150,10 @@ class DNFPlugin(Plugin, RedHatPlugin):
         #
         self.do_file_sub("/etc/dnf/dnf.conf", regexp, repl)
 
+        # Scrub credentials in http URIs
+        self.do_paths_http_sub([
+            '/etc/yum.repos.d/*',
+            '/var/log/dnf.*',
+        ])
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Examples of credentials:

`/var/log/dnf.librepo.log`:

    2025-05-20T11:28:23+0200 INFO Downloading: https://username:password@host.name.com/some/path/repodata/repomd.xml

or `/etc/yum.repos.d/cutom.repo` having either of:

    baseurl = https://username:password@host.name.com/some/path/
    gpgkey = https://username:password@host.name.com/some/path/GPG-KEY.pub

Closes: #4018

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
