### PR TITLE
fix: merge skip_plugins from config and cmdline instead of replacing

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -254,6 +254,8 @@ class SoSComponent():
                     oplugopts = [oopt for oopt in oplugopts
                                  if not oopt.startswith(cstring)]
                 setattr(opts, opt, list(set(val) | set(oplugopts)))
+            elif opt in ('skip_plugins', 'enable_plugins'):
+                setattr(opts, opt, list(set(val) | set(getattr(opts, opt))))
             elif val != opts.arg_defaults[opt]:
                 setattr(opts, opt, val)
 


### PR DESCRIPTION
When -n is passed on the cmdline, the config file's skip-plugins list was being replaced rather than merged, causing previously-skipped plugins to run unexpectedly.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
