### PR TITLE
[tests] Fix expected value for preset tests

### DIFF
--- a/tests/report_tests/options_tests/options_tests.py
+++ b/tests/report_tests/options_tests/options_tests.py
@@ -80,6 +80,6 @@ class PlugOptsConfigPresetCmdlineTest(StageTwoReportTest):
             "networking.timeout=20",                # cmd beats config&preset
             "crio.timeout=10",                      # cmdline beats preset
             "networking.ethtool-namespaces=False",  # preset setting is honored
-            "networking.namespaces=100",            # preset beats config file
+            "networking.namespaces=200",            # preset beats config file
         ]:
             self.assertSosLogContains(f"effective options now: .*{option}")


### PR DESCRIPTION
The default value for networking.namespaces in the file tests/report_tests/options_tests/options_tests_sos.conf is 100, while the value for this variable in
tests/report_tests/options_tests/options_tests_preset.json is 200. To make sure that preset beats the config file we need to change the value from 100 to 200.

Related: #4087

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
