### PR TITLE
[aap_containerized] Carry forward postproc from other AAP plugins

### DIFF
--- a/sos/report/plugins/aap_controller.py
+++ b/sos/report/plugins/aap_controller.py
@@ -83,12 +83,12 @@ class AAPControllerPlugin(Plugin, RedHatPlugin):
         self.do_path_regex_sub("/etc/tower/conf.d/postgres.py", jreg, repl)
 
         # remove email password
-        jreg = r"(EMAIL_HOST_PASSWORD\s*=)\'(.+)\'"
+        jreg = r"(EMAIL_HOST_PASSWORD\s*=\s*)\'(.+)\'"
         repl = r"\1********"
         self.do_path_regex_sub("/etc/tower/settings.py", jreg, repl)
 
         # remove email password (if customized)
-        jreg = r"(EMAIL_HOST_PASSWORD\s*=)\'(.+)\'"
+        jreg = r"(EMAIL_HOST_PASSWORD\s*=\s*)\'(.+)\'"
         repl = r"\1********"
         self.do_path_regex_sub("/etc/tower/conf.d/custom.py", jreg, repl)
 


### PR DESCRIPTION
Secrets obfuscations from 2a46e99 commit must be reflected in containerized plugin.

Further, fix a typo in a regexp, to properly obfuscate:

```
EMAIL_HOST_PASSWORD = 'FAKESECRET!!!'
```

in (both) controller's settings.

Closes: #4213

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
