### PR TITLE
[archive] Print stderr if the gpg command fails

### DIFF
--- a/sos/archive.py
+++ b/sos/archive.py
@@ -653,7 +653,7 @@ class FileCacheArchive(Archive):
             enc_cmd += "-c --passphrase-fd 0 "
             enc_cmd = f"/bin/bash -c \"echo $sos_gpg | {enc_cmd}\""
             enc_cmd += archive
-        r = sos_get_command_output(enc_cmd, timeout=0, env=env)
+        r = sos_get_command_output(enc_cmd, timeout=0, env=env, stderr=True)
         if r["status"] == 0:
             return arc_name
         if r["status"] == 2:
@@ -662,9 +662,7 @@ class FileCacheArchive(Archive):
             else:
                 msg = "Could not read passphrase"
         else:
-            # TODO: report the actual error from gpg. Currently, we cannot as
-            # sos_get_command_output() does not capture stderr
-            msg = f"gpg exited with code {r['status']}"
+            msg = f"gpg exited with code {r['status']} and error {r['output']}"
         raise Exception(msg)
 
     def _build_archive(self, method):  # pylint: disable=unused-argument


### PR DESCRIPTION
Since stderr is now captured in sos_get_command_output() this commit enables it for the _encrypt() function and prints the error received if the gpg command failed.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
