### PR TITLE
[plugin] Add a new option to capture spare files' size with the 'ls' command

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2064,7 +2064,7 @@ class Plugin():
     def add_dir_listing(self, paths, tree=False, recursive=False, chroot=True,
                         env=None, sizelimit=None, pred=None, subdir=None,
                         tags=[], runas=None, container=None,
-                        suggest_filename=None):
+                        suggest_filename=None, extra_opts=None):
         """
         Used as a way to standardize our collections of directory listings,
         either as an output of `ls` or `tree` depending on if the `tree`
@@ -2093,7 +2093,8 @@ class Plugin():
             paths = [p for p in paths if self.path_exists(p)]
 
         if not tree:
-            options = f"alZ{'R' if recursive else ''}"
+            options = (f"alZ{'R' if recursive else ''}"
+                       f"{extra_opts if extra_opts else ''}")
         else:
             options = 'lp'
 

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -56,7 +56,7 @@ class LogsBase(Plugin):
         ])
 
         self.add_cmd_output("journalctl --disk-usage")
-        self.add_dir_listing('/var/log', recursive=True)
+        self.add_dir_listing('/var/log', recursive=True, extra_opts='s')
 
         # collect journal logs if:
         # - there is some data present, either persistent or runtime only


### PR DESCRIPTION
Add a new option to capture sparse files' size when running ls.
Also, add this new option to the call in the 'logs' plugin.


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
