### PR TITLE
[auth] Add logic to store and retrieve auth tokens

### DIFF
--- a/man/en/sos-upload.1
+++ b/man/en/sos-upload.1
@@ -136,6 +136,16 @@ Secret key for the S3 bucket
 .B \-  --upload-s3-object-prefix PREFIX
 Prefix for the S3 object/key
 
+.SH TOKEN STORAGE
+When using web-based authentication for uploads, \fBsos\fR stores the
+refresh token locally in the file \fI~/.sos-oidc-token.json\fR so that
+subsequent uploads do not require re-authenticating through a browser.
+.PP
+\fBNote:\fR the token is stored in \fBplain text\fR with file permissions
+set to 0600 (owner read/write only).  If these permissions are changed,
+sos will issue a warning.  Users should ensure that the storage location
+and its parent directories have appropriately restrictive permissions.
+
 .SH SEE ALSO
 .BR sos (1)
 .BR sos-report (1)

--- a/sos/policies/auth/__init__.py
+++ b/sos/policies/auth/__init__.py
@@ -16,13 +16,15 @@ except ImportError:
     REQUESTS_LOADED = False
 import time
 from datetime import datetime, timedelta, timezone
+import os
+import json
 
-from sos.utilities import TIMEOUT_DEFAULT
+from sos.utilities import TIMEOUT_DEFAULT, path_join
 
 DEVICE_AUTH_CLIENT_ID = "sos-tools"
 GRANT_TYPE_DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code"
-
-logger = logging.getLogger("sos")
+OIDC_TOKEN_FILE = ".sos-auth-oidc-token.json"
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class DeviceAuthorizationClass:
@@ -30,15 +32,86 @@ class DeviceAuthorizationClass:
     Device Authorization Class
     """
 
-    def __init__(self, client_identifier_url, token_endpoint):
+    def __init__(self, client_identifier_url, token_endpoint, token_dir):
 
         self._access_token = None
         self._access_expires_at = None
         self.__device_code = None
+        self._token_dir = f"{token_dir}/"
 
         self.client_identifier_url = client_identifier_url
         self.token_endpoint = token_endpoint
+        self.ui_log = logging.getLogger('sos_ui')
         self._use_device_code_grant()
+
+    def try_read_refresh_token(self, base_path):
+        """
+        Try to read locally stored refresh token
+
+        Args:
+            base_path (str): Local path where OIDC token is stored
+
+        Returns:
+            str: Returns OIDC refresh token information if found,
+            otherwise None
+        """
+        token_file_path = path_join(base_path, OIDC_TOKEN_FILE)
+        if not os.path.exists(token_file_path):
+            self.ui_log.error("Cannot find "
+                              f"{OIDC_TOKEN_FILE} file using {base_path} "
+                              "path, so we'll request a new token.")
+            return None
+
+        self.ui_log.info("Retrieving OIDC token information from local "
+                         f"{OIDC_TOKEN_FILE} file")
+        try:
+            with open(token_file_path, "r", encoding='utf-8') as fileobj:
+                read_in = fileobj.read()
+        except OSError as err:
+            self.ui_log.error("There was an exception while reading "
+                              f"the token file - {err}")
+            raise
+
+        if not read_in.strip():
+            self.ui_log.info(f"The {OIDC_TOKEN_FILE} file was empty.")
+            return None
+
+        try:
+            token_data = json.loads(read_in)
+        except json.JSONDecodeError:
+            self.ui_log.error("There was an issue decoding the JSON file "
+                              f"while loading {OIDC_TOKEN_FILE}")
+            return None
+
+        refresh_token = token_data.get("refresh_token")
+        dt_str = token_data.get("refresh_expires_at")
+        if not refresh_token or not dt_str:
+            self.ui_log.error(
+                "Locally cached offline token is missing required fields "
+                f"in {OIDC_TOKEN_FILE}. We will request a new token."
+            )
+            return None
+
+        try:
+            refresh_expires_at = datetime.strptime(dt_str, DATETIME_FORMAT)
+            refresh_expires_at = refresh_expires_at.replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            self.ui_log.error(
+                f"Invalid refresh_expires_at in {OIDC_TOKEN_FILE}: "
+                f"{dt_str!r}"
+            )
+            return None
+
+        if refresh_expires_at - timedelta(seconds=300) <= \
+                datetime.now(timezone.utc):
+            self.ui_log.error("Locally cached offline token has expired "
+                              "or is incorrectly formatted. "
+                              "We will request a new token.")
+            return None
+
+        return refresh_token
 
     def _use_device_code_grant(self):
         """
