### PR TITLE
[generic] Add '--version' flag

### DIFF
--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -93,6 +93,10 @@ class SoS():
         epilog = "See `sos <component> --help` for more information"
         self.parser = ArgumentParser(usage=usage_string, epilog=epilog)
         self.parser.register('action', 'extend', SosListOption)
+        self.parser.add_argument(
+            '--version', action='version',
+            version=f"sos version {__version__}"
+        )
         # set the component subparsers
         self.subparsers = self.parser.add_subparsers(
             dest='component',


### PR DESCRIPTION
Add a '--version' flag to sos so that users can find which version of sos they are running without needing to run 'sos report'.

Assisted-by: Copilot:claude-sonnet-4.6 <github.com/features/copilot>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
