### PR TITLE
[ocf] Add plugin to collect OCF binaries and libraries

### DIFF
--- a/sos/report/plugins/ocf.py
+++ b/sos/report/plugins/ocf.py
@@ -8,11 +8,10 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
-                                UbuntuPlugin)
+from sos.report.plugins import Plugin, IndependentPlugin
 
 
-class Ocf(Plugin):
+class Ocf(Plugin, IndependentPlugin):
     """Archive OCF resource agent binaries and libraries.
 
     Collects OCF installation paths used by Pacemaker resource agents,
@@ -34,27 +33,13 @@ class Ocf(Plugin):
     )
 
     def setup(self):
-        specs = []
-        for path in self.ocf_paths:
-            if self.path_exists(path):
-                specs.append(path)
-
-        if not specs:
-            return
-
         self.add_file_tags({
             '/usr/lib/ocf/lib/heartbeat/ocf-binaries': 'ocf_binaries',
             '/usr/lib/ocf/lib/heartbeat/ocf-shellfuncs': 'ocf_shellfuncs',
         })
 
-        self.add_copy_spec(specs)
-        self.add_dir_listing(specs)
-
-    def setup_rpm_inventory(self):
-        self.add_cmd_output(
-            'sh -c "rpm -ql resource-agents resource-agents-base 2>/dev/null '
-            '| grep /ocf"'
-        )
+        self.add_copy_spec(self.ocf_paths)
+        self.add_dir_listing(self.ocf_paths)
 
     def postproc(self):
         # password=secret -> password=********
@@ -74,15 +59,5 @@ class Ocf(Plugin):
             r"(passw([^\s=]*)=)\S+",
             r"\1********"
         )
-
-
-class RedHatOcf(Ocf, RedHatPlugin):
-    def setup(self):
-        self.setup_rpm_inventory()
-        super().setup()
-
-
-class DebianOcf(Ocf, DebianPlugin, UbuntuPlugin):
-    """ Parent class Ocf setup() will be called """
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ocf.py
+++ b/sos/report/plugins/ocf.py
@@ -12,25 +12,19 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 
 class Ocf(Plugin, IndependentPlugin):
-    """Archive OCF resource agent binaries and libraries.
+    """Archive OCF resource agent scripts and libraries.
 
-    Collects OCF installation paths used by Pacemaker resource agents,
-    including helper binaries under /usr/bin/ocf and the standard OCF root
-    hierarchy under /usr/lib/ocf (resource agents, shared libraries, and
-    support scripts).
+    Collects the standard OCF root under /usr/lib/ocf used by Pacemaker
+    resource agents, including resource agent scripts under resource.d/
+    and shared libraries/support scripts under lib/heartbeat/.
     """
 
-    short_desc = 'OCF resource agent binaries and libraries'
+    short_desc = 'OCF resource agent scripts and libraries'
 
     plugin_name = 'ocf'
     profiles = ('cluster',)
     packages = ('resource-agents', 'resource-agents-base')
-    files = ('/usr/lib/ocf', '/usr/bin/ocf')
-
-    ocf_paths = (
-        '/usr/bin/ocf',
-        '/usr/lib/ocf',
-    )
+    files = ('/usr/lib/ocf',)
 
     def setup(self):
         self.add_file_tags({
@@ -38,8 +32,7 @@ class Ocf(Plugin, IndependentPlugin):
             '/usr/lib/ocf/lib/heartbeat/ocf-shellfuncs': 'ocf_shellfuncs',
         })
 
-        self.add_copy_spec(self.ocf_paths)
-        self.add_dir_listing(self.ocf_paths)
+        self.add_copy_spec('/usr/lib/ocf')
 
     def postproc(self):
         # password=secret -> password=********
@@ -53,11 +46,6 @@ class Ocf(Plugin, IndependentPlugin):
             r"/usr/lib/ocf/.*",
             r"(api[_]?key[^\s=]*)=\S+",
             r"\1=********"