@@ -46,13 +119,16 @@ class DeviceAuthorizationClass:
         store the tokens in an in-memory keyring.
 
         """
-
-        self._request_device_code()
-        print(
-            "Please visit the following URL to authenticate this"
-            f" device: {self._verification_uri_complete}"
-        )
-        self.poll_for_auth_completion()
+        stored_refresh_token = self.try_read_refresh_token(self._token_dir)
+        if not stored_refresh_token:
+            self._request_device_code()
+            self.ui_log.info(
+                "Please visit the following URL to authenticate this"
+                f" device: {self._verification_uri_complete}"
+            )
+            self.poll_for_auth_completion()
+        else:
+            self._use_refresh_token_grant(stored_refresh_token)
 
     def _request_device_code(self):
         """
@@ -108,7 +184,7 @@ class DeviceAuthorizationClass:
                 status_code = check_auth_completion.status_code
 
                 if status_code == 200:
-                    logger.info("The SSO authentication is successful")
+                    self.ui_log.info("The SSO authentication is successful")
                     self._set_token_data(check_auth_completion.json())
                 if status_code not in [200, 400]:
                     raise Exception(status_code, check_auth_completion.text)
@@ -117,13 +193,13 @@ class DeviceAuthorizationClass:
                         ("authorization_pending", "slow_down"):
                     raise Exception(status_code, check_auth_completion.text)
             except requests.exceptions.RequestException as e:
-                logger.error(f"Error was found while posting a request: {e}")
+                self.ui_log.error("An error was found while posting a request:"
+                                  f" {e}")
 
     def _set_token_data(self, token_data):
         """
         Set the class attributes as per the input token_data received.
-        In the future we will persist the token data in a local,
-        in-memory keyring, to avoid visting the browser frequently.
+
         :param token_data: Token data containing access_token, refresh_token
         and their expiry etc.
         """
@@ -137,6 +213,8 @@ class DeviceAuthorizationClass:
         else:
             self._refresh_expires_at = datetime.now(timezone.utc) + \
                 timedelta(seconds=self._refresh_expires_in)
