### PR TITLE
Sos openshift ovn enable  by crio containers

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -532,6 +532,7 @@ class Plugin():
     kernel_mods = ()
     services = ()
     containers = ()
+    runtime = None
     architectures = None
     archive = None
     profiles = ()
@@ -2808,7 +2809,7 @@ class Plugin():
         :returns: ``True`` if `name` exists, else ``False``
         :rtype: ``bool``
         """
-        _runtime = self._get_container_runtime(runtime)
+        _runtime = self._get_container_runtime(runtime or self.runtime)
         if _runtime is not None:
             return (_runtime.container_exists(name) or
                     _runtime.get_container_by_name(name) is not None)

--- a/sos/report/plugins/openshift_ovn.py
+++ b/sos/report/plugins/openshift_ovn.py
@@ -18,6 +18,7 @@ class OpenshiftOVN(Plugin, RedHatPlugin):
     plugin_name = "openshift_ovn"
     containers = ('ovnkube-master', 'ovnkube-node', 'ovn-ipsec',
                   'ovnkube-controller')
+    runtime = 'crio'
     profiles = ('openshift',)
 
     def setup(self):


### PR DESCRIPTION
OpenShift OVN has both `podman` and `crio` runtimes and sos detects `podman` as the default one. While the containers triggering `openshift_ovn` enabledness are under `crio` runtime.

To proper plugin enabledness detection, we must make the runtime customisable.

Closes: #4123
Relevant: RHEL-110512

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
