### PR TITLE
[report] Add UI message for post-processing

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1880,9 +1880,10 @@ class SoSReport(SoSComponent):
             if not self.opts.no_report:
                 self.generate_reports()
             if not self.opts.no_postproc:
+                self.ui_log.info('Starting post-processing of collected data')
                 self.postproc()
             else:
-                self.ui_log.info("Skipping postprocessing of collected data")
+                self.ui_log.info("Skipping post-processing of collected data")
             self.version()
             return self.final_work()
 


### PR DESCRIPTION
On systems that generate larger sized sos reports, post-processing can take an appreciable amount of time. This isn't an issue in itself, however the delay between the `Finished running plugins` message and the `Creating compressed archive` message can lead to some ambiguity as to what `sos` is currently doing, or even if it has "hung".

Add a UI message to tell users that we are actually doing something between the end of `collect()` and compressing the archive.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
