### PR TITLE
[foreman-installer] Scrub secrets in CLI arg dumps

### DIFF
--- a/sos/report/plugins/foreman_installer.py
+++ b/sos/report/plugins/foreman_installer.py
@@ -54,11 +54,12 @@ class ForemanInstaller(Plugin, DebianPlugin, UbuntuPlugin):
                           r"::(.*(token|secret|key|passw).*)\") value:) "
                           r"(.*)")
         self.do_path_regex_sub(install_logs, logs_debug_reg, r"\1 \2 ********")
-        # also hide passwords in yet different formats
+        # also hide passwords in yet different formats, including CLI arg dumps
         self.do_path_regex_sub(
             install_logs,
-            r"password(\", \"|=|\" value: \"|\": \")(.*?)(\", \".*|\"]]|\"|$)",
-            r"password\1********\3")
+            r"((?:password|consumer-key|consumer-secret|key-secret|secret-key|"
+            r"oauth-key|oauth-secret)(?:\", \"|\": \"|=))([^\"\n]*)(\"|$)",
+            r"\1********\3")
         self.do_path_regex_sub(
             "/var/log/foreman-installer/foreman-proxy*",
             r"(\s*proxy_password\s=) (.*)",


### PR DESCRIPTION
Installer logs dump CLI args we need to scrub.

Closes: #4367

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
