### PR TITLE
[cleaner] set mapper to initializing during prepper work

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -697,6 +697,7 @@ third party.
         :type prepper:  ``SoSPrepper`` subclass
         """
         for _parser in self.parsers:
+            _parser.mapping.initializing = True
             pname = _parser.name.lower().split()[0].strip()
             for _file in prepper.get_parser_file_list(pname, archive):
                 content = archive.get_file_content(_file)
@@ -720,6 +721,8 @@ third party.
 
             for ritem in prepper.regex_items[pname]:
                 _parser.mapping.add_regex_item(ritem)
+            _parser.mapping.initializing = False
+            _parser.mapping.generate_compiled_regexes()
         # we must initialize stuff inside (cloned processes') archive - REALLY?
         archive.set_parsers(self.parsers)
 


### PR DESCRIPTION
.. and call generate_compiled_regexes at the end. This prevents repetitive and redundant calling the method for each found item.

Resolves: #4356
Closes: #4357

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
