### PR TITLE
[dqlite] Conduct Dqlite Collection in Consumers

### DIFF
--- a/sos/report/plugins/microovn.py
+++ b/sos/report/plugins/microovn.py
@@ -8,6 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import json
 from sos.report.plugins import Plugin, UbuntuPlugin
 
 
@@ -38,3 +39,67 @@ class MicroOVN(Plugin, UbuntuPlugin):
         self.add_cmd_output([
             f"microovn {subcmd}" for subcmd in microovn_subcmds
         ])
+
+        dqlite_crt = "/var/snap/microovn/common/state/cluster.crt"
+        self.add_cmd_output(
+            f"openssl x509 -in {dqlite_crt} -noout -dates",
+        )
+
+        db_path = "/var/snap/microovn/common/state/database"
+
+        # Check for inconsistent dqlite db intervals
+        self.add_dir_listing(
+            db_path,
+            suggest_filename="ls_microovn_dqlite_dir",
+        )
+
+        self.add_copy_spec([
+                f"{db_path}/info.yaml",
+                f"{db_path}/cluster.yaml",
+                f"{db_path}/../daemon.yaml",
+        ])
+
+        queries = [
+            {
+                "query": "SELECT * FROM sqlite_master WHERE type=\"table\";",
+                "suggested_file_suffix": "schema",
+            },
+            {
+                "query": (
+                    "SELECT * FROM config WHERE NOT ( "
+                    "key LIKE \"%keyring%\" OR "
+                    "key LIKE \"%ca_cert%\" OR "
+                    "key LIKE \"%ca_key%\" );"
+                ),
+                "suggested_file_suffix": "config",
+            },
+            {
+                "query": "SELECT * FROM services;",
+                "suggested_file_suffix": "services",
+            },
+            {
+                "query": (
+                    "SELECT id, name, expiry_date "
+                    "FROM core_token_records;"
+                ),
+                "suggested_file_suffix": "token_records",
+            },
+            {
+                "query": (
+                    "SELECT id, name, address, schema_internal, "
+                    "schema_external, heartbeat, role, api_extensions "
+                    "FROM core_cluster_members;"
+                ),
+                "suggested_file_suffix": "core_cluster_members",
+            },
+        ]
+
+        for query_entry in queries:
+            query = json.dumps(query_entry.get("query"))
+            file_suffix = query_entry.get("suggested_file_suffix")
+            self.add_cmd_output(
+                f"microovn cluster sql {query}",
+                suggest_filename=f"microovn_cluster_sql_{file_suffix}",
+            )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Collect files relating to the configuration of the distributed cluster that underlies micro* applications like microceph, microovn, microcloud, microk8s, and lxd. Collect the directory listing of the dqlite database dir to check for corrupt intervals, and collect the expiry date of cluster certs. As well, inspect information pertinent to the cluster by querying against the dqlite db.

Signed-off-by: Bryan Fraschetti \<bryan.fraschetti@canonical.com\>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
