### PR TITLE
[scsi] add 'lsscsi -t' to capture transport details of SCSI targets.

### DIFF
--- a/sos/report/plugins/scsi.py
+++ b/sos/report/plugins/scsi.py
@@ -60,6 +60,7 @@ class Scsi(Plugin, IndependentPlugin):
             "lsscsi -s",
             "lsscsi -L",
             "lsscsi -iw",
+            "lsscsi -t"
         ])
 
         scsi_hosts = glob("/sys/class/scsi_host/*")


### PR DESCRIPTION
This adds the 'lsscsi -t' command output to the SCSI plugin to help capture detailed transport information such as target ports. This is useful for diagnosing SCSI device-level issues and topology.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
