### PR TITLE
[boot] Capture OVMF firmware logs

### DIFF
--- a/sos/report/plugins/boot.py
+++ b/sos/report/plugins/boot.py
@@ -56,5 +56,7 @@ class Boot(Plugin, IndependentPlugin):
                 self.add_cmd_output(f"lsinitrd {image}", priority=100)
                 self.add_cmd_output(f"lsinitramfs -l {image}", priority=100)
 
+        # Capture Open Virtual Machine Firmware information
+        self.add_copy_spec("/sys/firmware/efi/ovmf_debug_log")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Capture the new Open Virtual Machine Firmware
logs to diagnose issues related to UEFI support
for virtual machines.

Related: RHEL-100110

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
