### PR TITLE
[collect] update for strict confinement for juju

### DIFF
--- a/sos/collector/transports/juju.py
+++ b/sos/collector/transports/juju.py
@@ -10,10 +10,12 @@
 
 
 import subprocess
+import os
+import shutil
 
 from sos.collector.exceptions import JujuNotInstalledException
 from sos.collector.transports import RemoteTransport
-from sos.utilities import sos_get_command_output
+from sos.utilities import sos_get_command_output, parse_version
 
 
 class JujuSSH(RemoteTransport):
@@ -79,12 +81,44 @@ class JujuSSH(RemoteTransport):
         res = sos_get_command_output(cmd, timeout=15)
         return res["status"] == 0
 
+    def _get_juju_version(self):
+        """Grab the version of juju"""
+        res = sos_get_command_output("juju version")
+        return res['output'].split("-", maxsplit=1)[0]
+
     def _retrieve_file(self, fname, dest):
         self._chmod(fname)  # juju scp needs the archive to be world-readable
         model, unit = self.address.split(":")
         model_option = f"-m {model}" if model else ""
-        cmd = f"juju scp {model_option} -- -r {unit}:{fname} {dest}"
-        res = sos_get_command_output(cmd)
+
+        if parse_version(self._get_juju_version()) >= parse_version("3"):
+            # From juju 3.0 onwards the juju client is a strictly confined
+            # snap. Strict confinement prevents the snap from writing to
+            # arbitrary paths on the host (such as sos' tmpdir under /tmp or
+            # the snap's own private tmp namespace). It can, however, write
+            # into the invoking user's $HOME thanks to the 'home' snap
+            # interface. So we scp the file into a staging directory under
+            # $HOME and then move it to the requested destination ourselves.
+            #
+            # This avoids reaching into the snap's private confinement dir
+            # (/tmp/snap-private-tmp/...) and removes the previous requirement
+            # of running sos collect as root/with sudo for juju.
+            staging_dir = os.path.join(
+                os.path.expanduser("~"), ".cache", "sos-collect-juju"
+            )
+            os.makedirs(staging_dir, exist_ok=True)
+            staged_file = os.path.join(staging_dir, os.path.basename(fname))
+
+            cmd = (
+                f"juju scp {model_option} -- -r "
+                f"{unit}:{fname} {staging_dir}"
+            )
+            res = sos_get_command_output(cmd)
+            if res["status"] == 0:
+                shutil.move(staged_file, dest)
+        else:
+            cmd = f"juju scp {model_option} -- -r {unit}:{fname} {dest}"
+            res = sos_get_command_output(cmd)
         return res["status"] == 0
 
 

--- a/tests/unittests/juju/juju_transports_test.py
+++ b/tests/unittests/juju/juju_transports_test.py
@@ -33,6 +33,14 @@ class JujuSSHTest(unittest.TestCase):
             address="model_abc:unit_abc",
         )
 
+    # pylint: disable=no-method-argument
+    def get_juju_version():
+        return "2.9.45"
+
+    # pylint: disable=no-method-argument
+    def get_juju_version_3():
+        return "3.1.0"
+
     @patch("sos.collector.transports.juju.subprocess.check_output")
     def test_check_juju_installed_err(self, mock_subprocess_check_output):
         """Raise error if juju is not installed."""
@@ -73,15 +81,61 @@ class JujuSSHTest(unittest.TestCase):
         )
 
     @patch(
+        "sos.collector.transports.juju.JujuSSH._get_juju_version",
+        side_effect=get_juju_version,
+    )
+    @patch(
         "sos.collector.transports.juju.sos_get_command_output",
         return_value={"status": 0},
     )
     @patch("sos.collector.transports.juju.JujuSSH._chmod", return_value=True)
     # pylint: disable=unused-argument
-    def test_retrieve_file(self, mock_chmod, mock_sos_get_cmd_output):
+    def test_retrieve_file(
+        self,
+        mock_chmod,
+        mock_sos_get_cmd_output,
+        mock_get_juju_version
+    ):
         self.juju_ssh._retrieve_file(fname="file_abc", dest="/tmp/sos-juju/")
         mock_sos_get_cmd_output.assert_called_with(
             "juju scp -m model_abc -- -r unit_abc:file_abc /tmp/sos-juju/"
+        )
+
+    @patch("sos.collector.transports.juju.shutil.move")
+    @patch("sos.collector.transports.juju.os.makedirs")
+    @patch(
+        "sos.collector.transports.juju.os.path.expanduser",
+        return_value="/home/user_abc",
+    )
+    @patch(
+        "sos.collector.transports.juju.JujuSSH._get_juju_version",
+        side_effect=get_juju_version_3,
+    )
+    @patch(
+        "sos.collector.transports.juju.sos_get_command_output",
+        return_value={"status": 0},
+    )
+    @patch("sos.collector.transports.juju.JujuSSH._chmod", return_value=True)
+    # pylint: disable=unused-argument
+    def test_retrieve_file_juju_3(
+        self,
+        mock_chmod,
+        mock_sos_get_cmd_output,
+        mock_get_juju_version,
+        mock_expanduser,
+        mock_makedirs,
+        mock_move,
+    ):
+        """For juju 3+ the file is staged under $HOME (confinement-safe) and
+        then moved to the destination, without sudo or private-tmp hacks."""
+        staging_dir = "/home/user_abc/.cache/sos-collect-juju"
+        self.juju_ssh._retrieve_file(fname="file_abc", dest="/tmp/sos-juju/")
+        mock_makedirs.assert_called_with(staging_dir, exist_ok=True)
+        mock_sos_get_cmd_output.assert_called_with(
+            f"juju scp -m model_abc -- -r unit_abc:file_abc {staging_dir}"
+        )
+        mock_move.assert_called_with(
+            f"{staging_dir}/file_abc", "/tmp/sos-juju/"
         )
 
 


### PR DESCRIPTION
With juju versions 3 and above, when collecting the tarballs from machines it will grab them into a strictly confined area. This means that we need to be able to grab the data to a different location, such as somewhere in the home directory. Using a directory such as ~/.cache/sos-collect-juju is being used to overcome this issue.

Related: #3399
Related: #3422

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
