### PR TITLE
[apt] add list of held apt packages sos_commands

### DIFF
--- a/sos/report/plugins/apt.py
+++ b/sos/report/plugins/apt.py
@@ -32,7 +32,8 @@ class Apt(Plugin, DebianPlugin, UbuntuPlugin):
             "apt-get check",
             "apt-config dump",
             "apt-cache stats",
-            "apt-cache policy"
+            "apt-cache policy",
+            "apt-mark showhold"
         ])
         dpkg_result = self.exec_cmd(
             "dpkg-query -W -f='${binary:Package}\t${status}\n'"


### PR DESCRIPTION
The command apt-mark showhold is useful to show what packages have been marked as 'held' in apt, as this can lead to a variety of issues.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
