### PR TITLE
[insights] Obfuscate proxy password from logs

### DIFF
--- a/sos/report/plugins/insights.py
+++ b/sos/report/plugins/insights.py
@@ -64,5 +64,6 @@ class RedHatInsights(Plugin, RedHatPlugin):
             self.do_file_sub(
                 conf, r'(proxy[\t\ ]*=.*)(:)(.*)(@.*)', r'\1\2********\4'
             )
+        self.do_paths_http_sub(["/var/log/insights-client/*"])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Obfuscate proxy password from logs inside
/var/log/insights-client.

Related: RHEL-104245

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
