### PR TITLE
[tests] Add tests for skip/enable-plugins merge from config and cmdline

### DIFF
--- a/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_enabled_tests_sos.conf
+++ b/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_enabled_tests_sos.conf
@@ -1,0 +1,2 @@
+[report]
+enable-plugins = networking

--- a/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_only_tests_sos.conf
+++ b/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_only_tests_sos.conf
@@ -1,0 +1,2 @@
+[report]
+only-plugins = host

--- a/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_skipped_tests_sos.conf
+++ b/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_skipped_tests_sos.conf
@@ -1,0 +1,2 @@
+[report]
+skip-plugins = host

--- a/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_tests.py
+++ b/tests/report_tests/plugin_tests/config_cmdline/config_cmdline_tests.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2026 Red Hat, Inc., Jose Castillo <jcastillo@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+
+class SkippedPluginConfigCmdlineTest(StageTwoReportTest):
+    """Ensure that we handle skipped plugins specified
+    in sos.conf and merge them with cmdline properly
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [('config_cmdline_skipped_tests_sos.conf', '/etc/sos/sos.conf')]
+    sos_cmd = '-n kernel'
+
+    def test_skip_plugins_merged_from_conf_and_cmdline(self):
+        # Plugin host is deactivated via sos.conf file
+        # Plugin kernel is deactivated via cmdline
+        options = r'--skip-plugins (host,kernel|kernel,host)'
+        self.assertSosLogContains(f"effective options now: .*{options}")
+        self.assertPluginNotIncluded('host')
+        self.assertPluginNotIncluded('kernel')
+
+
+class EnabledPluginConfigCmdlineTest(StageTwoReportTest):
+    """Ensure that we handle enabled plugins specified in sos.conf
+    and merge them with cmdline properly
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [('config_cmdline_enabled_tests_sos.conf', '/etc/sos/sos.conf')]
+    sos_cmd = '-e memory'
+
+    def test_enabled_plugins_merged_from_conf_and_cmdline(self):
+        # Plugin networking is enabled via sos.conf file
+        # Plugin memory is enabled via cmdline
+        options = r'--enable-plugins (networking,memory|memory,networking)'
+        self.assertSosLogContains(f"effective options now: .*{options}")
+        self.assertPluginIncluded('networking')
+        self.assertPluginIncluded('memory')
+
+
+class PreferPluginPresetConfigTest(StageTwoReportTest):
+    """Test that the preset takes precedence over config file
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [('config_preset_precedence_tests_sos.conf', '/etc/sos/sos.conf'),
+             ('config_preset_precedence_tests.json',
+              '/etc/sos/presets.d/plugins_preset')]
+    sos_cmd = '--preset plugins_preset'
+
+    def test_precedence_preset_config(self):
+        # Plugin memory is enabled via sos.conf file
+        # Plugin memory is skipped via preset file
+        options = r'--skip-plugins memory'
+        self.assertSosLogContains(f"effective options now: .*{options}")
+        self.assertPluginNotIncluded('memory')
+
+
+class OnlyPluginConfigCmdlineTest(StageTwoReportTest):
+    """Test that only-plugins from cmdline replaces rather than merges
+    config value
+
+    Unlike skip-plugins and enable-plugins, which merge, only-plugins uses
+    replacement since it defines an exclusive set.
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [('config_cmdline_only_tests_sos.conf', '/etc/sos/sos.conf')]
+    sos_cmd = '-o kernel'
+
+    def test_only_plugins_cmdline_replaces_config(self):
+        # Plugin host is enabled (only) via sos.conf file
+        # Plugin kernel is specified via cmdline
+        options = r'--only-plugins kernel'
+        self.assertSosLogContains(f"effective options now: .*{options}")
+        self.assertPluginIncluded('kernel')
+        self.assertPluginNotIncluded('host')

--- a/tests/report_tests/plugin_tests/config_cmdline/config_preset_precedence_tests.json
+++ b/tests/report_tests/plugin_tests/config_cmdline/config_preset_precedence_tests.json
@@ -1,0 +1,10 @@
+{
+    "plugins_preset": {
+        "desc": "test preset for plugin skipping",
+        "args": {
+            "skip_plugins": [
+                "memory"
+            ]
+        }
+    }
+}

--- a/tests/report_tests/plugin_tests/config_cmdline/config_preset_precedence_tests_sos.conf
+++ b/tests/report_tests/plugin_tests/config_cmdline/config_preset_precedence_tests_sos.conf
@@ -1,0 +1,2 @@
+[report]
+enable-plugins = memory


### PR DESCRIPTION
Verify that skip-plugins and enable-plugins are merged (not replaced)
when specified in both sos.conf and command line.

This is a regression test for commit 8fc655a6, which fixed the merge
behavior. The new tests verify both effective options
logging in sos.log and actual plugin execution.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
