### PR TITLE
[presets] Ensure that presets override config files

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -300,7 +300,7 @@ class SoSComponent():
             if not self.preset:
                 self.preset = self.policy.probe_preset()
             # now merge preset options to opts
-            opts.merge(self.preset.opts)
+            opts.merge(self.preset.opts, prefer_new=True)
             # re-apply any cmdline overrides to the preset
             opts = self.apply_options_from_cmdline(opts)
 


### PR DESCRIPTION
Per the man pages:

'In other words, config files will override defaults, presets override config files, and command line values override presets and config files.'

This commit is an attempt t on ensure that the
any option in a preset has precedence/overrides
an existing option in the config file.

Related: RHEL-104463

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
