### PR TITLE
[networking] Add `/etc/gai.conf` copy spec

### DIFF
--- a/sos/report/plugins/networking.py
+++ b/sos/report/plugins/networking.py
@@ -62,6 +62,7 @@ class Networking(Plugin):
             "/etc/network*",
             "/etc/nsswitch.conf",
             "/etc/resolv.conf",
+            "/etc/gai.conf",
             "/etc/xinetd.conf",
             "/etc/xinetd.d",
             "/etc/yp.conf",


### PR DESCRIPTION
Capture the glibc `getaddrinfo(3)` configuration file.

Based on the obfuscation rules already present in `networking.py` and the [`gai.conf`](https://manpages.ubuntu.com/manpages/questing/en/man5/gai.conf.5.html) manpage I don't believe that obfuscation is needed.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
