### PR TITLE
[azure] Refactor IMDS collection with pretty-printed JSON

### DIFF
--- a/sos/report/plugins/azure.py
+++ b/sos/report/plugins/azure.py
@@ -9,8 +9,16 @@
 # See the LICENSE file in the source distribution for further information.
 
 import glob
+import json
 import os
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
 from sos.report.plugins import Plugin, UbuntuPlugin, RedHatPlugin
+
+
+IMDS_URL = ("http://169.254.169.254/metadata/instance?"
+            "api-version=2025-04-07&format=json")
 
 
 class Azure(Plugin, UbuntuPlugin):
@@ -41,11 +49,28 @@ class Azure(Plugin, UbuntuPlugin):
             for name in files:
                 self.add_copy_spec(self.path_join(path, name), sizelimit=limit)
 
-        self.add_cmd_output((
-            'curl -s -H Metadata:true --noproxy "*" '
-            '"http://169.254.169.254/metadata/instance/compute?'
-            'api-version=2023-07-01&format=json"'
-        ), suggest_filename='instance_metadata.json')
+    def collect(self):
+        with self.collection_file('instance_metadata.json') as mfile:
+            try:
+                metadata = self._get_imds_metadata()
+                mfile.write(json.dumps(metadata, indent=4))
+            except RuntimeError as err:
+                mfile.write(str(err))
+
+    @staticmethod
+    def _get_imds_metadata():
+        """Retrieve instance metadata from the Azure IMDS endpoint."""
+        try:
+            req = Request(IMDS_URL, headers={'Metadata': 'true'})
+            with urlopen(req, timeout=5) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(
+                        f"IMDS returned HTTP {resp.status}: "
+                        + resp.read().decode())
+                return json.loads(resp.read().decode())
+        except URLError as err:
+            raise RuntimeError(
+                "Failed to query Azure IMDS: " + str(err)) from err
 
 
 class RedHatAzure(Azure, RedHatPlugin):


### PR DESCRIPTION
Replace the curl-based IMDS metadata collection with a Python-based approach using `urllib`. This produces pretty-printed JSON output (4-space indentation) for improved readability in the sos report, matching the pattern used by the GCP plugin.

Update the IMDS API version from `2023-07-01` to `2025-04-07`, the latest supported version as documented at:
https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service

Collect the full instance metadata (`/metadata/instance`) instead of only `/metadata/instance/compute`, which now also includes network information.

Tested on RHEL 8.10, 9.7, 10.1, and SAP-HA 8.10 Azure VMs.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?