### PR TITLE
[spyre] new plugin to collect IBM spyre card data

### DIFF
--- a/sos/report/plugins/spyre.py
+++ b/sos/report/plugins/spyre.py
@@ -1,0 +1,74 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+#
+# This plugin enables collection of logs for system with IBM Spyre card
+
+import re
+import pyudev
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Spyre(Plugin, IndependentPlugin):
+    """Spyre chip is IBM’s AI accelerator, designed to handle AI inferencing
+    and workloads.
+
+    The Spyre plugin collects data about the Spyre card’s VFIO device node
+    tree, configuration files, and more.
+    """
+
+    short_desc = 'IBM Spyre Accelerator Information'
+    plugin_name = 'spyre'
+    architectures = ('ppc.*',)
+
+    @staticmethod
+    def get_spyre_cards_bus_ids():
+        context = pyudev.Context()
+        spyre_cards_bus_ids = []
+        card_vendor_ids = ["0x1014"]    # IBM : 0x1014
+        card_device_ids = ["0x06a7", "0x06a8"]  # spyre card device IDs
+
+        for device in context.list_devices(subsystem='pci'):
+            vendor_id = device.attributes.get("vendor").decode("utf-8").strip()
+            if vendor_id not in card_vendor_ids:
+                continue
+
+            device_id = device.attributes.get("device").decode("utf-8").strip()
+            if device_id not in card_device_ids:
+                continue
+
+            spyre_cards_bus_ids.append(device.sys_name)
+
+        return spyre_cards_bus_ids
+
+    def setup(self):
+        spyre_cards = self.get_spyre_cards_bus_ids()
+
+        # Nothing to collect if spyre card is not present in the system
+        if not spyre_cards:
+            return
+
+        # Collects the VFIO device's sysfs directory structure
+        for card in spyre_cards:
+            match = re.match(r"(\w+:\w+):", card)
+            if not match:
+                continue
+
+            pci_domain_bus = match.group(1)
+
+            pci_vfio_dir = f"/sys/devices/pci{pci_domain_bus}/{card}/vfio-dev"
+            self.add_dir_listing(pci_vfio_dir, tree=True)
+
+        # Spyre card configuration files
+        self.add_copy_spec([
+            "/etc/modprobe.d/vfio-pci.conf",
+            "/etc/udev/rules.d/95-vfio-3.rules",
+            "/etc/security/limits.d/memlock.conf",
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Spyre chip is IBM’s AI accelerator, designed to handle AI inferencing and workloads.

The Spyre plugin collects data about the Spyre card’s VFIO device node tree, configuration files, and more.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
