### PR TITLE
[block] Capture the /etc/crypttab file

### DIFF
--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -69,4 +69,6 @@ class Block(Plugin, IndependentPlugin):
                     self.add_cmd_output(f'cryptsetup luksDump /dev/{dev}')
                     self.add_cmd_output(f'clevis luks list -d /dev/{dev}')
 
+        self.add_copy_spec("/etc/crypttab")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Capture the /etc/crypttab file

Related: RHEL-108949

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
