### PR TITLE
[dnf] initial dnf5 support in dnf plugin

### DIFF
--- a/sos/report/plugins/dnf.py
+++ b/sos/report/plugins/dnf.py
@@ -30,7 +30,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
     profiles = ('system', 'packagemanager', 'sysmgmt')
 
     files = ('/etc/dnf/dnf.conf',)
-    packages = ('dnf',)
+    packages = ('dnf', 'dnf5')
 
     option_list = [
         PluginOpt('history-info', default=False,
@@ -51,6 +51,7 @@ class DNFPlugin(Plugin, RedHatPlugin):
                                         tags='dnf_module_info')
 
     def setup(self):
+        has_dnf5 = self.is_installed('dnf5')
 
         self.add_file_tags({
             '/etc/dnf/modules.d/.*.module': 'dnf_modules'
@@ -90,7 +91,10 @@ class DNFPlugin(Plugin, RedHatPlugin):
         self.add_cmd_output('dnf -C repolist',
                             tags=['yum_repolist', 'dnf_repolist'])
 
-        self.add_cmd_output('dnf -C repolist --verbose')
+        if has_dnf5:
+            self.add_cmd_output('dnf repo info')
+        else:
+            self.add_cmd_output('dnf -C repolist --verbose')
 
         self.add_forbidden_path([
             "/etc/pki/entitlement/key.pem",
@@ -103,11 +107,11 @@ class DNFPlugin(Plugin, RedHatPlugin):
             "/etc/pki/entitlement/*.pem"
         ])
 
+        cmd = f"dnf history {'list' if self.is_installed('dnf5') else ''}"
         if not self.get_option("history-info"):
-            self.add_cmd_output("dnf history", tags='dnf_history')
+            self.add_cmd_output(cmd, tags='dnf_history')
         else:
-            history = self.collect_cmd_output("dnf history",
-                                              tags='dnf_history')
+            history = self.collect_cmd_output(cmd, tags='dnf_history')
             transactions = -1
             if history['output']:
                 for line in history['output'].splitlines():
@@ -122,10 +126,11 @@ class DNFPlugin(Plugin, RedHatPlugin):
                                     subdir="history-info",
                                     tags='dnf_history_info')
 
-        # Get list of dnf installed modules and their details.
-        module_cmd = "dnf module list --installed"
-        modules = self.collect_cmd_output(module_cmd)
-        self.get_modules_info(modules['output'])
+        if not has_dnf5:
+            # Get list of dnf installed modules and their details.
+            module_cmd = "dnf module list --installed"
+            modules = self.collect_cmd_output(module_cmd)
+            self.get_modules_info(modules['output'])
 
     def postproc(self):
         # Scrub passwords in repositories and yum/dnf variables


### PR DESCRIPTION
Handling DNF5 changes where legacy dnf commands produce Missing command or Unknown argument errors, while
preserving existing dnf support unchanged.

https://dnf5.readthedocs.io/en/latest/changes_from_dnf4.7.html

Closes: #4308

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
