### PR TITLE
[testing] Restrict foreman tests to sos/report/**/__init__.py

### DIFF
--- a/.github/workflows/main-pipeline.yaml
+++ b/.github/workflows/main-pipeline.yaml
@@ -49,7 +49,7 @@ jobs:
           filters: |
             foreman:
               - '.github/workflows/**'
-              - '**/__init__.py'
+              - 'sos/report/**/__init__.py'
               - '**/apache.py'
               - '**/foreman*.py'
               - '**/candlepin.py'


### PR DESCRIPTION
Dont trigger foreman tests on changes of broad all __init__.py .

See [#4340](https://github.com/sosreport/sos/pull/4340) that triggered the foreman tests redundantly.

Closes: #4342

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
