### PR TITLE
[upload] "Generic Upload" directory issue

### DIFF
--- a/sos/upload/__init__.py
+++ b/sos/upload/__init__.py
@@ -204,6 +204,15 @@ this utility.
             self.upload_name = self.upload_target.name()
         self.ui_log.info(
                     f"Upload target set to {self.upload_name}")
+        if self.opts.upload_directory is None and \
+                self.upload_name == 'Generic Upload':
+            msg = ("No upload directory provided. The generic upload "
+                   "will fail without a defined upload directory. "
+                   "Please try the upload again, specifying either "
+                   "the --upload-directory parameter or an "
+                   "--upload-target.  If you are an OS distribution "
+                   "consider adding this in your distribution's policy.")
+            raise Exception(msg)
 
     def load_upload_targets(self):
         """Loads all upload targets supported by the local installation


### PR DESCRIPTION
	When a "Generic Upload" is encountered (meaning a
	non-implemented distribution) and the upload directory
	is not specified, fail with a helpful error message (the
	upload would previously fail on permissions as it tries
	to write to the root directory of sftp).

Related: RHEL-124680

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
