### PR TITLE
[subscription_manager] Obfuscate proxy env variables

### DIFF
--- a/sos/report/plugins/subscription_manager.py
+++ b/sos/report/plugins/subscription_manager.py
@@ -128,5 +128,9 @@ class SubscriptionManager(Plugin, RedHatPlugin):
         # if curl used config file to hide proxy password, remove the file
         if self._curl_cfg_fname:
             remove(self._curl_cfg_fname)
+        # Remove proxy information from curl command
+        http_proxy_regexp = r"(http(s)?://)\S+:\S+(@.*)"
+        http_proxy_repl = r"\1******:******\3"
+        self.do_cmd_output_sub('*curl*', http_proxy_regexp, http_proxy_repl)
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Obfuscate proxy env variables from the curl
command.

Related: RHEL-103749

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
