### PR TITLE
[cleaner] Treat IPv6 netmask as part of obfuscated string

### DIFF
--- a/sos/cleaner/parsers/ipv6_parser.py
+++ b/sos/cleaner/parsers/ipv6_parser.py
@@ -27,7 +27,7 @@ class SoSIPv6Parser(SoSCleanerParser):
         # a trailing prefix for the network bits.
         r"(?<![:\\.\\-a-z0-9])((([0-9a-f]{1,4})(:[0-9a-f]{1,4}){7})|"
         r"(([0-9a-f]{1,4}(:[0-9a-f]{0,4}){0,5}))([^.])::(([0-9a-f]{1,4}"
-        r"(:[0-9a-f]{1,4}){0,5})?))(/\d{1,3})?(?![:\\a-z0-9])"
+        r"(:[0-9a-f]{1,4}){0,5})?)(/\d{1,3})?)(?![:\\a-z0-9])"
     ]
     parser_skip_files = [
         'etc/dnsmasq.conf.*',


### PR DESCRIPTION
We need to add the netmask to the string to obfuscate, i.e. to the first group of matched r.e. Otherwise, '2620:52:0:25c0::/64' like string is obfuscated to '534f:53ff:fe00:0002::/64/64'.

Closes: #4124

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?