### PR TITLE
[foreman] Allow to set size limit instead of hardcoding it

### DIFF
--- a/sos/report/plugins/foreman.py
+++ b/sos/report/plugins/foreman.py
@@ -91,10 +91,15 @@ class Foreman(Plugin):
         _host_f = self.exec_cmd('hostname -f')['output']
         _host_f = _host_f.strip()
 
+        if not self.get_option("log_size"):
+            limit = 500
+        else:
+            limit = self.get_option("log_size")
+
         self.add_copy_spec([
             "/var/log/foreman/production.log",
             f"/var/log/{self.apachepkg}*/foreman-ssl_*_ssl.log"
-        ], sizelimit=500)
+        ], sizelimit=limit)
 
         # Allow limiting these
         self.add_copy_spec([


### PR DESCRIPTION
Allow the possibility to provide the `sizelimit` value using the `log_size` option.

Set it by default (when no option is provided) to the current value (500).

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
