### PR TITLE
[microovn] Collect all logs from microovn

### DIFF
--- a/sos/report/plugins/microovn.py
+++ b/sos/report/plugins/microovn.py
@@ -46,6 +46,7 @@ class MicroOVN(Plugin, UbuntuPlugin):
         )
 
         db_path = "/var/snap/microovn/common/state/database"
+        log_path = "/var/snap/microovn/common/logs"
 
         # Check for inconsistent dqlite db intervals
         self.add_dir_listing(
@@ -54,10 +55,14 @@ class MicroOVN(Plugin, UbuntuPlugin):
         )
 
         self.add_copy_spec([
-                f"{db_path}/info.yaml",
-                f"{db_path}/cluster.yaml",
-                f"{db_path}/../daemon.yaml",
+            f"{db_path}/info.yaml",
+            f"{db_path}/cluster.yaml",
+            f"{db_path}/../daemon.yaml",
+            f"{log_path}/*.log",
         ])
+
+        if self.get_option('all_logs'):
+            self.add_copy_spec(f"{log_path}/*.log.*")
 
         queries = [
             {


### PR DESCRIPTION
[microovn] Ensure all logs are collected from microovn

- Add support for collecting the actual microovn log files in `/var/snap/microovn/common/logs/`, which is missing in the current implementation
- The current implementation only collects `journalctl` logs
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [N/A] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [N/A] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
