### PR TITLE
[podman] collect podman disk usage

### DIFF
--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -64,7 +64,8 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
             'ps -a',
             'stats --no-stream --all',
             'version',
-            'volume ls'
+            'volume ls',
+            'system df -v',
         ]
 
         self.add_cmd_output([f"podman {s}" for s in subcmds])


### PR DESCRIPTION
Collect detailed disk usage of Podman resources, including images, containers, and volumes.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
