### PR TITLE
[leapp] Collect full /etc/leapp/ directory

### DIFF
--- a/sos/report/plugins/leapp.py
+++ b/sos/report/plugins/leapp.py
@@ -21,9 +21,8 @@ class Leapp(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec([
+            '/etc/leapp/',
             '/etc/migration-results',
-            '/etc/leapp/actor_cond.d',
-            '/etc/leapp/files/dnf.conf',
             '/var/log/leapp/answerfile',
             '/var/log/leapp/dnf-debugdata/',
             '/var/log/leapp/leapp-preupgrade.log',


### PR DESCRIPTION
Collect the entire contents of the /etc/leapp/ directory as part of default behavior of the leapp plugin.

As a support engineer for leapp we often require other files that are in this directory for analysis and it would be helpful if everything was captured to streamline the troubleshooting process.
  
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ X] Is the subject and message clear and concise?
- [ X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
