### PR TITLE
[component] Grab tmpdir from policy

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -168,7 +168,7 @@ class SoSComponent():
         if self.opts.tmp_dir:
             tmpdir = os.path.abspath(self.opts.tmp_dir)
         else:
-            tmpdir = os.getenv('TMPDIR', None) or '/var/tmp'
+            tmpdir = os.getenv('TMPDIR', None) or self.policy.get_tmp_dir(None)
 
         if os.getenv('HOST', None) and os.getenv('container', None):
             tmpdir = os.path.join(os.getenv('HOST'), tmpdir.lstrip('/'))


### PR DESCRIPTION
Rather than using /var/tmp by default, grab the tmp_dir from the policy. The default will be from tempfile.gettempdir() from the sos.policies, so should be getting it from the OS default.

Closes: #4061

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
