### PR TITLE
[dhcp] Update DHCP plugin to correctly support Debian/Ubuntu DHCP servers

### DIFF
--- a/sos/report/plugins/dhcp.py
+++ b/sos/report/plugins/dhcp.py
@@ -6,7 +6,7 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from sos.report.plugins import Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin
 
 
 class Dhcp(Plugin):
@@ -29,16 +29,38 @@ class RedHatDhcp(Dhcp, RedHatPlugin):
         ])
 
 
-class UbuntuDhcp(Dhcp, UbuntuPlugin):
+class DebianDhcp(Dhcp, DebianPlugin, UbuntuPlugin):
 
     files = ('/etc/init.d/udhcpd',)
-    packages = ('udhcpd',)
+    packages = ('udhcpd', 'isc-dhcp-server', 'dnsmasq')
 
     def setup(self):
         super().setup()
         self.add_copy_spec([
+
+            # udhcpd
             "/etc/default/udhcpd",
-            "/etc/udhcpd.conf"
+            "/etc/udhcpd.conf",
+
+            # ISC DHCP server
+            "/etc/dhcp",
+            "/etc/default/isc-dhcp-server",
+            "/var/lib/dhcp",
+
+            # dnsmasq
+            "/etc/dnsmasq.conf",
+            "/etc/dnsmasq.d",
+            "/etc/default/dnsmasq",
+        ])
+
+        self.add_cmd_output([
+            # ISC DHCP server
+            "systemctl --full status isc-dhcp-server",
+            "dhcp-lease-list",
+
+            # dnsmasq
+            "systemctl --full status dnsmasq",
+            "dnsmasq --test",
         ])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
**Update DHCP plugin to correctly support Debian/Ubuntu DHCP servers**

The previous Ubuntu plugin assumed the presence of BusyBox udhcpd,
which is not used on modern Debian or Ubuntu systems.

This patch replaces the Ubuntu-specific logic with a Debian/Ubuntu
plugin that collects data for the DHCP servers actually used on
these platforms: isc-dhcp-server and dnsmasq.

Obsolete udhcpd paths have been removed.

Signed-off-by: Leah Goldberg leah.goldberg@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
