### PR TITLE
[cleaner] Use "hostname -f" in HostnamePrepper

### DIFF
--- a/sos/cleaner/preppers/hostname.py
+++ b/sos/cleaner/preppers/hostname.py
@@ -29,7 +29,7 @@ class HostnamePrepper(SoSPrepper):
         items = []
         _file = 'hostname'
         if archive.is_sos:
-            _file = 'sos_commands/host/hostname'
+            _file = 'sos_commands/host/hostname_-f'
         elif archive.is_insights:
             _file = 'data/insights_commands/hostname_-f'
 


### PR DESCRIPTION
HostnamePrepper should always be fed by FQDN to ensure domain names are recognized properly.

This is important esp. when:
- /etc/hosts is empty
- "hostname" contains shortname only
- "hostname -f" contains FQDN

Resolves: #4022
Closes: #4026

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
