### PR TITLE
[apache] Skip collecting access logs of foreman_proxy plugin

### DIFF
--- a/sos/report/plugins/apache.py
+++ b/sos/report/plugins/apache.py
@@ -58,7 +58,9 @@ class Apache(Plugin):
             'nova',
             'octavia',
             'placement',
-            'pulp'
+            'pulp',
+            'katello-reverse-proxy',
+            'rhsm-pulpcore',
         ]
         self.add_forbidden_path([
             f"/var/log/{self.apachepkg}*/{sub}*" for sub in subdirs


### PR DESCRIPTION
katello-reverse-proxy* and rhsm-pulpcore-https-* are collected by foreman_proxy plugin, skip it here.

Closes: #4324

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
