### PR TITLE
[cleaner] Fix user permissions on extract

### DIFF
--- a/sos/cleaner/archives/__init__.py
+++ b/sos/cleaner/archives/__init__.py
@@ -37,7 +37,9 @@ def extract_archive(archive_path, tmpdir):
 
         # Guard against "Arbitrary file write during tarfile extraction"
         # Checks the extracted files don't stray out of the target directory.
-        for member in archive.getmembers():
+        not_root = os.getuid() != 0
+        members = archive.getmembers()
+        for member in members:
             member_path = os.path.join(path, member.name)
             abs_directory = os.path.abspath(path)
             abs_target = os.path.abspath(member_path)
@@ -45,7 +47,12 @@ def extract_archive(archive_path, tmpdir):
             if prefix != abs_directory:
                 raise Exception(f"Attempted path traversal in tarfle"
                                 f"{prefix} != {abs_directory}")
-            archive.extract(member, path)
+            # Directories collected from the host may lack u+w or u+x
+            # permissions, preventing child members from being created during
+            # extract
+            if not_root and member.isdir():
+                member.mode |= stat.S_IWUSR | stat.S_IXUSR
+        archive.extractall(path, members=members)
         return os.path.join(path, archive.name.split('/')[-1].split('.tar')[0])
 
 


### PR DESCRIPTION
sos archives may contain directories with permissions (like 0555 or 0600) insufficient for non-root user to extract files there.

That blocks running cleaner as non-root.

Similarly like post-extract permission fixup, enhance such permissions during the extraction, and use tarfile.extractall() so directory ownership/mode/mtime are applied after all members are on disk.

Closes: #4389

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
