### PR TITLE
[plugin_aws]fix unable to get metadata in aws.py

### DIFF
--- a/sos/report/plugins/aws.py
+++ b/sos/report/plugins/aws.py
@@ -41,21 +41,19 @@ class Aws(Plugin, IndependentPlugin):
 
         # Try to get an IMDSv2 token
         token_url = 'http://169.254.169.254/latest/api/token'
-        token_cmd = [
-            'curl', '-sS', '-X', 'PUT', '-H',
-            'X-aws-ec2-metadata-token-ttl-seconds: 21600',
-            token_url]
+        token_cmd = f'curl -sS -X PUT -H \
+            X-aws-ec2-metadata-token-ttl-seconds:21600 {token_url}'
 
         try:
-            token = self.exec_cmd(token_cmd, timeout=1)
+            token = self.exec_cmd(token_cmd, timeout=1)['output']
         except Exception:
             token = ''
 
         # Add header only if token retrieval succeeded
-        token_header = []
+        token_header = ''
 
         if token:
-            token_header = ['-H', f'X-aws-ec2-metadata-token: {token}']
+            token_header = f'-H X-aws-ec2-metadata-token:{token}'
 
         # List of metadata paths we want to get
         metadata_paths = [
@@ -73,7 +71,7 @@ class Aws(Plugin, IndependentPlugin):
             meta_url = base_url + path
             safe_name = path.replace('/', '_')
             self.add_cmd_output(
-                    ['curl', '-sS'] + token_header + [meta_url],
+                    f'curl -sS {token_header} {meta_url}',
                     suggest_filename=f'aws_metadata_{safe_name}.txt'
             )
 


### PR DESCRIPTION
- exec_cmd() cmd type is a str, cannot execute when it is a list
- removed spaces after X-aws-ec2-metadata-token and X-aws-ec2-metadata-token-ttl-seconds

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
