### PR TITLE
[libvirt] Exclude system.token from collection

### DIFF
--- a/sos/report/plugins/libvirt.py
+++ b/sos/report/plugins/libvirt.py
@@ -25,7 +25,8 @@ class Libvirt(Plugin, IndependentPlugin):
             "/etc/libvirt/passwd.db",
             "/etc/libvirt/krb5.tab",
             "/var/lib/libvirt/qemu/*/master-key.aes",
-            "/etc/libvirt/secrets"
+            "/etc/libvirt/secrets",
+            "/run/libvirt/common/system.token",
         ])
 
         self.add_copy_spec([


### PR DESCRIPTION
## Summary

The libvirt plugin collects `/run/libvirt/` broadly, which sweeps up
`/run/libvirt/common/system.token`. This file contains a raw hex token
used for libvirt daemon authentication (SASL/GSSAPI) and should not be
included in sosreports.

The plugin already excludes other sensitive files (`passwd.db`,
`krb5.tab`, `master-key.aes`, `/etc/libvirt/secrets`) via
`add_forbidden_path`, but `system.token` was missing from the list.

This PR adds `/run/libvirt/common/system.token` to the forbidden paths.

## Changes

- Added `/run/libvirt/common/system.token` to the `forbidden_paths`
  list in the `Libvirt` plugin class

Signed-off-by: Stephen Benjamin <stephen@redhat.com>