### PR TITLE
[report] Incrase column size for plugin list output

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1047,7 +1047,7 @@ class SoSReport(SoSComponent):
             self.ui_log.info(_("The following plugins are currently enabled:"))
             self.ui_log.info("")
             for (plugname, plug) in self.loaded_plugins:
-                self.ui_log.info(f" {plugname:<20} {plug.get_description()}")
+                self.ui_log.info(f" {plugname:<30} {plug.get_description()}")
         else:
             self.ui_log.info(_("No plugin enabled."))
         self.ui_log.info("")
@@ -1098,7 +1098,7 @@ class SoSReport(SoSComponent):
                 if tmpopt is None:
                     tmpopt = 0
 
-                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<35} "
+                self.ui_log.info(f" {f'{opt.plugin}.{opt.name}':<40} "
                                  f"{tmpopt:<15} {opt.desc}")
         else:
             self.ui_log.info(_("No plugin options available."))

--- a/tests/report_tests/help_output_tests.py
+++ b/tests/report_tests/help_output_tests.py
@@ -67,7 +67,7 @@ class ReportListPluginsTest(StageOneOutputTest):
             # Ignore empty lines
             if not plug.strip():
                 continue
-            self.assertRegex(plug, r' ([\S ]){20} ([\S ])*')
+            self.assertRegex(plug, r' ([\S ]){30} ([\S ])*')
         for plug in disabled_plugins:
             if not plug.strip():
                 continue
@@ -79,7 +79,7 @@ class ReportListPluginsTest(StageOneOutputTest):
         for opt in plugin_options:
             if not opt.strip():
                 continue
-            self.assertRegex(opt, r' ([\S ]){35} ([\S ]{15}) ([\S ])*')
+            self.assertRegex(opt, r' ([\S ]){40} ([\S ]{15}) ([\S ])*')
 
 
 class ReportListPresetsTest(StageOneOutputTest):


### PR DESCRIPTION
The current column size of 20 characters in the output of 'sos report --list-plugins' for 'active' plugins may not be enough in some cases. This commit increases the width to 30. The corresponding avocado test is modified as well to reflect this change.
The same happens with the column size in the
'plugin options' section, so it is increased to
40 characters, with the corresponding avocado test increasing as well.

Related: #4199

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
