### PR TITLE
[nvidia] Capture vgpu information

### DIFF
--- a/sos/report/plugins/nvidia.py
+++ b/sos/report/plugins/nvidia.py
@@ -31,7 +31,9 @@ class Nvidia(Plugin, IndependentPlugin):
             '-q',
             '-q -d ECC',
             'nvlink -s',
-            'nvlink -e'
+            'nvlink -e',
+            'vgpu',
+            'vgpu -q',
         ]
         ctk_subcmds = [
             'cdi list',


### PR DESCRIPTION
Capture two new vgpu outputs via the nvidia-smi command.

Related: RHEL-174400

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
