### PR TITLE
[cleaner] skip regenerating host obfuscation on empty host

### DIFF
--- a/sos/cleaner/mappings/ipv6_map.py
+++ b/sos/cleaner/mappings/ipv6_map.py
@@ -272,8 +272,12 @@ class ObfuscatedIPv6Network():
             _n = self.network_addr.rstrip(':')
             _host = addr.compressed[len(_n):].lstrip(':')
             _ob_host = _generate_address(_host)
-            while _ob_host in self.hosts.values():
-                _ob_host = _generate_address(_host)
+            # When _host is empty, all such addresses map to the obfuscated
+            # network prefix. Regeneration cannot disambiguate them, so do
+            # not retry on collision.
+            if _host:
+                while _ob_host in self.hosts.values():
+                    _ob_host = _generate_address(_host)
             self.add_obfuscated_host_address(addr.compressed, _ob_host)
         return self.hosts[addr.compressed]
 


### PR DESCRIPTION
When _host is empty, all such addresses map to the obfuscated network prefix. Regeneration cannot disambiguate them, so do not retry on collision.

Resolves: #4384
Closes: #4387

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
