### PR TITLE
fix(cloud_init): add cloud-init-main and cloud-init-network service names

### DIFF
--- a/sos/report/plugins/cloud_init.py
+++ b/sos/report/plugins/cloud_init.py
@@ -17,7 +17,7 @@ class CloudInit(Plugin, IndependentPlugin):
 
     plugin_name = 'cloud_init'
     packages = ('cloud-init',)
-    services = ('cloud-init',)
+    services = ('cloud-init', 'cloud-init-main', 'cloud-init-network')
 
     def setup(self):
 


### PR DESCRIPTION
cloud-init 24.3 introduced a "single process optimization" ([canonical/cloud-init#5489](https://github.com/canonical/cloud-init/pull/5489), merged Aug 2, 2024) that renamed `cloud-init.service` to `cloud-init-network.service` and added a new `cloud-init-main.service` as the primary single-process service.

Distros shipping cloud-init >= 24.3 no longer have a `cloud-init.service` unit. The sos `cloud_init` plugin only listed `cloud-init.service`, so it failed to collect service status and journal logs for the new service names on these distros.

## Fix

Adding `cloud-init-main` and `cloud-init-network` to the `services` tuple is backward-compatible: sos will simply skip services that do not exist on a given system.

## References

- https://github.com/canonical/cloud-init/pull/5489
- https://github.com/canonical/cloud-init/commit/143bc9e40f7f33695216db60f73e10a900d1d1cd
- https://discourse.ubuntu.com/t/announcement-cloud-init-perfomance-optimization-single-process/47505