### PR TITLE
[kdump|release] Change format of imports

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -7,8 +7,8 @@
 # See the LICENSE file in the source distribution for further information.
 
 import platform
-from sos.report.plugins import Plugin, PluginOpt, RedHatPlugin, DebianPlugin, \
-    UbuntuPlugin, CosPlugin, AzurePlugin
+from sos.report.plugins import (Plugin, PluginOpt, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, CosPlugin, AzurePlugin)
 
 
 class KDump(Plugin):

--- a/sos/report/plugins/release.py
+++ b/sos/report/plugins/release.py
@@ -6,8 +6,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, \
-    DebianPlugin, UbuntuPlugin, CosPlugin
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin, CosPlugin)
 
 
 class Release(Plugin, UbuntuPlugin, CosPlugin):


### PR DESCRIPTION
Change the format of the import line for plugins
to parenthesis so it matches what we do in all
other plugins that contain multiline imports.
Also, this change ensures that the script
plugins_overview.py's output is consistent
across all plugins and doesn't contain
errors.

Related: #4071

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
