### PR TITLE
[tests] Add Debian and fine tune tests

### DIFF
--- a/.github/workflows/avocado.yaml
+++ b/.github/workflows/avocado.yaml
@@ -1,15 +1,15 @@
-name: Avocado Tests
+name: Avocado
 
 on:
   workflow_call:
     inputs:
-      distro:
+      distro_image:
         required: true
         type: string
       distro_name:
         required: false
         type: string
-      build:
+      builds:
         required: true
         type: string
       test_name:
@@ -34,21 +34,47 @@ on:
 
 jobs:
   test:
-    name: ${{ inputs.stage_name }} Tests (${{ inputs.distro }})
-    runs-on: ${{ inputs.build == 'rpm' && 'ubuntu-latest' || format('ubuntu-{0}', inputs.distro) }}
+    name: ${{ inputs.stage_name }} Tests (${{ inputs.distro_name }}, ${{ matrix.build }})
+    runs-on: ${{ inputs.distro_image == '' && inputs.distro_name || 'ubuntu-latest' }}
     continue-on-error: ${{ inputs.can_fail }}
 
     container:
-      image: ${{ inputs.build == 'rpm' && inputs.distro || null }}
-      options: ${{ inputs.build == 'rpm' && '--privileged --tmpfs /tmp --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro' || '' }}
+      image: ${{ inputs.distro_image != '' && inputs.distro_image || null }}
+      options: ${{ inputs.distro_image != '' && '--user root --privileged --cgroupns=host --tmpfs /tmp --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro' || '' }}
 
     env:
       FOREMAN_VER: ${{ inputs.foreman_ver }}
       KATELLO_VER: ${{ inputs.katello_ver }}
-      DISTRO_NAME: >-
-        ${{ inputs.distro_name == '' && inputs.distro || inputs.distro_name }}
+      DISTRO_NAME: ${{ inputs.distro_name }}
+
+    strategy:
+      matrix:
+        build: ${{ fromJson(inputs.builds) }}
 
     steps:
+      - name: Bootstrap DEB Container based OS
+        if: ${{ contains(inputs.distro_name, 'debian') || ( contains(inputs.distro_name, 'ubuntu') && inputs.distro_image != '' ) }}
+        run: |
+          apt update
+          apt -y install sudo
+
+      - name: Bootstrap RPM based OS
+        if: ${{ matrix.build == 'rpm' }}
+        run: |
+          dnf -y install sudo
+          sed -i 's/^account.*pam_unix.so/account sufficient pam_permit.so/' /etc/pam.d/sudo
+          sed -i 's/^account.*required.*pam_unix.so/account sufficient pam_permit.so/' /etc/pam.d/system-auth
+
+      - name: Setup sudoers on containers
+        if: ${{ inputs.distro_image != '' }}
+        run: |
+          CURRENT_USER=$(whoami)
+          echo "Fixing sudo for user: $CURRENT_USER"
+
+          mkdir -p /etc/sudoers.d
+          echo "${CURRENT_USER} ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/gh-actions
+          chmod 0440 /etc/sudoers.d/gh-actions
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -56,43 +82,40 @@ jobs:
 
       - name: Install functional test dependencies
         run: |
-          if [[ $(command -v apt) ]]; then
+          if [ $(command -v apt) ]; then
             sudo apt update
             sudo apt -y install tox
+            # Install packages required for testing
+            sudo apt -y install kmod ethtool gnupg2 iproute2 procps curl wget
+            [ $(echo "${{ inputs.distro_name }}" | grep ubuntu) ] && sudo apt -y install ubuntu-advantage-tools
           else
             dnf config-manager --set-enabled crb || true
-            [[ "${{ inputs.distro_name }}" == centos* ]] && dnf -y install epel-release
-            dnf -y install tox sudo
+            [ $( echo "${{ inputs.distro_name }}" | grep centos) ] && dnf -y install epel-release
+            dnf -y install tox
             # Install packages required for testing
-            dnf -y install kmod ethtool gnupg2 iproute hostname procps-ng file systemd dbus
+            dnf -y install kmod ethtool gnupg2 iproute hostname procps-ng file systemd
           fi
+        continue-on-error: true
 
