### PR TITLE
[upload] Avoid asking twice for case id

### DIFF
--- a/sos/upload/targets/redhat.py
+++ b/sos/upload/targets/redhat.py
@@ -81,9 +81,7 @@ class RHELUploadTarget(UploadTarget):
                 return self.commons['cmdlineopts'].upload_url
             if self.commons['cmdlineopts'].upload_protocol == 'sftp':
                 return self.RH_SFTP_HOST
-            if not self.commons['cmdlineopts'].case_id and not\
-                self.commons['policy'].prompt_for_case_id(
-                    self.commons['cmdlineopts']):
+            if not self.commons['cmdlineopts'].case_id:
                 return self.RH_SFTP_HOST
 
         except Exception as e:


### PR DESCRIPTION
Resolve an issue where sos could ask twice for a case id.

Related: RHEL-95366

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
