### PR TITLE
[block] Added support to collect '/dev/disk/by-dname'

### DIFF
--- a/sos/report/plugins/block.py
+++ b/sos/report/plugins/block.py
@@ -41,6 +41,7 @@ class Block(Plugin, IndependentPlugin):
 
         # legacy location for non-/run distributions
         self.add_copy_spec([
+            "/dev/disk/by-dname/",
             "/etc/blkid.tab",
             "/run/blkid/blkid.tab",
             "/proc/partitions",


### PR DESCRIPTION
### Description

This patch updates the block plugin to include `/dev/disk/by-dname/` in the collected paths.
It ensures that logical volume symlinks are captured for troubleshooting storage issues.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?