### PR TITLE
[powerpc] Collect hot-pluggable PCI and PHB slots

### DIFF
--- a/sos/report/plugins/powerpc.py
+++ b/sos/report/plugins/powerpc.py
@@ -93,7 +93,9 @@ class PowerPC(Plugin, IndependentPlugin):
                 f"ctsnap -xrunrpttr -d {ctsnap_path}",
                 "lsdevinfo",
                 "lsslot",
-                "amsstat"
+                "amsstat",
+                "lsslot -c phb",
+                "lsslot -c pci",
             ])
 
             # Due to the lack of options in invscout for generating log files


### PR DESCRIPTION
Add lsslot commands to collect information about hot-plug capable PCI and PHB slots and their resources.

The output from the added commands is generally only a few KBs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
