### PR TITLE
[sos-collect] Allow equals sign on sos-collect cluster value options

### DIFF
--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -603,7 +603,9 @@ class SoSCollector(SoSComponent):
                 try:
                     # there are no instances currently where any cluster option
                     # should contain a legitimate space.
-                    value = option.split('=')[1].split()[0]
+                    # however, some options like ocp.label or kubernetes.label
+                    # do contain equals
+                    value = '='.join(option.split('=')[1:]).split()[0]
                 except IndexError:
                     # conversion to boolean is handled during validation
                     value = 'True'


### PR DESCRIPTION
Option parsing on sos-collect mistakenly assumed that no '='  would be present in the value of the options, which breaks some cluster options like `kubernetes.label` or `ocp.label` (as labels in kubernetes are key-pair values separated by '=' for filtering).

Fixes [SUPDEV-227](https://redhat.atlassian.net/browse/SUPDEV-227)