### PR TITLE
[rhel_drivers] New plugin

### DIFF
--- a/sos/report/plugins/rhel_drivers.py
+++ b/sos/report/plugins/rhel_drivers.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2025 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class RhelDrivers(Plugin, RedHatPlugin):
+
+    short_desc = 'RHEL-drivers information'
+
+    plugin_name = 'rhel_drivers'
+    profiles = ('system', 'kernel', 'ai',)
+    packages = ('rhel-drivers',)
+
+    def setup(self):
+        self.add_cmd_output([
+            "rhel-drivers list --installed",
+            "rhel-drivers --verbose list --installed",
+            "rhel-drivers list --available",
+            "rhel-drivers --verbose list --available",
+        ])
+
+# vim: et ts=4 sw=4


### PR DESCRIPTION
New plugin to capture data from the rhel-drivers tool.
rhel-drivers is a new command-line tool introduced in RHEL-10.1
designed to streamline the installation of NVIDIA and AMD
AI/ML accelerator drivers.

Related: RHEL-130848

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
