### PR TITLE
[kdump] Capture kdumpctl outputs

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -102,6 +102,12 @@ class RedHatKDump(KDump, RedHatPlugin):
         if self.get_option("get-vm-core"):
             self.add_copy_spec(f"{path}/*/vmcore", sizelimit=2048, maxage=24)
 
+        # collect status via kdumpctl
+        self.add_cmd_output([
+            "kdumpctl status",
+            "kdumpctl estimate",
+        ])
+
 
 class DebianKDump(KDump, DebianPlugin, UbuntuPlugin):
 


### PR DESCRIPTION
The kdumpctl status command is the most reliable way to determine the result of the last kdumpctl test.
It retrieves this information from the
/var/lib/kdump/vmcore-creation.status file, even if the associated test directory has been removed.

kdumpctl estimate provides an estimate of the memory required for kdump and displays detailed
memory usage breakdowns.

Related: RHEL-104041

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
