### PR TITLE
[lustre] Capture lnet.conf file

### DIFF
--- a/sos/report/plugins/lustre.py
+++ b/sos/report/plugins/lustre.py
@@ -49,6 +49,9 @@ class Lustre(Plugin, RedHatPlugin):
             ["version", "health_check", "debug"]
         )
 
+        # copy lnet settings if present
+        self.add_copy_spec("/etc/lnet.conf")
+
         # Client Specific
         self.add_cmd_output([
             "lfs df",


### PR DESCRIPTION
The /etc/lnet.conf file can have configured lnet settings for a lustre server or client.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
