### PR TITLE
[collector] resolve regex library warnings

### DIFF
--- a/sos/collector/clusters/juju.py
+++ b/sos/collector/clusters/juju.py
@@ -141,7 +141,9 @@ class juju(Cluster):
 
     def _cleanup_juju_output(self, output):
         """Remove leading characters before {."""
-        return re.sub(r"(^[^{]*)(.*)", "\\2", output, 0, re.MULTILINE)
+        return re.sub(
+            r"(^[^{]*)(.*)", "\\2", output, count=0, flags=re.MULTILINE
+        )
 
     def _get_model_info(self, model_name):
         """Parse juju status output and return target dict.


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [ x Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?

# PR Summary
This small PR resolves the regex library warnings showing in Python3.13:
```python
'count' is passed as positional argument
```
