### PR TITLE
Add preset for Canonical OpenStack with Sunbeam

### DIFF
--- a/sos/policies/distros/debian.py
+++ b/sos/policies/distros/debian.py
@@ -44,6 +44,7 @@ class DebianPolicy(LinuxPolicy):
         self.package_manager = DpkgPackageManager(chroot=self.sysroot,
                                                   remote_exec=remote_exec)
         self.valid_subclasses += [DebianPlugin]
+        self.load_presets()
 
     def _get_pkg_name_for_binary(self, binary):
         # for binary not specified inside {..}, return binary itself

--- a/sos/policies/distros/ubuntu.py
+++ b/sos/policies/distros/ubuntu.py
@@ -14,6 +14,8 @@ from sos.policies.package_managers.snap import SnapPackageManager
 from sos.policies.package_managers.dpkg import DpkgPackageManager
 from sos.policies.package_managers import MultiPackageManager
 
+from sos.presets.ubuntu import SUNBEAM, UBUNTU_PRESETS, UBUNTU
+
 
 class UbuntuPolicy(DebianPolicy):
     vendor = "Canonical"
@@ -51,6 +53,12 @@ class UbuntuPolicy(DebianPolicy):
             pass
 
         self.valid_subclasses += [UbuntuPlugin]
+        self.register_presets(UBUNTU_PRESETS)
+
+    def probe_preset(self):
+        if self.pkg_by_name("sunbeam") is not None:
+            return self.find_preset(SUNBEAM)
+        return self.find_preset(UBUNTU)
 
     def dist_version(self):
         """ Returns the version stated in DISTRIB_RELEASE

--- a/sos/presets/ubuntu/__init__.py
+++ b/sos/presets/ubuntu/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Canonical Ltd., Arif Ali <arif-ali@ubuntu.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.options import SoSOptions
+from sos.presets import PresetDefaults
+
+
+UBUNTU = "ubuntu"
+UBUNTU_DESC = "Ubuntu"
+
+SUNBEAM = "sunbeam"
+SUNBEAM_DESC = "Canonical OpenStack"
+SUNBEAM_OPTS = SoSOptions(
+    all_logs=True,
+    plugopts=[
+        'sunbeam.juju-allow-login = True',
+        'kubernetes.all = True',
+        'kubernetes.describe = True',
+        'kubernetes.kubelogs = True',
+        'kubernetes.podlogs = True',
+    ])
+
+UBUNTU_PRESETS = {
+    SUNBEAM: PresetDefaults(name=SUNBEAM, desc=SUNBEAM_DESC,
+                            opts=SUNBEAM_OPTS),
+    UBUNTU: PresetDefaults(name=UBUNTU, desc=UBUNTU_DESC),
+}
+
+# vim: set et ts=4 sw=4 :

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -927,11 +927,13 @@ class SoSReport(SoSComponent):
             opts = {}
             for opt in self.opts.plugopts:
                 try:
-                    opt, val = opt.split("=")
+                    opt, val = opt.split("=", 1)
                 except ValueError:
                     val = True
 
+                opt = opt.strip()
                 if isinstance(val, str):
+                    val = val.strip()
                     arg = val.lower()
                     if arg in ["on", "enable", "enabled", "true", "yes"]:
                         val = True

--- a/tests/unittests/report_tests.py
+++ b/tests/unittests/report_tests.py
@@ -5,6 +5,7 @@
 # version 2 of the GNU General Public License.
 #
 # See the LICENSE file in the source distribution for further information.
+import logging
 import unittest
 
 try:
@@ -12,8 +13,12 @@ try:
 except ImportError:
     import simplejson as json
 
+from sos.report import SoSReport
+from sos.report.plugins import Plugin, PluginOpt
 from sos.report.reporting import (Report, Section, Command, CopiedFile,
                                   CreatedFile, Alert, PlainTextReport)
+from sos.policies.distros import LinuxPolicy
+from sos.policies.init_systems import InitSystem
 
 
 class ReportTest(unittest.TestCase):
@@ -147,6 +152,73 @@ class TestPlainReport(unittest.TestCase):
             "-  alerts:\n  ! this is an alert"
         ]),
             PlainTextReport(self.report).unicode())
+
+
+class MockOptions:
+    all_logs = False
+    dry_run = False
+    log_size = 25
+    allow_system_changes = False
+    skip_commands = []
+    skip_files = []
+    plugopts = []
+
+
+class MockPlugin(Plugin):
+
+    option_list = [
+        PluginOpt('baz', default=False),
+        PluginOpt('empty', default=None),
+        PluginOpt('test_option', default='foobar', val_type=str)
+    ]
+
+    def __init__(self, commons):
+        super().__init__(commons=commons)
+
+
+class SetTunablesPresetSpacesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.commons = {
+            'sysroot': '/',
+            'policy': LinuxPolicy(init=InitSystem()),
+            'cmdlineopts': MockOptions(),
+            'devices': {}
+        }
+        self.plugin = MockPlugin(self.commons)
+
+        self.report = SoSReport.__new__(SoSReport)
+        self.report.opts = MockOptions()
+        self.report.soslog = logging.getLogger('sos_test_set_tunables')
+        self.report.loaded_plugins = [('mock', self.plugin)]
+
+    def set_tunables(self, plugopts):
+        """Run _set_tunables with the given preset-style plugopts list."""
+        self.report.opts.plugopts = plugopts
+        self.report._set_tunables()
+
+    def test_plugopt_without_spaces_still_parses(self):
+        self.set_tunables(['mock.baz=True'])
+        self.assertIs(self.plugin.options['baz'].value, True)
+
+    def test_plugopt_with_spaces_around_equals(self):
+        self.set_tunables(['mock.baz = True'])
+        self.assertIs(self.plugin.options['baz'].value, True)
+
+    def test_plugopt_with_spaces_disables_option(self):
+        self.set_tunables(['mock.baz = False'])
+        self.assertIs(self.plugin.options['baz'].value, False)
+
+    def test_plugopt_string_value_with_spaces_around_equals(self):
+        self.set_tunables(['mock.test_option = bar'])
+        self.assertEqual(self.plugin.options['test_option'].value,
+                         'bar')
+
+    def test_unknown_plugopt_exits_even_with_spaces(self):
+        # An unknown option name (with surrounding whitespace) should still
+        # be reported as unknown rather than silently mis-stripped.
+        with self.assertRaises(SystemExit):
+            self.set_tunables(['mock.bogus = True'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also loads presets for both Ubuntu and Debian, so that local presets can also be loaded.

Closes: #4331

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
