### PR TITLE
[cleaner] Ignore compiled regexes matching static regex_pattern

### DIFF
--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -35,7 +35,7 @@ class SoSMap():
 
     _token_split_re = re.compile(r'[^a-z0-9]+')
 
-    def __init__(self, workdir):
+    def __init__(self, workdir, _static_regex=re.compile(r'(?!)')):
         self.initializing = True
         self.dataset = {}
         self._regexes_made = set()
@@ -44,6 +44,7 @@ class SoSMap():
         self._simple_tokens = set()
         self._complex_items = []
         self._regex_dict = {}
+        self._static_regex = _static_regex
         self.cname = self.__class__.__name__.lower()
         # workdir's default value '/tmp' is used just by avocado tests,
         # otherwise we override it to /etc/sos/cleaner (or map_file dir)
@@ -156,7 +157,10 @@ class SoSMap():
         """
         if self.ignore_item(item):
             return
-        if item not in self._regexes_made:
+        # skip items already in the _regexes_made set and items detected by
+        # parser._parse_line via the static regex_pattern
+        if (item not in self._regexes_made and
+                not self._static_regex.fullmatch(item)):
             # we do re.I everywhere, so unify the item
             item = item.lower()
             # save the item in a set to avoid clobbering existing regexes,

--- a/sos/cleaner/parsers/hostname_parser.py
+++ b/sos/cleaner/parsers/hostname_parser.py
@@ -22,7 +22,7 @@ class SoSHostnameParser(SoSCleanerParser):
     )
 
     def __init__(self, config, workdir, skip_cleaning_files=[]):
-        self.mapping = SoSHostnameMap(workdir)
+        self.mapping = SoSHostnameMap(workdir, self.regex_pattern)
         super().__init__(config, skip_cleaning_files)
 
     def parse_line(self, line):

--- a/sos/cleaner/parsers/ip_parser.py
+++ b/sos/cleaner/parsers/ip_parser.py
@@ -47,5 +47,5 @@ class SoSIPParser(SoSCleanerParser):
     compile_regexes = False
 
     def __init__(self, config, workdir, skip_cleaning_files=[]):
-        self.mapping = SoSIPMap(workdir)
+        self.mapping = SoSIPMap(workdir, self.regex_pattern)
         super().__init__(config, skip_cleaning_files)

--- a/sos/cleaner/parsers/ipv6_parser.py
+++ b/sos/cleaner/parsers/ipv6_parser.py
@@ -47,7 +47,7 @@ class SoSIPv6Parser(SoSCleanerParser):
         return super()._parse_line(line)
 
     def __init__(self, config, workdir, skip_cleaning_files=[]):
-        self.mapping = SoSIPv6Map(workdir)
+        self.mapping = SoSIPv6Map(workdir, self.regex_pattern)
         super().__init__(config, skip_cleaning_files)
 
     def get_map_contents(self):

--- a/sos/cleaner/parsers/mac_parser.py
+++ b/sos/cleaner/parsers/mac_parser.py
@@ -56,7 +56,7 @@ class SoSMacParser(SoSCleanerParser):
     compile_regexes = False
 
     def __init__(self, config, workdir, skip_cleaning_files=[]):
-        self.mapping = SoSMacMap(workdir)
+        self.mapping = SoSMacMap(workdir, self.regex_pattern)
         super().__init__(config, skip_cleaning_files)
 
     def reduce_mac_match(self, match):


### PR DESCRIPTION
Items that match both `mapping.compiled_regexes` and `parser.regex_pattern` are currently checked twice (by `_parse_line_with_compiled_regexes` and `_parse_line`). That is redundant.

Add to `mapping.compiled_regexes` only the items that don't match `parser.regex_pattern`, to make the `compiled_regex` simplier and faster to check.

Resolves: #4335
Closes: #4340

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
