### PR TITLE
[sssd] Collect more information about domains

### DIFF
--- a/sos/report/plugins/sssd.py
+++ b/sos/report/plugins/sssd.py
@@ -51,7 +51,8 @@ class Sssd(Plugin):
         domain = self.collect_cmd_output("sssctl domain-list", pred=sssd_pred)
         if domain['status'] == 0:
             for domain_name in domain['output'].splitlines():
-                self.add_cmd_output("sssctl domain-status -o " + domain_name)
+                self.add_cmd_output("sssctl domain-status " + domain_name)
+                self.add_cmd_output("sssctl access-report " + domain_name)
 
     def postproc(self):
         regexp = r"((\s*ldap_default_authtok\s*=)(.*))"


### PR DESCRIPTION
Substitute the current 'domain-status -o' command
with 'sssctl domain-status $domain' which shows
list of of available AD/IPA servers as well
along with online/offline status for the specified domain.

Also include output of command sssctl access-report $domain

Related: RHEL-108358

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
