### PR TITLE
[report] Add rhui_containerized plugin

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -3189,6 +3189,11 @@ class Plugin():
                     # archives, with no way to control that
                     self.archive.add_string(cpret['output'], arcdest)
                 self._add_container_file_to_manifest(con, path, arcdest, tags)
+                self.copied_files.append({
+                    'srcpath': path,
+                    'dstpath': arcdest,
+                    'symlink': "no"
+                })
             else:
                 self._log_info(f"error copying '{path}' from container "
                                f"'{con}': {cpret['output']}")

--- a/sos/report/plugins/pulpcore.py
+++ b/sos/report/plugins/pulpcore.py
@@ -32,6 +32,7 @@ class PulpCore(Plugin, IndependentPlugin):
     staticroot = "/var/lib/pulp/assets"
     uploaddir = "/var/lib/pulp/media/upload"
     env = {"PGPASSWORD": dbpasswd}
+    settings_file = "/etc/pulp/settings.py"
 
     def parse_settings_config(self):
         """ Parse pulp settings """
@@ -47,7 +48,7 @@ class PulpCore(Plugin, IndependentPlugin):
             return val
 
         try:
-            with open("/etc/pulp/settings.py", 'r', encoding='UTF-8') as file:
+            with open(self.settings_file, 'r', encoding='UTF-8') as file:
                 # split the lines to "one option per line" format
                 for line in file.read() \
                         .replace(',', ',\n').replace('{', '{\n') \
@@ -87,23 +88,36 @@ class PulpCore(Plugin, IndependentPlugin):
         self.env = {"PGPASSWORD": self.dbpasswd}
 
     def setup(self):
+        self.runas = self.in_container = None
+        rhui_podman_ps = self.exec_cmd("podman ps --filter name=rhui5-rhua",
+                                       runas="rhui")
+        if rhui_podman_ps['status'] == 0:
+            lines = rhui_podman_ps['output'].splitlines()
+            if len(lines) > 1:  # we know there is a container of given name
+                self.runas = 'rhui'
+                self.in_container = 'rhui5-rhua'
+                self.settings_file = '/var/lib/rhui/config/pulp/settings.py'
         self.parse_settings_config()
 
         self.add_copy_spec([
             "/etc/pulp/settings.py",
             "/etc/pki/pulp/*"
-        ])
+        ], runas=self.runas, container=self.in_container)
+
         # skip collecting certificate keys
         self.add_forbidden_path("/etc/pki/pulp/**/*.key")
 
         self.add_cmd_output("curl -ks https://localhost/pulp/api/v3/status/",
-                            suggest_filename="pulp_status")
+                            suggest_filename="pulp_status", runas=self.runas,
+                            container=self.in_container)
         dynaconf_env = {"LC_ALL": "en_US.UTF-8",
                         "PULP_SETTINGS": "/etc/pulp/settings.py",
                         "DJANGO_SETTINGS_MODULE": "pulpcore.app.settings"}
-        self.add_cmd_output("dynaconf list", env=dynaconf_env)
+        self.add_cmd_output("dynaconf list", env=dynaconf_env,
+                            runas=self.runas, container=self.in_container)
         for _dir in [self.staticroot, self.uploaddir]:
-            self.add_dir_listing(_dir)
+            self.add_dir_listing(_dir, runas=self.runas,
+                                 container=self.in_container)
 
         task_days = self.get_option('task-days')
         for table in ['core_task', 'core_taskgroup',
@@ -113,13 +127,16 @@ class PulpCore(Plugin, IndependentPlugin):
                       "AND table_schema = 'public' AND column_name NOT IN"
                       " ('args', 'kwargs', 'enc_args', 'enc_kwargs'))"
                       " TO STDOUT;")
-            col_out = self.exec_cmd(self.build_query_cmd(_query), env=self.env)
+            col_out = self.exec_cmd(self.build_query_cmd(_query), env=self.env,
+                                    runas=self.runas,
+                                    container=self.in_container)
             columns = col_out['output'] if col_out['status'] == 0 else '*'
             _query = (f"select {columns} from {table} where pulp_last_updated"
                       f"> NOW() - interval '{task_days} days' order by"
                       " pulp_last_updated")
             _cmd = self.build_query_cmd(_query)
