### PR TITLE
[cleaner] Make cleaner's obfuscate_file properly working

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -537,7 +537,7 @@ third party.
                 logfile.write(line)
 
         if archive:
-            self.obfuscate_file(log_name, short_name="sos_logs/cleaner.log")
+            self.obfuscate_file(log_name)
             self.archive.add_file(log_name, dest="sos_logs/cleaner.log")
 
     def get_new_checksum(self, archive_path):
@@ -678,6 +678,7 @@ third party.
         for prepper in self.get_preppers():
             for archive in self.report_paths:
                 self._prepare_archive_with_prepper(archive, prepper)
+        self.main_archive.set_parsers(self.parsers)
 
     def obfuscate_report(self, archive):  # pylint: disable=too-many-branches
         """Individually handle each archive or directory we've discovered by
@@ -784,8 +785,8 @@ third party.
             self.ui_log.info("Exception while processing "
                              f"{archive.archive_name}: {err}")
 
-    def obfuscate_file(self, filename, short_name):
-        self.main_archive.obfuscate_filename(filename, short_name)
+    def obfuscate_file(self, filename):
+        self.main_archive.obfuscate_arc_files([filename])
 
     def obfuscate_symlinks(self, archive):
         """Iterate over symlinks in the archive and obfuscate their names.

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -1405,16 +1405,13 @@ this utility or remote systems that it connects to.
             if do_clean:
                 _dir = os.path.join(self.tmpdir, self.archive._name)
                 cleaner.obfuscate_file(
-                    os.path.join(_dir, 'sos_logs', 'sos.log'),
-                    short_name='sos.log'
+                        os.path.join(_dir, 'sos_logs', 'sos.log')
                 )
                 cleaner.obfuscate_file(
-                    os.path.join(_dir, 'sos_logs', 'ui.log'),
-                    short_name='ui.log'
+                    os.path.join(_dir, 'sos_logs', 'ui.log')
                 )
                 cleaner.obfuscate_file(
-                    os.path.join(_dir, 'sos_reports', 'manifest.json'),
-                    short_name='manifest.json'
+                    os.path.join(_dir, 'sos_reports', 'manifest.json')
                 )
 
             arc_name = self.archive.finalize(method=None)

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1571,13 +1571,10 @@ class SoSReport(SoSComponent):
         # Now, separately clean the log files that cleaner also wrote to
         if do_clean:
             _dir = os.path.join(self.tmpdir, self.archive._name)
-            cleaner.obfuscate_file(os.path.join(_dir, 'sos_logs', 'sos.log'),
-                                   short_name='sos.log')
-            cleaner.obfuscate_file(os.path.join(_dir, 'sos_logs', 'ui.log'),
-                                   short_name='ui.log')
+            cleaner.obfuscate_file(os.path.join(_dir, 'sos_logs', 'sos.log'))
+            cleaner.obfuscate_file(os.path.join(_dir, 'sos_logs', 'ui.log'))
             cleaner.obfuscate_file(
-                os.path.join(_dir, 'sos_reports', 'manifest.json'),
-                short_name='manifest.json'
+                    os.path.join(_dir, 'sos_reports', 'manifest.json')
             )
 
         # Now, just (optionally) pack the report and print work outcome; let


### PR DESCRIPTION
The fix is three-fold:
- obfuscate_file must clean file content and not filename
- cleaner's main_archive must be populated by parsers first
- obfuscate_file dont need short_name as it is always called with implicit value of short_name that cleaner will strip itself

Closes: #4109
Closes: #4110

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
