### PR TITLE
[Graylog]: Add Graylog plugin

### DIFF
--- a/sos/report/plugins/graylog.py
+++ b/sos/report/plugins/graylog.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2026 Canonical Ltd.,
+# Leah Goldberg <leah.goldberg@canonical.com>
+#
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Graylog(Plugin, IndependentPlugin):
+    """
+    Collects diagnostic information for Graylog Server.
+    """
+
+    short_desc = "Graylog centralized logging server"
+
+    plugin_name = "graylog"
+    profiles = ("security",)
+    packages = ("graylog-datanode", "graylog-server", "graylog-enterprise",)
+    services = ("graylog-server",)
+
+    def setup(self):
+        self.add_copy_spec([
+            "/etc/graylog",
+            "/var/lib/graylog-server/journal",
+        ])
+
+    def postproc(self):
+        # Obfuscate secrets in Graylog config files
+        self.do_path_regex_sub(
+            r"/etc/graylog/.*\.conf$",
+            r"(?i)^(\s*[^#\n]*(password|secret|token|key|_sha\d*)\s*=\s*).*$",
+            r"\1******"
+        )
+
+        # Obfuscate credentials embedded in URLs (user:password@host)
+        self.do_cmd_output_sub(
+            "systemctl status graylog-server",
+            r"(://)[^:@/\s]+:[^@/\s]+@",
+            r"\1******:******@"
+        )
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
### **Add Graylog Plugin**

Create a new plugin for collection of Graylog configuration files, journals, and service status. The plugin includes sanitation of passwords collected from configuration files.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?