### PR TITLE
[report] Add --pack-dir to pack verbose dirs into tarballs

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -111,6 +111,12 @@ Users should review any archive that keeps binary files in place before sending 
 a third party.
 
 Default: False (remove encountered binary files)
+
+Note that uncompressed tarballs produced by the report \fB\-\-pack-dir\fR option
+(for example \fBproc.tar\fR or \fBsys.tar\fR) are an exception: they are always
+kept in place regardless of this option, so that the collected data they hold is
+not silently dropped from the cleaned archive. Their contents are not obfuscated,
+so the same review caution applies.
 .TP
 .B \-\-archive-type TYPE
 Specify the type of archive that TARGET was generated as.

--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -32,6 +32,7 @@ sos_report \- Collect and package diagnostic and support data
           [--since YYYYMMDD[HHMMSS]]\fR
           [--skip-commands commands]\fR
           [--skip-files files]\fR
+          [--pack-dir directories]\fR
           [--allow-system-changes]\fR
           [--low-priority]\fR
           [-z|--compression-type method]\fR
@@ -231,6 +232,16 @@ will skip all commands with names that begin with the string "hostname".
 A comma delimited list of files or filepath wildcard matches to skip collection
 of. Values may either be exact filepaths or paths using UNIX shell-style wildcards,
 for example \fB/etc/sos/*\fR.
+.TP
+.B \--pack-dir DIRECTORIES
+A comma delimited list of collected directories to replace with a single tarball
+within the report, for example \fB/proc/fs/\fR. The named directory is packed into
+an uncompressed tarball alongside it (e.g. \fBproc/fs/\fR becomes \fBproc/fs.tar\fR)
+and the original tree is removed; the rest of the report is unchanged. This is
+useful for verbose trees containing very large numbers of small files, where
+extracting the report would otherwise have to recreate every file on disk. The
+tarball is not compressed here since the whole report is compressed when packaged.
+Directories not collected as a directory are skipped. May be repeated.
 .TP
 .B \--allow-system-changes
 Run commands even if they can change the system (e.g. load kernel modules).

--- a/sos/archive.py
+++ b/sos/archive.py
@@ -602,6 +602,48 @@ class FileCacheArchive(Archive):
             replacements = 0
         return replacements
 
+    def tar_subdirs(self, paths):
+        """Replace one or more collected directories with a single tarball.
+
+        For each host path in ``paths`` that was collected into this archive,
+        the corresponding directory tree under the archive root is packed into
+        a single uncompressed tarball alongside it (e.g. ``proc/fs/`` becomes
+        ``proc/fs.tar``) and the original tree is removed. The rest of the
+        archive is left untouched.
+
+        The tarball is deliberately not compressed here: the final report
+        archive is compressed as a whole, so compressing again would only
+        duplicate that work and cannot shrink already-compressed data. The
+        point is to collapse a directory of many small files into one member,
+        so extracting the top-level archive does not have to recreate every
+        file on disk. This backs the report ``--pack-dir`` option, used
+        for verbose trees such as ``/proc/fs/``.
+
+        :param paths: Iterable of host directory paths to pack in place
+        :returns: A list of the host paths that were successfully packed
+        """
+        packed = []
+        for path in paths:
+            dest = self.dest_path(path.rstrip(os.sep))
+            if not os.path.isdir(dest):
+                self.log_info(f"skipping --pack-dir '{path}': not collected"
+                              " as a directory in the archive")
+                continue
+            tarpath = f"{dest}.tar"
+            try:
+                with tarfile.open(tarpath, mode="w") as tar:
+                    tar.add(dest, arcname=os.path.basename(dest))
+                shutil.rmtree(dest)
+                self.log_info(f"packed collected directory '{path}' into "
+                              f"'{tarpath}'")
+                packed.append(path)
+            except Exception as err:
+                self.log_error(f"Could not pack directory '{path}': {err}")
+                # leave the directory in place on failure
+                if os.path.exists(tarpath):
+                    os.unlink(tarpath)
+        return packed
+
     def finalize(self, method):
         self.log_info(f"finalizing archive '{self._archive_root}' using method"
                       f" '{method}'")

--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -8,6 +8,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import json
 import logging
 import os
 import shutil
@@ -74,6 +75,7 @@ class SoSObfuscationArchive():
         self.soslog = logging.getLogger('sos')
         self.ui_log = logging.getLogger('sos_ui')
         self.skip_list = self._load_skip_list()
+        self.packed_dirs = []
         self.is_extracted = False
         self._load_self()
         self.archive_root = ''
@@ -157,6 +159,17 @@ class SoSObfuscationArchive():
         try:
             rel_name = os.path.relpath(filename, start=self.extracted_path)
             if self.should_skip_file(rel_name):
+                return
+            if self.is_packed_dir_tarball(rel_name):
+                # tarballs produced by the report '--pack-dir' option hold
+                # collected data the user explicitly asked to retain. We can't
+                # obfuscate their contents in place, but unlike other binary
+                # files we must not drop them, or that collected data would be
+                # silently lost from the cleaned report.
+                self.log_warn(
+                    f"Keeping packed directory tarball '{rel_name}'; its "
+                    "contents are not obfuscated"
+                )
                 return
             if (not self.keep_binary_files and
                     self.should_remove_file(rel_name)):
@@ -281,6 +294,9 @@ class SoSObfuscationArchive():
     def log_info(self, msg, caller=None):
         self.soslog.info(self._fmt_log_msg(msg, caller))
 
+    def log_warn(self, msg, caller=None):
+        self.soslog.warning(self._fmt_log_msg(msg, caller))
+
     def log_error(self, msg, caller=None):
         self.soslog.error(self._fmt_log_msg(msg, caller))
 
@@ -399,6 +415,7 @@ class SoSObfuscationArchive():
                             os.chmod(fname, stat.S_IRUSR | stat.S_IWUSR)
                 except Exception as err:
                     self.log_debug(f"Error while trying to set perms: {err}")
+        self.packed_dirs = self._load_packed_dirs()
         self.log_debug(f"Extracted path is {self.extracted_path}")
 
     def rename_top_dir(self, new_name):
@@ -586,5 +603,51 @@ class SoSObfuscationArchive():
             return file_is_binary(_full_path)
         # don't fail on dir-level symlinks
         return False
+
+    def _load_packed_dirs(self):
+        """Load the list of directories the report '--pack-dir' option packed
+        into tarballs, as recorded in the archive's manifest, and translate
+        each into the archive-relative path of its tarball (e.g. ``/proc/fs``
+        becomes ``proc/fs.tar``).
+
+        Archives without a manifest, or whose manifest predates the pack-dir
+        feature, yield an empty list, meaning no tarball is treated as
+        packed-dir output.
+
+        :returns:   Archive-relative paths of packed directory tarballs
+        :rtype:     ``list``
+        """
+        manifest = self.get_file_content('sos_reports/manifest.json')
+        if not manifest:
+            return []
+        try:
+            report_md = json.loads(manifest)['components']['report']
+            return [
+                f"{path.rstrip(os.sep).lstrip(os.sep)}.tar"
+                for path in report_md.get('packed_dirs', [])
+            ]
+        except Exception as err:
+            self.log_debug(f"Could not load packed_dirs from manifest: {err}")
+            return []
+
+    def is_packed_dir_tarball(self, rel_name):
+        """Determine if the file is a tarball produced by the report
+        '--pack-dir' option, which collapses a collected directory tree into a
+        single archive member (e.g. ``/proc/fs`` becomes ``proc/fs.tar``),
+        recording it in the manifest's ``packed_dirs`` list.
+
+        Such tarballs are binary and so would otherwise be removed by the
+        cleaner, but they hold collected data the user asked to retain, so the
+        caller keeps them in the archive instead. Tarballs not listed in the
+        manifest are ordinary collected files and are left to the normal
+        removal logic.
+
+        :param rel_name:    Path of the file relative to the archive root
+        :type rel_name:     ``str``
+
+        :returns:   ``True`` if the file is a packed directory tarball
+        :rtype:     ``bool``
+        """
+        return rel_name in self.packed_dirs
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -94,6 +94,7 @@ class SoSReport(SoSComponent):
         'case_id': '',
         'chroot': 'auto',
         'clean': False,
+        'pack_dir': [],
         'container_runtime': 'auto',
         'keep_binary_files': False,
         'desc': '',
@@ -220,6 +221,12 @@ class SoSReport(SoSComponent):
                                 dest="chroot", default='auto',
                                 help="chroot executed commands to SYSROOT "
                                      "[auto, always, never] (default=auto)")
+        report_grp.add_argument("--pack-dir", action="extend",
+                                dest="pack_dir", type=str, default=[],
+                                help="pack these collected directories into a "
+                                     "single tarball within the report "
+                                     "(e.g. /proc/fs/); may be repeated or "
+                                     "comma-separated")
         report_grp.add_argument("--container-runtime", default="auto",
                                 help="Default container runtime to use for "
                                      "collections. 'auto' for policy control.")
@@ -1572,6 +1579,17 @@ class SoSReport(SoSComponent):
                 do_clean = True
             except Exception as err:
                 print(_(f"ERROR: Unable to obfuscate report: {err}"))
+
+        # pack any directories the user asked into a single tarball within the
+        # report. Done after cleaning so obfuscation still applies to the
+        # readable files, and before the manifest is written so the list of
+        # packed tarballs is recorded in it - cleaning an already-built report
+        # relies on that list to know which tarballs to keep. The tarball is
+        # left uncompressed since the whole report is compressed when packaged.
+        if self.opts.pack_dir:
+            packed = self.archive.tar_subdirs(self.opts.pack_dir)
+            if packed:
+                self.report_md.add_list('packed_dirs', packed)
 
         self._add_sos_logs()
         if self.manifest is not None:

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -9,6 +9,7 @@
 import unittest
 from ipaddress import ip_interface
 from os.path import join
+from unittest import mock
 
 import sos.policies
 from sos.cleaner.parsers.ip_parser import SoSIPParser
@@ -481,3 +482,55 @@ class PrepperTests(unittest.TestCase):
             [],
             self.ipv4_prepper.get_parser_file_list('foobar', self.archive)
         )
+
+
+class PackedDirTarballTests(unittest.TestCase):
+    """Verify the cleaner only keeps tarballs that the manifest's
+    'packed_dirs' list records as produced by the report '--pack-dir'
+    option, rather than any tarball found in the archive."""
+
+    def setUp(self):
+        self.archive = SoSReportArchive(
+            archive_path='tests/test_data/'
+                         'sosreport-cleanertest-2021-08-03-qpkxdid.tar.xz',
+            keep_binary_files=[],
+            tmpdir='/tmp',
+            treat_certificates='obfuscate'
+        )
+
+    def test_manifest_listed_tarball_is_kept(self):
+        self.archive.packed_dirs = ['proc/fs.tar']
+        self.assertTrue(self.archive.is_packed_dir_tarball('proc/fs.tar'))
+
+    def test_unlisted_tarball_is_not_kept(self):
+        # a tarball collected from the host, e.g. etc/foreman/backup.tar,
+        # is not packed-dir output and must follow normal removal logic
+        self.archive.packed_dirs = ['proc/fs.tar']
+        self.assertFalse(
+            self.archive.is_packed_dir_tarball('etc/foreman/backup.tar'))
+
+    def test_no_packed_dirs_keeps_nothing(self):
+        # archives with no manifest, or one without packed_dirs
+        self.archive.packed_dirs = []
+        self.assertFalse(self.archive.is_packed_dir_tarball('proc/fs.tar'))
+
+    def test_packed_dirs_loaded_from_manifest(self):
+        manifest = (
+            '{"components": {"report": '
+            '{"packed_dirs": ["/proc/fs", "/etc/foreman/"]}}}'
+        )
+        with mock.patch.object(self.archive, 'get_file_content',
+                               return_value=manifest):
+            self.assertEqual(self.archive._load_packed_dirs(),
+                             ['proc/fs.tar', 'etc/foreman.tar'])
+
+    def test_packed_dirs_empty_without_manifest(self):
+        with mock.patch.object(self.archive, 'get_file_content',
+                               return_value=''):
+            self.assertEqual(self.archive._load_packed_dirs(), [])
+
+    def test_packed_dirs_empty_for_premature_manifest(self):
+        # manifests from sos versions predating --pack-dir
+        with mock.patch.object(self.archive, 'get_file_content',
+                               return_value='{"components": {"report": {}}}'):
+            self.assertEqual(self.archive._load_packed_dirs(), [])


### PR DESCRIPTION
- Add --pack-dir to pack collected directories into a single tar in
    place (e.g. proc/fs/ -> proc/fs.tar) and drop the original tree
- Avoids slow extraction of dirs like /proc/fs/ with millions of
    files: the top-level archive yields one member instead of millions
- Tar is left uncompressed; the whole report is already compressed
    when packaged, so compressing again only duplicates that work
- Accepts multiple dirs, comma-separated or by repeating the flag
- Runs after clean (obfuscation applies) and before packaging
-  Fixes: https://github.com/sosreport/sos/issues/4346
---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
