### PR TITLE
[plugin_aws]fix plugin is not loaded in aws xen instances

### DIFF
--- a/sos/report/plugins/aws.py
+++ b/sos/report/plugins/aws.py
@@ -19,12 +19,9 @@ class Aws(Plugin, IndependentPlugin):
     profiles = ('virt',)
 
     def _is_ec2(self):
-        try:
-            with open('/sys/devices/virtual/dmi/id/sys_vendor',
-                      encoding='utf-8') as f:
-                return 'Amazon' in f.read()
-        except FileNotFoundError:
-            return False
+        dmi_files = ("/sys/devices/virtual/dmi/id/sys_vendor",
+                     "/sys/devices/virtual/dmi/id/bios_version")
+        return bool(self.file_grep(r"(Amazon|.*amazon)", *dmi_files))
 
     # Called by sos to determine if the plugin will run
     def check_enabled(self):


### PR DESCRIPTION
Plugin aws is not loaded in aws xen instances, update _is_ec2() to add bios_version check.
$ cat /sys/devices/virtual/dmi/id/sys_vendor
Xen
$ cat /sys/devices/virtual/dmi/id/bios_version
4.11.amazon

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
