### PR TITLE
[Policy] Add os_release_id check

### DIFF
--- a/sos/policies/distros/azure.py
+++ b/sos/policies/distros/azure.py
@@ -13,11 +13,12 @@ from sos.policies.distros.redhat import RedHatPolicy
 
 
 class AzurePolicy(RedHatPolicy):
-    vendor = "Microsoft"
+    vendor = "Microsoft Azure Linux"
     vendor_urls = [
         ('Distribution Website', 'https://github.com/microsoft/azurelinux')
     ]
     os_release_name = 'Azure Linux'
+    os_release_id = 'azurelinux'
     os_release_file = ''
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,


### PR DESCRIPTION
Add additional check introducing os_release_id in azure.py policy.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
