### PR TITLE
suse: add SLESPolicy and fix OpenSuSEPolicy detection

### DIFF
--- a/sos/policies/distros/suse.py
+++ b/sos/policies/distros/suse.py
@@ -61,8 +61,8 @@ class SuSEPolicy(LinuxPolicy):
 class OpenSuSEPolicy(SuSEPolicy):
     vendor = "SuSE"
     vendor_urls = [('Community Website', 'https://www.opensuse.org/')]
-    os_release_name = "OpenSuSE"
-    os_release_file = '/etc/SUSE-brand'
+    os_release_name = "openSUSE Leap"
+    os_release_id = "opensuse-leap"
     msg = _("""\
 This command will collect diagnostic and configuration \
 information from this %(os_release_name)s system and installed \
@@ -76,10 +76,31 @@ No changes will be made to system configuration.
 %(vendor_text)s
 """)
 
-    def __init__(self, sysroot=None, init=None, probe_runtime=True,
-                 remote_exec=None):
-        super().__init__(sysroot=sysroot, init=init,
-                         probe_runtime=probe_runtime,
-                         remote_exec=remote_exec)
+    @classmethod
+    def check(cls, remote=''):
+        return LinuxPolicy.check.__func__(cls, remote)
+
+
+class SLESPolicy(SuSEPolicy):
+    vendor = "SUSE"
+    vendor_urls = [('Distribution Website', 'https://www.suse.com/')]
+    os_release_name = "SLES"
+    os_release_id = "sles"
+    msg = _("""\
+This command will collect diagnostic and configuration \
+information from this %(os_release_name)s system and installed \
+applications.
+
+An archive containing the collected information will be \
+generated in %(tmpdir)s and may be provided to a %(vendor)s \
+support representative.
+
+No changes will be made to system configuration.
+%(vendor_text)s
+""")
+
+    @classmethod
+    def check(cls, remote=''):
+        return LinuxPolicy.check.__func__(cls, remote)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
  SuSEPolicy.check() always returns False, requiring concrete subclasses
  to override it. OpenSuSEPolicy never did, and no SLESPolicy existed,
  so both openSUSE and SLES systems fell back to GenericLinuxPolicy which
  uses a no-op PackageManager with an empty package dict. This caused all
  package-gated plugins (rdma, roce, infiniband, etc.) to show as inactive
  regardless of what was installed.

  Add SLESPolicy with os_release_name/os_release_id matching SLES
  /etc/os-release values, and fix OpenSuSEPolicy to override check() via
  LinuxPolicy.check() so both policies are correctly detected and
  RpmPackageManager is used for package lookups.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
