### PR TITLE
[nvidia] Capture sysfs data

### DIFF
--- a/sos/report/plugins/nvidia.py
+++ b/sos/report/plugins/nvidia.py
@@ -49,5 +49,6 @@ class Nvidia(Plugin, IndependentPlugin):
         self.add_cmd_output(
             f"nvidia-smi --query-retired-pages={querypages} --format=csv"
         )
+        self.add_copy_spec(["/sys/class/mdev_bus", "/sys/bus/mdev"])
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Capture the contents of the following sysfs directories:

/sys/class/mdev_bus
/sys/bus/mdev

Containing information about the Mediated device Core Driver.

Related: RHEL-185654

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
