### PR TITLE
[RFC] [podman] Collect podman Data for All Users

### DIFF
--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -8,6 +8,8 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import shlex
+import subprocess
 from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin, PluginOpt
 
 
@@ -44,7 +46,9 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
                     'container produces stdout/stderr output. Use cautiously '
                     'when also using the \'all\' option.')),
         PluginOpt('size', default=False,
-                  desc='collect image sizes for podman ps')
+                  desc='collect image sizes for podman ps'),
+        PluginOpt('allusers', default=False,
+                  desc='collect for all users, including non root users')
     ]
 
     def setup(self):
@@ -68,57 +72,212 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
             'system df -v',
         ]
 
-        self.add_cmd_output([f"podman {s}" for s in subcmds])
-
-        # separately grab ps -s as this can take a *very* long time
-        if self.get_option('size'):
-            self.add_cmd_output('podman ps -as', priority=100)
-
+        # Collect directory listings
         self.add_dir_listing([
             '/etc/cni',
             '/etc/containers'
         ], recursive=True)
 
-        pnets = self.collect_cmd_output('podman network ls',
-                                        tags='podman_list_networks')
+        # Always collect for root (None represents root user)
+        self._collect_for_user(None, '', subcmds)
+
+        # Only collect for non-root users if allusers option is enabled
+        if self.get_option('allusers'):
+            non_root_users = self._get_non_root_users()
+            for user in non_root_users:
+                if self._user_has_containers(user):
+                    self._collect_for_user(user, f'{user}/', subcmds)
+
+    def _collect_for_user(self, user, subdir, subcmds):
+        """Collect all podman data for a specific user"""
+        self._collect_basic_info(user, subdir, subcmds)
+        self._collect_networks(user, subdir)
+
+        containers = self._get_containers_list(user)
+        images = self._get_images_list(user)
+        volumes = self._get_volumes_list(user)
+
+        self._inspect_containers(user, subdir, containers)
+        self._inspect_images(user, subdir, images)
+        self._inspect_volumes(user, subdir, volumes)
+        self._collect_logs(user, subdir, containers)
+
+    def _get_non_root_users(self):
+        """Get list of non-root users from the system"""
+        users = []
+        result = self.exec_cmd("lslogins -u -o USER --noheadings")
+        if result['status'] == 0:
+            for line in result['output'].splitlines():
+                user = line.strip()
+                if user and user != "root":
+                    users.append(user)
+        return users
+
+    def _user_has_containers(self, user):
+        """Check if user has any containers before collecting data"""
+        try:
+            cmd = self.exec_cmd("podman ps -aq", runas=user)
+            return cmd['status'] == 0 and cmd['output'].strip()
+        except subprocess.SubprocessError:
+            return False
+
+    def _collect_basic_info(self, user, subdir, subcmds):
+        """Collect basic podman information and status"""
+        self.add_cmd_output(
+            [f"podman {s}" for s in subcmds],
+            subdir=subdir,
+            runas=user
+        )
+
+        # separately grab ps -s as this can take a *very* long time
+        if self.get_option('size'):
+            self.add_cmd_output(
+                'podman ps -as',
+                priority=100,
+                subdir=subdir,
+                runas=user
+            )
+
+    def _collect_networks(self, user, subdir):
+        """Collect podman network information"""
+        self.collect_cmd_output(
+            'podman network ls',
+            subdir=f'{subdir}networks',
+            tags='podman_list_networks',
+            runas=user
+        )
+        pnets = self.exec_cmd(
+            'podman network ls',
+            runas=user,
+            stderr=False
+        )
         if pnets['status'] == 0:
-            nets = [pn.split()[0] for pn in pnets['output'].splitlines()[1:]]
-            self.add_cmd_output([
-                f"podman network inspect {net}" for net in nets
-            ], subdir='networks', tags='podman_network_inspect')
+            nets = [
+                pn.split()[0]
+                for pn in pnets['output'].splitlines()[1:]
+            ]
+            self.add_cmd_output(
+                [f"podman network inspect {shlex.quote(net)}" for net in nets],
+                subdir=f'{subdir}networks',
+                tags='podman_network_inspect',
+                runas=user
+            )
 
-        containers = [
-            c[0] for c in self.get_containers(runtime='podman',
-                                              get_all=self.get_option('all'))
-        ]
-        images = self.get_container_images(runtime='podman')
-        volumes = self.get_container_volumes(runtime='podman')
+    def _get_containers_list(self, user):
+        """Get list of container IDs for the specified user"""
+        if user is None:
+            # Use built-in method for root user
+            return [
+                c[0] for c in self.get_containers(
+                    runtime='podman',
+                    get_all=self.get_option('all')
+                )
+            ]
 
