### PR TITLE
[cleaner] Catch KeyboardInterrupt in child processes

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -40,25 +40,32 @@ from sos.utilities import (get_human_readable, import_module,
 
 # an auxiliary method to kick off child processes over its instances
 def _obfuscate_arc_files(arc, input_queue, output_queue):
-    while True:
-        try:
-            file = input_queue.get()
-        except (EOFError, OSError) as e:
-            print(f"Child process exception when reading input queue: '{e}'")
-            break
-        if file is None:  # Sentinel value to stop the process
+    try:
+        while True:
             try:
-                output_queue.put((
-                    arc.files_obfuscated_count,
-                    arc.total_sub_count,
-                    arc.removed_file_count))
-            except OSError as e:
+                file = input_queue.get()
+            except (EOFError, OSError) as e:
                 print(
-                    f"Child process exception when writing to output queue: "
-                    f"'{e}'"
+                    f"Child process exception when reading input "
+                    f"queue: '{e}'"
                 )
-            break
-        arc.obfuscate_arc_file(file)
+                break
+            if file is None:  # Sentinel value to stop the process
+                try:
+                    output_queue.put((
+                        arc.files_obfuscated_count,
+                        arc.total_sub_count,
+                        arc.removed_file_count))
+                except OSError as e:
+                    print(
+                        f"Child process exception when writing to output "
+                        f"queue: '{e}'"
+                    )
+                break
+            arc.obfuscate_arc_file(file)
+    except KeyboardInterrupt:
+        # catch user's interruption cleanly in the child process
+        pass
 
 
 class SoSCleaner(SoSComponent):


### PR DESCRIPTION
Currently, pressing Ctrl+C during cleaner execution raises uncaght KeyboardInterrupt exception in all child processes.

Thanks @tiredPotato for raising the issue.

Closes: #4360

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
