### PR TITLE
[foremanctl|valkey] Enable plugin for containerized deployments

### DIFF
--- a/sos/report/plugins/foremanctl.py
+++ b/sos/report/plugins/foremanctl.py
@@ -19,6 +19,7 @@ class Foremanctl(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
     plugin_name = 'foremanctl'
     profiles = ('sysmgmt',)
     packages = ('foremanctl', )
+    containers = ('foreman', 'foreman-proxy',)
 
     def setup(self):
         self.add_copy_spec([
@@ -29,14 +30,34 @@ class Foremanctl(Plugin, RedHatPlugin, DebianPlugin, UbuntuPlugin):
 
         self.add_cmd_output([
             "foremanctl features",
+            "foremanctl health",
         ])
 
         self.add_dir_listing(["/var/lib/foremanctl/"], recursive=True)
 
     def postproc(self):
-        self.do_path_regex_sub("/var/lib/foremanctl/parameters.yaml",
-                               r"(foreman_initial_admin_password:\s*)(.*)",
-                               r"\1********")
+        # Scrub passwords, credentials, tokens, secrets, and keys
+        self.do_path_regex_sub(
+            "/var/lib/foremanctl/parameters.yaml",
+            r"((.*)?(passw|cred|token|secret|key).*(\:\s|=))(.*)",
+            r"\1********")
 
+        # Scrub passwords from foremanctl logs - Pattern 1: key=value format
+        self.do_path_regex_sub(
+            "/var/log/foremanctl/foremanctl.*log*",
+            r"((passw|cred|token|secret|key)\w*\s*=\s*)(.*?)(\s|,|\"|'|$)",
+            r"\1********\4")
+
+        # Scrub passwords from foremanctl logs - Pattern 2: "password something" format
+        self.do_path_regex_sub(
+            "/var/log/foremanctl/foremanctl.*log*",
+            r"(password\s+)(.*?)(\s|,|\"|$)",
+            r"\1********\3")
+
+        # Scrub admin credentials in username:password format
+        self.do_path_regex_sub(
+            "/var/log/foremanctl/foremanctl.*log*",
+            r"(Admin credentials:\s+\w+:)(.*?)(\"|,|$)",
+            r"\1********\3")
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/valkey.py
+++ b/sos/report/plugins/valkey.py
@@ -19,6 +19,7 @@ class Valkey(Plugin, IndependentPlugin):
     profiles = ('services',)
 
     packages = ('valkey',)
+    containers = ('valkey',)
 
     var_puppet_gen = "/var/lib/config-data/puppet-generated/valkey"
 


### PR DESCRIPTION
The plugin required foremanctl package which doesn't exist in containerized mode. Add container detection to enable the plugin and collect foremanctl health diagnostics for support cases.

