### PR TITLE
[plugins] Fix UnboundLocalError in fmt_container_cmd

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -2965,8 +2965,8 @@ class Plugin():
                   within the `container` and not on the host
         :rtype: ``str``
         """
-        if self.container_exists(container, runtime) or \
-           ((_runtime := self._get_container_runtime(runtime)) and
+        _runtime = self._get_container_runtime(runtime)
+        if _runtime and (self.container_exists(container, runtime) or
            runas is not None):
             return _runtime.fmt_container_cmd(container, cmd, quotecmd)
         return ''


### PR DESCRIPTION
The walrus operator inside the 'or' condition caused _runtime
to not be assigned when container_exists() returned True, due
to Python's short-circuit evaluation. This led to
UnboundLocalError when trying to use
_runtime.fmt_container_cmd().

This issue affects (at least) to ovn_central and rabbitmq
plugins. Fix by assigning _runtime before the condition check.

Resolves: https://github.com/sosreport/sos/issues/4184
Closes: https://github.com/sosreport/sos/issues/4184

**Signed-off-by: Fernando Royo <froyo@redhat.com>**

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
