### PR TITLE
[policy] Re-add logic to request case-id if not present

### DIFF
--- a/sos/policies/distros/__init__.py
+++ b/sos/policies/distros/__init__.py
@@ -13,6 +13,7 @@
 import os
 import re
 
+from sos import _sos as _
 from sos.policies import Policy
 from sos.policies.init_systems import InitSystem
 from sos.policies.init_systems.systemd import SystemdInit
@@ -296,10 +297,21 @@ class LinuxPolicy(Policy):
         # this method will be called before the gathering begins
 
         cmdline_opts = self.commons['cmdlineopts']
+        caseid = cmdline_opts.case_id if cmdline_opts.case_id else ""
 
         if cmdline_opts.low_priority:
             self._configure_low_priority()
 
+        # set or query for case id
+        if not cmdline_opts.batch and not \
+                cmdline_opts.quiet:
+            if caseid:
+                self.commons['cmdlineopts'].case_id = caseid
+            else:
+                self.commons['cmdlineopts'].case_id = input(
+                    _("Optionally, please enter the case id that you are "
+                      "generating this report for [%s]: ") % caseid
+                )
         if cmdline_opts.case_id:
             self.case_id = cmdline_opts.case_id
 


### PR DESCRIPTION
This commit re-adds the logic to ask for case-id if the user hasn't specified it in the command line
explicitly.

Related: RHEL-92071

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
