### PR TITLE
[systemd] Config files location changed in latest systemd

### DIFF
--- a/sos/report/plugins/systemd.py
+++ b/sos/report/plugins/systemd.py
@@ -79,6 +79,7 @@ class Systemd(Plugin, IndependentPlugin):
 
         self.add_copy_spec([
             "/etc/systemd",
+            "/lib/systemd/*.conf",
             "/lib/systemd/system",
             "/lib/systemd/user",
             "/etc/vconsole.conf",


### PR DESCRIPTION
In newer versions of systemd all component's default config is now
moved from /etc/systemd to /usr/lib/systemd folder. /etc/systemd/*.conf
files are still valid but they will act as overrides. Default configs
are needed in sosreport to check any changes are made to them or not.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X ] Is the subject and message clear and concise?
- [X ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
