### PR TITLE
[plugins] Resolve symlink targets from real parent path

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1362,7 +1362,12 @@ class Plugin():
     def _copy_symlink(self, srcpath):
         # the target stored in the original symlink
         linkdest = os.readlink(srcpath)
-        dest = os.path.join(os.path.dirname(srcpath), linkdest)
+        srcdir = os.path.dirname(srcpath)
+        realdir = os.path.realpath(srcdir)
+        if os.path.isabs(linkdest):
+            dest = linkdest
+        else:
+            dest = os.path.join(realdir, linkdest)
         # Absolute path to the link target. If SYSROOT != '/' this path
         # is relative to the host root file system.
         absdest = os.path.normpath(dest)
@@ -1375,7 +1380,6 @@ class Plugin():
         if os.path.isabs(linkdest):
             # Canonicalize the link target path to avoid additional levels
             # of symbolic links (that would affect the path nesting level).
-            realdir = os.path.realpath(os.path.dirname(srcpath))
             reldest = os.path.relpath(linkdest, start=realdir)
             # trim leading /sysroot
             if self.use_sysroot():

--- a/tests/unittests/plugin_tests.py
+++ b/tests/unittests/plugin_tests.py
@@ -289,6 +289,44 @@ class PluginTests(unittest.TestCase):
         self.mp._do_copy_path("not_here_tests")
         self.assertEqual(self.mp.archive.m, {})
 
+    def test_copy_relative_symlink_from_symlinked_parent(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+
+        sysdir = os.path.join(tmpdir, "sys")
+        real_parent = os.path.join(
+            sysdir, "bus", "cpu", "drivers", "processor"
+        )
+        os.makedirs(real_parent)
+
+        target = os.path.join(sysdir, "devices", "system", "cpu", "cpu0")
+        os.makedirs(os.path.dirname(target))
+        with open(target, "w", encoding="utf-8") as target_file:
+            target_file.write("cpu0\n")
+
+        visible_cpu = os.path.join(
+            sysdir, "devices", "system", "cpu", "cpu3"
+        )
+        os.makedirs(visible_cpu)
+        os.symlink("../../../../bus/cpu",
+                   os.path.join(visible_cpu, "subsystem"))
+        os.symlink("../../../../devices/system/cpu/cpu0",
+                   os.path.join(real_parent, "cpu0"))
+
+        visible_link = os.path.join(
+            visible_cpu, "subsystem", "drivers", "processor", "cpu0"
+        )
+        bad_target = os.path.normpath(os.path.join(
+            os.path.dirname(visible_link),
+            "../../../../devices/system/cpu/cpu0"
+        ))
+
+        self.mp.sysroot = "/"
+        self.mp._do_copy_path(visible_link)
+
+        self.assertIn(target, self.mp.archive.m)
+        self.assertNotIn(bad_target, self.mp.archive.m)
+
     def test_copy_dir_forbidden_path(self):
         p = ForbiddenMockPlugin({
             'cmdlineopts': MockOptions(),


### PR DESCRIPTION
Relative symlink targets must be resolved from the real directory that contains the symlink, not from the visible path used to reach it.

When a copied sysfs path contains symlinked parent components, resolving the relative target with dirname(srcpath) can produce invalid paths such as:

/sys/devices/system/cpu/devices/system/cpu/cpu0

Resolve the parent directory with realpath() before joining relative symlink targets. This avoids repeated failed stat messages from plugins that walk sysfs paths, including processor, scsi, md, and hardware.

Pablo Prado reported the issue and proposed this fix.

Reported-by: Pablo Prado <pablo.prado@oracle.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
