### PR TITLE
[gcp] Catch exceptions when PRODUCT_PATH doesnt exist

### DIFF
--- a/sos/report/plugins/gcp.py
+++ b/sos/report/plugins/gcp.py
@@ -38,8 +38,11 @@ class GCP(Plugin, IndependentPlugin):
         Checks if this plugin should be executed based on the presence of
         GCE entry in sysfs.
         """
-        with open(self.PRODUCT_PATH, encoding='utf-8') as sys_file:
-            return "Google Compute Engine" in sys_file.read()
+        try:
+            with open(self.PRODUCT_PATH, encoding='utf-8') as sys_file:
+                return "Google Compute Engine" in sys_file.read()
+        except OSError:
+            return False
 
     def setup(self):
         """


### PR DESCRIPTION
Catch exceptions when /sys/devices/virtual/dmi/id/product_name does not exist on a (rare) system, while user manually enabled gcp plugin.

Closes: #4215

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
