### PR TITLE
[report] Fix typo in container runtime disable option

### DIFF
--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -492,7 +492,7 @@ class SoSReport(SoSComponent):
         """
         if self.opts.container_runtime != 'auto':
             crun = self.opts.container_runtime.lower()
-            if crun in ['none', 'off', 'diabled']:
+            if crun in ['none', 'off', 'disabled']:
                 self.policy.runtimes = {}
                 self.soslog.info(
                     "Disabled all container runtimes per user option."


### PR DESCRIPTION
The container runtime check currently looks for "diabled", which is a typo for "disabled". As a result, passing "--container-runtime disabled" does not disable container runtime collection.
Replace the misspelled value with the intended spelling.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
