### PR TITLE
[kubernetes] Don't use wildcard for k8s systemd units

### DIFF
--- a/sos/report/plugins/kubernetes.py
+++ b/sos/report/plugins/kubernetes.py
@@ -348,7 +348,15 @@ class UbuntuKubernetes(Kubernetes, UbuntuPlugin, DebianPlugin):
         super().setup()
 
     def _canonical_kubernetes(self):
-        self.add_journal(units="snap.k8s.*")
+        k8s_units = ['snap.k8s.containerd.service',
+                     'snap.k8s.etcd.service',
+                     'snap.k8s.k8sd.service',
+                     'snap.k8s.kube-apiserver.service',
+                     'snap.k8s.kube-controller-manager.service',
+                     'snap.k8s.kube-proxy.service',
+                     'snap.k8s.kube-scheduler.service',
+                     'snap.k8s.kubelet.service']
+        self.add_journal(units=k8s_units)
 
         k8s_cmd = "k8s"
         k8s_common = "/var/snap/k8s/common"


### PR DESCRIPTION
Using a wildcard to get all k8s units from journald takes inordinately longer than specifying each unit individually. We now explicity list each systemd k8s unit we want to get logs for.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
