### PR TITLE
[policies] Prefer most specific policy when multiple match

### DIFF
--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -29,20 +29,24 @@ def import_policy(name):
         return None
 
 
-def load(cache={}, sysroot=None, init=None, probe_runtime=True,
+def load(cache=None, sysroot=None, init=None, probe_runtime=True,
          remote_exec=None, remote_check=''):
+    if cache is None:
+        cache = {}
     if 'policy' in cache:
         return cache.get('policy')
 
     import sos.policies.distros
     helper = ImporterHelper(sos.policies.distros)
+    matches = []
     for module in helper.get_modules():
-        for policy in import_policy(module):
-            if policy.check(remote=remote_check):
-                cache['policy'] = policy(sysroot=sysroot, init=init,
-                                         probe_runtime=probe_runtime,
-                                         remote_exec=remote_exec)
-                break
+        matches.extend([policy for policy in (import_policy(module) or [])
+                        if policy.check(remote=remote_check)])
+    if matches:
+        matches.sort(key=lambda p: len(p.__mro__), reverse=True)
+        cache['policy'] = matches[0](sysroot=sysroot, init=init,
+                                     probe_runtime=probe_runtime,
+                                     remote_exec=remote_exec)
 
     if sys.platform != 'linux':
         raise Exception("SoS is not supported on this platform")


### PR DESCRIPTION
## Problem

When multiple policies return `True` from `check()`, the policy loader selects whichever class sorts first alphabetically via `inspect.getmembers()`. This causes `RHELPolicy` to always win over `RedHatCoreOSPolicy` inside a toolbox container on RHCOS, because uppercase `H` sorts before lowercase `e` in ASCII.

Both policies return `True` in that context: RHEL matches the container's `/etc/redhat-release`, and RHCOS matches the host's `$HOST/etc/os-release`. But `RHELPolicy` is iterated first and the loader breaks on first match.

The same issue affects policies split across different module files. For example, `UbuntuPolicy` (child of `DebianPolicy`) lives in `ubuntu.py` while `DebianPolicy` lives in `debian.py`. Since `debian` sorts before `ubuntu`, `DebianPolicy` matches first and the loader never reaches `ubuntu.py`. This also applies to AlmaLinux, Rocky, and other RedHatPolicy subclasses in separate module files.

This has existed since `RedHatCoreOSPolicy` was introduced in 2019 (commit fa06bc09c95c) but was never visible because RHCOS had no behavioral differences from RHEL. After the archive naming change in commit 0e919b6, `RedHatCoreOSPolicy.get_archive_name()` includes the OCP node role and cluster name, but it is never called because the RHEL policy is selected instead.

## Reproduction

Inside a toolbox container on an RHCOS node:

```python
from sos.policies import import_policy
for p in import_policy('redhat'):
    print(p.__name__, '->', 'check():', p.check())
```

Output:
```
RHELPolicy -> check(): True
RedHatCoreOSPolicy -> check(): True
```

The loader picks `RHELPolicy` (first match) and never reaches `RedHatCoreOSPolicy`.

## Fix

Three changes to `load()`:

1. **Collect matches across all modules** before selecting, instead of breaking on the first module with a match. This handles policies split across different files (e.g. Ubuntu/Debian).

2. **Sort by MRO depth** (descending) so a subclass is always preferred over its parent. A subclass that returns `True` from `check()` is by definition a more precise match.

```
RedHatCoreOSPolicy  MRO depth: 6  (RedHatCoreOSPolicy > RHELPolicy > RedHatPolicy > LinuxPolicy > Policy > object)
RHELPolicy          MRO depth: 5  (RHELPolicy > RedHatPolicy > LinuxPolicy > Policy > object)
```

3. **Guard against broken policy modules**: `(import_policy(module) or [])` prevents a TypeError if `import_policy()` returns None from a failed import.

Additionally, changed `cache={}` to `cache=None` with a local fallback to fix a pre-existing CodeQL warning about mutable default arguments.

## Test

Verified on OCP 4.22.4, RHCOS 9.8, toolbox with sos-4.11.2-2.el9_8:

- `RedHatCoreOSPolicy.check()` returns True
- `_get_node_role()` returns correct role (e.g. `worker`)
- `_get_cluster_name()` returns correct cluster name (e.g. `sharedocp422`)
- Without this fix: archive is `sosreport-<hostname>-<date>-<rand>.tar.xz`
- With this fix: the RHCOS policy is selected, enabling the role and cluster name in the archive

Related: RHEL-188753