### PR TITLE
[logs] Collect complete rsyslog configuration

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -95,12 +95,13 @@ class LogsBase(Plugin):
                     "/run/log/journal/*"
                 ])
 
+        self.add_cmd_output("rsyslogd -N3 -o /dev/stdout",)
+
     def postproc(self):
-        self.do_path_regex_sub(
-            r"/etc/rsyslog*",
-            r"(ActionLibdbiPassword |pwd=)(.*)",
-            r"\1[********]"
-        )
+        regex = r"(ActionLibdbiPassword |pwd=)(.*)"
+        repl = r"\1[********]"
+        self.do_path_regex_sub(r"/etc/rsyslog*", regex, repl)
+        self.do_cmd_output_sub("rsyslogd", regex, repl)
 
 
 class IndependentLogs(LogsBase, IndependentPlugin):


### PR DESCRIPTION
Collect complete rsyslog configuration using "-o fullconf" option and gather syntax verification from "-N3" option

Related: RHEL-155938

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
