### PR TITLE
[ipa] Collect Ipa configuration output in sosreport

### DIFF
--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -173,6 +173,11 @@ class Ipa(Plugin, RedHatPlugin):
             "klist -ket /var/lib/ipa/gssproxy/http.keytab"
         ])
 
+        self.add_cmd_output(
+            "ipa -e in_server=true config-show",
+            suggest_filename="ipa_config_show"
+        )
+
         self.add_dir_listing("/etc/dirsrv/slapd-*/schema/")
 
         getcert_pred = SoSPredicate(self,


### PR DESCRIPTION
This helps capture the active IPA server configuration directly in sosreports, which is useful for troubleshooting IPA configuration issues, replication problems, CA/KDC settings, DNS configuration, and general FreeIPA environment validation during support investigations.

Resolves: RHEL-166260

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
