### PR TITLE
[archive] Add option for tar-only archive

### DIFF
--- a/man/en/sos.1
+++ b/man/en/sos.1
@@ -163,8 +163,9 @@ The following table summarizes the effects of different verbosity levels:
 .B \-q, \--quiet
 Only log fatal errors to stderr.
 .TP
-.B \-z, \-\-compression-type {auto|xz|gzip}
-Compression type to use when compression the final archive output
+.B \-z, \-\-compression-type {auto|xz|gzip|none}
+Compression type to use when compressing the final archive output. If the value \fBnone\fP is given
+the tar archive will be written directly with no compression.
 .TP
 .B \--help
 Display usage message.

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -148,7 +148,8 @@ class SoS():
 
         global_grp.add_argument('-z', '--compression-type',
                                 dest="compression_type",
-                                choices=['auto', 'gzip', 'xz'],
+                                choices=['auto', 'gzip', 'xz',
+                                         'none'],
                                 help="compression technology to use")
 
         # Group to make tarball encryption (via GPG/password) exclusive

--- a/sos/archive.py
+++ b/sos/archive.py
@@ -729,6 +729,8 @@ class TarFileArchive(FileCacheArchive):
         _mode = 'w'
         if method == 'auto':
             method = 'xz' if find_spec('lzma') is not None else 'gzip'
+        if method == 'none':
+            method = None
         if method is not None:
             _comp_mode = method.strip('ip')
             self._archive_name = f"{self._archive_name}.{_comp_mode}"


### PR DESCRIPTION
Add new option --compression-type=none to
create a tarfile only, and avoid compressing the file.

Related: RHEL-139389, RHEL-89615

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