+        # For non-root users, use podman ps -q
+        cmd = "podman ps -q"
+        if self.get_option('all'):
+            cmd = "podman ps -aq"
+
+        containers_data = self.exec_cmd(cmd, runas=user, stderr=False)
+        if containers_data['status'] == 0:
+            return [
+                line.strip()
+                for line in containers_data['output'].splitlines()
+                if line.strip()
+            ]
+        return []
+
+    def _get_images_list(self, user):
+        """Get list of images for the specified user"""
+        if user is None:
+            # Use built-in method for root user
+            return self.get_container_images(runtime='podman')
+
+        # For non-root users, collect image information manually
+        img_format = '{{.Repository}}:{{.Tag}} {{.ID}}'
+        image_data = self.exec_cmd(
+            f'podman images --no-trunc --format "{img_format}"',
+            runas=user,
+            stderr=False
+        )
+
+        if image_data['status'] == 0:
+            return [
+                line.rsplit(" ", 1)
+                for line in image_data['output'].strip().split("\n")
+                if line.strip()
+            ]
+        return []
+
+    def _get_volumes_list(self, user):
+        """Get list of volumes for the specified user"""
+        if user is None:
+            # Use built-in method for root user
+            return self.get_container_volumes(runtime='podman')
+
+        # For non-root users, collect volume information manually
+        vol_format = '{{.Name}}'
+        vols = self.exec_cmd(
+            f'podman volume ls --format "{vol_format}"',
+            runas=user,
+            stderr=False
+        )
+        if vols['status'] == 0:
+            return [
+                v for v in vols['output'].splitlines()
+                if v.strip()
+            ]
+        return []
+
+    def _inspect_containers(self, user, subdir, containers):
+        """Collect detailed inspection data for containers"""
         for container in containers:
-            self.add_cmd_output(f"podman inspect {container}",
-                                subdir='containers',
-                                tags='podman_container_inspect')
+            self.add_cmd_output(
+                f"podman inspect {shlex.quote(container)}",
+                subdir=f'{subdir}containers',
+                tags='podman_container_inspect',
+                runas=user
+            )
 
+    def _inspect_images(self, user, subdir, images):
+        """Collect detailed inspection data for images"""
         for img in images:
             name, img_id = img
             insp = name if 'none' not in name else img_id
-            self.add_cmd_output(f"podman inspect {insp}", subdir='images',
-                                tags='podman_image_inspect')
             self.add_cmd_output(
-                f"podman image tree {insp}",
-                subdir='images/tree',
-                tags='podman_image_tree'
+                f"podman inspect {shlex.quote(insp)}",
+                subdir=f'{subdir}images',
+                tags='podman_image_inspect',
+                runas=user
+            )
+            self.add_cmd_output(
+                f"podman image tree {shlex.quote(insp)}",
+                subdir=f'{subdir}images/tree',
+                tags='podman_image_tree',
+                runas=user
             )
 
+    def _inspect_volumes(self, user, subdir, volumes):
+        """Collect detailed inspection data for volumes"""
         for vol in volumes:
-            self.add_cmd_output(f"podman volume inspect {vol}",
-                                subdir='volumes',
-                                tags='podman_volume_inspect')
+            self.add_cmd_output(
+                f"podman volume inspect {shlex.quote(vol)}",
+                subdir=f'{subdir}volumes',
+                tags='podman_volume_inspect',
+                runas=user
+            )
 
+    def _collect_logs(self, user, subdir, containers):
+        """Collect container logs if logs option is enabled"""
         if self.get_option('logs'):
             for con in containers:
-                self.add_cmd_output(f"podman logs -t {con}",
-                                    subdir='containers', priority=50)
+                self.add_cmd_output(
+                    f"podman logs -t {shlex.quote(con)}",
+                    subdir=f'{subdir}containers',
+                    priority=50,
+                    runas=user
+                )
 
     def postproc(self):
         # Attempts to match key=value pairs inside container inspect output

--- a/sos/report/plugins/podman.py
+++ b/sos/report/plugins/podman.py
@@ -44,7 +44,9 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
                     'container produces stdout/stderr output. Use cautiously '
                     'when also using the \'all\' option.')),
         PluginOpt('size', default=False,
-                  desc='collect image sizes for podman ps')
+                  desc='collect image sizes for podman ps'),
+        PluginOpt('allusers', default=False,
+                  desc='collect for all users, including non root users')
     ]
 
     def setup(self):
