### PR TITLE
[openshift_ovn] Allow specific container runtime for plugin command

### DIFF
--- a/sos/report/plugins/openshift_ovn.py
+++ b/sos/report/plugins/openshift_ovn.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2021 Nadia Pinaeva <npinaeva@redhat.com>
-
 # This file is part of the sos project: https://github.com/sosreport/sos
 #
 # This copyrighted material is made available to anyone wishing to use,
@@ -8,6 +7,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import glob
 from sos.report.plugins import Plugin, RedHatPlugin
 
 
@@ -21,6 +21,7 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
     profiles = ('openshift',)
 
     def setup(self):
+
         all_logs = self.get_option("all_logs")
 
         self.add_copy_spec([
@@ -50,21 +51,29 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
             'cluster/status OVN_Northbound',
             'ovn-appctl -t /var/run/ovn/ovnsb_db.ctl ' +
             'cluster/status OVN_Southbound'],
-            container='ovnkube-master')
-        self.add_cmd_output([
-            'ovs-appctl -t /var/run/ovn/ovn-controller.*.ctl ' +
-            'ct-zone-list'],
-            container='ovnkube-node')
-        self.add_cmd_output([
-            'ovs-appctl -t /var/run/ovn/ovn-controller.*.ctl ' +
-            'ct-zone-list'],
-            container='ovnkube-controller')
+            container='ovnkube-master',
+            runtime='crio')
+        # We need to determine the actual file name to send
+        # to the command
+        files = glob.glob("/var/run/ovn/ovn-controller.*.ctl")
+        for file in files:
+            self.add_cmd_output([
+                f"ovs-appctl -t {file} ct-zone-list"],
+                container='ovnkube-node',
+                runtime='crio')
+            self.add_cmd_output([
+                f"ovs-appctl -t {file} ct-zone-list"],
+                container='ovnkube-controller',
+                runtime='crio')
         # Collect ovs ct-zone-list directly on host for interconnect setup.
-        self.add_cmd_output([
-            'ovs-appctl -t /var/run/ovn-ic/ovn-controller.*.ctl ' +
-            'ct-zone-list'])
+        files = glob.glob("/var/run/ovn-ic/ovn-controller.*.ctl")
+        for file in files:
+            self.add_cmd_output([
+                f"ovs-appctl -t {file} ct-zone-list'"],
+                runtime='crio')
         self.add_cmd_output([
             'ovs-appctl -t ovs-monitor-ipsec tunnels/show',
             'ipsec status',
             'certutil -L -d sql:/etc/ipsec.d'],
-            container='ovn-ipsec')
+            container='ovn-ipsec',
+            runtime='crio')


### PR DESCRIPTION
This Update allows a specific container runtime to be passed to add_cmd_output so commands that must use a specific runtime do so.

Related: SUPDEV-180

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
