### PR TITLE
[cleaner] Better distribution of files among child cleaner processes

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -14,8 +14,8 @@ import logging
 import os
 import shutil
 import fnmatch
+import multiprocessing
 
-from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from pwd import getpwuid
 
@@ -39,8 +39,26 @@ from sos.utilities import (get_human_readable, import_module,
 
 
 # an auxiliary method to kick off child processes over its instances
-def obfuscate_arc_files(arc, flist):
-    return arc.obfuscate_arc_files(flist)
+def _obfuscate_arc_files(arc, input_queue, output_queue):
+    while True:
+        try:
+            file = input_queue.get()
+        except (EOFError, OSError) as e:
+            print(f"Child process exception when reading input queue: '{e}'")
+            break
+        if file is None:  # Sentinel value to stop the process
+            try:
+                output_queue.put((
+                    arc.files_obfuscated_count,
+                    arc.total_sub_count,
+                    arc.removed_file_count))
+            except OSError as e:
+                print(
+                    f"Child process exception when writing to output queue: "
+                    f"'{e}'"
+                )
+            break
+        arc.obfuscate_arc_file(file)
 
 
 class SoSCleaner(SoSComponent):
@@ -726,6 +744,18 @@ third party.
             :param archive str:      Filepath to the directory or archive
         """
 
+        def _order_files_by_size(file_list, base_path):
+            """ Order files per their sizes, if they are provided relatively
+            to base_path
+            """
+            files_with_sizes = [
+                (f, os.path.getsize(os.path.join(base_path, f)))
+                for f in file_list
+            ]
+            files_sizes_sorted = sorted(files_with_sizes, key=lambda x: x[1],
+                                        reverse=True)
+            return [file for file, _ in files_sizes_sorted]
+
         try:
             arc_md = self.cleaner_md.add_section(archive.archive_name)
             start_time = datetime.now()
@@ -735,39 +765,51 @@ third party.
                 archive.extract()
             archive.report_msg("Beginning obfuscation...")
 
-            file_list = list(archive.get_files())
-            # we can't call simple
-            # executor.map(archive.obfuscate_arc_files,archive.get_files())
-            # because a child process does not carry forward internal changes
-            # (e.g. mappings' datasets) from one call of obfuscate_arc_files
-            # method to another. Each obfuscate_arc_files method starts with
-            # vanilla parent archive, that is initialised *once* at its
-            # beginning via initializer=archive.load_parser_entries
-            # - but not afterwards..
-            #
-            # So we must pass list of all files for each worker at the
-            # beginning. This means less granularity of the child processes
-            # work (one worker can finish much sooner than the other), but
-            # it is the best we can have (or have found)
-            #
-            # At least, the "file_list[i::self.opts.jobs]" means subsequent
-            # files (speculativelly of similar size and content) are
-            # distributed to different processes, which attempts to split the
-            # load evenly. Yet better approach might be reorderig file_list
-            # based on files' sizes.
-
+            # we will spawn multiprocessing.Process instances that will get
+            # individual files to obfuscate via `input_queue`. Once all files
+            # are sent there, `None` items are pushed to the queue as a
+            # sentinel mark. That triggers the child processes to report back
+            # to output_queue some stats, and finish.
             files_obfuscated_count = total_sub_count = removed_file_count = 0
-            archive_list = [archive for i in range(self.opts.jobs)]
-            with ProcessPoolExecutor(
-                    max_workers=self.opts.jobs,
-                    initializer=archive.load_parser_entries) as executor:
-                futures = executor.map(obfuscate_arc_files, archive_list,
-                                       [file_list[i::self.opts.jobs] for i in
-                                        range(self.opts.jobs)])
-                for (foc, tsc, rfc) in futures:
-                    files_obfuscated_count += foc
-                    total_sub_count += tsc
-                    removed_file_count += rfc
+            input_queue = multiprocessing.Queue()
+            output_queue = multiprocessing.Queue()
+
+            # Create and start processes
+            processes = []
+            for _ in range(self.opts.jobs):
+                p = multiprocessing.Process(
+                    target=_obfuscate_arc_files,
+                    args=(archive, input_queue, output_queue)
+                )
+                p.start()
+                processes.append(p)
+            # Distribute items to the input queue, after reordering them by
+            # size. Since files can be both relative and absolute paths,
+            # depending on input tarball or directory, we must pass the
+            # relative base_path to call os.path.getsize properly
+            for file in _order_files_by_size(
+                list(archive.get_files()),
+                os.path.dirname(os.path.abspath(archive.extracted_path))
+            ):
+                input_queue.put(file)
+            # Stop processes by sending a sentinel value
+            for _ in range(self.opts.jobs):
+                input_queue.put(None)
+            # Wait for all processes to finish
+            for p in processes:
+                p.join()
+            # Collect stats from the output queue
+            while not output_queue.empty():
+                try:
+                    (foc, tsc, rfc) = output_queue.get()
+                except OSError as e:
+                    self.log_info(
+                        f"Failed to receive obfuscation stats from child; "
+                        f"statistics might be incomplete. Error: '{e}'"
+                    )
+                files_obfuscated_count += foc
+                total_sub_count += tsc
+                removed_file_count += rfc
 
             # As there is no easy way to get dataset dicts from child
             # processes' mappings, we can reload our own parent-process
@@ -823,7 +865,7 @@ third party.
                              f"{archive.archive_name}: {err}")
 
     def obfuscate_file(self, filename):
-        self.main_archive.obfuscate_arc_files([filename])
+        self.main_archive.obfuscate_arc_file(filename)
 
     def obfuscate_symlinks(self, archive):
         """Iterate over symlinks in the archive and obfuscate their names.

--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -92,7 +92,7 @@ class SoSObfuscationArchive():
                 self.log_info(f"Error obfuscating string data: {err}")
         return string_data
 
-    # TODO: merge content to obfuscate_arc_files as that is the only place we
+    # TODO: merge content to obfuscate_arc_file as that is the only place we
     # call obfuscate_filename ?
     def obfuscate_filename(self, short_name, filename):
         _ob_short_name = self.obfuscate_string(short_name.split('/')[-1])
@@ -152,86 +152,82 @@ class SoSObfuscationArchive():
                 self.log_debug(f"failed to parse line: {err}", parser.name)
         return line, count
 
-    def obfuscate_arc_files(self, flist):
-        for filename in flist:
-            self.log_debug(f"    pid={os.getpid()}: obfuscating {filename}")
-            try:
-                rel_name = os.path.relpath(filename, start=self.extracted_path)
-                if self.should_skip_file(rel_name):
-                    continue
-                if (not self.keep_binary_files and
-                        self.should_remove_file(rel_name)):
-                    # We reach this case if the option --keep-binary-files
-                    # was not used, and the file is in a list to be removed
+    def obfuscate_arc_file(self, filename):
+        self.log_debug(f"    pid={os.getpid()}: obfuscating {filename}")
+        try:
+            rel_name = os.path.relpath(filename, start=self.extracted_path)
+            if self.should_skip_file(rel_name):
+                return
+            if (not self.keep_binary_files and
+                    self.should_remove_file(rel_name)):
+                # We reach this case if the option --keep-binary-files
+                # was not used, and the file is in a list to be removed
+                self.remove_file(rel_name)
+                return
+            if (self.keep_binary_files and
+                    (file_is_binary(filename) or
+                     self.should_remove_file(rel_name))):
+                # We reach this case if the option --keep-binary-files
+                # is used. In this case we want to make sure
+                # the cleaner doesn't try to clean a binary file
+                return
+            if os.path.islink(filename):
+                # don't run the obfuscation on the link, but on the actual
+                # file at some other point.
+                return
+            is_certificate = file_is_certificate(filename)
+            if is_certificate:
+                if is_certificate == "certificatekey":
+                    # Always remove certificate Key files
                     self.remove_file(rel_name)
-                    continue
-                if (self.keep_binary_files and
-                        (file_is_binary(filename) or
-                         self.should_remove_file(rel_name))):
-                    # We reach this case if the option --keep-binary-files
-                    # is used. In this case we want to make sure
-                    # the cleaner doesn't try to clean a binary file
-                    continue
-                if os.path.islink(filename):
-                    # don't run the obfuscation on the link, but on the actual
-                    # file at some other point.
-                    continue
-                is_certificate = file_is_certificate(filename)
-                if is_certificate:
-                    if is_certificate == "certificatekey":
-                        # Always remove certificate Key files
-                        self.remove_file(rel_name)
-                        continue
-                    if self.treat_certificates == "keep":
-                        continue
-                    if self.treat_certificates == "remove":
-                        self.remove_file(rel_name)
-                        continue
-                    if self.treat_certificates == "obfuscate":
-                        # since the original filename is deleted, we must
-                        # update both "filename" and "rel_name"
-                        filename = self.certificate_to_text(filename)
-                        rel_name = os.path.relpath(filename,
-                                                   start=self.extracted_path)
-                _parsers = [
-                    _p for _p in self.parsers if not
-                    any(
-                        _skip.match(rel_name) for _skip in _p.skip_patterns
-                    )
-                ]
-                if not _parsers:
-                    self.log_debug(
-                        f"Skipping obfuscation of {rel_name or filename} "
-                        f"due to matching file skip pattern"
-                    )
-                    continue
-                self.log_debug(f"Obfuscating {rel_name or filename}")
-                subs = 0
-                with tempfile.NamedTemporaryFile(mode='w', dir=self.tmpdir) \
-                        as tfile:
-                    with open(filename, 'r', encoding='utf-8',
-                              errors='replace') as fname:
-                        for line in fname:
-                            try:
-                                line, cnt = self.obfuscate_line(line, _parsers)
-                                subs += cnt
-                                tfile.write(line)
-                            except Exception as err:
-                                self.log_debug(f"Unable to obfuscate "
-                                               f"{rel_name}: {err}")
-                    tfile.seek(0)
-                    if subs:
-                        shutil.copyfile(tfile.name, filename)
-                        self.update_sub_count(subs)
+                    return
+                if self.treat_certificates == "keep":
+                    return
+                if self.treat_certificates == "remove":
+                    self.remove_file(rel_name)
+                    return
+                if self.treat_certificates == "obfuscate":
+                    # since the original filename is deleted, we must
+                    # update both "filename" and "rel_name"
+                    filename = self.certificate_to_text(filename)
+                    rel_name = os.path.relpath(filename,
+                                               start=self.extracted_path)
+            _parsers = [
+                _p for _p in self.parsers if not
+                any(
+                    _skip.match(rel_name) for _skip in _p.skip_patterns
+                )
+            ]
+            if not _parsers:
+                self.log_debug(
+                    f"Skipping obfuscation of {rel_name or filename} "
+                    f"due to matching file skip pattern"
+                )
+                return
+            self.log_debug(f"Obfuscating {rel_name or filename}")
+            subs = 0
+            with tempfile.NamedTemporaryFile(mode='w', dir=self.tmpdir) \
+                    as tfile:
+                with open(filename, 'r', encoding='utf-8',
+                          errors='replace') as fname:
+                    for line in fname:
+                        try:
+                            line, cnt = self.obfuscate_line(line, _parsers)
+                            subs += cnt
+                            tfile.write(line)
+                        except Exception as err:
+                            self.log_debug(f"Unable to obfuscate "
+                                           f"{rel_name}: {err}")
+                tfile.seek(0)
+                if subs:
+                    shutil.copyfile(tfile.name, filename)
+                    self.update_sub_count(subs)
 
-                self.obfuscate_filename(rel_name, filename)
+            self.obfuscate_filename(rel_name, filename)
 
-            except Exception as err:
-                self.log_debug(f"    pid={os.getpid()}: caught exception on "
-                               f"obfuscating file {filename}: {err}")
-
-        return (self.files_obfuscated_count, self.total_sub_count,
-                self.removed_file_count)
+        except Exception as err:
+            self.log_debug(f"    pid={os.getpid()}: caught exception on "
+                           f"obfuscating file {filename}: {err}")
 
     @classmethod
     def check_is_type(cls, arc_path):
@@ -543,10 +539,16 @@ class SoSObfuscationArchive():
 
         if (not os.path.isfile(self.get_file_path(filename)) and not
                 os.path.islink(self.get_file_path(filename))):
+            self.log_debug(
+                f"{filename} isn't a file or link, skipping obfuscation."
+            )
             return True
 
         for _skip in self.skip_list:
             if filename.startswith(_skip) or re.match(_skip, filename):
+                self.log_debug(
+                    f"{filename} is in skip list, skipping obfuscation."
+                )
                 return True
         return False
 


### PR DESCRIPTION
Static split of input files often meant uneven distribution of load among the child processes. That caused just one process being busy at the end for many minutes, which ruins concurrency benefits.

Using multiprocessing.[Process|Queue] allow to:
1) order files per sizes, starting from biggest (with the assumption of
   longest cleanup time)
2) dynamic fetching of new file by a child process, only when it gets
   idle

Relevant: #4227
Closes: #4228

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