@@ -68,57 +70,209 @@ class Podman(Plugin, RedHatPlugin, UbuntuPlugin):
             'system df -v',
         ]
 
-        self.add_cmd_output([f"podman {s}" for s in subcmds])
-
-        # separately grab ps -s as this can take a *very* long time
-        if self.get_option('size'):
-            self.add_cmd_output('podman ps -as', priority=100)
-
+        # Collect directory listings
         self.add_dir_listing([
             '/etc/cni',
             '/etc/containers'
         ], recursive=True)
 
-        pnets = self.collect_cmd_output('podman network ls',
-                                        tags='podman_list_networks')
+        # Always collect for root (None represents root user)
+        self._collect_for_user(None, '', subcmds)
+
+        # Only collect for non-root users if allusers option is enabled
+        if self.get_option('allusers'):
+            non_root_users = self._get_non_root_users()
+            for user in non_root_users:
+                if self._user_has_containers(user):
+                    self._collect_for_user(user, f'users/{user}/', subcmds)
+
+    def _collect_for_user(self, user, subdir, subcmds):
+        """Collect all podman data for a specific user"""
+        self._collect_basic_info(user, subdir, subcmds)
+        self._collect_networks(user, subdir)
+
+        containers = self._get_containers_list(user)
+        images = self._get_images_list(user)
+        volumes = self._get_volumes_list(user)
+
+        self._inspect_containers(user, subdir, containers)
+        self._inspect_images(user, subdir, images)
+        self._inspect_volumes(user, subdir, volumes)
+        self._collect_logs(user, subdir, containers)
+
+    def _get_non_root_users(self):
+        """Get list of non-root users from the system"""
+        users = []
+        result = self.exec_cmd("lslogins -u -o USER --noheadings")
+        if result['status'] == 0:
+            for line in result['output'].splitlines():
+                user = line.strip()
+                if user and user != "root":
+                    users.append(user)
+        return users
+
+    def _user_has_containers(self, user):
+        """Check if user has any containers before collecting data"""
+        cmd = self.exec_cmd("podman ps -aq", runas=user)
+        return cmd['status'] == 0 and cmd['output'].strip()
+
+    def _collect_basic_info(self, user, subdir, subcmds):
+        """Collect basic podman information and status"""
+        self.add_cmd_output(
+            [f"podman {s}" for s in subcmds],
+            subdir=subdir,
+            runas=user
+        )
+
+        # separately grab ps -s as this can take a *very* long time
+        if self.get_option('size'):
+            self.add_cmd_output(
+                'podman ps -as',
+                priority=100,
+                subdir=subdir,
+                runas=user
+            )
+
+    def _collect_networks(self, user, subdir):
+        """Collect podman network information"""
+        self.collect_cmd_output(
+            'podman network ls',
+            subdir=f'{subdir}networks',
+            tags='podman_list_networks',
+            runas=user
+        )
+        pnets = self.exec_cmd(
+            'podman network ls',
+            runas=user,
+            stderr=False
+        )
         if pnets['status'] == 0:
-            nets = [pn.split()[0] for pn in pnets['output'].splitlines()[1:]]
-            self.add_cmd_output([
-                f"podman network inspect {net}" for net in nets
-            ], subdir='networks', tags='podman_network_inspect')
+            nets = [
+                pn.split()[0]
+                for pn in pnets['output'].splitlines()[1:]
+            ]
+            self.add_cmd_output(
+                [f"podman network inspect {net}" for net in nets],
+                subdir=f'{subdir}networks',
+                tags='podman_network_inspect',
+                runas=user
+            )
 
-        containers = [
-            c[0] for c in self.get_containers(runtime='podman',
-                                              get_all=self.get_option('all'))
-        ]
-        images = self.get_container_images(runtime='podman')
-        volumes = self.get_container_volumes(runtime='podman')
+    def _get_containers_list(self, user):
+        """Get list of container IDs for the specified user"""
+        if user is None:
+            # Use built-in method for root user
+            return [
+                c[0] for c in self.get_containers(
+                    runtime='podman',
+                    get_all=self.get_option('all')
+                )
+            ]
 