+        self.persist_refresh_token(self._token_dir)
+        self.ui_log.info(f"Token data stored in: {self._token_dir}")
 
     def get_access_token(self):
         """
@@ -199,10 +277,11 @@ class DeviceAuthorizationClass:
 
         elif refresh_token_res.status_code == 400 and 'invalid' in\
                 refresh_token_res.json()['error']:
-            logger.warning("Problem while fetching the new tokens from refresh"
-                           f" token grant - {refresh_token_res.status_code} "
-                           f"{refresh_token_res.json()['error']}."
-                           " New Device code will be requested !")
+            self.ui_log.warning("Problem while fetching the new tokens "
+                                f"from refresh token grant "
+                                f"- {refresh_token_res.status_code} "
+                                f"{refresh_token_res.json()['error']}."
+                                " New Device code will be requested!")
             self._use_device_code_grant()
         else:
             raise Exception(
@@ -210,3 +289,51 @@ class DeviceAuthorizationClass:
                 "Refresh token grant for fetching tokens:"
                 f" Returned status code {refresh_token_res.status_code}"
                 f" and error {refresh_token_res.json()['error']}")
+
+    def request_new_device_code(self):
+        """
+        Initialize new Device Authorization Grant attempt by requesting
+          a new device code.
+        """
+        self._use_device_code_grant()
+
+    def persist_refresh_token(self, base_path):
+        """
+        Persist current refresh token to a local file
+        Args:
+            base_path (str): Local path to a directory where token
+            should be stored
+
+        Returns:
+            bool: True if refresh token was successfully persisted,
+            otherwise False
+        """
+        if self.is_refresh_token_valid():
+            # ToDo: While now we'll use the user's home directory
+            # in the future we may want to offer the possibility
+            # of specifying the directory (making sure the user knows
+            # the security implications of this decision)
+            if not os.path.exists(base_path):
+                os.mkdir(base_path)
+            token_data = {
+                "refresh_token": self._refresh_token,
+                "refresh_expires_at": self._refresh_expires_at.strftime(
+                    DATETIME_FORMAT
+                    )
+            }
+            token_file_path = path_join(base_path, OIDC_TOKEN_FILE)
+            fd = os.open(
+                token_file_path,
+                os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, 'w', encoding='utf-8') as fileobj:
+                json.dump(token_data, fileobj)
+            os.chmod(token_file_path, 0o600)
+            self.ui_log.info("The new refresh token was successfully saved to"
+                             f" {token_file_path}")
+            return True
+        self.ui_log.error("Cannot save invalid refresh token")
+        return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/policies/auth/__init__.py
+++ b/sos/policies/auth/__init__.py
@@ -16,13 +16,15 @@ except ImportError:
     REQUESTS_LOADED = False
 import time
 from datetime import datetime, timedelta, timezone
+import os
+import json
 
-from sos.utilities import TIMEOUT_DEFAULT
+from sos.utilities import TIMEOUT_DEFAULT, path_join
 
 DEVICE_AUTH_CLIENT_ID = "sos-tools"
 GRANT_TYPE_DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code"
-
-logger = logging.getLogger("sos")
+OIDC_TOKEN_FILE = ".sos-oidc-token.json"
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class DeviceAuthorizationClass:
@@ -30,29 +32,117 @@ class DeviceAuthorizationClass:
     Device Authorization Class
     """
 
-    def __init__(self, client_identifier_url, token_endpoint):
+    def __init__(self, client_identifier_url, token_endpoint, token_dir):
 
         self._access_token = None
         self._access_expires_at = None
         self.__device_code = None
+        self._token_dir = f"{token_dir}/"
 
         self.client_identifier_url = client_identifier_url
         self.token_endpoint = token_endpoint
+        self.ui_log = logging.getLogger('sos_ui')
         self._use_device_code_grant()
 
-    def _use_device_code_grant(self):
+    def try_read_refresh_token(self, base_path):
         """
-        Start the device auth flow. In the future we will
-        store the tokens in an in-memory keyring.
+        Try to read locally stored refresh token
 
+        Args:
+            base_path (str): Local path where OIDC token is stored
+
+        Returns:
+            str: Returns OIDC refresh token information if found,
+            otherwise None
         """
+        token_file_path = path_join(base_path, OIDC_TOKEN_FILE)
+        if not os.path.exists(token_file_path):
+            self.ui_log.info("Cannot find "
+                             f"{OIDC_TOKEN_FILE} file using {base_path} "
+                             "path, so we'll request a new token.")
+            return None
 
