### PR TITLE
[tftpserver] Add Directory Listing /var/lib/tftpboot

### DIFF
--- a/sos/report/plugins/tftpserver.py
+++ b/sos/report/plugins/tftpserver.py
@@ -24,7 +24,7 @@ class TftpServer(Plugin, IndependentPlugin):
         self.add_dir_listing([
             '/var/lib/tftpboot',
             '/tftpboot',
-            '/sr/tftp'
+            '/srv/tftp'
         ], recursive=True)
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/tftpserver.py
+++ b/sos/report/plugins/tftpserver.py
@@ -21,6 +21,10 @@ class TftpServer(Plugin, IndependentPlugin):
     packages = ('tftp-server',)
 
     def setup(self):
-        self.add_dir_listing(['/tftpboot', '/sr/tftp'], recursive=True)
+        self.add_dir_listing([
+            '/var/lib/tftpboot',
+            '/tftpboot',
+            '/sr/tftp'
+        ], recursive=True)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Add /var/lib/tftpboot to the directory listing.
This is the default directory for boot files for tftp booting. 
Reference: /usr/share/doc/tftp-server/README.security

Signed-off-by: Charlie Krell <ckrell@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
