### PR TITLE
[juju] Fix 2nd non-regexp glob of path for obfuscation

### DIFF
--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -220,7 +220,7 @@ class Juju(Plugin, UbuntuPlugin):
         self.do_path_regex_sub(agents_path, keys_regex, sub_regex)
 
         # Redact keys from Nova compute logs
-        self.do_path_regex_sub("/var/log/juju/unit-nova-compute-(.*).log*",
+        self.do_path_regex_sub("/var/log/juju/unit-nova-compute-(.*).log(.*)",
                                r"auth\(key=(.*)\)", r"auth(key=******)")
 
         # Redact certificates


### PR DESCRIPTION
Closes: #4144
Relevant: #4129

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