-        self._request_device_code()
-        print(
-            "Please visit the following URL to authenticate this"
-            f" device: {self._verification_uri_complete}"
-        )
-        self.poll_for_auth_completion()
+        self.ui_log.info("Retrieving OIDC token information from local "
+                         f"{OIDC_TOKEN_FILE} file")
+        try:
+            with open(token_file_path, "r", encoding='utf-8') as fileobj:
+                read_in = fileobj.read()
+        except OSError as err:
+            self.ui_log.error("There was an exception while reading "
+                              f"the token file - {err}")
+            return None
+
+        if not read_in.strip():
+            self.ui_log.info(f"The {OIDC_TOKEN_FILE} file was empty.")
+            return None
+
+        try:
+            token_data = json.loads(read_in)
+        except json.JSONDecodeError:
+            self.ui_log.error("There was an issue decoding the JSON file "
+                              f"while loading {OIDC_TOKEN_FILE}")
+            self._remove_token_file(token_file_path)
+            return None
+
+        refresh_token = token_data.get("refresh_token")
+        dt_str = token_data.get("refresh_expires_at")
+        if not refresh_token or not dt_str:
+            self.ui_log.error(
+                "Locally cached offline token is missing required fields "
+                f"in {OIDC_TOKEN_FILE}. We will request a new token."
+            )
+            self._remove_token_file(token_file_path)
+            return None
+
+        try:
+            refresh_expires_at = datetime.strptime(dt_str, DATETIME_FORMAT)
+            refresh_expires_at = refresh_expires_at.replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            self.ui_log.error(
+                f"Invalid refresh_expires_at in {OIDC_TOKEN_FILE}: "
+                f"{dt_str!r}"
+            )
+            self._remove_token_file(token_file_path)
+            return None
+
+        if refresh_expires_at - timedelta(seconds=300) <= \
+                datetime.now(timezone.utc):
+            self.ui_log.error("Locally cached offline token has expired. "
+                              "We will remove the old file and"
+                              " request a new token.")
+            self._remove_token_file(token_file_path)
+            return None
+
+        return refresh_token
+
+    def _remove_token_file(self, token_file_path):
+        """Safely remove a cached token file, logging on failure."""
+        try:
+            os.remove(token_file_path)
+        except FileNotFoundError:
+            pass  # Already gone -- nothing to do
+        except OSError as err:
+            self.ui_log.warning(
+                f"Unable to remove cached token file {token_file_path}: {err}"
+            )
+
+    def _use_device_code_grant(self, force=False):
+        """
+        Start the device auth flow.
+        """
+        stored_refresh_token = None if force else \
+            self.try_read_refresh_token(self._token_dir)
+        if not stored_refresh_token:
+            self._request_device_code()
+            self.ui_log.info(
+                "Please visit the following URL to authenticate this"
+                f" device: {self._verification_uri_complete}"
+            )
+            self.poll_for_auth_completion()
+        else:
+            self._use_refresh_token_grant(stored_refresh_token)
 
     def _request_device_code(self):
         """
@@ -108,7 +198,7 @@ class DeviceAuthorizationClass:
                 status_code = check_auth_completion.status_code
 
                 if status_code == 200:
-                    logger.info("The SSO authentication is successful")
+                    self.ui_log.info("The SSO authentication is successful")
                     self._set_token_data(check_auth_completion.json())
                 if status_code not in [200, 400]:
                     raise Exception(status_code, check_auth_completion.text)
@@ -117,13 +207,13 @@ class DeviceAuthorizationClass:
                         ("authorization_pending", "slow_down"):
                     raise Exception(status_code, check_auth_completion.text)
             except requests.exceptions.RequestException as e:
-                logger.error(f"Error was found while posting a request: {e}")
+                self.ui_log.error("An error was found while posting a request:"
+                                  f" {e}")
 
     def _set_token_data(self, token_data):
         """
         Set the class attributes as per the input token_data received.
-        In the future we will persist the token data in a local,
-        in-memory keyring, to avoid visting the browser frequently.
+
         :param token_data: Token data containing access_token, refresh_token
         and their expiry etc.
         """
@@ -137,6 +227,9 @@ class DeviceAuthorizationClass:
         else:
             self._refresh_expires_at = datetime.now(timezone.utc) + \
                 timedelta(seconds=self._refresh_expires_in)
+        if not self.persist_refresh_token(self._token_dir):
+            self.ui_log.warning("Token obtained but could not "
+                                f"be persisted locally in {self._token_dir}")
 
     def get_access_token(self):
         """
@@ -193,20 +286,78 @@ class DeviceAuthorizationClass:
         refresh_token_res = requests.post(self.token_endpoint,
                                           data=refresh_token_data,
                                           timeout=TIMEOUT_DEFAULT)
+        try:
+            refresh_token_res_json = refresh_token_res.json()
+        except ValueError:
+            refresh_token_res_json = {}
 
         if refresh_token_res.status_code == 200:
-            self._set_token_data(refresh_token_res.json())
+            self._set_token_data(refresh_token_res_json)
 
         elif refresh_token_res.status_code == 400 and 'invalid' in\
