### PR TITLE
[report] Fix formatting of distros in plugins_overview

### DIFF
--- a/plugins_overview.py
+++ b/plugins_overview.py
@@ -55,7 +55,10 @@ def add_all_items(method, dest, plugfd, wrapopen=r'\(', wrapclose=r'\)'):
                         # dirty hack to remove spaces and "Plugin"
                         if "Plugin" not in it:
                             continue
-                        it = it.strip(' ()')[0:-6]
+                        if "=" in it:
+                            it = re.sub(r"Plugin.*", "Plugin", it)
+                        plug_col_len = 9 if "PluginOpt" in it else 6
+                        it = it.strip(' ()')[:-plug_col_len]
                         if len(it):
                             dest.append(it)
         # list of specs separated by comma ..
@@ -94,7 +97,8 @@ for plugfile in sorted(os.listdir(PLUGDIR)):
         pfd_content = pfd.read().replace('\n', '')
         add_all_items(
             "from sos.report.plugins import ", plugs_data[plugname]['distros'],
-            pfd_content, wrapopen='', wrapclose='(class|from|import)'
+            pfd_content, wrapopen='',
+            wrapclose=r'(class|from|import|#|\))'
         )
         add_all_items("profiles = ", plugs_data[plugname]['profiles'],
                       pfd_content, wrapopen='')


### PR DESCRIPTION
The formatting of the distros column was leaving the string 'Plu' when it found 'PluginOpt'. This fix
explicitly deals with both 'PluginOpt' and 'Plugin' strings and removes them.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