+        # For non-root users, use podman ps -q
+        cmd = "podman ps -q"
+        if self.get_option('all'):
+            cmd = "podman ps -aq"
+
+        containers_data = self.exec_cmd(cmd, runas=user, stderr=False)
+        if containers_data['status'] == 0:
+            return [
+                line.strip()
+                for line in containers_data['output'].splitlines()
+                if line.strip()
+            ]
+        return []
+
+    def _get_images_list(self, user):
+        """Get list of images for the specified user"""
+        if user is None:
+            # Use built-in method for root user
+            return self.get_container_images(runtime='podman')
+
+        # For non-root users, collect image information manually
+        img_format = '{{.Repository}}:{{.Tag}} {{.ID}}'
+        image_data = self.exec_cmd(
+            f'podman images --no-trunc --format "{img_format}"',
+            runas=user,
+            stderr=False
+        )
+
+        if image_data['status'] == 0:
+            return [
+                line.rsplit(" ", 1)
+                for line in image_data['output'].strip().split("\n")
+                if line.strip()
+            ]
+        return []
+
+    def _get_volumes_list(self, user):
+        """Get list of volumes for the specified user"""
+        if user is None:
+            # Use built-in method for root user
+            return self.get_container_volumes(runtime='podman')
+
+        # For non-root users, collect volume information manually
+        vol_format = '{{.Name}}'
+        vols = self.exec_cmd(
+            f'podman volume ls --format "{vol_format}"',
+            runas=user,
+            stderr=False
+        )
+        if vols['status'] == 0:
+            return [
+                v for v in vols['output'].splitlines()
+                if v.strip()
+            ]
+        return []
+
+    def _inspect_containers(self, user, subdir, containers):
+        """Collect detailed inspection data for containers"""
         for container in containers:
-            self.add_cmd_output(f"podman inspect {container}",
-                                subdir='containers',
-                                tags='podman_container_inspect')
+            self.add_cmd_output(
+                f"podman inspect {container}",
+                subdir=f'{subdir}containers',
+                tags='podman_container_inspect',
+                runas=user
+            )
 
+    def _inspect_images(self, user, subdir, images):
+        """Collect detailed inspection data for images"""
         for img in images:
             name, img_id = img
             insp = name if 'none' not in name else img_id
-            self.add_cmd_output(f"podman inspect {insp}", subdir='images',
-                                tags='podman_image_inspect')
+            self.add_cmd_output(
+                f"podman inspect {insp}",
+                subdir=f'{subdir}images',
+                tags='podman_image_inspect',
+                runas=user
+            )
             self.add_cmd_output(
                 f"podman image tree {insp}",
-                subdir='images/tree',
-                tags='podman_image_tree'
+                subdir=f'{subdir}images/tree',
+                tags='podman_image_tree',
+                runas=user
             )
 
+    def _inspect_volumes(self, user, subdir, volumes):
+        """Collect detailed inspection data for volumes"""
         for vol in volumes:
-            self.add_cmd_output(f"podman volume inspect {vol}",
-                                subdir='volumes',
-                                tags='podman_volume_inspect')
+            self.add_cmd_output(
+                f"podman volume inspect {vol}",
+                subdir=f'{subdir}volumes',
+                tags='podman_volume_inspect',
+                runas=user
+            )
 
+    def _collect_logs(self, user, subdir, containers):
+        """Collect container logs if logs option is enabled"""
         if self.get_option('logs'):
             for con in containers:
-                self.add_cmd_output(f"podman logs -t {con}",
-                                    subdir='containers', priority=50)
+                self.add_cmd_output(
+                    f"podman logs -t {con}",
+                    subdir=f'{subdir}containers',
+                    priority=50,
+                    runas=user
+                )
 
     def postproc(self):
         # Attempts to match key=value pairs inside container inspect output

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -294,7 +294,10 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
             'HOME': pwd_user.pw_dir,
             'LOGNAME': runas,
             'PWD': pwd_user.pw_dir,
-            'USER': runas
+            'USER': runas,
+            # XDG_RUNTIME_DIR is required for rootless podman to access
+            # user-specific runtime files and sockets
+            'XDG_RUNTIME_DIR': f"/run/user/{pwd_user.pw_uid}"
         })
 
     cmd_env = os.environ.copy()

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -302,7 +302,10 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
             'HOME': pwd_user.pw_dir,
             'LOGNAME': runas,
             'PWD': pwd_user.pw_dir,
-            'USER': runas
+            'USER': runas,
+            # XDG_RUNTIME_DIR is required for rootless podman to access
+            # user-specific runtime files and sockets
+            'XDG_RUNTIME_DIR': f"/run/user/{pwd_user.pw_uid}"
         })
 
     cmd_env = os.environ.copy()


### PR DESCRIPTION
Issue Description:
The current sos report only gathers podman data for the root user. It is unable to collect container data belonging to non‑root users because sos report runs with elevated (sudo) privileges.

Solution:
Added a new plugin option, allusers, to the podman plugin. When enabled, this option collects podman container data for all non‑root users which has container running on the system in addition to the root user.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