-                refresh_token_res.json()['error']:
-            logger.warning("Problem while fetching the new tokens from refresh"
-                           f" token grant - {refresh_token_res.status_code} "
-                           f"{refresh_token_res.json()['error']}."
-                           " New Device code will be requested !")
-            self._use_device_code_grant()
+                (refresh_token_res_json.get('error') or ''):
+            self.ui_log.warning("Problem while fetching the new tokens "
+                                f"from refresh token grant "
+                                f"- {refresh_token_res.status_code} "
+                                f"{refresh_token_res_json.get('error')}."
+                                " New Device code will be requested!")
+            token_file_path = path_join(self._token_dir, OIDC_TOKEN_FILE)
+            self._remove_token_file(token_file_path)
+            self._use_device_code_grant(force=True)
         else:
             raise Exception(
                 "Something went wrong while using the "
                 "Refresh token grant for fetching tokens:"
                 f" Returned status code {refresh_token_res.status_code}"
-                f" and error {refresh_token_res.json()['error']}")
+                f" and error {refresh_token_res_json.get('error')}")
+
+    def persist_refresh_token(self, base_path):
+        """
+        Persist current refresh token to a local file
+        Args:
+            base_path (str): Local path to a directory where token
+            should be stored
+
+        Returns:
+            bool: True if refresh token was successfully persisted,
+            otherwise False
+        """
+        if self.is_refresh_token_valid():
+            # ToDo: While now we'll use the user's home directory
+            # in the future we may want to offer the possibility
+            # of specifying the directory (making sure the user knows
+            # the security implications of this decision)
+            try:
+                os.makedirs(base_path, mode=0o700, exist_ok=True)
+                token_data = {
+                    "refresh_token": self._refresh_token,
+                    "refresh_expires_at": self._refresh_expires_at.strftime(
+                        DATETIME_FORMAT
+                        )
+                }
+                token_file_path = path_join(base_path, OIDC_TOKEN_FILE)
+                fd = os.open(token_file_path,
+                             os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
+                             0o600)
+                with os.fdopen(fd, 'w', encoding='utf-8') as fileobj:
+                    json.dump(token_data, fileobj)
+                self.ui_log.info("The new refresh token was successfully"
+                                 f" saved to {token_file_path}")
+                stat_info = os.stat(token_file_path)
+                if stat_info.st_mode & 0o077:
+                    self.ui_log.warning(
+                        f"Token file {token_file_path} has overly "
+                        "permissive permissions. The token is stored "
+                        "in plain text, so please ensure that only the "
+                        "owner has access to this file"
+                    )
+                return True
+            except OSError as err:
+                self.ui_log.error(
+                    f"Failed to persist refresh token: {err}"
+                )
+                return False
+        self.ui_log.error("Cannot save invalid refresh token")
+        return False
+
+# vim: set et ts=4 sw=4 :

--- a/sos/upload/targets/redhat.py
+++ b/sos/upload/targets/redhat.py
@@ -8,6 +8,7 @@
 # See the LICENSE file in the source distribution for further information.
 import os
 import json
+from pathlib import Path
 from sos.upload.targets import UploadTarget
 from sos.utilities import convert_bytes, TIMEOUT_DEFAULT
 from sos.policies.auth import DeviceAuthorizationClass
@@ -111,7 +112,8 @@ class RHELUploadTarget(UploadTarget):
         # longer than the token timeout
         RHELAuth = DeviceAuthorizationClass(
                 self.client_identifier_url,
-                self.token_endpoint
+                self.token_endpoint,
+                Path.home()
             )
         self._device_token = RHELAuth.get_access_token()
         self.ui_log.info("Device authorized correctly. Uploading file to "
@@ -167,7 +169,8 @@ class RHELUploadTarget(UploadTarget):
             try:
                 RHELAuth = DeviceAuthorizationClass(
                     self.client_identifier_url,
-                    self.token_endpoint
+                    self.token_endpoint,
+                    Path.home()
                 )
             except Exception as e:
                 # We end up here if the user cancels the device


### PR DESCRIPTION
This commit implements functionality to store and 
retrieve authorization tokens obtained remotely from a
distribution-defined authentication portal. This
enables users to reuse previously obtained tokens
that remain valid, eliminating the need to request a new token for each subsequent interaction.

Related: RHEL-167336, SUPDEV-186

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
