### PR TITLE
[utilities] - Fix runas issue for rootless Podman containers

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -281,11 +281,17 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
         if chroot and chroot != '/':
             os.chroot(chroot)
         if runas:
-            os.setgid(pwd.getpwnam(runas).pw_gid)
-            os.setuid(pwd.getpwnam(runas).pw_uid)
-            os.chdir(pwd.getpwnam(runas).pw_dir)
+            # re-use pwd_user from the outer scope to avoid redundant lookups
+            os.initgroups(runas, pwd_user.pw_gid)
+            os.setgid(pwd_user.pw_gid)
+            os.setuid(pwd_user.pw_uid)
+
+        # prioritize explicit chdir and failback only if runas is set and
+        # no explicit chdir was provided.
         if chdir:
             os.chdir(chdir)
+        elif runas:
+            os.chdir(pwd_user.pw_dir)
 
     def _check_poller(proc):
         if poller() or proc.poll() == 124:
@@ -298,6 +304,11 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
             pwd_user = pwd.getpwnam(runas)
         except KeyError:  # no such user
             return {'status': 127, 'output': "", 'truncated': ''}
+
+        # handle env=None case to prevent AttributeError on None.update()
+        if env is None:
+            env = {}
+
         env.update({
             'HOME': pwd_user.pw_dir,
             'LOGNAME': runas,
@@ -305,7 +316,10 @@ def sos_get_command_output(command, timeout=TIMEOUT_DEFAULT, stderr=False,
             'USER': runas,
             # XDG_RUNTIME_DIR is required for rootless podman to access
             # user-specific runtime files and sockets
-            'XDG_RUNTIME_DIR': f"/run/user/{pwd_user.pw_uid}"
+            'XDG_RUNTIME_DIR': f"/run/user/{pwd_user.pw_uid}",
+            # DBUS_SESSION_BUS_ADDRESS is required for rootless podman
+            'DBUS_SESSION_BUS_ADDRESS':
+                f"unix:path=/run/user/{pwd_user.pw_uid}/bus"
         })
 
     cmd_env = os.environ.copy()


### PR DESCRIPTION
In `sos/utilities.py`:
- Add `os.initgroups()` call to properly initialize supplementary groups when dropping privileges to the target user
- Add `DBUS_SESSION_BUS_ADDRESS` pointing to the target rootless user session bus
- Handle `env=None` case to prevent `AttributeError` on `None.update()`

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
