### PR TITLE
[saltmaster] Obfuscate pillar roots in any path

### DIFF
--- a/sos/report/plugins/saltmaster.py
+++ b/sos/report/plugins/saltmaster.py
@@ -64,7 +64,10 @@ class SaltMaster(Plugin, IndependentPlugin):
         self.add_copy_spec(all_pillar_roots)
 
     def postproc(self):
-        regexp = r'(^\s*.*(pass|secret|(?<![A-z])key(?![A-z])).*:\ ).+$'
+        regexp = (
+            r'(^\s*.*(pass|secret|(?<![A-z])key(?![A-z])|'
+            r'api_?key|encryption_?key).*:\ ).+'
+        )
         subst = r'\1******'
         self.do_path_regex_sub("/etc/salt/*", regexp, subst)
 

--- a/sos/report/plugins/saltmaster.py
+++ b/sos/report/plugins/saltmaster.py
@@ -64,7 +64,7 @@ class SaltMaster(Plugin, IndependentPlugin):
         self.add_copy_spec(all_pillar_roots)
 
     def postproc(self):
-        regexp = r'(^\s+.*(pass|secret|(?<![A-z])key(?![A-z])).*:\ ).+$'
+        regexp = r'(^\s*.*(pass|secret|(?<![A-z])key(?![A-z])).*:\ ).+$'
         subst = r'\1******'
         self.do_path_regex_sub("/etc/salt/*", regexp, subst)
 

--- a/sos/report/plugins/saltmaster.py
+++ b/sos/report/plugins/saltmaster.py
@@ -20,11 +20,9 @@ class SaltMaster(Plugin, IndependentPlugin):
 
     packages = ('salt-master', 'salt-api',)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setup(self):
         self.collected_pillar_roots = []
 
-    def setup(self):
         if self.get_option("all_logs"):
             self.add_copy_spec("/var/log/salt")
         else:


### PR DESCRIPTION
- Obfuscates root level passwords, secrets and keys
- Includes api and encryption keys, but keeps original negative lookbehind for any other "key"
- Obfuscates a pillar root in any collected path in addition to `/etc/salt`

Closes #4058

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