-      - name: Bootstrap RPM based OS
-        if: ${{ inputs.build == 'rpm' }}
+      - name: Enable systemd in containers
+        if: ${{ matrix.build == 'rpm' || ( contains(inputs.distro_name, 'ubuntu') && inputs.distro_image != '' )}}
         run: |
-          CURRENT_USER=$(whoami)
-          echo "Fixing sudo for user: $CURRENT_USER"
-
-          echo "${CURRENT_USER} ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/gh-actions
-          chmod 0440 /etc/sudoers.d/gh-actions
-
-          sed -i 's/^account.*pam_unix.so/account sufficient pam_permit.so/' /etc/pam.d/sudo
-          sed -i 's/^account.*required.*pam_unix.so/account sufficient pam_permit.so/' /etc/pam.d/system-auth
+          /usr/lib/systemd/systemd --user &
 
       - name: Download Distro-Specific DEB
-        if: ${{ inputs.build == 'deb' }}
+        if: ${{ matrix.build == 'deb' }}
         uses: actions/download-artifact@v8
         with:
           name: sos-${{ env.DISTRO_NAME }}.deb
 
       - name: Download Distro-Specific RPM
-        if: ${{ inputs.build == 'rpm' }}
+        if: ${{ matrix.build == 'rpm' }}
         uses: actions/download-artifact@v8
         with:
           name: sos-${{ env.DISTRO_NAME }}.rpm
 
       - name: Download snap
-        if: ${{ inputs.build == 'snap' }}
+        if: ${{ matrix.build == 'snap' }}
         uses: actions/download-artifact@v8
         with:
           name: sos-build.snap
@@ -100,17 +123,37 @@ jobs:
       - name: Install the package
         run: |
           if [ $(command -v apt) ] ; then
-            [[ "$(dpkg -l sos)" ]] && sudo apt -y purge sos ubuntu-server
-            [[ "$(dpkg -l sosreport)" ]] && sudo apt -y purge sosreport ubuntu-server
+            [ "$(dpkg -l sos)" ] && sudo apt -y purge sos ubuntu-server
+            [ "$(dpkg -l sosreport)" ] && sudo apt -y purge sosreport ubuntu-server
           fi
-          if [[ "${{ inputs.build }}" == "deb" ]] ; then
+          if [ "${{ matrix.build }}" == "deb" ] ; then
             sudo apt -y install ./"sos-${{ env.DISTRO_NAME }}.deb"
-          elif [[ "${{ inputs.build }}" == "snap" ]] ; then
+          elif [ "${{ matrix.build }}" == "snap" ] ; then
+            sudo apt -y install snapd
             sudo snap install "sos-build.snap" --classic --dangerous
-          elif [[ "${{ inputs.build }}" == "rpm" ]] ; then
+          elif [ "${{ matrix.build }}" == "rpm" ] ; then
             dnf -y remove sos
             dnf -y install "sos-${{ env.DISTRO_NAME }}.rpm"
           fi
+
+      # This is primarily required for container systems
+      - name: Pre-initialization of foreman test
+        if: ${{ inputs.stage_name == 'foreman' && inputs.distro_image != '' }}
+        run: |
+          if [ $(command -v apt) ] ; then
+            sudo apt -y install facter jq
+          elif [ "${{ matrix.build }}" == "rpm" ] ; then
+            dnf -y install facter jq
+          fi
+          FQDN=$(facter fqdn)
+          SHORT=$(hostname -s)
+
+          ip=$(ip -j -4 a show eth0 | jq -r '.[0].addr_info[0].local')
+
+          cat > /etc/hosts << EOF
+          127.0.0.1    localhost
+          $ip    $FQDN $SHORT
+          EOF
 
       - name: Run Extra script
         if: ${{ inputs.extra_script != '' }}
@@ -128,7 +171,8 @@ jobs:
         run: |
           ls -lh
 
-          mkdir -p ./debug-logs/{var-tmp,root-home}
+          mkdir -p ./debug-logs/var-tmp
+          mkdir -p ./debug-logs/root-home
 
           sudo cp -ra /var/tmp/avocado* ./debug-logs/var-tmp || true
           sudo cp -ra /root/avocado ./debug-logs/root-home || true

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -3,14 +3,33 @@ name: Build DEB Package
 on:
   workflow_call:
     inputs:
-      distro:
+      distro_image:
+        required: true
+        type: string
+      distro_name:
         required: true
         type: string
 jobs:
   build:
-    runs-on: "ubuntu-${{ inputs.distro }}"
+    runs-on: ${{ inputs.distro_image == '' && inputs.distro_name || 'ubuntu-latest' }}
+
+    container:
+      image: ${{ inputs.distro_image != '' && inputs.distro_image || null }}
+      options: ${{ inputs.distro_image != '' && '--privileged --tmpfs /tmp --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro' || '' }}
 
     steps:
+      - name: Bootstrap Container system
+        if: ${{ inputs.distro_image != '' }}
+        run: |
+          apt update
+          apt -y install sudo
+
+          CURRENT_USER=$(whoami)
+          echo "Fixing sudo for user: $CURRENT_USER"
+
+          echo "${CURRENT_USER} ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/gh-actions
+          chmod 0440 /etc/sudoers.d/gh-actions
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -25,15 +44,16 @@ jobs:
 
       - name: Create DEB Package
         working-directory: ./sos
+        shell: bash
         run: |
-          dpkg-buildpackage -b -us -uc -rfakeroot -m --build-by="noreply@canonical.com"
-          mv ../*.deb ../sos-${{ inputs.distro }}.deb
+          dpkg-buildpackage -b -us -uc -rfakeroot --build-by="No Reply <noreply@canonical.com>"
+          mv ../*.deb ../sos-${{ inputs.distro_name }}.deb
 
       - name: Upload Distro Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: sos-${{ inputs.distro }}.deb
-          path: sos-${{ inputs.distro }}.deb
+          name: sos-${{ inputs.distro_name }}.deb
+          path: sos-${{ inputs.distro_name }}.deb
           retention-days: 1
 
       - name: Post-Build Cleanup

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -3,7 +3,7 @@ name: Build RPM Package
 on:
   workflow_call:
     inputs:
-      distro:
+      distro_image:
         required: true
         type: string
       build:
@@ -18,7 +18,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     container:
-      image: ${{ inputs.distro }}
+      image: ${{ inputs.distro_image }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main-pipeline.yaml
+++ b/.github/workflows/main-pipeline.yaml
@@ -1,4 +1,4 @@
-name: Main Pipeline
+name: CI
 
 on:
   push:
@@ -17,24 +17,38 @@ jobs:
     outputs:
       distros: ${{ steps.set-matrix.outputs.distros }}
       builds: ${{ steps.set-matrix.outputs.builds }}
+      distro_matrix: ${{ steps.set-matrix.outputs.distro_matrix }}
       rpm_matrix: ${{ steps.set-matrix.outputs.rpm_matrix }}
-      centos_matrix: ${{ steps.set-matrix.outputs.centos_matrix }}
+      deb_matrix: ${{ steps.set-matrix.outputs.deb_matrix }}
+      stagetwo_matrix: ${{ steps.set-matrix.outputs.stagetwo_matrix }}
+      foreman_matrix: ${{ steps.set-matrix.outputs.foreman_matrix }}
     steps:
       - id: set-matrix
         run: |
-          echo "distros=[\"22.04\", \"24.04\"]" >> $GITHUB_OUTPUT
-          echo "builds=[\"deb\", \"snap\"]" >> $GITHUB_OUTPUT
-          RPM_JSON='[
-            {"name": "fedora-43", "image": "fedora:43"},
-            {"name": "fedora-44", "image": "fedora:44"},
-            {"name": "centos-9",  "image": "quay.io/centos/centos:stream9"},
-            {"name": "centos-10", "image": "quay.io/centos/centos:stream10"}
+          DISTRO_JSON='[
+            {"name": "ubuntu-22.04",  "image": "",              "builds": ["deb", "snap"], "stages": "foreman"},
+            {"name": "ubuntu-24.04",  "image": "",              "builds": ["deb", "snap"], "stages": "two"},
+            {"name": "ubuntu-latest", "image": "ubuntu:latest", "builds": ["deb"],         "stages": ""},
+            {"name": "debian-12",     "image": "debian:12",     "builds": ["deb"],         "stages": ""},
+            {"name": "debian-13",     "image": "debian:13",     "builds": ["deb"],         "stages": "two"},
+            {"name": "fedora-43",     "image": "fedora:43",     "builds": ["rpm"],         "stages": ""},
+            {"name": "fedora-44",     "image": "fedora:44",     "builds": ["rpm"],         "stages": ""},
+            {"name": "centos-9",      "image": "quay.io/centos/centos:stream9",  "builds": ["rpm"], "stages": ""},
+            {"name": "centos-10",     "image": "quay.io/centos/centos:stream10", "builds": ["rpm"], "stages": "two"}
           ]'
+          echo "distro_matrix=$(echo $DISTRO_JSON | jq -c .)" >> $GITHUB_OUTPUT
 
-          echo "rpm_matrix=$(echo $RPM_JSON | jq -c .)" >> $GITHUB_OUTPUT
+          RPM_JSON=$(echo "$DISTRO_JSON" | jq -c '[.[] | select(.name | contains("centos") or contains("fedora"))]')
+          echo "rpm_matrix=$RPM_JSON" >> $GITHUB_OUTPUT
 
-          CENTOS_JSON=$(echo "$RPM_JSON" | jq -c '[.[] | select(.name | contains("centos"))]')
-          echo "centos_matrix=$CENTOS_JSON" >> $GITHUB_OUTPUT
+          DEB_JSON=$(echo "$DISTRO_JSON" | jq -c '[.[] | select(.name | contains("ubuntu") or contains("debian"))]')
+          echo "deb_matrix=$DEB_JSON" >> $GITHUB_OUTPUT
+
+          STAGETWO_JSON=$(echo "$DISTRO_JSON" | jq -c '[.[] | select(.stages | contains("two"))]')
+          echo "stagetwo_matrix=$STAGETWO_JSON" >> $GITHUB_OUTPUT
+
+          FOREMAN_JSON=$(echo "$DISTRO_JSON" | jq -c '[.[] | select(.stages | contains("foreman"))]')
+          echo "foreman_matrix=$FOREMAN_JSON" >> $GITHUB_OUTPUT
 
   filters:
     runs-on: ubuntu-latest
@@ -80,10 +94,11 @@ jobs:
     if: needs.filters.outputs.docs == 'true'
     strategy:
       matrix:
-        distro: ${{ fromJson(needs.setup.outputs.distros) }}
+        distro: ${{ fromJson(needs.setup.outputs.deb_matrix) }}
     uses: ./.github/workflows/build-deb.yaml
     with:
-      distro: ${{ matrix.distro }}
+      distro_image: ${{ matrix.distro.image }}
+      distro_name: ${{ matrix.distro.name }}
 
   build_rpm:
     needs: [filters, setup]
@@ -91,11 +106,9 @@ jobs:
     strategy:
       matrix:
         distro: ${{ fromJson(needs.setup.outputs.rpm_matrix) }}
-        build: [ 'rpm' ]
     uses: ./.github/workflows/build-rpm.yaml
     with:
-      distro: ${{ matrix.distro.image }}
-      build: ${{ matrix.build }}
+      distro_image: ${{ matrix.distro.image }}
       distro_name: ${{ matrix.distro.name }}
 
   build_snap:
@@ -118,95 +131,49 @@ jobs:
       test_name: pylint
 
   unit:
-    needs: [filters, setup, build_deb, build_snap]
+    needs: [filters, setup, build_deb, build_snap, build_rpm]
     if: needs.filters.outputs.docs == 'true'
     strategy:
       matrix:
-        distro: ${{ fromJson(needs.setup.outputs.distros) }}
-        build: ${{ fromJson(needs.setup.outputs.builds) }}
+        distro: ${{ fromJson(needs.setup.outputs.distro_matrix) }}
     uses: ./.github/workflows/avocado.yaml
     with:
-      distro: ${{ matrix.distro }}
-      build: ${{ matrix.build }}
-      test_name: "unit_tests"
-      stage_name: "Unit"
-
-  unit_rpm:
-    needs: [filters, setup, build_rpm]
-    if: needs.filters.outputs.docs == 'true'
-    strategy:
-      matrix:
-        distros: ${{ fromJson(needs.setup.outputs.rpm_matrix) }}
-        build: [ 'rpm' ]
-    uses: ./.github/workflows/avocado.yaml
-    with:
-      distro: ${{ matrix.distros.image }}
-      distro_name: ${{ matrix.distros.name }}
-      build: ${{ matrix.build }}
+      distro_image: ${{ matrix.distro.image }}
+      distro_name: ${{ matrix.distro.name }}
+      builds: ${{ toJson(matrix.distro.builds) }}"
       test_name: "unit_tests"
       stage_name: "Unit"
 
   stage_one:
-    needs: [filters, setup, build_deb, build_snap, unit]
+    needs: [filters, setup, build_deb, build_snap, build_rpm, unit]
     if: needs.filters.outputs.docs == 'true'
     strategy:
       matrix:
-        distro: ${{ fromJson(needs.setup.outputs.distros) }}
-        build: ${{ fromJson(needs.setup.outputs.builds) }}
+        distro: ${{ fromJson(needs.setup.outputs.distro_matrix) }}
     uses: ./.github/workflows/avocado.yaml
     with:
-      distro: ${{ matrix.distro }}
-      build: ${{ matrix.build }}
+      distro_image: ${{ matrix.distro.image }}
+      distro_name: ${{ matrix.distro.name }}
+      builds: ${{ toJson(matrix.distro.builds) }}
       test_name: "stageone_tests"
       stage_name: "Stage One"
       can_fail: true
     secrets: inherit
 
-  stage_one_rpm:
-    needs: [filters, setup, build_rpm, unit_rpm]
-    if: needs.filters.outputs.docs == 'true'
-    strategy:
-      matrix:
-        distros: ${{ fromJson(needs.setup.outputs.rpm_matrix) }}
-        build: [ 'rpm' ]
-    uses: ./.github/workflows/avocado.yaml
-    with:
-      distro: ${{ matrix.distros.image }}
-      distro_name: ${{ matrix.distros.name }}
-      build: ${{ matrix.build }}
-      test_name: "stageone_tests"
-      stage_name: "Stage One"
-    secrets: inherit
-
   stage_two:
-    needs: [filters, setup, build_deb, build_snap, stage_one]
+    needs: [filters, setup, build_deb, build_snap, build_rpm, stage_one]
     if: needs.filters.outputs.docs == 'true'
     strategy:
       matrix:
-        distro: ${{ fromJson(needs.setup.outputs.distros) }}
-        build: ${{ fromJson(needs.setup.outputs.builds) }}
+        distro: ${{ fromJson(needs.setup.outputs.stagetwo_matrix) }}
     uses: ./.github/workflows/avocado.yaml
     with:
-      distro: ${{ matrix.distro }}
-      build: ${{ matrix.build }}
+      distro_image: ${{ matrix.distro.image }}
+      distro_name: ${{ matrix.distro.name }}
+      builds: ${{ toJson(matrix.distro.builds) }}
       test_name: "stagetwo_tests"
       stage_name: "Stage Two"
-    secrets: inherit
-
-  stage_two_rpm:
-    needs: [filters, setup, build_rpm, stage_one_rpm]
-    if: needs.filters.outputs.docs == 'true'
-    strategy:
-      matrix:
-        distros: ${{ fromJson(needs.setup.outputs.centos_matrix) }}
-        build: [ 'rpm' ]
-    uses: ./.github/workflows/avocado.yaml
-    with:
-      distro: ${{ matrix.distros.image }}
-      distro_name: ${{ matrix.distros.name }}
-      build: ${{ matrix.build }}
-      test_name: "stagetwo_tests"
-      stage_name: "Stage Two"
+      can_fail: true
     secrets: inherit
 
   foreman:
@@ -214,15 +181,16 @@ jobs:
     if: needs.filters.outputs.foreman == 'true'
     strategy:
       matrix:
-        distro: [ "22.04" ]
-        build: [ "deb" ]
+        distro: ${{ fromJson(needs.setup.outputs.foreman_matrix) }}
     uses: ./.github/workflows/avocado.yaml
     with:
-      distro: ${{ matrix.distro }}
-      build: ${{ matrix.build }}
+      distro_image: ${{ matrix.distro.image }}
+      distro_name: ${{ matrix.distro.name }}
+      builds: ${{ toJson(matrix.distro.builds) }}
       extra_script: ./tests/test_data/foreman_setup.sh
       test_name: "foreman_tests"
       stage_name: "Foreman"
       foreman_ver: "3.15"
       katello_ver: "4.17"
+      can_fail: true
     secrets: inherit

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,4 +1,4 @@
-name: Tox Tests
+name: Tox
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: ${{ inputs.test_name }} Test
+    name: ${{ inputs.test_name }}
     runs-on: "ubuntu-latest"
 
     steps:

--- a/sos/report/plugins/grout.py
+++ b/sos/report/plugins/grout.py
@@ -69,12 +69,15 @@ class Grout(Plugin, IndependentPlugin):
         daemon PID.
         """
         res = self.collect_cmd_output("systemctl show -p MainPID grout")
-        for m in re.finditer(r"MainPID=(\d+)", res["output"]):
-            pid = m[0]
-            if pid == "0":
-                continue
-            cmds = [f"nsenter --net -t {pid} {cmd}" for cmd in ip_cmds]
-            self.add_cmd_output(cmds)
+        try:
+            for m in re.finditer(r"MainPID=(\d+)", res["output"]):
+                pid = m[0]
+                if pid == "0":
+                    continue
+                cmds = [f"nsenter --net -t {pid} {cmd}" for cmd in ip_cmds]
+                self.add_cmd_output(cmds)
+        except TypeError as e:
+            self._log_error(f"Issue with finditer: {e}")
 
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/hyperv.py
+++ b/sos/report/plugins/hyperv.py
@@ -18,11 +18,14 @@ class Hyperv(Plugin, IndependentPlugin):
 
     def setup(self):
 
-        self.add_copy_spec([
-            "/sys/bus/vmbus/drivers/",
-            # copy devices/*/* instead of devices/ to follow link files
-            "/sys/bus/vmbus/devices/*/*"
-        ])
+        try:
+            self.add_copy_spec([
+                "/sys/bus/vmbus/drivers/",
+                # copy devices/*/* instead of devices/ to follow link files
+                "/sys/bus/vmbus/devices/*/*"
+            ])
+        except OSError as e:
+            self._log_error(f"Received OSError accessing files: {e}")
 
         self.add_cmd_output("lsvmbus -vv")
 