-        )
-        self.do_path_regex_sub(
-            r"/usr/bin/ocf/.*",
-            r"(passw([^\s=]*)=)\S+",
-            r"\1********"
         )
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/ocf.py
+++ b/sos/report/plugins/ocf.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2026
+#
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin)
+
+
+class Ocf(Plugin):
+    """Archive OCF resource agent binaries and libraries.
+
+    Collects OCF installation paths used by Pacemaker resource agents,
+    including helper binaries under /usr/bin/ocf and the standard OCF root
+    hierarchy under /usr/lib/ocf (resource agents, shared libraries, and
+    support scripts).
+    """
+
+    short_desc = 'OCF resource agent binaries and libraries'
+
+    plugin_name = 'ocf'
+    profiles = ('cluster',)
+    packages = ('resource-agents', 'resource-agents-base')
+    files = ('/usr/lib/ocf', '/usr/bin/ocf')
+
+    ocf_paths = (
+        '/usr/bin/ocf',
+        '/usr/lib/ocf',
+    )
+
+    def setup(self):
+        specs = []
+        for path in self.ocf_paths:
+            if self.path_exists(path):
+                specs.append(path)
+
+        if not specs:
+            return
+
+        self.add_file_tags({
+            '/usr/lib/ocf/lib/heartbeat/ocf-binaries': 'ocf_binaries',
+            '/usr/lib/ocf/lib/heartbeat/ocf-shellfuncs': 'ocf_shellfuncs',
+        })
+
+        self.add_copy_spec(specs)
+        self.add_dir_listing(specs)
+
+    def setup_rpm_inventory(self):
+        self.add_cmd_output(
+            'sh -c "rpm -ql resource-agents resource-agents-base 2>/dev/null '
+            '| grep /ocf"'
+        )
+
+    def postproc(self):
+        # password=secret -> password=********
+        self.do_path_regex_sub(
+            r"/usr/lib/ocf/.*",
+            r"(passw([^\s=]*)=)\S+",
+            r"\1********"
+        )
+        # api_key=abc123 -> api_key=********
+        self.do_path_regex_sub(
+            r"/usr/lib/ocf/.*",
+            r"(api[_]?key[^\s=]*)=\S+",
+            r"\1=********"
+        )
+        self.do_path_regex_sub(
+            r"/usr/bin/ocf/.*",
+            r"(passw([^\s=]*)=)\S+",
+            r"\1********"
+        )
+
+
+class RedHatOcf(Ocf, RedHatPlugin):
+    def setup(self):
+        self.setup_rpm_inventory()
+        super().setup()
+
+
+class DebianOcf(Ocf, DebianPlugin, UbuntuPlugin):
+    """ Parent class Ocf setup() will be called """
+
+# vim: set et ts=4 sw=4 :

--- a/tests/report_tests/plugin_tests/ocf/ocf.py
+++ b/tests/report_tests/plugin_tests/ocf/ocf.py
@@ -10,14 +10,13 @@ from sos_tests import StageTwoReportTest
 
 
 class OcfPluginTest(StageTwoReportTest):
