### PR TITLE
[processor] Limit /sys/devices/system/cpu/cpu* subdirs collected

### DIFF
--- a/sos/report/plugins/processor.py
+++ b/sos/report/plugins/processor.py
@@ -6,7 +6,9 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin, SoSPredicate
+import re
+from sos.report.plugins import (Plugin, IndependentPlugin, SoSPredicate,
+                                PluginOpt)
 from sos.policies.distros.ubuntu import UbuntuPolicy
 
 
@@ -18,6 +20,11 @@ class Processor(Plugin, IndependentPlugin):
     profiles = ('system', 'hardware', 'memory')
     files = ('/proc/cpuinfo',)
     packages = ('cpufreq-utils', 'cpuid')
+    option_list = [
+        PluginOpt('max_cpu_dirs', default=64, val_type=int,
+                  desc='Maximum number of cpu[0-9]+ directories '
+                       'to collect from /sys/devices/system/cpu'),
+    ]
 
     cpu_kmods = []
 
@@ -43,7 +50,39 @@ class Processor(Plugin, IndependentPlugin):
         # copy /sys/devices/system/cpu/cpuX with separately applied sizelimit
         # this is required for systems with tens/hundreds of CPUs where the
         # cumulative directory size exceeds 25MB or even 100MB.
+        # Limit cpu[0-9]* directories to avoid excessive collection.
+        # All non-cpu* directories are always collected.
+        max_cpu_dirs = self.get_option('max_cpu_dirs')
+        if max_cpu_dirs < 0:
+            self._log_info(f"Invalid {max_cpu_dirs=} value provided, "
+                           f"replacing by 0."
+                           )
+            max_cpu_dirs = 0
         cdirs = self.listdir('/sys/devices/system/cpu')
+
+        if len(cdirs) > max_cpu_dirs:
+            # separate cpu from non-cpu, then limit cpu dirs
+            cpu_pattern = re.compile(r'cpu(\d+)')
+            cpu_dirs = []
+            other_dirs = []
+
+            for cdir in cdirs:
+                if cpu_pattern.fullmatch(cdir):
+                    cpu_dirs.append(cdir)
+                else:
+                    other_dirs.append(cdir)
+
+            # Only limit if cpu_dirs specifically exceeds max
+            if len(cpu_dirs) > max_cpu_dirs:
+                self._log_info(
+                    f"Limiting cpu directories from {len(cpu_dirs)} to "
+                    f"{max_cpu_dirs} (use '-k processor.max_cpu_dirs=N' "
+                    f"to change)."
+                )
+                cpu_dirs = sorted(cpu_dirs)[:max_cpu_dirs]
+
+            cdirs = other_dirs + cpu_dirs
+
         self.add_copy_spec([
             self.path_join('/sys/devices/system/cpu', cdir) for cdir in cdirs
         ])


### PR DESCRIPTION
For systems with >500 CPUs, collecting all such directories means millions of files to be collected, what excessivelly slows down the plugin until its timeout.

Limit the default number of such directories to 64, configurable via a plugin option.

Resolves: #4399

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
