### PR TITLE
[mysql_router] Add dedicated MySQL Router plugin

### DIFF
--- a/sos/report/plugins/mysql.py
+++ b/sos/report/plugins/mysql.py
@@ -35,7 +35,6 @@ class Mysql(Plugin):
 
         self.add_copy_spec([
             self.mysql_cnf,
-            "/etc/mysqlrouter/",
             "/var/lib/mysql/grastate.dat",
             "/var/lib/mysql/gvwstate.dat"
         ])
@@ -44,14 +43,12 @@ class Mysql(Plugin):
             self.add_copy_spec([
                 "/var/log/mysql*",
                 "/var/log/mariadb*",
-                "/var/log/mysqlrouter/*"
             ])
         else:
             self.add_copy_spec([
                 # Required for MariaDB under pacemaker (MariaDB-Galera)
                 "/var/log/mysqld.log",
                 "/var/log/mysql/mysqld.log",
-                "/var/log/mysqlrouter/mysqlrouter.log",
                 "/var/log/mariadb/mariadb.log"
             ])
 

--- a/sos/report/plugins/mysql_router.py
+++ b/sos/report/plugins/mysql_router.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 Canonical Ltd.,
+# Munir Siddiqui <munir.siddiqui@canonical.com>
+#
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class MysqlRouter(Plugin, IndependentPlugin):
+    """
+    Collects configuration and logs for MySQL Router.
+    """
+
+    short_desc = "MySQL Router"
+
+    plugin_name = "mysql_router"
+    profiles = ("services",)
+    packages = ("mysql-router", "mysql-router-community",)
+
+    def setup(self):
+        super().setup()
+
+        self.add_copy_spec([
+            "/etc/mysqlrouter/",
+            "/var/lib/mysql/*-mysql-router/mysqlrouter.conf",
+        ])
+
+        if self.get_option("all_logs"):
+            self.add_copy_spec([
+                "/var/log/mysqlrouter/*",
+                "/var/lib/mysql/*-mysql-router/log/*",
+            ])
+        else:
+            self.add_copy_spec([
+                "/var/log/mysqlrouter/mysqlrouter.log",
+                "/var/lib/mysql/*-mysql-router/log/mysqlrouter.log*",
+            ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
[mysql_router] Add dedicated MySQL Router plugin with added support for mysql-router conf and log collection

1. In the current implementation, MySQL Router collection is embedded in the `mysql` plugin, which is gated on MySQL/MariaDB server packages. As a result, on nodes with only MySQL Router installed, the `mysql` plugin never activates, so no router config or logs are collected.
2. The current implementation does not collect conf and logs from `/var/lib/mysql/*-mysql-router/`.

- Remove all `mysqlrouter` references from the `mysql` plugin
- Extract MySQL Router into a new `mysql_router` plugin that:
    - Gates on `mysql-router` / `mysql-router-community` packages
    - Collects information from `/var/lib/mysql/*-mysql-router/` in addition to the previously collected data
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [N/A] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
