### PR TITLE
[cleaner] Fix short hostname obfuscation

### DIFF
--- a/sos/cleaner/preppers/hostname.py
+++ b/sos/cleaner/preppers/hostname.py
@@ -50,12 +50,17 @@ class HostnamePrepper(SoSPrepper):
         for line in _hosts.splitlines():
             if line.startswith('#') or 'localhost' in line:
                 continue
+            # strip inline comments before processing
+            line = line.split('#')[0].strip()
+            if not line:
+                continue
             hostln = line.split()[1:]
             for host in hostln:
                 if len(host.split('.')) == 1:
                     self.regex_items['hostname'].add(host)
-                else:
-                    items.append(host)
+                # unconditionally append host to items to avoid
+                # missing short hostnames like 'my-computer'
+                items.append(host)
 
         for domain in self.opts.domains:
             items.append(domain)

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -358,6 +358,88 @@ class PrepperTests(unittest.TestCase):
             self.host_prepper.get_items_for_map('hostname', self.archive)
         )
 
+    def test_hostname_prepper_etc_hosts_short_name_in_items(self):
+        """Short hostnames from /etc/hosts must appear in items so that
+        mapping.add() is called and self.hosts is populated, allowing proper
+        obfuscation."""
+        class MockArchive:
+            is_sos = True
+            is_insights = False
+
+            def get_file_content(self, path):
+                if path == 'sos_commands/host/hostname_-f':
+                    return 'myhost.example.com'
+                if path == 'etc/hosts':
+                    return ('192.168.1.100 other.example.com otherhost\n'
+                            '10.0.0.1 shortonly\n')
+                return ''
+
+        items = self.host_prepper.get_items_for_map('hostname', MockArchive())
+        self.assertIn('otherhost', items,
+                      'Short hostname from /etc/hosts must be in items')
+        self.assertIn('shortonly', items,
+                      'Short-name-only /etc/hosts entry must be in items')
+
+    def test_hostname_prepper_etc_hosts_short_name_obfuscated(self):
+        """Verify that short hostnames added from /etc/hosts are actually
+        obfuscated during file parsing."""
+        workdir = join(sos.policies.load().get_tmp_dir(None),
+                       'sos_avocado_testing')
+
+        class MockArchive:
+            is_sos = True
+            is_insights = False
+
+            def get_file_content(self, path):
+                if path == 'sos_commands/host/hostname_-f':
+                    return 'myhost.example.com'
+                if path == 'etc/hosts':
+                    return '10.0.0.1 shortonly\n'
+                return ''
+
+        prepper = HostnamePrepper(SoSOptions(domains=[]))
+        items = prepper.get_items_for_map('hostname', MockArchive())
+        parser = SoSHostnameParser(config={}, workdir=workdir)
+        for item in items:
+            parser.mapping.add(item)
+        for ritem in prepper.regex_items['hostname']:
+            parser.mapping.add_regex_item(ritem)
+        parser.generate_item_regexes()
+
+        line = 'connected to shortonly for configuration'
+        result = parser.parse_line(line)[0]
+        self.assertNotEqual(line, result,
+                            'Short hostname from /etc/hosts was not '
+                            'obfuscated')
+        self.assertNotIn('shortonly', result,
+                         'shortonly still present after obfuscation')
+
+    def test_hostname_prepper_etc_hosts_inline_comment_stripped(self):
+        """Inline comments in /etc/hosts lines must not be treated as
+        hostnames."""
+        class MockArchive:
+            is_sos = True
+            is_insights = False
+
+            def get_file_content(self, path):
+                if path == 'sos_commands/host/hostname_-f':
+                    return 'myhost.example.com'
+                if path == 'etc/hosts':
+                    return '192.168.1.100 otherhost # production server\n'
+                return ''
+
+        items = self.host_prepper.get_items_for_map('hostname', MockArchive())
+        self.assertNotIn('production', items,
+                         'Comment word "production" must not be treated as a '
+                         'hostname')
+        self.assertNotIn('server', items,
+                         'Comment word "server" must not be treated as a '
+                         'hostname')
+        self.assertNotIn('production',
+                         self.host_prepper.regex_items['hostname'],
+                         'Comment word "production" must not be in '
+                         'regex_items')
+
     def test_ipv4_prepper_parser_files(self):
         self.assertEqual(
             ['sos_commands/networking/ip_-o_addr'],


### PR DESCRIPTION
Any hostname in /etc/hosts/ not in FQDN format, such as 'my-computer', was being missed by sos clean in /etc/hosts.

Modify control flow in sos/cleaner/preppers/hostname.py to strip trailing comments (denoted by '#') and unconditionally add remaining lines in /etc/hosts to the 'items' list, allowing the hostnames within the lines to be obfuscated.

Add unit tests for short hostname obfuscation. The new unit tests avoid modifying the existing test archive by declaring some mock objects, but I can submit a revision if desired.

Closes: https://github.com/sosreport/sos/issues/3388
Assisted-by: Copilot:claude-sonnet-4.6 <github.com/features/copilot>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
