### PR TITLE
[rhc] Block the 'rhc' plugin starting the rhsm service

### DIFF
--- a/sos/report/plugins/rhc.py
+++ b/sos/report/plugins/rhc.py
@@ -8,7 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, SoSPredicate
 
 
 class Rhc(Plugin, RedHatPlugin):
@@ -30,9 +30,10 @@ class Rhc(Plugin, RedHatPlugin):
             "/var/log/rhc-worker-playbook",
         ])
 
-        self.add_cmd_output([
+        self.add_cmd_output(
             "rhc status",
-        ])
+            pred=SoSPredicate(self, services=["rhsm"])
+        )
 
     def postproc(self):
         # hide workers/foreman_rh_cloud.toml FORWARDER_PASSWORD


### PR DESCRIPTION
When the command 'rhc status' runs in the plugin rhc, it starts automatically the rhsm service. This
commit gates the command to make sure it's not
run when the rhssm service is not running.

Related: RHEL-112563

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
