### PR TITLE
[lxd] include --all-projects in relevant commands

### DIFF
--- a/sos/report/plugins/lxd.py
+++ b/sos/report/plugins/lxd.py
@@ -23,13 +23,22 @@ class LXD(Plugin, UbuntuPlugin):
 
     def setup(self):
 
+        # Some LXD versions do not support the --all-projects option for
+        # all resource types. Include both variants of the affected
+        # commands so that sosreport can collect the available data across
+        # a wider range of LXD releases.
         lxc_cmds = [
+            "lxc image list local: --all-projects",
+            "lxc list local: --all-projects",
+            "lxc network list local: --all-projects",
+            "lxc profile list local: --all-projects",
+            "lxc operation list local: --all-projects",
             "lxc image list local:",
             "lxc list local:",
             "lxc network list local:",
             "lxc profile list local:",
-            "lxc storage list local:",
             "lxc operation list local:",
+            "lxc storage list local:",
             "lxc info local:",
             "lxc alias list",
             "lxc remote list",


### PR DESCRIPTION
### [lxd] include --all-projects in relevant commands

Update LXD plugin commands to collect resources from all LXD
projects rather than only the default project.
    
Some LXD versions do not support the --all-projects option for
all resource types. Include both variants of the affected
commands so that sosreport can collect the available data across
a wider range of LXD releases.

Addresses #4362 

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?