### PR TITLE
[dracut] Add Ubuntu support and enhance dracut plugin

### DIFF
--- a/sos/report/plugins/dracut.py
+++ b/sos/report/plugins/dracut.py
@@ -8,10 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 
-class Dracut(Plugin, RedHatPlugin):
+class Dracut(Plugin, RedHatPlugin, UbuntuPlugin):
 
     short_desc = 'Dracut initramfs generator'
 
@@ -22,12 +22,18 @@ class Dracut(Plugin, RedHatPlugin):
     def setup(self):
         self.add_copy_spec([
             "/etc/dracut.conf",
-            "/etc/dracut.conf.d"
+            "/etc/dracut.conf.d",
+            "/usr/lib/dracut/dracut.conf.d",
+
+            # only generated if system drops into emergency mode during boot
+            "/run/initramfs/rdsosreport.txt",
         ])
 
         self.add_cmd_output([
             "dracut --list-modules",
-            "dracut --print-cmdline"
+            "dracut --print-cmdline",
+            "dracut --version",
+            "lsinitrd",
         ], env={"RPMOSTREE_CLIWRAP_SKIP": "true"})
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
**Add Ubuntu support and enhance dracut plugin**

Enable Ubuntu plugin support and collect additional
initramfs/boot debug data including cmdline, dracut
config paths,and lsinitrd output.

Signed-off-by: Leah Goldberg <leah.goldberg@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