-            self.add_cmd_output(_cmd, env=self.env, suggest_filename=table)
+            self.add_cmd_output(_cmd, env=self.env, suggest_filename=table,
+                                runas=self.runas, container=self.in_container)
 
         # collect tables sizes, ordered
         _cmd = self.build_query_cmd(
@@ -138,7 +155,8 @@ class PulpCore(Plugin, IndependentPlugin):
             "total_bytes DESC"
         )
         self.add_cmd_output(_cmd, suggest_filename='pulpcore_db_tables_sizes',
-                            env=self.env)
+                            env=self.env, runas=self.runas,
+                            container=self.in_container)
 
     def build_query_cmd(self, query, csv=False):
         """

--- a/sos/report/plugins/rhui_containerized.py
+++ b/sos/report/plugins/rhui_containerized.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2025 Red Hat, Inc., Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import fnmatch
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class RhuiContainer(Plugin, RedHatPlugin):
+
+    short_desc = 'Red Hat Update Infrastructure in Containers'
+
+    plugin_name = "rhui_containerized"
+    services = ("rhui_rhua", )
+    files = ("/var/lib/rhui/config/rhua/rhui-tools.conf", )
+
+    def setup(self):
+        self.add_copy_spec([
+            "/var/lib/rhui/config/rhua/rhui-tools.conf",
+            "/var/lib/rhui/config/rhua/registered_subscriptions.conf",
+            "/var/lib/rhui/pki/*",
+            "/var/lib/rhui/cache/*",
+            "/var/lib/rhui/root/.rhui/*",
+            "/var/lib/rhui/log/*",
+        ])
+        # skip collecting certificate keys
+        self.add_forbidden_path("/var/lib/rhui/pki/**/*.key")
+
+        # call rhui-manager commands with 1m timeout and
+        # with an env. variable ensuring that "RHUI Username:"
+        # even unanswered prompt gets collected
+        # TODO: is the timeout and env applicable?
+        rhui_cont_exe = "podman exec rhui5-rhua rhui-manager --noninteractive"
+        for subcmd in ["status", "cert info"]:
+            suggest_fname = f"rhui-manager_{subcmd.replace(' ', '_')}"
+            self.add_cmd_output(f"{rhui_cont_exe} {subcmd}",
+                                runas="rhui",
+                                runat="/var/lib/rhui",
+                                suggest_filename=suggest_fname)
+
+        self.add_dir_listing('/var/lib/rhui/remote_share', recursive=True)
+
+        # collect postgres diagnostics data
+        # ideally, postgresql plugin would do so but that would need bigger
+        # changes to the plugin redundantly affecting its execution on
+        # non-RHUI systems
+        pghome = '/var/lib/pgsql'
+        self.add_cmd_output(f"du -sh {pghome}", container='rhui5-rhua',
+                            runas='rhui')
+        # Copy PostgreSQL log and config files.
+        # we must first find all their names, since `stat` inside add_copy_spec
+        # does not treat globs at all
+        podman_find = self.exec_cmd("podman exec rhui5-rhua find "
+                                    f"{pghome}/data", runas="rhui")
+        if podman_find['status'] == 0:
+            allfiles = podman_find['output'].splitlines()
+            logfiles = fnmatch.filter(allfiles, '*.log')
+            configs = fnmatch.filter(allfiles, '*.conf')
+            self.add_copy_spec(logfiles, container='rhui5-rhua', runas='rhui')
+            self.add_copy_spec(configs, container='rhui5-rhua', runas='rhui')
+        # copy PG_VERSION and postmaster.opts
+        for file in ["PG_VERSION", "postmaster.opts"]:
+            self.add_copy_spec(f"{pghome}/data/{file}",
+                               container='rhui5-rhua', runas='rhui')
+
+    def postproc(self):
+        # hide registry_password value in rhui-tools.conf
+        self.do_path_regex_sub("/var/lib/rhui/config/rhua/rhui-tools.conf",
+                               r"(.+_pass(word|):)\s*(.+)",
+                               r"\1 ********")
+        # obfuscate two cookies for login session
+        for cookie in ["csrftoken", "sessionid"]:
+            self.do_path_regex_sub(
+                r"/var/lib/rhui/root/\.rhui/.*/cookies.txt",
+                fr"({cookie}\s+)(\S+)",
+                r"\1********")
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -263,7 +263,10 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
         time.sleep(0.01)
 
     if runas:
-        pwd_user = pwd.getpwnam(runas)
+        try:
+            pwd_user = pwd.getpwnam(runas)
+        except KeyError:  # no such user
+            return {'status': 127, 'output': "", 'truncated': ''}
         env.update({
             'HOME': pwd_user.pw_dir,
             'LOGNAME': runas,


### PR DESCRIPTION
As RHUI5 will run inside a container run under a non-root user, this PR aims to:

1) Enhance `add_copy_spec` to collect files from containers run as non-root.
2) Support scrubbing secrets in files collected from containers
3) Enhance pulpcore plugin to collect the same data but within the `rhui5-rhua` container under `rhui` user
4) Add a new `rhui_containerized` plugin to collect RHUI5 specific data, as well as collect postgres data (enhancing postgres plugin would make more mess than gain, esp. due to `find` method)

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?