### PR TITLE
[cleaner] fix a typo in ui log

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -646,7 +646,7 @@ third party.
                 self.ui_log.warning(
                     "WARNING: certificate files that potentially contain "
                     "sensitive information will\n"
-                    "be CONVERTED to text and OBFUSCATED in the final"
+                    "be CONVERTED to text and OBFUSCATED in the final "
                     "archive.\n"
                 )
             elif self.opts.treat_certificates == "keep":


### PR DESCRIPTION
"in the finalarchive." -> "in the final archive."

Closes: #4391

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
