### PR TITLE
[kdump] collect everything under /sys/kernel/kexec dir

### DIFF
--- a/sos/report/plugins/kdump.py
+++ b/sos/report/plugins/kdump.py
@@ -25,6 +25,7 @@ class KDump(Plugin):
             "/proc/sys/kernel/panic",
             "/proc/sys/kernel/panic_on_oops",
             "/sys/kernel/kexec_loaded",
+            "/sys/kernel/kexec",
             "/sys/kernel/fadump",
             "/sys/kernel/fadump_enabled",
             "/sys/kernel/fadump_registered",


### PR DESCRIPTION
Kernel commit cf4340bdd967 ("kexec: move sysfs entries to /sys/kernel/kexec") and commit 5c991b6d9b30 ("Documentation/ABI: mark old kexec sysfs deprecated") moved all kexec and kdump sysfs entries under the new directory /sys/kernel/kexec. Kernel commit aa0145563ce2 ("crash: export crashkernel CMA reservation to userspace") introduced a new sysfs node, which is also located under this new directory.

So collect everything under /sys/kernel/kexec. The old kexec and kdump sysfs entries are expected to be removed from the kernel after 2028. For now, collect both sets of entries, and in the future the old entries can be dropped once they are removed from the kernel.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
