### PR TITLE
[anaconda] scrub SSL certs and keys in anaconda-ks.cfg

### DIFF
--- a/sos/report/plugins/anaconda.py
+++ b/sos/report/plugins/anaconda.py
@@ -52,5 +52,6 @@ class Anaconda(Plugin, RedHatPlugin):
             r"\1********"
         )
         self.do_paths_http_sub(self.copypaths)
+        self.do_file_private_sub("/root/anaconda-ks.cfg")
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
SSL certs and keys in `/root/anaconda-ks.cfg` can contain arbitrarily sensitive data that should be scrubbed by default.

Closes: #4386

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
