### PR TITLE
[net_diagram] add plugin for topology visualization

### DIFF
--- a/sos/report/plugins/net_diagram.py
+++ b/sos/report/plugins/net_diagram.py
@@ -1,23 +1,29 @@
-# Copyright (C) 2026 Harshith Hari <ghari@redhat.com>
-# License: GPLv2
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+#
+# Copyright (C) 2026 Harshith Hari <harshithhari000111@gmail.com>
 
 import os
-import subprocess
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class NetDiagram(Plugin, RedHatPlugin):
-    """
-    CEE-Grade Network Topology Visualizer.
-    Generates a DOT graph and PNG image of the network hierarchy.
+class NetDiagram(Plugin, IndependentPlugin):
+    """This plugin generates a visual network topology diagram (PNG) using
+    Graphviz. It maps relationships between physical NICs, Bonds, Bridges,
+    and Team devices to help support engineers visualize complex network
+    hierarchies.
     """
 
     plugin_name = 'net_diagram'
     profiles = ('network',)
     packages = ('graphviz', 'teamd')
 
-    def setup(self):
-        # 1. Initial DOT Graph Header
+    def collect(self):
         dot_lines = [
             "digraph network {",
             "  rankdir=LR; overlap=false; splines=true;",
@@ -26,115 +32,72 @@ class NetDiagram(Plugin, RedHatPlugin):
             "  edge [penwidth=2, color=\"#444444\"];"
         ]
 
-        # 2. Capture IPs using standard subprocess
+        # 1. Map IP Addresses with stacking logic
         ips = {}
-        try:
-            out = subprocess.check_output(
-                ["ip", "-br", "addr"], encoding='utf-8'
-            )
-            for line in out.splitlines():
+        res = self.exec_cmd("ip -br addr")
+        if res['status'] == 0:
+            for line in res['output'].splitlines():
                 parts = line.split()
                 if len(parts) >= 3:
                     ips[parts[0]] = "\\n".join(parts[2:])
-        except (subprocess.SubprocessError, FileNotFoundError):
-            pass
 
-        net_path = "/sys/class/net/"
-        if not os.path.exists(net_path):
-            return
-
-        # 3. Process Interfaces and Relationships
-        for iface in os.listdir(net_path):
-            if iface in ('lo', 'bonding_masters'):
-                continue
-
-            path = os.path.join(net_path, iface)
-            fill = "white"
-
-            if os.path.exists(os.path.join(path, "bridge")):
-                fill = "#ADD8E6"
-            elif os.path.exists(os.path.join(path, "bonding")):
-                fill = "#FFFFE0"
-            elif os.path.islink(os.path.join(path, "device")):
-                fill = "#90EE90"
-            elif "team" in iface:
-                fill = "#FADBD8"
-
-            label = f"{iface}"
-            if iface in ips:
-                label += f"\\n{ips[iface]}"
-
-            dot_lines.append(
-                f'  "{iface}" [label="{label}", fillcolor="{fill}"];'
-            )
-
-            master_link = os.path.join(path, "master")
-            if os.path.islink(master_link):
-                m_name = os.path.basename(os.readlink(master_link))
+        # 2. Identify Default Gateway and create a Cloud node
+        res_gw = self.exec_cmd("ip route show default")
+        if res_gw['status'] == 0 and res_gw['output']:
+            parts = res_gw['output'].split()
+            if 'via' in parts and 'dev' in parts:
+                gw_ip = parts[parts.index('via') + 1]
+                gw_dev = parts[parts.index('dev') + 1]
                 dot_lines.append(
-                    f'  "{iface}" -> "{m_name}" [label="master"];'
+                    f'  "gateway" [label="Gateway\\n{gw_ip}", '
+                    'shape=cloud, fillcolor="#f9f9f9"];'
+                )
+                dot_lines.append(
+                    f'  "{gw_dev}" -> "gateway" [label="default route", '
+                    'color="#27ae60", style=dashed];'
                 )
 
-            proc_bond = f"/proc/net/bonding/{iface}"
-            if os.path.exists(proc_bond):
-                try:
-                    with open(proc_bond, 'r') as f:
-                        for line in f:
-                            if "Slave Interface:" in line:
-                                slave = line.split(":")[1].strip()
-                                dot_lines.append(
-                                    f'  "{slave}" -> "{iface}" '
-                                    f'[style=bold, color=blue];'
-                                )
-                except (IOError, OSError):
-                    pass
+        # 3. Build Topology from Sysfs relationships using Plugin API
+        net_path = self.path_join("/sys", "class", "net")
+        # Use self.path_exists and self.listdir for sysroot compliance
+        if self.path_exists(net_path):
+            for iface in self.listdir(net_path):
+                if iface in ('lo', 'bonding_masters'):
+                    continue
 
-        # 4. Gateway Detection
-        try:
-            route_out = subprocess.check_output(
-                ["ip", "route", "show"], encoding='utf-8'
-            )
-            for line in route_out.splitlines():
-                if "default via" in line:
-                    p = line.split()
-                    gw_ip = p[p.index("via") + 1]
-                    gw_dev = p[p.index("dev") + 1]
+                path = self.path_join(net_path, iface)
+                fill = "white"
+
+                if self.path_exists(self.path_join(path, "bridge")):
+                    fill = "#ADD8E6"
+                elif self.path_exists(self.path_join(path, "bonding")):
+                    fill = "#FFFFE0"
+                elif self.path_exists(self.path_join(path, "device")):
+                    fill = "#90EE90"
+                elif "team" in iface:
+                    fill = "#FADBD8"
+
+                label = f"{iface}"
+                if iface in ips:
+                    label += f"\\n{ips[iface]}"
+
+                dot_lines.append(
+                    f'  "{iface}" [label="{label}", fillcolor="{fill}"];'
+                )
+
+                master_link = self.path_join(path, "master")
+                # For readlink, we still use os as Plugin doesn't wrap it
+                if os.path.islink(master_link):
+                    m_name = os.path.basename(os.readlink(master_link))
                     dot_lines.append(
-                        f'  "gw" [label="GW\\n{gw_ip}", shape=doublecircle, '
-                        f'fillcolor="#98FB98"];'
+                        f'  "{iface}" -> "{m_name}" [label="master"];'
                     )
-                    dot_lines.append(
-                        f'  "{gw_dev}" -> "gw" [color=red, style=dashed, '
-                        f'label="default"];'
-                    )
-                    break
-        except (subprocess.SubprocessError, ValueError, IndexError):
-            pass
 
         dot_lines.append("}")
-        dot_str = "\n".join(dot_lines)
 
-        # 5. Save and Render (Using the safe add_string_as_file)
-        self.add_string_as_file(dot_str, "topology.dot")
+        with self.collection_file("network_topology.dot") as dotf:
+            dotf.write("\n".join(dot_lines))
+            dot_path = dotf.name
 
-        # Create temporary files in /tmp with fixed names for rendering
-        tmp_dot = "/tmp/sos_net.dot"
-        tmp_png = "/tmp/sos_net.png"
-
-        try:
-            with open(tmp_dot, "w") as f:
-                f.write(dot_str)
-            # Use subprocess to run graphviz
-            subprocess.run(
-                ["dot", "-Tpng", tmp_dot, "-o", tmp_png], check=True
-            )
-            # Pull the PNG into the report
-            self.add_copy_spec(tmp_png)
-        except (subprocess.SubprocessError, IOError):
-            pass
-
-    def postproc(self):
-        # Cleanup the /tmp files after SOS finishes
-        for f in ["/tmp/sos_net.dot", "/tmp/sos_net.png"]:
-            if os.path.exists(f):
-                os.remove(f)
+        png_path = dot_path.replace(".dot", ".png")
+        self.exec_cmd(f"dot -Tpng {dot_path} -o {png_path}")

--- a/sos/report/plugins/net_diagram.py
+++ b/sos/report/plugins/net_diagram.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2026 Harshith Hari <ghari@redhat.com>
+# License: GPLv2
+
+import os
+import subprocess
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class NetDiagram(Plugin, RedHatPlugin):
+    """
+    CEE-Grade Network Topology Visualizer.
+    Generates a DOT graph and PNG image of the network hierarchy.
+    """
+
+    plugin_name = 'net_diagram'
+    profiles = ('network',)
+    packages = ('graphviz', 'teamd')
+
+    def setup(self):
+        # 1. Initial DOT Graph Header
+        dot_lines = [
+            "digraph network {",
+            "  rankdir=LR; overlap=false; splines=true;",
+            "  node [shape=box, style=filled, fontname=\"Arial\", "
+            "fontsize=10];",
+            "  edge [penwidth=2, color=\"#444444\"];"
+        ]
+
+        # 2. Capture IPs using standard subprocess
+        ips = {}
+        try:
+            out = subprocess.check_output(
+                ["ip", "-br", "addr"], encoding='utf-8'
+            )
+            for line in out.splitlines():
+                parts = line.split()
+                if len(parts) >= 3:
+                    ips[parts[0]] = "\\n".join(parts[2:])
+        except (subprocess.SubprocessError, FileNotFoundError):
+            pass
+
+        net_path = "/sys/class/net/"
+        if not os.path.exists(net_path):
+            return
+
+        # 3. Process Interfaces and Relationships
+        for iface in os.listdir(net_path):
+            if iface in ('lo', 'bonding_masters'):
+                continue
+
+            path = os.path.join(net_path, iface)
+            fill = "white"
+
+            if os.path.exists(os.path.join(path, "bridge")):
+                fill = "#ADD8E6"
+            elif os.path.exists(os.path.join(path, "bonding")):
+                fill = "#FFFFE0"
+            elif os.path.islink(os.path.join(path, "device")):
+                fill = "#90EE90"
+            elif "team" in iface:
+                fill = "#FADBD8"
+
+            label = f"{iface}"
+            if iface in ips:
+                label += f"\\n{ips[iface]}"
+
+            dot_lines.append(
+                f'  "{iface}" [label="{label}", fillcolor="{fill}"];'
+            )
+
+            master_link = os.path.join(path, "master")
+            if os.path.islink(master_link):
+                m_name = os.path.basename(os.readlink(master_link))
+                dot_lines.append(
+                    f'  "{iface}" -> "{m_name}" [label="master"];'
+                )
+
+            proc_bond = f"/proc/net/bonding/{iface}"
+            if os.path.exists(proc_bond):
+                try:
+                    with open(proc_bond, 'r') as f:
+                        for line in f:
+                            if "Slave Interface:" in line:
+                                slave = line.split(":")[1].strip()
+                                dot_lines.append(
+                                    f'  "{slave}" -> "{iface}" '
+                                    f'[style=bold, color=blue];'
+                                )
+                except (IOError, OSError):
+                    pass
+
+        # 4. Gateway Detection
+        try:
+            route_out = subprocess.check_output(
+                ["ip", "route", "show"], encoding='utf-8'
+            )
+            for line in route_out.splitlines():
+                if "default via" in line:
+                    p = line.split()
+                    gw_ip = p[p.index("via") + 1]
+                    gw_dev = p[p.index("dev") + 1]
+                    dot_lines.append(
+                        f'  "gw" [label="GW\\n{gw_ip}", shape=doublecircle, '
+                        f'fillcolor="#98FB98"];'
+                    )
+                    dot_lines.append(
+                        f'  "{gw_dev}" -> "gw" [color=red, style=dashed, '
+                        f'label="default"];'
+                    )
+                    break
+        except (subprocess.SubprocessError, ValueError, IndexError):
+            pass
+
+        dot_lines.append("}")
+        dot_str = "\n".join(dot_lines)
+
+        # 5. Save and Render (Using the safe add_string_as_file)
+        self.add_string_as_file(dot_str, "topology.dot")
+
+        # Create temporary files in /tmp with fixed names for rendering
+        tmp_dot = "/tmp/sos_net.dot"
+        tmp_png = "/tmp/sos_net.png"
+
+        try:
+            with open(tmp_dot, "w") as f:
+                f.write(dot_str)
+            # Use subprocess to run graphviz
+            subprocess.run(
+                ["dot", "-Tpng", tmp_dot, "-o", tmp_png], check=True
+            )
+            # Pull the PNG into the report
+            self.add_copy_spec(tmp_png)
+        except (subprocess.SubprocessError, IOError):
+            pass
+
+    def postproc(self):
+        # Cleanup the /tmp files after SOS finishes
+        for f in ["/tmp/sos_net.dot", "/tmp/sos_net.png"]:
+            if os.path.exists(f):
+                os.remove(f)


### PR DESCRIPTION
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[net_diagram]**?
- [X] Does the commit contain a **Signed-off-by: Harshith Hari <harshithhari000111@.gmail.com>**?
- [X] Are all passwords or private data gathered by this PR obfuscated?

---

Problem:
On systems with a high number of interfaces, the standard ip a output is overwhelming. It is difficult to visualize the relationships between interfaces and trace network flow.

Solution:
The net_diagram plugin automates the generation of a topology map. It helps create a clear and understandable network diagram.

