### PR TITLE
[juju] obfuscate keys from Landscape client logs

### DIFF
--- a/sos/report/plugins/juju.py
+++ b/sos/report/plugins/juju.py
@@ -227,4 +227,11 @@ class Juju(Plugin, UbuntuPlugin):
         self.do_file_private_sub(agents_path)
         self.do_cmd_private_sub('juju controllers')
 
+        # Redact registration keys in Landscape client logs
+        self.do_path_regex_sub(
+            "/var/log/juju/unit-landscape-client-(.*).log(.*)",
+            r"('registration-key'\s*:\s*)'[^']+'",
+            r"\1*********"
+        )
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
**juju: obfuscate keys from Landscape client logs**
    
Sensitive Landscape client configuration (registration-key and
customer domain URLs) was being included in /var/log/juju unit logs
and subsequently collected by sosreport.
    
This commit adds redaction rules to ensure these values are masked
during post processing.
    
Signed-off-by: Leah Goldberg <leah.goldberg@canonical.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?