### PR TITLE
[azure] Update Azure IMDS API version to 2025-04-07

### DIFF
--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -43,7 +43,7 @@ class Azure(Plugin, UbuntuPlugin):
         self.add_cmd_output((
             'curl -s -H Metadata:true --noproxy "*" '
             '"http://169.254.169.254/metadata/instance/compute?'
-            'api-version=2023-07-01&format=json"'
+            'api-version=2025-04-07&format=json"'
         ), suggest_filename='instance_metadata.json')
 
 


### PR DESCRIPTION
Update the Azure Instance Metadata Service API version from 2023-07-01 to 2025-04-07, which is the latest supported version as documented at:
https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service

This brings access to newer fields such as `physicalZone` (introduced in 2023-11-15) and aligns with Microsoft's current recommended API version.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?