### PR TITLE
[plugins] Fixes #4104 - Improved AAP plugins to capture more useful diagnostics

### DIFF
--- a/sos/report/plugins/aap_containerized.py
+++ b/sos/report/plugins/aap_containerized.py
@@ -143,8 +143,8 @@ class AAPContainerized(Plugin, RedHatPlugin):
                 'dumb-init -- /usr/bin/supervisord',
                 'dumb-init -- /usr/bin/launch_awx_web.sh',
                 'dumb-init -- /usr/bin/launch_awx_task.sh',
-                'pulpcore-content --name pulp-content --bind',
                 'dumb-init -- aap-eda-manage',
+                'pulpcore-content --name pulp-content --bind 127.0.0.1',
             ]
 
         ps_output = self.exec_cmd("ps --noheaders -eo args")

--- a/sos/report/plugins/aap_gateway.py
+++ b/sos/report/plugins/aap_gateway.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Lucas Benedito <lbenedit@redhat.com>
+# Copyright (c) 2025 Nagoor Shaik <nshaik@redhat.com>
 
 # This file is part of the sos project: https://github.com/sosreport/sos
 #
@@ -35,7 +36,14 @@ class AAPGatewayPlugin(Plugin, RedHatPlugin):
             "/etc/ansible-automation-platform/gateway/*.cert",
         ])
 
-        self.add_cmd_output("aap-gateway-manage list_services")
+        self.add_cmd_output([
+            "automation-gateway-service status",
+            "aap-gateway-manage print_settings",
+            "aap-gateway-manage authenticators",
+            "aap-gateway-manage showmigrations",
+            "aap-gateway-manage list_services",
+            "aap-gateway-manage --version",
+        ])
         self.add_dir_listing("/etc/ansible-automation-platform/",
                              recursive=True)
 
@@ -47,5 +55,19 @@ class AAPGatewayPlugin(Plugin, RedHatPlugin):
             "/etc/ansible-automation-platform/gateway/settings.py",
             jreg,
             repl)
+
+        # Mask PASSWORD from print_settings command
+        jreg = r'((["\']?PASSWORD["\']?\s*[:=]\s*)[rb]?["\'])(.*?)(["\'])'
+        self.do_cmd_output_sub(
+            "aap-gateway-manage print_settings",
+            jreg,
+            r'\1**********\4')
+
+        # Mask SECRET_KEY from print_settings command
+        jreg = r'((SECRET_KEY\s*=\s*)([rb]?["\']))(.*?)(["\'])'
+        self.do_cmd_output_sub(
+            "aap-gateway-manage print_settings",
+            jreg,
+            r'\1**********\5')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/aap_hub.py
+++ b/sos/report/plugins/aap_hub.py
@@ -26,7 +26,27 @@ class AAPAutomationHub(Plugin, RedHatPlugin):
             "/var/log/ansible-automation-platform/hub/pulpcore-content.log*",
             "/var/log/nginx/automationhub.access.log*",
             "/var/log/nginx/automationhub.error.log*",
+        ])
 
+        # systemd service status which starts with "pulpcore"
+        result = self.exec_cmd(
+            'systemctl list-units --type=service --no-legend pulpcore*'
+        )
+        if result['status'] == 0:
+            for svc in result['output'].splitlines():
+                pulpcore_svc = svc.split()
+                if not pulpcore_svc:
+                    continue
+                self.add_service_status(pulpcore_svc[0])
+
+        self.add_service_status([
+                "nginx",
+                "redis"
+        ])
+
+        self.add_forbidden_path([
+            "/etc/ansible-automation-platform/redis/server.crt",
+            "/etc/ansible-automation-platform/redis/server.key",
         ])
 
         self.add_dir_listing([


### PR DESCRIPTION
- **[aap_containerized]** – Resolved an issue where aap_containerized was incorrectly enabled on RPM-based Private Automation Hub servers.

- **[aap_controller]** – Expanded the set of gathered command outputs and now conditionally collect run_wsbroadcast or run_wsrelay depending on the AWX release version.

- **[aap_eda]** – Collected service output details based on the installed EDA version. Starting from AAP 2.5, specific commands are used to obtain service status information.

- **[aap_gateway]** – Added additional command outputs for improved troubleshooting on Gateway servers.

- **[aap_hub]** – Centralized the collection of service information for PAH servers under a single location within the plugin directory.

Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
