### PR TITLE
[cleaner] Skip obfuscating 'test' user

### DIFF
--- a/sos/cleaner/preppers/usernames.py
+++ b/sos/cleaner/preppers/usernames.py
@@ -28,10 +28,11 @@ class UsernamePrepper(SoSPrepper):
         'stack',
         'reboot',
         'root',
+        'test',
         'timeout:',
         'ubuntu',
         'username',
-        'wtmp'
+        'wtmp',
     ]
 
     def _get_items_for_username(self, archive):


### PR DESCRIPTION
'test' username is generic enough to allow it not obfuscated. While such user is easily present on systems that test sos, what confuses the avocado tests (cf. clean_config_test.txt mock file).

Closes: #4349

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
