### PR TITLE
[doc] Remove deprecated call to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $ sudo ./bin/sos report -l
 
 To install locally (as root):
 ```
-# python3 setup.py install
+# python3 -m pip install .
 ```
 
 


### PR DESCRIPTION
When running 'python3 setup.py install' we get an alert about deprecation:

running install
/usr/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated. !!

setup.py per se is not deprecated, but the way
it's invoked is. This commit provides an alternative way to install sos still using setup.py.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
