### PR TITLE
[workflow] Add ubuntu 26.04 to the CI jobs

### DIFF
--- a/.github/workflows/main-pipeline.yaml
+++ b/.github/workflows/main-pipeline.yaml
@@ -27,7 +27,8 @@ jobs:
         run: |
           DISTRO_JSON='[
             {"name": "ubuntu-22.04",  "image": "",              "builds": ["deb", "snap"], "stages": "foreman"},
-            {"name": "ubuntu-24.04",  "image": "",              "builds": ["deb", "snap"], "stages": "two"},
+            {"name": "ubuntu-24.04",  "image": "",              "builds": ["deb", "snap"], "stages": ""},
+            {"name": "ubuntu-26.04",  "image": "",              "builds": ["deb", "snap"], "stages": "two"},
             {"name": "ubuntu-latest", "image": "ubuntu:latest", "builds": ["deb"],         "stages": ""},
             {"name": "debian-12",     "image": "debian:12",     "builds": ["deb"],         "stages": ""},
             {"name": "debian-13",     "image": "debian:13",     "builds": ["deb"],         "stages": "two"},


### PR DESCRIPTION
Move stagetwo from 24.04 to 26.04 as well

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
