### PR TITLE
[upload] Enable sos uploads of files bigger than 1Gb

### DIFF
--- a/sos/upload/targets/__init__.py
+++ b/sos/upload/targets/__init__.py
@@ -465,7 +465,7 @@ class UploadTarget():
                 self.upload_password or
                 self._upload_password)
 
-    def upload_sftp(self, user=None, password=None):
+    def upload_sftp(self, user=None, password=None, user_dir=None):
         """Attempts to upload the archive to an SFTP location.
 
         Due to the lack of well maintained, secure, and generally widespread
@@ -540,10 +540,13 @@ class UploadTarget():
             raise Exception("Unable to connect via SFTP to "
                             f"{self.get_upload_url_string()}")
 
-        put_cmd = (f'put {self.upload_archive_name} '
-                   f'{self._get_sftp_upload_name()}')
+        # certain implementations require file to be put in the user dir
+        put_cmd = (
+            f"put {self.upload_archive_name} "
+            f"{f'{user_dir}/' if user_dir else ''}"
+            f"{self._get_sftp_upload_name()}"
+        )
         ret.sendline(put_cmd)
-
         put_expects = [
             '100%',
             pexpect.TIMEOUT,

--- a/sos/upload/targets/redhat.py
+++ b/sos/upload/targets/redhat.py
@@ -145,7 +145,7 @@ class RHELUploadTarget(UploadTarget):
         return fname
 
     # pylint: disable=too-many-branches
-    def upload_sftp(self, user=None, password=None):
+    def upload_sftp(self, user=None, password=None, user_dir=None):
         """Override the base upload_sftp to allow for setting an on-demand
         generated anonymous login for the RH SFTP server if a username and
         password are not given
@@ -217,7 +217,8 @@ class RHELUploadTarget(UploadTarget):
                     f"{anon.status_code}): {anon.json()}"
                 )
         if _user and _token:
-            return super().upload_sftp(user=_user, password=_token)
+            return super().upload_sftp(user=_user, password=_token,
+                                       user_dir=_user)
         raise Exception("Could not retrieve valid or anonymous credentials")
 
     def check_file_too_big(self, archive):


### PR DESCRIPTION
Uploads of files greater than 1Gb switch to go to sftp. The code incorrectly tried to write to the home directory in sftp, but should switch into the /{user} directory instead so proper permissions exist.

Related: RHEL-52919

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X ] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
