### PR TITLE
Include OCP node role and cluster name in RHCOS archive name

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -8,6 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import json
 import os
 import sys
 import re
@@ -334,6 +335,129 @@ support representative.
         # As of the creation of this policy, RHCOS is only available for
         # RH OCP environments.
         return self.find_preset(RHOCP)
+
+    def _get_node_role(self):
+        """Determine the OCP node role from the machine-config-daemon
+        currentconfig file on the host filesystem.
+
+        Checks in order: the ``machineconfiguration.openshift.io/role``
+        label, the owning MachineConfigPool name from
+        ``ownerReferences``, and finally the rendered config name
+        (format ``rendered-<role>-<hash>``).
+
+        :returns: The node role (e.g. 'master', 'worker') or empty string
+        :rtype: ``str``
+        """
+        config_path = self.join_sysroot(
+            '/etc/machine-config-daemon/currentconfig'
+        )
+        try:
+            with open(config_path, 'r', encoding='utf-8') as cfile:
+                config = json.load(cfile)
+            metadata = config.get('metadata', {})
+            role = metadata.get('labels', {}).get(
+                'machineconfiguration.openshift.io/role', ''
+            )
+            if not role:
+                owners = metadata.get('ownerReferences', [])
+                for ref in owners:
+                    if ref.get('kind') == 'MachineConfigPool':
+                        role = ref.get('name', '')
+                        break
+            if not role:
+                name = metadata.get('name', '')
+                if name.startswith('rendered-'):
+                    parts = name.split('-', 2)
+                    if len(parts) >= 2:
+                        role = parts[1]
+            if role:
+                self.soslog.debug(f"OCP node role detected: {role}")
+            return role
+        except (IOError, ValueError, KeyError) as err:
+            self.soslog.debug(
+                f"Unable to determine OCP node role: {err}"
+            )
+            return ''
+
+    def _get_cluster_name(self):
+        """Determine the OCP cluster name from the node kubeconfig
+        or the node's hostname.
+
+        Tries to extract the cluster name from the API server URL in
+        ``/etc/kubernetes/kubeconfig`` first (format
+        ``https://api-int.<clustername>.<basedomain>:6443`` or
+        ``https://api.<clustername>.<basedomain>:6443``). Falls back
+        to parsing the hostname if the kubeconfig is unavailable.
+
+        :returns: The cluster name or empty string
+        :rtype: ``str``
+        """
+        kubeconfig = self.join_sysroot(
+            '/etc/kubernetes/kubeconfig'
+        )
+        try:
+            with open(kubeconfig, 'r', encoding='utf-8') as kfile:
+                for line in kfile:
+                    match = re.search(
+                        r'server:\s*https://api(?:-int)?\.([^.:]+)\.', line
+                    )
+                    if match:
+                        cluster = match.group(1)
+                        self.soslog.debug(
+                            f"OCP cluster name from kubeconfig: "
+                            f"{cluster}"
+                        )
+                        return cluster
+        except IOError as err:
+            self.soslog.debug(
+                f"Unable to read kubeconfig: {err}"
+            )
+
+        hostname = self.host_name()
+        parts = hostname.split('.')
+        if len(parts) >= 2:
+            self.soslog.debug(
+                f"OCP cluster name from hostname: {parts[1]}"
+            )
+            return parts[1]
+        return ''
+
+    def get_archive_name(self):
+        """Override archive naming to include OCP node role and cluster
+        name when available on RHCOS systems.
+
+        Prepends the detected role and cluster name to the label field
+        and delegates to the parent implementation. This avoids
+        duplicating the archive name formatting logic.
+
+        :returns: A name to be used for the archive
+        :rtype: ``str``
+        """
+        role = self._get_node_role()
+        cluster = self._get_cluster_name()
+
+        if not role and not cluster:
+            return super().get_archive_name()
+
+        ocp_context = ''
+        if role:
+            ocp_context = role
+        if cluster:
+            ocp_context += ('-' + cluster if ocp_context else cluster)
+
+        opts = self.commons['cmdlineopts']
+        original_label = opts.label
+        if original_label:
+            opts.label = f"{ocp_context}-{original_label}"
+        else:
+            opts.label = ocp_context
+
+        try:
+            archive_name = super().get_archive_name()
+        finally:
+            opts.label = original_label
+
+        return archive_name
 
     def create_sos_container(self, image=None, auth=None, force_pull=False):
         _image = image or self.container_image

--- a/tests/unittests/policy_tests.py
+++ b/tests/unittests/policy_tests.py
@@ -5,12 +5,16 @@
 # version 2 of the GNU General Public License.
 #
 # See the LICENSE file in the source distribution for further information.
+import json
+import logging
 import unittest
+from unittest.mock import patch, mock_open, MagicMock
 
 from avocado.utils import distro
 
 from sos.policies import Policy, import_policy
 from sos.policies.distros import LinuxPolicy
