### PR TITLE
[cleaner] Exclude RHOSO service usernames from obfuscation

### DIFF
--- a/sos/cleaner/preppers/usernames.py
+++ b/sos/cleaner/preppers/usernames.py
@@ -21,9 +21,15 @@ class UsernamePrepper(SoSPrepper):
     name = 'username'
 
     skip_list = [
+        'ceilometer',
+        'ceph',
+        'cloud-admin',
         'core',
+        'libvirt',
         'nobody',
         'nfsnobody',
+        'nova',
+        'openvswitch',
         'shutdown',
         'stack',
         'reboot',

--- a/tests/unittests/cleaner_tests.py
+++ b/tests/unittests/cleaner_tests.py
@@ -26,6 +26,7 @@ from sos.cleaner.mappings.ipv6_map import SoSIPv6Map
 from sos.cleaner.preppers import SoSPrepper
 from sos.cleaner.preppers.hostname import HostnamePrepper
 from sos.cleaner.preppers.ip import IPPrepper
+from sos.cleaner.preppers.usernames import UsernamePrepper
 from sos.cleaner.archives.sos import SoSReportArchive
 from sos.options import SoSOptions
 
@@ -490,6 +491,64 @@ class PrepperTests(unittest.TestCase):
             [],
             self.ipv4_prepper.get_parser_file_list('foobar', self.archive)
         )
+
+    def test_username_prepper_rhoso_skip_list(self):
+        """Verify that RHOSO service usernames are in the skip list and will
+        not be obfuscated."""
+        username_prepper = UsernamePrepper(SoSOptions())
+        rhoso_usernames = [
+            'nova',
+            'ceilometer',
+            'ceph',
+            'libvirt',
+            'openvswitch',
+            'cloud-admin'
+        ]
+        for username in rhoso_usernames:
+            self.assertIn(username, username_prepper.skip_list,
+                          f"RHOSO service username '{username}' should be in "
+                          f"skip_list to prevent obfuscation")
+
+    def test_username_prepper_rhoso_not_collected(self):
+        """Verify that RHOSO service usernames found in mock lastlog output
+        are not included in the items to obfuscate."""
+        class MockArchive:
+            is_sos = True
+            is_insights = False
+
+            def get_file_content(self, path):
+                if 'lastlog' in path or 'last' in path:
+                    return ('nova                     pts/0    10.0.0.1'
+                            '         Mon Jan 01 10:00:00 +0000 2024\n'
+                            'ceilometer               pts/1    10.0.0.2'
+                            '         Mon Jan 01 11:00:00 +0000 2024\n'
+                            'ceph                     pts/2    10.0.0.3'
+                            '         Mon Jan 01 12:00:00 +0000 2024\n'
+                            'libvirt                  pts/3    10.0.0.4'
+                            '         Mon Jan 01 13:00:00 +0000 2024\n'
+                            'openvswitch              pts/4    10.0.0.5'
+                            '         Mon Jan 01 14:00:00 +0000 2024\n'
+                            'cloud-admin              pts/5    10.0.0.6'
+                            '         Mon Jan 01 15:00:00 +0000 2024\n'
+                            'testuser                 pts/6    10.0.0.7'
+                            '         Mon Jan 01 16:00:00 +0000 2024\n')
+                return ''
+
+        username_prepper = UsernamePrepper(SoSOptions(usernames=[]))
+        items = username_prepper.get_items_for_map('username', MockArchive())
+
+        # RHOSO usernames should NOT be in the items list
+        rhoso_usernames = ['nova', 'ceilometer', 'ceph', 'libvirt',
+                           'openvswitch', 'cloud-admin']
+        for username in rhoso_usernames:
+            self.assertNotIn(username, items,
+                             f"RHOSO service username '{username}' should not "
+                             f"be collected for obfuscation")
+
+        # Regular users should still be collected
+        self.assertIn('testuser', items,
+                      "Regular username 'testuser' should be collected for "
+                      "obfuscation")
 
 
 class PackedDirTarballTests(unittest.TestCase):


### PR DESCRIPTION
Standard RHOSO data plane service usernames (nova, libvirt, openvswitch, cloud-admin, ceilometer, ceph) should not be obfuscated as they exist by default on RHOSO data plane nodes and obfuscating them breaks automated checks and complicates troubleshooting without security benefits.

This change adds these usernames to the skip_list in UsernamePrepper so they are excluded from obfuscation during cleaning operations. Control plane usernames are not included as they only exist in pods, not on the data plane nodes themselves.

Also adds comprehensive unit tests to verify the fix.

Related: RHEL-188075

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
