### PR TITLE
[pam] Capture 'authselect check'

### DIFF
--- a/sos/report/plugins/pam.py
+++ b/sos/report/plugins/pam.py
@@ -43,7 +43,7 @@ class RedHatPam(Pam, RedHatPlugin):
 
     def setup(self):
         super().setup()
-        self.add_cmd_output(["authselect current"])
+        self.add_cmd_output(["authselect current", "authselect check"])
 
 
 class DebianPam(Pam, DebianPlugin, UbuntuPlugin):


### PR DESCRIPTION
Capture 'authselect check' to verify local configuration.

Related: RHEL-166368

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
