### PR TITLE
[lightspeed] Add new plugin for RH command-line-assistant

### DIFF
--- a/sos/report/plugins/command_line_assistant.py
+++ b/sos/report/plugins/command_line_assistant.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2025 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
+
+
+class CommandLineAssistant(Plugin, RedHatPlugin):
+
+    short_desc = 'Lightspeed Command Line Assistant'
+
+    plugin_name = 'command_line_assistant'
+    profiles = ('ai',)
+    services = ('clad',)
+
+    option_list = [
+        PluginOpt('historydb', default=False,
+                  desc='collect the history database')
+    ]
+
+    config_file = "/etc/xdg/command-line-assistant/config.toml"
+
+    def setup(self):
+        self.add_copy_spec([
+            self.config_file,
+            "/etc/systemd/system/clad.service.d/"
+        ])
+
+        if self.get_option('historydb'):
+            self.add_copy_spec(
+                    "/var/lib/command-line-assistant/history.db",
+            )
+
+    def postproc(self):
+        self.do_path_regex_sub(self.config_file,
+                               r"(password\s+=\s+)(\S+)",
+                               r"\1********\n")
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This commit creates the plugin for RHEL Lightspeed Command Line Assistant.

Related: RSPEED-549, RHEL-102037

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
