### PR TITLE
[foreman] Add option to collect Content View filters

### DIFF
--- a/tests/product_tests/foreman/foreman_tests.py
+++ b/tests/product_tests/foreman/foreman_tests.py
@@ -73,6 +73,11 @@ class ForemanBasicTest(StageOneReportTest):
             "sos_commands/foreman/smart_proxies_features/*"
         )
 
+    def test_cv_filters_not_collected(self):
+        self.assertFileGlobNotInArchive(
+            "sos_commands/foreman/content_view_filters/*"
+        )
+
     def test_foreman_config_postproc_worked(self):
         self.assertFileNotHasContent(
             '/etc/foreman/database.yml',
@@ -119,13 +124,19 @@ class ForemanWithOptionsTest(StageOneReportTest):
     :avocado: tags=foreman
     """
 
-    sos_cmd = '-v -k foreman.proxyfeatures=on'
+    sos_cmd = '-v -k foreman.proxyfeatures=on -k foreman.cvfilters=on'
     arch = ['x86_64']
 
     @redhat_only
     def test_proxyfeatures_collected(self):
         self.assertFileGlobInArchive(
             "sos_commands/foreman/smart_proxies_features/*"
+        )
+
+    @redhat_only
+    def test_cv_filters_collected(self):
+        self.assertFileGlobInArchive(
+            "sos_commands/foreman/content_view_filters/*"
         )
 
 


### PR DESCRIPTION
This adds a new plugin option '--foreman.cvfilters' to collect Content View filter definitions directly from the database (tables like katello_content_view_filters and related rule tables).

This helps debug issues with missing packages or errata in Content Views without requiring UI screenshots from the user. This collection is disabled by default to keep the report lightweight.

For https://github.com/sosreport/sos/pull/4169#issuecomment-3605729727

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
