### PR TITLE
[openstack_edpm] Collect /var/lib/openstack on EDPM nodes

### DIFF
--- a/sos/report/plugins/openstack_edpm.py
+++ b/sos/report/plugins/openstack_edpm.py
@@ -17,25 +17,52 @@ class OpenStackEDPM(Plugin, RedHatPlugin):
 
     plugin_name = 'openstack_edpm'
     profiles = ('openstack', 'openstack_edpm')
-    services = 'edpm-container-shutdown'
+    services = ('edpm-container-shutdown',)
     edpm_log_paths = []
 
     def setup(self):
-        # Notes: recursion is max 2 for edpm-config
-        # Those directories are present on all OpenStack nodes
+        # These directories are present on OpenStack EDPM nodes and are
+        # collected recursively.
         self.edpm_log_paths = [
             '/etc/os-net-config/',
             '/var/lib/config-data/',
             '/var/lib/edpm-config/',
+            '/var/lib/openstack/',
         ]
         self.add_copy_spec(self.edpm_log_paths)
+        self.add_forbidden_path([
+            "/var/lib/openstack/**/ssh-privatekey",
+            "/var/lib/openstack/certs",
+            "/var/lib/openstack/cacerts",
+        ])
 
     def postproc(self):
-        # Ensures we do not leak passwords from the edpm related locations
-        # Other locations don't have sensitive data.
+        # Ensures we do not leak passwords from the EDPM related locations.
         regexp = r'(".*(key|password|pass|secret|database_connection))' \
                  r'([":\s]+)(.*[^"])([",]+)'
         for path in self.edpm_log_paths:
             self.do_path_regex_sub(path, regexp, r'\1\3*********\5')
+
+        protect_keys = [
+            ".*_key",
+            ".*_pass(wd|word)?",
+            "password",
+            "metadata_proxy_shared_secret",
+            "rbd_secret_uuid",
+        ]
+        connection_keys = ["connection", "sql_connection", "transport_url"]
+
+        join_con_keys = "|".join(connection_keys)
+
+        self.do_path_regex_sub(
+            r"/var/lib/openstack/.*",
+            fr"(^\s*({'|'.join(protect_keys)})\s*=\s*)(.*)",
+            r"\1*********"
+        )
+        self.do_path_regex_sub(
+            r"/var/lib/openstack/.*",
+            fr"(^\s*({join_con_keys})\s*=\s*(.*)://(\w*):)(.*)(@(.*))",
+            r"\1*********\6"
+        )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openstack_nova.py
+++ b/sos/report/plugins/openstack_nova.py
@@ -214,6 +214,8 @@ class RedHatNova(OpenStackNova, RedHatPlugin):
     apachepkg = "httpd"
     nova = False
     packages = ('openstack-selinux',)
+    # Pre-FR5 deployments stored containerized nova config under
+    # /var/lib/openstack/config/nova.
     postproc_dirs = ["/etc/nova/", "/var/lib/openstack/config/nova"]
 
     def setup(self):


### PR DESCRIPTION
Collect the new EDPM OpenStack layout from /var/lib/openstack while excluding certs, cacerts, and ssh-privatekey data. Keep legacy pre-FR5 collection paths for backward compatibility.

Closes: [OSPRH-30140](https://redhat.atlassian.net/browse/OSPRH-30140)


---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
