### PR TITLE
[cirrus] Temporarily disable Fedora testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -106,14 +106,14 @@ rpm_build_task:
             PROJECT: ${CENTOS_PROJECT}
             BUILD_NAME: ${CENTOS_9_NAME}
             VM_FAMILY_NAME: ${CENTOS_9_FAMILY_NAME}
-        - env: &fedora
-            PROJECT: ${FEDORA_PROJECT}
-            BUILD_NAME: ${FEDORA_NAME}
-            VM_FAMILY_NAME: ${FEDORA_FAMILY_NAME}
-        - env: &fedoraprior
-            PROJECT: ${FEDORA_PROJECT}
-            BUILD_NAME: ${FEDORA_PRIOR_NAME}
-            VM_FAMILY_NAME: ${FEDORA_PRIOR_FAMILY_NAME}
+#        - env: &fedora
+#            PROJECT: ${FEDORA_PROJECT}
+#            BUILD_NAME: ${FEDORA_NAME}
+#            VM_FAMILY_NAME: ${FEDORA_FAMILY_NAME}
+#        - env: &fedoraprior
+#            PROJECT: ${FEDORA_PROJECT}
+#            BUILD_NAME: ${FEDORA_PRIOR_NAME}
+#            VM_FAMILY_NAME: ${FEDORA_PRIOR_FAMILY_NAME}
     setup_script: |
         dnf clean all
         dnf -y install rpm-build rpmdevtools gettext python3-devel python3-pexpect python3-pyyaml
@@ -207,8 +207,8 @@ report_stageone_task:
     gce_instance: *standardvm
     matrix:
         - env: *centos9
-        - env: *fedora
-        - env: *fedoraprior
+#        - env: *fedora
+#        - env: *fedoraprior
         - env: &ubuntu
             PKG: "snap"
             PROJECT: ${UBUNTU_PROJECT}
@@ -311,7 +311,7 @@ report_stagetwo_task:
     gce_instance: *standardvm
     matrix:
         - env: *centos9
-        - env: *fedora
+#        - env: *fedora
         - env: *ubuntu
         - env: *ubuntu-latest-snap
         - env: *ubuntu-latest-deb


### PR DESCRIPTION
We have been seeing some odd failures with the CI around F41, particularly with the rpmbuild failing which then cancels the rest of the suite due to dependency resolution.

We're working with Cirrus support, but until we have a fix let's disable the F41 (fedoraprior) testing to unblock the rest of the suite.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