-    """Ensure that the ocf plugin collects OCF binaries and libraries when
-    the standard paths are present on the system.
+    """Ensure that the ocf plugin collects OCF scripts and libraries when
+    /usr/lib/ocf is present on the system.
 
     :avocado: tags=stagetwo
     """
 
     files = [
-        ('usr_bin_ocf/sample-ocf-bin', '/usr/bin/ocf/sample-ocf-bin'),
         ('usr_lib_ocf/resource.d/heartbeat/Dummy',
          '/usr/lib/ocf/resource.d/heartbeat/Dummy'),
     ]
@@ -27,13 +26,6 @@ class OcfPluginTest(StageTwoReportTest):
     def test_plugin_ran(self):
         self.assertPluginIncluded('ocf')
 
-    def test_usr_bin_ocf_collected(self):
-        self.assertFileCollected('/usr/bin/ocf/sample-ocf-bin')
-
     def test_usr_lib_ocf_collected(self):
         self.assertFileCollected(
             '/usr/lib/ocf/resource.d/heartbeat/Dummy')
-
-    def test_dir_listing_collected(self):
-        self.assertFileGlobInArchive('sos_commands/ocf/ls_-alZ_*usr*bin*ocf*')
-        self.assertFileGlobInArchive('sos_commands/ocf/ls_-alZ_*usr*lib*ocf*')

--- a/tests/report_tests/plugin_tests/ocf/ocf.py
+++ b/tests/report_tests/plugin_tests/ocf/ocf.py
@@ -1,0 +1,39 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+
+class OcfPluginTest(StageTwoReportTest):
+    """Ensure that the ocf plugin collects OCF binaries and libraries when
+    the standard paths are present on the system.
+
+    :avocado: tags=stagetwo
+    """
+
+    files = [
+        ('usr_bin_ocf/sample-ocf-bin', '/usr/bin/ocf/sample-ocf-bin'),
+        ('usr_lib_ocf/resource.d/heartbeat/Dummy',
+         '/usr/lib/ocf/resource.d/heartbeat/Dummy'),
+    ]
+
+    sos_cmd = '-o ocf'
+
+    def test_plugin_ran(self):
+        self.assertPluginIncluded('ocf')
+
+    def test_usr_bin_ocf_collected(self):
+        self.assertFileCollected('/usr/bin/ocf/sample-ocf-bin')
+
+    def test_usr_lib_ocf_collected(self):
+        self.assertFileCollected(
+            '/usr/lib/ocf/resource.d/heartbeat/Dummy')
+
+    def test_dir_listing_collected(self):
+        self.assertFileGlobInArchive('sos_commands/ocf/ls_-alZ_*usr*bin*ocf*')
+        self.assertFileGlobInArchive('sos_commands/ocf/ls_-alZ_*usr*lib*ocf*')

--- a/tests/report_tests/plugin_tests/ocf/usr_bin_ocf/sample-ocf-bin
+++ b/tests/report_tests/plugin_tests/ocf/usr_bin_ocf/sample-ocf-bin
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Sample OCF helper binary for sos plugin testing
+echo "ocf-test-binary"

--- a/tests/report_tests/plugin_tests/ocf/usr_bin_ocf/sample-ocf-bin
+++ b/tests/report_tests/plugin_tests/ocf/usr_bin_ocf/sample-ocf-bin
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Sample OCF helper binary for sos plugin testing
-echo "ocf-test-binary"

--- a/tests/report_tests/plugin_tests/ocf/usr_lib_ocf/resource.d/heartbeat/Dummy
+++ b/tests/report_tests/plugin_tests/ocf/usr_lib_ocf/resource.d/heartbeat/Dummy
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Sample OCF resource agent for sos plugin testing
+. ${OCF_ROOT}/lib/heartbeat/ocf-shellfuncs 2>/dev/null || true
+
+case "$1" in
+    meta-data)
+        cat <<EOF
+<?xml version="1.0"?>
+<resource-agent name="Dummy" version="1.0">
+  <shortdesc lang="en">Dummy test agent</shortdesc>
+</resource-agent>
+EOF
+        ;;
+    start|stop|monitor)
+        exit 0
+        ;;
+    *)
+        exit $OCF_ERR_UNIMPLEMENTED
+        ;;
+esac


### PR DESCRIPTION
[ocf] Add plugin to collect OCF binaries and libraries

When sos report runs on Pacemaker/HA nodes, the existing pacemaker plugin
collects cluster manager state (pcs/crm output, pacemaker logs, and
crm_report) but does not archive OCF resource agent scripts or shared OCF
library files. Support engineers analyzing sosreports often need those
files to correlate cluster behavior with resource agent code.

Add a new ocf plugin that collects OCF installation paths used by
Pacemaker resource agents:

- /usr/bin/ocf (OCF helper binaries, when present)
- /usr/lib/ocf (standard OCF root: resource agents, libraries, and
  support scripts)

The plugin enables when resource-agents or resource-agents-base is
installed, or when either path exists. It belongs to the cluster profile.

Collections are file-only: add_copy_spec() and add_dir_listing() are
used for both paths. No OCF agent actions (start/stop/monitor) are
executed, so sos does not change cluster state during collection.

On Red Hat systems, an rpm -ql inventory of packaged OCF files is also
collected. postproc() scrubs password= and api_key= patterns from
collected OCF content.

A stage-2 test with mocked /usr/bin/ocf and /usr/lib/ocf paths verifies
that the plugin runs and archives the expected files.

**Tested on a cluster server running on RHEL 8 :** 
[root@dell-r640-21 sosreport-rhel8gfs22-2026-07-13-tfofnfr]# ll usr/lib/ocf/resource.d/heartbeat/
total 1176
-rwxr-xr-x. 1 root root 19270 Apr 28 14:01 apache
-rwxr-xr-x. 1 root root 10545 Apr 28 14:01 awseip
-rwxr-xr-x. 1 root root  9221 Apr 28 14:01 awsvip
-rwxr-xr-x. 1 root root 16889 Apr 28 14:01 aws-vpc-move-ip
-rwxr-xr-x. 1 root root 15776 Apr 28 14:01 aws-vpc-route53
-rwxr-xr-x. 1 root root 30123 Apr 28 14:01 azure-events
-rwxr-xr-x. 1 root root 26914 Apr 28 14:01 azure-events-az
-rwxr-xr-x. 1 root root  5882 Apr 28 14:01 azure-lb
-rwxr-xr-x. 1 root root  9758 Apr 28 14:01 conntrackd
-rwxr-xr-x. 1 root root 10268 Apr 28 14:01 crypt
-rwxr-xr-x. 1 root root 35144 Apr 28 14:01 CTDB
-rwxr-xr-x. 1 root root 33419 Apr 28 14:01 db2
-rwxr-xr-x. 1 root root  5051 Apr 28 14:01 Delay
-rwxr-xr-x. 1 root root 19129 Apr 28 14:01 dhcpd
-rwxr-xr-x. 1 root root 17324 Apr 28 14:01 docker
-rwxr-xr-x. 1 root root  5566 Apr 28 14:01 Dummy

Assisted-by: Cursor <https://cursor.com>
Signed-off-by: Reshma Vijayan <revijaya@redhat.com>