### PR TITLE
[collect] Allow sudo alternatives for privilege escalation

### DIFF
--- a/man/en/sos-collect.1
+++ b/man/en/sos-collect.1
@@ -41,6 +41,7 @@ sos_collect \- Collect sos reports from multiple (cluster) nodes
     [\-\-skip-files FILES]
     [\-s|\-\-sysroot SYSROOT]
     [\-\-ssh\-user SSH_USER]
+    [\-\-sudo\-binary BINARY]
     [\-t|\-\-threads THREADS]
     [\-\-timeout TIMEOUT]
     [\-\-transport TRANSPORT]
@@ -335,6 +336,11 @@ for example \fB/etc/sos/*\fR.
 Specify an SSH user for sos collect to connect to nodes with. Default is root.
 
 sos collect will prompt for a sudo password for non-root users.
+.TP
+\fB\-\-sudo\-binary\fR BINARY
+Specify the binary to use for privilege escalation on remote hosts when connecting
+as a non-root user. Note that this binary MUST be in the connecting user's PATH
+on the remote host.
 .TP
 \fB\-s\fR SYSROOT, \fB\-\-sysroot\fR SYSROOT
 Report option. Specify an alternate root file system path.

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -128,6 +128,7 @@ class SoSCollector(SoSComponent):
         'ssh_key': '',
         'ssh_port': 22,
         'ssh_user': 'root',
+        'sudo_binary': 'sudo',
         'timeout': 600,
         'transport': 'auto',
         'treat_certificates': 'obfuscate',
@@ -436,6 +437,8 @@ class SoSCollector(SoSComponent):
                                  help='Specify a sos preset to use')
         collect_grp.add_argument('--ssh-user',
                                  help='Specify an SSH user. Default root')
+        collect_grp.add_argument('--sudo-binary', default='sudo', type=str,
+                                 help='Privilege escalation binary to use.')
         collect_grp.add_argument('--timeout', type=int, required=False,
                                  help='Timeout for sos report on each node.')
         collect_grp.add_argument('--transport', default='auto', type=str,


### PR DESCRIPTION
This commit allows for users to specify a different privilege escalation binary to use in place of `sudo`, for environments where that utility is not used.

We will perform a basic sanity test on any provided value by way of ensuring that the binary is in $PATH on the remote host.

Signed-off-by: Jake Hunsaker <jacob.r.hunsaker@gmail.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
