### PR TITLE
[collector] Prevent password leakage and incompatible flag usage

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -363,9 +363,17 @@ class SoSCollector(SoSComponent):
             'Collector Options',
             'These options control how collect runs locally'
         )
-        collect_grp.add_argument('-b', '--become', action='store_true',
-                                 dest='become_root',
-                                 help='Become root on the remote nodes')
+        # These privilege escalation options are mutually exclusive
+        priv_grp = collect_grp.add_mutually_exclusive_group()
+        priv_grp.add_argument('-b', '--become', action='store_true',
+                              dest='become_root',
+                              help=('Become root on the remote nodes using '
+                                    'su. Do not use with --nopasswd-sudo'))
+        priv_grp.add_argument('--nopasswd-sudo', action='store_true',
+                              help=('Use passwordless sudo for privilege '
+                                    'escalation on nodes. Implied for '
+                                    'non-root SSH users. Do not use with '
+                                    '--become'))
         collect_grp.add_argument('--case-id', help='Specify case number')
         collect_grp.add_argument('--inherit-config-file', default=False,
                                  action='store_true',
@@ -414,8 +422,6 @@ class SoSCollector(SoSComponent):
                                  dest='primary', default='',
                                  help='Specify a primary node for cluster '
                                       'enumeration')
-        collect_grp.add_argument('--nopasswd-sudo', action='store_true',
-                                 help='Use passwordless sudo on nodes')
         collect_grp.add_argument('--nodes', action="append",
                                  help=('Provide a comma delimited list of '
                                        'nodes, or a regex to match against'))

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -227,11 +227,11 @@ class SosNode():
                                   f"{self.host.sos_container_name} created")
                     return True
                 self.log_error("Could not start container after create: "
-                               f"{ret['output']}")
+                               f"{self._sanitize_log_msg(ret['output'])}")
                 raise Exception
 
             self.log_error("Could not create container on host: "
-                           f"{res['output']}")
+                           f"{self._sanitize_log_msg(res['output'])}")
             raise Exception
         return False
 


### PR DESCRIPTION
When using sos collect with passwordless sudo, two issues occurred:

1. Passwords could leak into error messages when container creation failed. The error "Could not create container on host: <output>" would include the full command output, which could contain passwords passed via the command line.

2. Users could combine --become (which uses 'su' to become root and requires a root password) with --nopasswd-sudo (which uses passwordless sudo). These are incompatible privilege escalation methods and should not be used together.

Fixes:
- Sanitize container creation error output to prevent password leakage
- Make --become and --nopasswd-sudo mutually exclusive flags
- Improve help text to clarify that --nopasswd-sudo is implied for non-root SSH users and should not be combined with --become

Related: SUPDEV-166

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
