### PR TITLE
[openstack_*] Improve obfuscation with better regex

### DIFF
--- a/sos/report/plugins/openstack_aodh.py
+++ b/sos/report/plugins/openstack_aodh.py
@@ -75,9 +75,8 @@ class OpenStackAodh(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "admin_password", "connection_password", "host_password",
-            "os_password", "password", "qpid_password", "rabbit_password",
-            "memcache_secret_key"
+            ".*_key",
+            "(.*_)?password",
         ]
         connection_keys = ["connection", "backend_url", "transport_url"]
 

--- a/sos/report/plugins/openstack_ceilometer.py
+++ b/sos/report/plugins/openstack_ceilometer.py
@@ -52,12 +52,15 @@ class OpenStackCeilometer(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "admin_password", "connection_password", "host_password",
-            "memcache_secret_key", "os_password", "password", "qpid_password",
-            "rabbit_password", "readonly_user_password", "secret_key",
-            "ssl_key_password", "telemetry_secret", "metering_secret"
+            ".*_key",
+            ".*_pass(wd|word)?",
+            ".*_secret",
+            "password",
         ]
-        connection_keys = ["connection", "backend_url", "transport_url"]
+        connection_keys = [
+            ".*_urls?",
+            "connection",
+        ]
 
         join_con_keys = "|".join(connection_keys)
 