--- a/tests/test_data/foreman_setup.sh
+++ b/tests/test_data/foreman_setup.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 SUCCESS=0
-EXTRA_OPTS=""
+EXTRA_OPTS="-l DEBUG"
 puppet_ver=8
 
 if grep -iq centos /etc/os-release; then
+    dnf -y install glibc-langpack-en glibc-locale-source
+    localedef -i en_US -f UTF-8 en_US.UTF-8
+    export LANG=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
     os_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID=\"\(.*\)\"/\1/')
     dnf -y install https://yum.puppet.com/puppet${puppet_ver}-release-el-${os_version}.noarch.rpm
     dnf -y install https://yum.theforeman.org/releases/$FOREMAN_VER/el${os_version}/x86_64/foreman-release.rpm
@@ -12,7 +16,7 @@ if grep -iq centos /etc/os-release; then
     dnf -y module enable foreman:el${os_version}
     dnf -y install foreman-installer-katello
     dnf -y install foreman-installer && SUCCESS=1
-    EXTRA_OPTS="--scenario katello"
+    EXTRA_OPTS="$EXTRA_OPTS --scenario katello"
 elif grep -iq debian /etc/os-release; then
     series=$(grep VERSION_CODENAME /etc/os-release | sed s/VERSION_CODENAME=//g)
     apt-get update


### PR DESCRIPTION
* Refactor, so that the configuration for workflow is templated, and the same workflow can be used for all distros
* All debian added including 12 and 13 with foreman tests for 12
* Added ubuntu latest, which is allowed to fail
* Add foreman tests for centos9
* Fedora44 and Ubuntu Latest stagetwo not added due to py3.14 issues. Issue: #4313
* Fixed a few errors coming out of grout and hyperv plugins on Debian containers

Closes: #4288

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
