### PR TITLE
[component] Fix regression 57bbc89 in toolbox containers

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -170,9 +170,6 @@ class SoSComponent():
         else:
             tmpdir = os.getenv('TMPDIR', None) or self.policy.get_tmp_dir(None)
 
-        if os.getenv('HOST', None) and os.getenv('container', None):
-            tmpdir = os.path.join(os.getenv('HOST'), tmpdir.lstrip('/'))
-
         # no standard library method exists for this, so call out to stat to
         # avoid bringing in a dependency on psutil
         self.tmpfstype = shell_out(


### PR DESCRIPTION
57bbc89 commit set tmpdir to source the dir from Policy. Which means HOST sysroot directory is newly applied already in LinuxPolicy._container_init method.

Removed lines mimic the same in worse way, so let drop them here.

Resolves: #4116
Closes: #4118

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