+from sos.policies.distros.redhat import RedHatCoreOSPolicy
 from sos.policies.package_managers import PackageManager, MultiPackageManager
 from sos.policies.package_managers.rpm import RpmPackageManager
 from sos.policies.package_managers.dpkg import DpkgPackageManager
@@ -160,6 +164,173 @@ class MultiPackageManagerTests(unittest.TestCase):
             self.assertEqual(kpkg['pkg_manager'], 'dpkg')
         else:
             self.assertEqual(kpkg['pkg_manager'], 'rpm')
+
+
+class RedHatCoreOSArchiveNameTests(unittest.TestCase):
+
+    def _make_policy(self, hostname='master-0.mycluster.example.com'):
+        policy = RedHatCoreOSPolicy.__new__(RedHatCoreOSPolicy)
+        policy.hostname = hostname
+        policy.sysroot = '/host'
+        policy.soslog = logging.getLogger('test')
+        return policy
+
+    def _make_currentconfig(self, role):
+        return json.dumps({
+            'metadata': {
+                'labels': {
+                    'machineconfiguration.openshift.io/role': role
+                }
+            }
+        })
+
+    def _make_kubeconfig(self, cluster='mycluster', domain='example.com',
+                         api_prefix='api-int'):
+        return (
+            "apiVersion: v1\n"
+            "clusters:\n"
+            "- cluster:\n"
+            f"    server: https://{api_prefix}.{cluster}.{domain}:6443\n"
+            f"  name: {cluster}\n"
+        )
+
+    # _get_node_role tests
+
+    def test_get_node_role_master(self):
+        policy = self._make_policy()
+        config = self._make_currentconfig('master')
+        with patch('builtins.open', mock_open(read_data=config)):
+            self.assertEqual(policy._get_node_role(), 'master')
+
+    def test_get_node_role_worker(self):
+        policy = self._make_policy()
+        config = self._make_currentconfig('worker')
+        with patch('builtins.open', mock_open(read_data=config)):
+            self.assertEqual(policy._get_node_role(), 'worker')
+
+    def test_get_node_role_missing_file(self):
+        policy = self._make_policy()
+        with patch('builtins.open', side_effect=IOError):
+            self.assertEqual(policy._get_node_role(), '')
+
+    def test_get_node_role_bad_json(self):
+        policy = self._make_policy()
+        with patch('builtins.open', mock_open(read_data='not json')):
+            self.assertEqual(policy._get_node_role(), '')
+
+    def test_get_node_role_from_owner_reference(self):
+        policy = self._make_policy()
+        config = json.dumps({
+            'metadata': {
+                'labels': {},
+                'name': 'rendered-master-abc123',
+                'ownerReferences': [{
+                    'kind': 'MachineConfigPool',
+                    'name': 'master'
+                }]
+            }
+        })
+        with patch('builtins.open', mock_open(read_data=config)):
+            self.assertEqual(policy._get_node_role(), 'master')
+
+    def test_get_node_role_from_rendered_name(self):
+        policy = self._make_policy()
+        config = json.dumps({
+            'metadata': {
+                'name': 'rendered-worker-abc123'
+            }
+        })
+        with patch('builtins.open', mock_open(read_data=config)):
+            self.assertEqual(policy._get_node_role(), 'worker')
+
+    def test_get_node_role_no_label_no_owner_no_name(self):
+        policy = self._make_policy()
+        config = json.dumps({'metadata': {}})
+        with patch('builtins.open', mock_open(read_data=config)):
+            self.assertEqual(policy._get_node_role(), '')
+
+    # _get_cluster_name tests
+
+    def test_get_cluster_name_from_kubeconfig(self):
+        policy = self._make_policy('master-0.mycluster.example.com')
+        kubeconfig = self._make_kubeconfig('mycluster')
+        with patch('builtins.open', mock_open(read_data=kubeconfig)):
+            self.assertEqual(policy._get_cluster_name(), 'mycluster')
+
+    def test_get_cluster_name_from_kubeconfig_api_prefix(self):
+        policy = self._make_policy('master-0.mycluster.example.com')
+        kubeconfig = self._make_kubeconfig('mycluster', api_prefix='api')
+        with patch('builtins.open', mock_open(read_data=kubeconfig)):
+            self.assertEqual(policy._get_cluster_name(), 'mycluster')
+
+    def test_get_cluster_name_kubeconfig_missing_falls_back_to_hostname(self):
+        policy = self._make_policy('master-0.mycluster.example.com')
+        with patch('builtins.open', side_effect=IOError):
+            self.assertEqual(policy._get_cluster_name(), 'mycluster')
+
+    def test_get_cluster_name_short_hostname(self):
+        policy = self._make_policy('master-0')
+        with patch('builtins.open', side_effect=IOError):
+            self.assertEqual(policy._get_cluster_name(), '')
+
+    def test_get_cluster_name_complex_fqdn(self):
+        policy = self._make_policy('worker-1.prod-cluster.dc1.example.com')
+        with patch('builtins.open', side_effect=IOError):
+            self.assertEqual(policy._get_cluster_name(), 'prod-cluster')
+
+    # get_archive_name tests
+
+    def _make_policy_for_archive(
+            self, hostname='master-0.mycluster.example.com',
+            label='', case_id=''):
+        policy = self._make_policy(hostname)
+        policy.name_pattern = 'friendly'
+        policy.case_id = case_id
+        opts = MagicMock()
+        opts.label = label
+        policy.commons = {'cmdlineopts': opts}
+        return policy
+
+    def test_archive_name_includes_role_and_cluster(self):
+        policy = self._make_policy_for_archive()
+        with patch.object(policy, '_get_node_role', return_value='master'), \
+             patch.object(policy, '_get_cluster_name',
+                          return_value='mycluster'):
+            name = policy.get_archive_name()
+        self.assertTrue(name.startswith('sosreport-master-0-'))
+        self.assertIn('master-mycluster', name)
+
+    def test_archive_name_preserves_user_label(self):
+        policy = self._make_policy_for_archive(label='debug')
+        with patch.object(policy, '_get_node_role', return_value='worker'), \
+             patch.object(policy, '_get_cluster_name',
+                          return_value='prod'):
+            name = policy.get_archive_name()
+        self.assertIn('worker-prod-debug', name)
+
+    def test_archive_name_role_only(self):
+        policy = self._make_policy_for_archive()
+        with patch.object(policy, '_get_node_role', return_value='master'), \
+             patch.object(policy, '_get_cluster_name', return_value=''):
+            name = policy.get_archive_name()
+        self.assertIn('-master-', name)
+        self.assertNotIn('mycluster', name)
+
+    def test_archive_name_fallback_when_nothing_detected(self):
+        policy = self._make_policy_for_archive()
+        with patch.object(policy, '_get_node_role', return_value=''), \
+             patch.object(policy, '_get_cluster_name', return_value=''):
+            name = policy.get_archive_name()
+        self.assertTrue(name.startswith('sosreport-master-0-'))
+        self.assertNotIn('master-master', name)
+
+    def test_archive_name_restores_original_label(self):
+        policy = self._make_policy_for_archive(label='original')
+        with patch.object(policy, '_get_node_role', return_value='master'), \
+             patch.object(policy, '_get_cluster_name',
+                          return_value='mycluster'):
+            policy.get_archive_name()
+        self.assertEqual(policy.commons['cmdlineopts'].label, 'original')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When `sos report` runs standalone on an RHCOS node, the archive name only contains the short hostname (e.g. `sosreport-master-0-2026-05-06-abcdefg.tar.xz`). In customer environments where a single bastion host is used to collect sosreports from multiple OpenShift clusters, archives from nodes with similar hostnames across clusters are indistinguishable without extraction.

