### PR TITLE
[openstack_*] Add Ubuntu support to openstack database plugin

### DIFF
--- a/sos/report/plugins/openstack_database.py
+++ b/sos/report/plugins/openstack_database.py
@@ -9,9 +9,9 @@
 # See the LICENSE file in the source distribution for further information.
 
 import re
+import sqlite3
 
-
-from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt
+from sos.report.plugins import Plugin, RedHatPlugin, PluginOpt, UbuntuPlugin
 
 
 class OpenStackDatabase(Plugin):
@@ -22,7 +22,9 @@ class OpenStackDatabase(Plugin):
 
     option_list = [
         PluginOpt('dump', default=False, desc='Dump select databases'),
-        PluginOpt('dumpall', default=False, desc='Dump ALL databases')
+        PluginOpt('dumpall', default=False, desc='Dump ALL databases'),
+        PluginOpt("dbpass", default="", val_type=str,
+                  desc="Password for database dump collection"),
     ]
 
     databases = [
@@ -55,10 +57,18 @@ class OpenStackDatabase(Plugin):
 
         if self.get_option('dump') or self.get_option('dumpall'):
             db_dump = self.get_mysql_db_string(container=cname)
+            dbpass = self.get_mysql_password()
             db_cmd = f"mysqldump --opt {db_dump}"
 
+            # Pass password via MYSQL_PWD env var if available
+            mysql_env = {"MYSQL_PWD": dbpass} if dbpass else None
+
             self.add_cmd_output(db_cmd, suggest_filename='mysql_dump.sql',
-                                sizelimit=0, container=cname)
+                                sizelimit=0, container=cname, env=mysql_env)
+
+    def get_mysql_password(self):
+        """Return MySQL password from user-provided option (default: empty)."""
+        return self.get_option("dbpass")
 
     def get_mysql_db_string(self, container=None):
         """ Get mysql DB command to be dumped """
@@ -78,6 +88,69 @@ class OpenStackDatabase(Plugin):
 class RedHatOpenStackDatabase(OpenStackDatabase, RedHatPlugin):
 
     packages = ('openstack-selinux', )
+
+
+class UbuntuOpenStackDatabase(OpenStackDatabase, UbuntuPlugin):
+
+    packages = ('mysql-server',)
+
+    def get_mysql_password(self):
+        """
+        Return MySQL password.
+        1. User provided option (--dbpass)
+        2. SQLite (Ubuntu only)
+        3. Default empty (no password)
+        """
+
+        # 1. Try user provided password
+        dbpass = self.get_option("dbpass")
+        if dbpass:
+            return dbpass
+
+        # 2. Try SQLite
+        sqlite_file = self.find_mysql_sqlite_file()
+        if sqlite_file:
+            try:
+                conn = sqlite3.connect(sqlite_file)
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT data FROM kv "
+                    "WHERE key='leadership.settings.mysql.passwd';"
+                )
+                row = cursor.fetchone()
+                if row and row[0]:
+                    return row[0]  # password from SQLite
+            except (sqlite3.Error, OSError) as e:
+                self._log_error(
+                    f"Failed to read MySQL password from SQLite file "
+                    f"{sqlite_file}: {e}"
+                )
+            finally:
+                if 'conn' in locals():
+                    conn.close()
+
+        # 3. Fallback to default: no password
+        return ""
+
+    def find_mysql_sqlite_file(self):
+        """
+        Dynamically locate the Juju SQLite file for MySQL password.
+        Returns the full path if found, else None.
+        """
+        base_path = "/var/lib/juju/agents/"
+        try:
+            for unit_dir in self.listdir(base_path):
+                charm_path = f"{base_path}/{unit_dir}/charm"
+                meta_file = f"{charm_path}/metadata.yaml"
+                if self.path_exists(meta_file):
+                    sqlite_file = f"{charm_path}/.unit-state.db"
+                    if self.path_exists(sqlite_file):
+                        return sqlite_file
+        except OSError as e:
+            self._log_error(
+                f"Failed to locate MySQL SQLite file: {e}"
+            )
+        return None
 
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
**Description**

This PR adds Ubuntu support for MySQL database dumps with password retrieval. This enables Ubuntu systems to run mysqldump by retrieving the necessary MySQL password, which is required for database dumps.

Changes in this PR include:

- In base class (OpenStackDatabase), added a `get_mysql_password` function to return the user-provided `--dbpass` option or default to empty.

- In new Ubuntu subclass (UbuntuOpenStackDatabase, extend `get_mysql_password` to check the local Juju SQLite file if no `--dbpass` is provided. 

            1. Firsts checks user-provided --dbpass option
            2. Then checks SQLite file for password
            3. Finally, defaults to empty password

-  Added `find_mysql_sqlite_file` to Ubuntu subclass to automatically locate the SQLite file containing the MySQL password.

- The MySQL password is passed via the `MYSQL_PWD` environment variable to avoid logging sensitive information.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?