### PR TITLE
[cloud_init] Add missing systemd service units

### DIFF
--- a/sos/report/plugins/cloud_init.py
+++ b/sos/report/plugins/cloud_init.py
@@ -17,7 +17,8 @@ class CloudInit(Plugin, IndependentPlugin):
 
     plugin_name = 'cloud_init'
     packages = ('cloud-init',)
-    services = ('cloud-init', 'cloud-init-main', 'cloud-init-network')
+    services = ('cloud-init', 'cloud-init-local', 'cloud-init-network',
+                'cloud-init-main', 'cloud-config', 'cloud-final')
 
     def setup(self):
 


### PR DESCRIPTION
Add cloud-init-local, cloud-config, and cloud-final to the services tuple so sos report captures their status alongside the existing cloud-init, cloud-init-main, and cloud-init-network units.

As of cloud-init 24.3, cloud-init uses a single-process optimization with multiple systemd service units acting as shims for each boot stage (see canonical/cloud-init#5489):

- cloud-init-local.service — Local stage
- cloud-init-network.service — Network stage (renamed from cloud-init.service)
- cloud-config.service — Config stage
- cloud-final.service — Final stage
- cloud-init-main.service — Main single-process service

Previously only cloud-init, cloud-init-main, and cloud-init-network were listed, missing the local, config, and final stage services.