### PR TITLE
[ipa] Collect ipactl status output

### DIFF
--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -106,6 +106,9 @@ class Ipa(Plugin, RedHatPlugin):
                 "/var/log/ipa-custodia.audit.log"
             ])
 
+            # Collect IPA services status
+            self.add_cmd_output("ipactl status")
+
         if self.ca_installed():
             self._log_debug("CA is installed: retrieving PKI logs")
             self.collect_pki_logs(ipa_version)


### PR DESCRIPTION
## Summary

This PR adds collection of `ipactl status` command output to the IPA plugin.

## Changes

Added `ipactl status` command  in the IPA server detection block. 
(Only executes on systems with ipa-server or freeipa-server packages & 
provides diagnostic information about all IPA services)

## Use-Case

The `ipactl status` command shows the running state of all IPA services
This is essential when troubleshooting IPA deployment issues,
service failures, or understanding the overall health of an IPA server.

## Testing

This can be easily tested on a RHEL/CentOS/Fedora system with ipa-server or freeipa-server 
pkgs installed:

```bash
sudo sos report -o ipa --batch
```

Generated sosreport will include `ipactl status` output in the `sos_commands/ipa/` directory.

Resolves: RHEL-168368

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
