### PR TITLE
[utilities] Handle SubprocessError in sos_get_command_output

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -10,7 +10,7 @@ import os
 import pwd
 import re
 import inspect
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import Popen, PIPE, STDOUT, SubprocessError
 import logging
 import fnmatch
 import errno
@@ -421,6 +421,10 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
         if e.errno == errno.ENOENT:
             return {'status': 127, 'output': "", 'truncated': ''}
         raise e
+    except SubprocessError:
+        # Handle exceptions in preexec_fn (e.g., user switching failures)
+        # Return 126 (command cannot execute)
+        return {'status': 126, 'output': "", 'truncated': ''}
     finally:
         if hasattr(_output, 'close'):
             _output.close()


### PR DESCRIPTION
Issue Description:
During testing of plugins that execute commands as non-root users, unhandled SubprocessError exceptions occur when preexec_fn fails during user switching. This happens at Popen() initialization when switching to users with permission issues or invalid user contexts.

Solution:
Added SubprocessError exception handling in
sos_get_command_output() to gracefully handle preexec_fn failures. The function now returns status code 126 (command cannot execute) instead of crashing, allowing plugins to continue execution and properly handle user-switching failures.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