This PR overrides `get_archive_name()` in `RedHatCoreOSPolicy` to include the OCP node role and cluster name in the archive name when running on RHCOS:

**Before:** `sosreport-master-0-2026-05-06-abcdefg.tar.xz`
**After:** `sosreport-master-0-master-mycluster-2026-05-06-abcdefg.tar.xz`

### How it works

- **Node role** is detected from `/etc/machine-config-daemon/currentconfig` using three fallbacks in order:
  1. The `machineconfiguration.openshift.io/role` label
  2. The owning `MachineConfigPool` name from `ownerReferences`
  3. The rendered config name (format `rendered-<role>-<hash>`)

  Testing on a live RHCOS 9.6 node showed the label is not always present — the `ownerReferences` fallback was needed to detect the role.

- **Cluster name** is extracted from `/etc/kubernetes/kubeconfig` by parsing the API server URL (`https://api-int.<clustername>.<basedomain>:6443` or `https://api.<clustername>.<basedomain>:6443`). Falls back to hostname parsing (`<role>-<index>.<clustername>.<basedomain>`) if the kubeconfig is unavailable.

- The detected role and cluster name are prepended to the `--label` field, delegating all archive name formatting to the parent `get_archive_name()` to avoid duplicating logic.
- No API access needed — all values come from local filesystem
- Falls back to standard naming when neither value is available
- Existing `--label` and `--case-id` options continue to work as before

Note: `sos collect` already handles node role labeling via the `ocp` cluster profile's `set_node_label()`, but that only works through the collector. This change bridges the gap for standalone `sos report` runs.

## Test plan

- [x] All existing unit tests pass (32 passed, 2 skipped)
- [x] Added 16 new unit tests covering:
  - `_get_node_role()`: label detection, ownerReferences fallback, rendered name fallback, missing file, bad JSON, empty metadata
  - `_get_cluster_name()`: extraction from kubeconfig (`api-int` and `api` prefixes), fallback to hostname, short hostname, complex FQDN
  - `get_archive_name()`: end-to-end with role+cluster, user label preservation, role-only, fallback, label restoration
- [x] Verified on a live RHCOS 9.6 (OCP 4.21) master node — role detected as `master` via ownerReferences, cluster name `sharedocp421` from kubeconfig
- [ ] Manual verification with full `sos report` run on an RHCOS node

RFE: https://redhat.atlassian.net/browse/RFE-9249