--- a/sos/report/plugins/openstack_cinder.py
+++ b/sos/report/plugins/openstack_cinder.py
@@ -143,16 +143,10 @@ class OpenStackCinder(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "admin_password", "backup_tsm_password", "chap_password",
-            "nas_password", "cisco_fc_fabric_password", "coraid_password",
-            "eqlx_chap_password", "fc_fabric_password",
-            "hitachi_auth_password", "hitachi_horcm_password",
-            "hp3par_password", "hplefthand_password", "memcache_secret_key",
-            "netapp_password", "netapp_sa_password", "nexenta_password",
-            "password", "qpid_password", "rabbit_password", "san_password",
-            "ssl_key_password", "vmware_host_password", "zadara_password",
-            "zfssa_initiator_password", "hmac_keys", "zfssa_target_password",
-            "os_privileged_user_password", "transport_url"
+            ".*_pass(wd|word)?",
+            ".*_keys?",
+            "password",
+            "transport_url",
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_designate.py
+++ b/sos/report/plugins/openstack_designate.py
@@ -85,9 +85,11 @@ class OpenStackDesignate(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "password", "connection", "transport_url", "admin_password",
-            "ssl_key_password", "ssl_client_key_password",
-            "memcache_secret_key"
+            ".*_key",
+            ".*_pass(wd|word)?",
+            "password",
+            "connection",
+            "transport_url",
         ]
         regexp = fr"(^\s*({'|'.join(protect_keys)})\s*=\s*)(.*)"
 

--- a/sos/report/plugins/openstack_glance.py
+++ b/sos/report/plugins/openstack_glance.py
@@ -98,10 +98,10 @@ class OpenStackGlance(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "admin_password", "password", "qpid_password", "rabbit_password",
-            "s3_store_secret_key", "ssl_key_password",
-            "vmware_server_password", "transport_url",
-            "memcache_secret_key"
+            ".*_key",
+            ".*_pass(wd|word)?",
+            "password",
+            "transport_url",
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_heat.py
+++ b/sos/report/plugins/openstack_heat.py
@@ -117,9 +117,10 @@ class OpenStackHeat(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "admin_password", "memcache_secret_key", "password",
-            "qpid_password", "rabbit_password", "stack_domain_admin_password",
-            "transport_url", "auth_encryption_key",
+            ".*_key",
+            ".*_pass(wd|word)?",
+            "password",
+            "transport_url",
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_instack.py
+++ b/sos/report/plugins/openstack_instack.py
@@ -119,22 +119,9 @@ class OpenStackInstack(Plugin):
         # do_file_sub is case insensitive, so protected_keys can be lowercase
         # only
         protected_keys = [
-            "os_password",
-            "undercloud_admin_password",
-            "undercloud_ceilometer_metering_secret",
-            "undercloud_ceilometer_password",
-            "undercloud_ceilometer_snmpd_password",
-            "undercloud_db_password",
-            "undercloud_glance_password",
-            "undercloud_heat_password",
-            "undercloud_heat_stack_domain_admin_password",
-            "undercloud_horizon_secret_key",
-            "undercloud_ironic_password",
-            "undercloud_neutron_password",
-            "undercloud_nova_password",
-            "undercloud_rabbit_password",
-            "undercloud_swift_password",
-            "undercloud_tuskar_password",
+            ".*_password",
+            ".*_secret",
+            ".*_key",
         ]
         regexp = fr"(({'|'.join(protected_keys)})=)(.*)"
         self.do_file_sub("/home/stack/.instack/install-undercloud.log",

--- a/sos/report/plugins/openstack_ironic.py
+++ b/sos/report/plugins/openstack_ironic.py
@@ -142,9 +142,10 @@ class OpenStackIronic(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "dns_passkey", "memcache_secret_key", "rabbit_password",
-            "password", "qpid_password", "admin_password", "ssl_key_password",
-            "os_password", "transport_url"
+            ".*_(pass)?key",
+            ".*_pass(wd|word)?",
+            "password",
+            "transport_url",
         ]
         connection_keys = ["connection", "sql_connection"]
 

--- a/sos/report/plugins/openstack_keystone.py
+++ b/sos/report/plugins/openstack_keystone.py
@@ -98,9 +98,9 @@ class OpenStackKeystone(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "password", "qpid_password", "rabbit_password", "ssl_key_password",
-            "ldap_dns_password", "neutron_admin_password", "host_password",
-            "admin_password", "admin_token", "ca_password", "transport_url",
+            "(.*_)?password",
+            "admin_token",
+            "transport_url",
             "OIDCClientSecret",
         ]
         connection_keys = ["connection"]

--- a/sos/report/plugins/openstack_neutron.py
+++ b/sos/report/plugins/openstack_neutron.py
@@ -123,14 +123,9 @@ class OpenStackNeutron(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "rabbit_password", "qpid_password", "nova_admin_password",
-            "xenapi_connection_password", "password", "server_auth",
-            "admin_password", "metadata_proxy_shared_secret", "eapi_password",
-            "crd_password", "primary_l3_host_password", "serverauth",
-            "ucsm_password", "ha_vrrp_auth_password", "ssl_key_password",
-            "nsx_password", "vcenter_password", "edge_appliance_password",
-            "tenant_admin_password", "apic_password", "transport_url",
-            "memcache_secret_key"
+            "(.*_)?(key|password|secret)",
+            "server_?auth",
+            "transport_url",
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -152,12 +152,11 @@ class OpenStackNova(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "ldap_dns_password", "neutron_admin_password", "rabbit_password",
-            "qpid_password", "powervm_mgr_passwd", "virtual_power_host_pass",
-            "xenapi_connection_password", "password", "host_password",
-            "vnc_password", "admin_password", "connection_password",
-            "memcache_secret_key", "s3_secret_key",
-            "metadata_proxy_shared_secret", "fixed_key", "rbd_secret_uuid"
+            ".*_key",
+            ".*_pass(wd|word)?",
+            "password",
+            "metadata_proxy_shared_secret",
+            "rbd_secret_uuid",
         ]
         connection_keys = ["connection", "sql_connection", "transport_url"]
 

--- a/sos/report/plugins/openstack_sahara.py
+++ b/sos/report/plugins/openstack_sahara.py
@@ -46,9 +46,9 @@ class OpenStackSahara(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "admin_password", "memcache_secret_key", "password",
-            "qpid_password", "rabbit_password", "ssl_key_password",
-            "xenapi_connection_password", "transport_url"
+            "(.*_)?password",
+            "memcache_secret_key",
+            "transport_url",
         ]
         connection_keys = ["connection"]
 

--- a/sos/report/plugins/openstack_swift.py
+++ b/sos/report/plugins/openstack_swift.py
@@ -55,10 +55,9 @@ class OpenStackSwift(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "ldap_dns_password", "neutron_admin_password", "rabbit_password",
-            "qpid_password", "powervm_mgr_passwd", "virtual_power_host_pass",
-            "xenapi_connection_password", "password", "host_password",
-            "vnc_password", "admin_password", "transport_url"
+            ".*_pass(wd|word)?",
+            "password",
+            "transport_url",
         ]
         connection_keys = ["connection", "sql_connection"]
 

--- a/sos/report/plugins/openstack_trove.py
+++ b/sos/report/plugins/openstack_trove.py
@@ -45,9 +45,10 @@ class OpenStackTrove(Plugin):
 
     def postproc(self):
         protect_keys = [
-            "default_password_length", "notifier_queue_password",
-            "rabbit_password", "replication_password", "admin_password",
-            "dns_passkey", "transport_url", "memcache_secret_key"
+            ".*_(password|key)",
+            "default_password_length",
+            "dns_passkey",
+            "transport_url",
         ]
         connection_keys = ["connection"]
 


### PR DESCRIPTION
* Config option messaging_urls was not detected in ceilometer.
* Revamp the regex for this plugin to potentially detect most scenarios.
* Revamp other plugins to have better regex, to potentially pick up others.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
