### PR TITLE
[cleaner] Add user-defined regexp patterns matching

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -8,6 +8,7 @@ sos_clean, sos_mask \- Obfuscate sensitive data from one or more sos reports
     [\-\-skip-cleaning-files|\-\-skip-masking-files]
     [\-\-keywords]
     [\-\-keyword-file]
+    [\-\-regexp-file]
     [\-\-map-file]
     [\-\-jobs]
     [\-\-no-update]
@@ -62,7 +63,7 @@ the target archive, so only use this option when absolutely necessary or you hav
 trust in the party/parties that may handle the generated report.
 
 Valid values for this option are currently: \fBhostname\fR, \fBip\fR, \fBipv6\fR,
-\fBmac\fR, \fBkeyword\fR, and \fBusername\fR.
+\fBmac\fR, \fBkeyword\fR, \fBusername\fR, and \fBregexp\fR.
 .TP
 .B \-\-skip-cleaning-files, \-\-skip-masking-files FILES
 Provide a comma-delimited list of files inside an archive, that cleaner should skip in cleaning.
@@ -83,6 +84,32 @@ both standalone words and in substring matches.
 .B \-\-keyword-file FILE
 Provide a file that contains a list of keywords that should be obfuscated. Each word must
 be specified on a newline within the file.
+.TP
+.B \-\-regexp-file FILE
+Provide a file containing custom regular expression patterns for obfuscating sensitive data
+that is not covered by the built-in parsers. Each line in the file should follow the format:
+
+    \fBkeyword pattern\fR
+
+Where \fBkeyword\fR is a lowercase alphanumeric identifier (ending with a letter, not a digit)
+and \fBpattern\fR is a Python regular expression containing exactly one capturing group () that
+marks the sensitive data to obfuscate. Use non-capturing groups (?:...) for additional matching
+logic.
+
+Example pattern file entries:
+
+    shorthost host=([^,\s]+)(?:,|$)
+    apikey api(?:_key|key)=([a-zA-Z0-9]+)
+
+The first example matches "host=foobar," and obfuscates "foobar" as "obfuscatedshorthost0".
+The second matches both "api_key=" and "apikey=" and obfuscates the value.
+
+Keywords cannot be reserved names (host, hostname, domain, ip, ipv6, mac, word, keyword,
+user, username) and must not end with digits to avoid ambiguity.
+
+Lines starting with '#' are treated as comments and are ignored.
+
+Default: /etc/sos/cleaner/regexp_patterns.conf
 .TP
 .B \-\-map-file FILE
 Provide a location to a valid mapping file to use as a reference for existing obfuscation pairs.

--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -8,9 +8,10 @@ sos_clean, sos_mask \- Obfuscate sensitive data from one or more sos reports
     [\-\-skip-cleaning-files|\-\-skip-masking-files]
     [\-\-keywords]
     [\-\-keyword-file]
+    [\-\-regexp-file]
+    [\-\-map-file]
     [\-\-usernames]
     [\-\-treat-certificates]
-    [\-\-map-file]
     [\-j|\-\-jobs]
     [\-\-no-update]
     [\-\-keep-binary-files]
@@ -64,7 +65,7 @@ the target archive, so only use this option when absolutely necessary or you hav
 trust in the party/parties that may handle the generated report.
 
 Valid values for this option are currently: \fBhostname\fR, \fBip\fR, \fBipv6\fR,
-\fBmac\fR, \fBkeyword\fR, and \fBusername\fR.
+\fBmac\fR, \fBkeyword\fR, \fBusername\fR, and \fBregexp\fR.
 .TP
 .B \-\-skip-cleaning-files, \-\-skip-masking-files FILES
 Provide a comma-delimited list of files inside an archive, that cleaner should skip in cleaning.
@@ -97,6 +98,32 @@ leaves it in place unmodified, and \fBremove\fR deletes it. Files identified as
 private keys are always removed regardless of this setting.
 
 Default: obfuscate
+.TP
+.B \-\-regexp-file FILE
+Provide a file containing custom regular expression patterns for obfuscating sensitive data
+that is not covered by the built-in parsers. Each line in the file should follow the format:
+
+    \fBkeyword pattern\fR
+
+Where \fBkeyword\fR is a lowercase alphanumeric identifier (ending with a letter, not a digit)
+and \fBpattern\fR is a Python regular expression containing exactly one capturing group () that
+marks the sensitive data to obfuscate. Use non-capturing groups (?:...) for additional matching
+logic.
+
+Example pattern file entries:
+
+    shorthost host=([^,\s]+)(?:,|$)
+    apikey api(?:_key|key)=([a-zA-Z0-9]+)
+
+The first example matches "host=foobar," and obfuscates "foobar" as "obfuscatedshorthost0".
+The second matches both "api_key=" and "apikey=" and obfuscates the value.
+
+Keywords cannot be reserved names (host, hostname, domain, ip, ipv6, mac, word, keyword,
+user, username) and must not end with digits to avoid ambiguity.
+
+Lines starting with '#' are treated as comments and are ignored.
+
+Default: /etc/sos/cleaner/regexp_patterns.conf
 .TP
 .B \-\-map-file FILE
 Provide a location to a valid mapping file to use as a reference for existing obfuscation pairs.

--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -31,6 +31,7 @@ from sos.cleaner.parsers.hostname_parser import SoSHostnameParser
 from sos.cleaner.parsers.keyword_parser import SoSKeywordParser
 from sos.cleaner.parsers.username_parser import SoSUsernameParser
 from sos.cleaner.parsers.ipv6_parser import SoSIPv6Parser
+from sos.cleaner.parsers.regexp_parser import SoSRegexpParser
 from sos.cleaner.archives.sos import (SoSReportArchive, SoSReportDirectory,
                                       SoSCollectorArchive,
                                       SoSCollectorDirectory)
@@ -127,6 +128,7 @@ class SoSCleaner(SoSComponent):
         'map_file': '/etc/sos/cleaner/default_mapping',
         'no_update': False,
         'keep_binary_files': False,
+        'regexp_file': '/etc/sos/cleaner/regexp_patterns.conf',
         'target': '',
         'usernames': [],
         'treat_certificates': 'obfuscate'
@@ -182,6 +184,7 @@ class SoSCleaner(SoSComponent):
             SoSMacParser,
             SoSKeywordParser,
             SoSUsernameParser,
+            SoSRegexpParser,
         ]
         parser_names = [
             cls.__name__ for cls in parser_classes
@@ -333,6 +336,12 @@ third party.
         clean_grp.add_argument('--keyword-file', default=None,
                                dest='keyword_file',
                                help='Provide a file a keywords to obfuscate')
+        clean_grp.add_argument(
+            '--regexp-file',
+            default='/etc/sos/cleaner/regexp_patterns.conf',
+            dest='regexp_file',
+            help='Provide a file of regular expressions to obfuscate'
+        )
         clean_grp.add_argument('--map-file', dest='map_file',
                                default='/etc/sos/cleaner/default_mapping',
                                help=('Provide a previously generated mapping '
@@ -755,6 +764,8 @@ third party.
                 _parser.mapping.add_regex_item(ritem)
             _parser.mapping.initializing = False
             _parser.mapping.generate_compiled_regexes()
+            # Allow prepper to configure its parser after initialization
+            prepper.set_parser(_parser)
         # we must initialize stuff inside (cloned processes') archive - REALLY?
         archive.set_parsers(self.parsers)
 

--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -30,6 +30,7 @@ from sos.cleaner.parsers.hostname_parser import SoSHostnameParser
 from sos.cleaner.parsers.keyword_parser import SoSKeywordParser
 from sos.cleaner.parsers.username_parser import SoSUsernameParser
 from sos.cleaner.parsers.ipv6_parser import SoSIPv6Parser
+from sos.cleaner.parsers.regexp_parser import SoSRegexpParser
 from sos.cleaner.archives.sos import (SoSReportArchive, SoSReportDirectory,
                                       SoSCollectorArchive,
                                       SoSCollectorDirectory)
@@ -122,6 +123,7 @@ class SoSCleaner(SoSComponent):
         'map_file': '/etc/sos/cleaner/default_mapping',
         'no_update': False,
         'keep_binary_files': False,
+        'regexp_file': '/etc/sos/cleaner/regexp_patterns.conf',
         'target': '',
         'usernames': [],
         'treat_certificates': 'obfuscate'
@@ -177,6 +179,7 @@ class SoSCleaner(SoSComponent):
             SoSMacParser,
             SoSKeywordParser,
             SoSUsernameParser,
+            SoSRegexpParser,
         ]
         parser_names = [
             cls.__name__ for cls in parser_classes
@@ -328,6 +331,12 @@ third party.
         clean_grp.add_argument('--keyword-file', default=None,
                                dest='keyword_file',
                                help='Provide a file a keywords to obfuscate')
+        clean_grp.add_argument(
+            '--regexp-file',
+            default='/etc/sos/cleaner/regexp_patterns.conf',
+            dest='regexp_file',
+            help='Provide a file of regular expressions to obfuscate'
+        )
         clean_grp.add_argument('--map-file', dest='map_file',
                                default='/etc/sos/cleaner/default_mapping',
                                help=('Provide a previously generated mapping '
@@ -737,6 +746,8 @@ third party.
                 _parser.mapping.add_regex_item(ritem)
             _parser.mapping.initializing = False
             _parser.mapping.generate_compiled_regexes()
+            # Allow prepper to configure its parser after initialization
+            prepper.set_parser(_parser)
         # we must initialize stuff inside (cloned processes') archive - REALLY?
         archive.set_parsers(self.parsers)
 

--- a/sos/cleaner/mappings/__init__.py
+++ b/sos/cleaner/mappings/__init__.py
@@ -98,6 +98,19 @@ class SoSMap():
         if self.compile_regexes:
             self.add_regex_item(item)
 
+    def _read_item_from_cache_file(self, fname):
+        """Read an item from a cache file.
+
+        Default format: plain text file containing only the item itself.
+
+        Override this method in subclasses that use a different cache format.
+
+        :param fname:  Full path to the cache file
+        :returns:      The item to add to the dataset
+        """
+        with open(fname, 'r', encoding='utf-8') as f:
+            return f.read()
+
     def load_new_entries_from_dir(self):
         # Load all new items from the cache_dir. "New" = any numbered file not
         # lower than self.cache_counter.
@@ -112,12 +125,24 @@ class SoSMap():
         num_files.sort(key=int)
         for file_name in num_files:
             fname = os.path.join(self.cache_dir, file_name)
-            with open(fname, 'r', encoding='utf-8') as f:
-                item = f.read()
-            if not self.dataset.get(item, False):
+            item = self._read_item_from_cache_file(fname)
+            if item and not self.dataset.get(item, False):
                 self.add_sanitised_item_to_dataset(item)
         if num_files:
             self.cache_counter = int(num_files[-1])  # last/biggest number
+
+    def _write_item_to_cache_file(self, item, tmpfile):
+        """Write an item to a cache file.
+
+        Default format: plain text file containing only the item itself.
+
+        Override this method in subclasses that use a different cache format.
+
+        :param item:     The item to write to the cache
+        :param tmpfile:  The NamedTemporaryFile to write to
+        """
+        with open(tmpfile.name, 'w', encoding='utf-8') as f:
+            f.write(item)
 
     def add(self, item):
         """Add a particular item to the map, generating an obfuscated pair
@@ -135,8 +160,7 @@ class SoSMap():
             if not tmpfile:
                 # pylint: disable=consider-using-with
                 tmpfile = tempfile.NamedTemporaryFile(dir=self.cache_dir)
-                with open(tmpfile.name, 'w', encoding='utf-8') as f:
-                    f.write(item)
+                self._write_item_to_cache_file(item, tmpfile)
             try:
                 self.cache_counter += 1
                 os.link(tmpfile.name,

--- a/sos/cleaner/mappings/regexp_map.py
+++ b/sos/cleaner/mappings/regexp_map.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Red Hat, Inc. Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import json
+import logging
+import re
+from sos.cleaner.mappings import SoSMap
+
+
+class SoSRegexpMap(SoSMap):
+    """Runtime obfuscation mapping for user-defined regex patterns.
+
+    The class maintains per-keyword counters, generates obfuscated
+    values, persists state. See RegexpPrepper for pattern
+    loading/validation.
+
+    Does not define patterns - relies on RegexpPrepper loading from
+    --regexp-file. Parser finds matches, this map generates
+    obfuscation.
+
+    Obfuscation: Each keyword has independent counter starting at 0.
+    Example:
+        Pattern: shorthost host=([^,\\s]+)(?:,|$)
+        Input:   "host=foobar,os=rhel9"
+        Output:  "host=obfuscatedshorthost0,os=rhel9"
+        Next:    "host=obfuscatedshorthost1,..."
+
+    Persistence:
+    - Map file: {"foobar": "obfuscatedshorthost5"} → counter
+      restored to 6
+    - Cache files (multi-process): ["keyword", "item"] JSON arrays,
+      DIFFERENT from other Map classes.
+
+    Keywords cannot end with digits to avoid ambiguity parsing
+    obfuscated values: for keyword "api2", "obfuscatedapi25" can be
+    interpreted as either:
+      - keyword="api2", counter=5, or
+      - keyword="api", counter=25
+    """
+
+    # Regexp patterns define their own matching boundaries, so we don't
+    # need word boundaries or token lookup.
+    match_full_words_only = False
+    use_token_lookup = False
+    compile_regexes = False  # Prepper does its own compile
+
+    # Pattern to parse obfuscated values: obfuscated + keyword + counter
+    # Greedy [a-z0-9]* stops at last letter before trailing digits
+    # Examples: obfuscatedshorthost10 → keyword="shorthost", counter=10
+    #           obfuscatedapi2key5 → keyword="api2key", counter=5
+    _OBFUSCATED_PATTERN = re.compile(
+        r'^obfuscated([a-z0-9]*[a-z])(\d+)$'
+    )
+
+    def __init__(self, workdir, _static_regex=None):
+        # Initialize these BEFORE calling super().__init__() because the
+        # parent will call load_entries() -> load_new_entries_from_dir()
+        # which needs them
+        # Map of keyword -> counter for each keyword type
+        self.keyword_counts = {}
+        # Map of item -> keyword (so we know which keyword matched)
+        self.item_keywords = {}
+        # Logger for warning/error messages
+        self.soslog = logging.getLogger('sos')
+
+        super().__init__(workdir, _static_regex)
+
+        # Initialize keywords' counters from any pre-loaded dataset
+        self._initialize_counters_from_dataset()
+
+    def _initialize_counters_from_dataset(self):
+        """Initialize keyword counters from pre-loaded dataset.
+
+        If dataset was loaded from a previous run (via --map-file or cache
+        dir), we need to initialize counters to avoid generating duplicate
+        obfuscated values.
+
+        Parses existing obfuscated values like "obfuscatedshorthost5" to
+        extract the keyword and counter, then sets each keyword's counter
+        to max(existing) + 1.
+
+        This method RESETS keyword_counts from scratch based on dataset,
+        so it can be called multiple times (e.g., after conf_update).
+        """
+        # Reset counters - we'll rebuild from dataset
+        self.keyword_counts = {}
+
+        for obfuscated_value in self.dataset.values():
+            match = self._OBFUSCATED_PATTERN.match(obfuscated_value)
+            if match:
+                keyword = match.group(1)
+                counter = int(match.group(2))
+                # Set counter to max(current, this_counter + 1) for next
+                # available value
+                next_value = self.keyword_counts.get(keyword, 0)
+                self.keyword_counts[keyword] = max(next_value, counter + 1)
+            else:
+                # Malformed obfuscated value - log warning
+                self.soslog.warning(
+                    f"Cannot extract keyword from obfuscated value "
+                    f"'{obfuscated_value}' - skipping its counter "
+                    f"initialization"
+                )
+
+    def conf_update(self, config):
+        """Override to extract keyword-to-item associations from map file.
+
+        When loading from a previous run's map file, we need to restore
+        the item→keyword associations so that load_new_entries_from_dir()
+        can properly re-sanitize items from cache.
+
+        Parses obfuscated values like "obfuscatedshorthost5" to extract
+        the keyword, then associates it with the original item.
+        """
+        for item, obfuscated_value in config.items():
+            match = self._OBFUSCATED_PATTERN.match(obfuscated_value)
+            if match:
+                keyword = match.group(1)
+                self.item_keywords[item] = keyword
+            else:
+                # Malformed obfuscated value - log warning
+                self.soslog.warning(
+                    f"Cannot extract keyword from obfuscated value "
+                    f"'{obfuscated_value}' for item '{item}'"
+                )
+
+        # Call parent to update dataset
+        super().conf_update(config)
+
+        # Re-initialize counters from the updated dataset to ensure
+        # keyword_counts reflects all items from the map file
+        self._initialize_counters_from_dataset()
+
+    def _read_item_from_cache_file(self, fname):
+        """Read item and keyword from JSON cache file.
+
+        Cache files for regexp map are JSON arrays with format:
+        ["keyword", "item"]
+
+        Example: ["myshorthost", "foobar"]
+
+        This preserves the keyword association needed for proper obfuscation.
+
+        :param fname:  Full path to the cache file
+        :returns:      The item to add to the dataset, or None to skip
+        """
+        try:
+            with open(fname, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                if isinstance(data, list) and len(data) == 2:
+                    keyword, item = data
+                    # Restore the keyword association
+                    self.item_keywords[item] = keyword
+                    return item
+
+                self.soslog.warning(
+                    f"Cache file {fname} has invalid format, "
+                    f"expected [keyword, item] array, skipping"
+                )
+                return None
+        except json.JSONDecodeError:
+            self.soslog.warning(
+                f"Cache file {fname} contains invalid JSON, skipping"
+            )
+            return None
+
+    def _write_item_to_cache_file(self, item, tmpfile):
+        """Write item and keyword as JSON array to cache file.
+
+        Format: [keyword, item]
+        Example: ["myshorthost", "foobar"]
+
+        :param item:     The item to write
+        :param tmpfile:  The temporary file to write to
+        """
+        # Get the keyword for this item - must exist, set by parser, but
+        # let support the 'unknown' fallback also here (see sanitize_item)
+        keyword = self.item_keywords.get(item, 'unknown')
+
+        # Write JSON array: [keyword, item]
+        with open(tmpfile.name, 'w', encoding='utf-8') as f:
+            json.dump([keyword, item], f)
+
+    def set_keyword_for_item(self, item, keyword):
+        """Associate an item with its keyword for obfuscation.
+
+        This should be called when adding items to the map, so that
+        sanitize_item knows which keyword pattern matched.
+        """
+        self.item_keywords[item] = keyword
+
+    def sanitize_item(self, item):
+        if item in self.dataset:
+            return self.dataset[item]
+
+        # Get the keyword for this item
+        # This should always be present - if not, it's a bug in the parser
+        keyword = self.item_keywords.get(item, None)
+        if keyword is None:
+            # This should never happen - log error and use fallback
+            self.soslog.error(
+                f"Regexp item '{item}' has no associated keyword. "
+                f"This indicates a bug in the regexp parser. "
+                f"Using fallback name 'unknown'."
+            )
+            keyword = 'unknown'
+
+        # Get and increment counter for this keyword
+        count = self.keyword_counts.get(keyword, 0)
+        _ob_item = f"obfuscated{keyword}{count}"
+        self.keyword_counts[keyword] = count + 1
+
+        return _ob_item

--- a/sos/cleaner/parsers/regexp_parser.py
+++ b/sos/cleaner/parsers/regexp_parser.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Red Hat, Inc. Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+from sos.cleaner.parsers import SoSCleanerParser
+from sos.cleaner.mappings.regexp_map import SoSRegexpMap
+
+
+class SoSRegexpParser(SoSCleanerParser):
+    """Parser for user-defined regular expressions from --regexp-file.
+
+    Unlike other parsers, this does not define static patterns. Patterns
+    are loaded by RegexpPrepper and transferred here via regexp_patterns
+    dict.
+
+    For each line, iterates all user patterns, extracts capturing groups,
+    and calls SoSRegexpMap to generate obfuscated<keyword><number>
+    values. See RegexpPrepper for pattern validation and SoSRegexpMap for
+    obfuscation.
+    """
+
+    name = 'Regexp Parser'
+    map_file_key = 'regexp_map'
+    compile_regexes = False  # We handle our own regex matching
+
+    def __init__(self, config, workdir, skip_cleaning_files=None):
+        if skip_cleaning_files is None:
+            skip_cleaning_files = []
+        self.mapping = SoSRegexpMap(workdir)
+        super().__init__(config, skip_cleaning_files)
+        # Will be populated by prepper with {name: compiled_pattern}
+        self.regexp_patterns = {}
+
+    def _parse_line(self, line):
+        """Parse line against all registered regexp patterns.
+
+        For each pattern that matches, extract ALL capturing groups
+        and obfuscate them using the pattern's keyword.
+        """
+        count = 0
+        for keyword, pattern in self.regexp_patterns.items():
+            # Collect all matches for this pattern
+            matches = list(pattern.finditer(line))
+
+            # Process matches right-to-left to avoid position shifts
+            for match in reversed(matches):
+                # Extract the captured group (group 1)
+                captured_value = match.group(1)
+
+                # Tell the mapping which keyword this value belongs to
+                self.mapping.set_keyword_for_item(captured_value, keyword)
+
+                # Get or create the obfuscated value
+                obfuscated = self.mapping.get(captured_value)
+
+                # Replace the captured group in the line
+                # We need to replace the full match but only obfuscate group 1
+                full_match = match.group(0)
+                # Reconstruct by replacing group 1 in the full match
+                replacement = full_match.replace(captured_value, obfuscated, 1)
+                # Use span() to replace at exact position
+                start, end = match.span()
+                line = line[:start] + replacement + line[end:]
+                count += 1
+
+        return line, count

--- a/sos/cleaner/preppers/__init__.py
+++ b/sos/cleaner/preppers/__init__.py
@@ -56,6 +56,7 @@ class SoSPrepper():
             'ipv6': set(),
             'keyword': set(),
             'mac': set(),
+            'regexp': set(),
             'username': set()
         }
         self.opts = options
@@ -73,6 +74,18 @@ class SoSPrepper():
 
     def log_error(self, msg):
         self.soslog.error(self._fmt_log_msg(msg))
+
+    def set_parser(self, parser):
+        """Hook for preppers to configure their parser after initialization.
+
+        Called after the parser's mapping is fully initialized and compiled
+        regexes are generated. Usually, this method is not needed. Override
+        it in subclasses that need to transfer state or configuration to
+        their corresponding parser.
+
+        :param parser: The parser instance to configure
+        :type parser:  ``SoSCleanerParser``
+        """
 
     def get_parser_file_list(self, parser, archive):
         """

--- a/sos/cleaner/preppers/regexps.py
+++ b/sos/cleaner/preppers/regexps.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Red Hat, Inc. Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+import re
+
+from sos.cleaner.preppers import SoSPrepper
+
+
+class RegexpPrepper(SoSPrepper):
+    """
+    Load and validate user-defined regex patterns from --regexp-file.
+
+    The class reads config file, validates syntax, transfers patterns
+    to parser. See SoSRegexpMap for runtime obfuscation behavior.
+
+    File format (lines starting with '#' are comments):
+        <keyword> <pattern>
+
+    - keyword: lowercase alphanumeric, ending with letter only
+    - pattern: Python regex with EXACTLY ONE capturing group () marking
+               sensitive data to obfuscate as
+               'obfuscated<keyword><number>'
+
+    Use non-capturing groups (?:...) for additional matching logic, to
+    keep the "exactly one capturing group".
+
+    Examples:
+        shorthost host=([^,\\s]+)(?:,|$)
+            → "host=foobar," becomes "host=obfuscatedshorthost0,"
+
+        apikey api(?:_key|key)=([a-zA-Z0-9]+)
+            → Matches both "api_key=" and "apikey=", obfuscates value
+              only
+
+    Rejected patterns: keyword ends with digit, uppercase letters,
+    reserved names (host, ip, mac, user, etc.), no capturing group,
+    multiple groups.
+    """
+
+    name = 'regexp'
+
+    # Reserved names from other mapping types that cannot be used
+    # to avoid confusion with their obfuscation patterns
+    RESERVED_NAMES = {
+        'host',      # hostname_map: produces 'host1', 'host2', etc.
+        'hostname',  # alias for host
+        'domain',    # hostname_map: domain handling
+        'ip',        # ip_map: produces IP addresses like 10.x.x.x
+        'ipv6',      # ipv6_map: produces IPv6 addresses
+        'mac',       # mac_map: produces MAC addresses like 53:4f:53:x:x:x
+        'word',      # keyword_map: produces 'obfuscatedword1', etc.
+        'keyword',   # alias for word
+        'user',      # username_map: produces 'obfuscateduser1', etc.
+        'username',  # alias for user
+    }
+
+    def __init__(self, options):
+        super().__init__(options)
+        # Map of name -> compiled regex pattern
+        self.regexp_map = {}
+        # Reference to the parser (will be set later)
+        self.parser = None
+
+    # pylint: disable=unused-argument
+    def _get_items_for_regexp(self, archive):
+        """Load regexp patterns from file and store in regexp_map.
+
+        This method does not return items because regexp patterns work
+        differently - they need to be matched by the parser with knowledge
+        of which keyword pattern matched. The regexp_map is transferred
+        to the parser via set_parser().
+
+        :returns: Empty list (patterns are not items to obfuscate)
+        """
+
+        if not self.opts.regexp_file:
+            return []
+
+        if not os.path.exists(self.opts.regexp_file):
+            self.log_debug(
+                f"Regexp patterns file not found: "
+                f"{self.opts.regexp_file}"
+            )
+            return []
+
+        self.log_info(
+            f"Loading regexp patterns from {self.opts.regexp_file}"
+        )
+
+        with open(self.opts.regexp_file, 'r', encoding='utf-8') as regexpf:
+            for line_num, line in enumerate(regexpf, 1):
+                line = line.strip()
+
+                # Skip empty lines and comments
+                if not line or line.startswith('#'):
+                    continue
+
+                # Parse name and pattern (split on first whitespace)
+                parts = line.split(None, 1)
+                if len(parts) != 2:
+                    self.log_error(
+                        f"Line {line_num}: Invalid format, "
+                        f"expected 'name pattern'. Skipping line: {line}"
+                    )
+                    continue
+
+                name, pattern = parts
+
+                # Validate keyword format
+                # Must be lowercase alphanumeric, start with letter, not
+                # end with digit
+                if not re.match(r'^[a-z0-9]*[a-z]$', name):
+                    self.log_error(
+                        f"Line {line_num}: Keyword '{name}' must contain "
+                        f"only lowercase letters and digits and end with a "
+                        f"lowercase letter. Skipping."
+                    )
+                    continue
+
+                # Check if name is a reserved word
+                if name in self.RESERVED_NAMES:
+                    self.log_error(
+                        f"Line {line_num}: Pattern name '{name}' is "
+                        f"reserved for built-in obfuscation types. "
+                        f"Reserved names: "
+                        f"{', '.join(sorted(self.RESERVED_NAMES))}. "
+                        f"Please choose a different name. Skipping."
+                    )
+                    continue
+
+                # Validate the regular expression
+                try:
+                    compiled_pattern = re.compile(pattern)
+
+                    # Check if pattern contains exactly one capturing group
+                    num_groups = compiled_pattern.groups
+                    if num_groups != 1:
+                        self.log_error(
+                            f"Line {line_num}: Pattern '{name}' must "
+                            f"contain exactly one capturing group (). "
+                            f"Found {num_groups} groups. Use "
+                            f"non-capturing groups (?:...) for additional "
+                            f"matching logic. Skipping."
+                        )
+                        continue
+
+                    # Store in map, log if overriding existing keyword
+                    # name.
+                    if name in self.regexp_map:
+                        self.log_info(
+                            f"Line {line_num}: Duplicate name '{name}'. "
+                            f"Previous pattern will be overwritten."
+                        )
+                    self.regexp_map[name] = compiled_pattern
+                    self.log_debug(f"Loaded pattern '{name}': {pattern}")
+
+                except re.error as e:
+                    self.log_error(
+                        f"Line {line_num}: Invalid regex pattern "
+                        f"for '{name}': {e}. Skipping."
+                    )
+                    continue
+
+        self.log_info(f"Loaded {len(self.regexp_map)} regexp patterns")
+        return []
+
+    def set_parser(self, parser):
+        """Transfer loaded patterns to the regexp parser.
+
+        This should be called after patterns are loaded to give the
+        parser access to the compiled patterns and their keywords.
+        """
+        parser.regexp_patterns = self.regexp_map
+        self.log_debug(
+            f"Transferred {len(self.regexp_map)} patterns to parser"
+        )
+
+# vim: set et ts=4 sw=4 :

--- a/sos/cleaner/preppers/regexps.py
+++ b/sos/cleaner/preppers/regexps.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Red Hat, Inc. Pavel Moravec <pmoravec@redhat.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+import re
+
+from sos.cleaner.preppers import SoSPrepper
+
+
+class RegexpPrepper(SoSPrepper):
+    r"""
+    Load and validate user-defined regex patterns from --regexp-file.
+
+    The class reads config file, validates syntax, transfers patterns
+    to parser. See SoSRegexpMap for runtime obfuscation behavior.
+
+    File format (lines starting with '#' are comments):
+        <keyword> <pattern>
+
+    - keyword: lowercase alphanumeric, ending with letter only
+    - pattern: Python regex with EXACTLY ONE capturing group () marking
+               sensitive data to obfuscate as
+               'obfuscated<keyword><number>'
+
+    Use non-capturing groups (?:...) for additional matching logic, to
+    keep the "exactly one capturing group".
+
+    Examples:
+        shorthost host=([^,\\s]+)(?:,|$)
+            → "host=foobar," becomes "host=obfuscatedshorthost0,"
+
+        webhost (?:https?:\/\/|www\.)([a-zA-Z0-9.-]*[a-zA-Z0-9])
+            → "https://foohost" becomes "https://obfuscatedwebhost0"
+
+        apikey api(?:_key|key)=([a-zA-Z0-9]+)
+            → Matches both "api_key=" and "apikey=", obfuscates value
+              only
+
+    Rejected patterns: keyword ends with digit, uppercase letters,
+    reserved names (host, ip, mac, user, etc.), no capturing group,
+    multiple groups.
+    """
+
+    name = 'regexp'
+
+    # Reserved names from other mapping types that cannot be used
+    # to avoid confusion with their obfuscation patterns
+    RESERVED_NAMES = {
+        'host',      # hostname_map: produces 'host1', 'host2', etc.
+        'hostname',  # alias for host
+        'domain',    # hostname_map: domain handling
+        'ip',        # ip_map: produces IP addresses like 10.x.x.x
+        'ipv6',      # ipv6_map: produces IPv6 addresses
+        'mac',       # mac_map: produces MAC addresses like 53:4f:53:x:x:x
+        'word',      # keyword_map: produces 'obfuscatedword1', etc.
+        'keyword',   # alias for word
+        'user',      # username_map: produces 'obfuscateduser1', etc.
+        'username',  # alias for user
+    }
+
+    def __init__(self, options):
+        super().__init__(options)
+        # Map of name -> compiled regex pattern
+        self.regexp_map = {}
+        # Reference to the parser (will be set later)
+        self.parser = None
+
+    # pylint: disable=unused-argument
+    def _get_items_for_regexp(self, archive):
+        """Load regexp patterns from file and store in regexp_map.
+
+        This method does not return items because regexp patterns work
+        differently - they need to be matched by the parser with knowledge
+        of which keyword pattern matched. The regexp_map is transferred
+        to the parser via set_parser().
+
+        :returns: Empty list (patterns are not items to obfuscate)
+        """
+
+        if not self.opts.regexp_file:
+            return []
+
+        if not os.path.exists(self.opts.regexp_file):
+            self.log_debug(
+                f"Regexp patterns file not found: "
+                f"{self.opts.regexp_file}"
+            )
+            return []
+
+        self.log_info(
+            f"Loading regexp patterns from {self.opts.regexp_file}"
+        )
+
+        with open(self.opts.regexp_file, 'r', encoding='utf-8') as regexpf:
+            for line_num, line in enumerate(regexpf, 1):
+                line = line.strip()
+
+                # Skip empty lines and comments
+                if not line or line.startswith('#'):
+                    continue
+
+                # Parse name and pattern (split on first whitespace)
+                parts = line.split(None, 1)
+                if len(parts) != 2:
+                    self.log_error(
+                        f"Line {line_num}: Invalid format, "
+                        f"expected 'name pattern'. Skipping line: {line}"
+                    )
+                    continue
+
+                name, pattern = parts
+
+                # Validate keyword format
+                # Must be lowercase alphanumeric, start with letter, not
+                # end with digit
+                if not re.match(r'^[a-z0-9]*[a-z]$', name):
+                    self.log_error(
+                        f"Line {line_num}: Keyword '{name}' must contain "
+                        f"only lowercase letters and digits and end with a "
+                        f"lowercase letter. Skipping."
+                    )
+                    continue
+
+                # Check if name is a reserved word
+                if name in self.RESERVED_NAMES:
+                    self.log_error(
+                        f"Line {line_num}: Pattern name '{name}' is "
+                        f"reserved for built-in obfuscation types. "
+                        f"Reserved names: "
+                        f"{', '.join(sorted(self.RESERVED_NAMES))}. "
+                        f"Please choose a different name. Skipping."
+                    )
+                    continue
+
+                # Validate the regular expression
+                try:
+                    compiled_pattern = re.compile(pattern)
+
+                    # Check if pattern contains exactly one capturing group
+                    num_groups = compiled_pattern.groups
+                    if num_groups != 1:
+                        self.log_error(
+                            f"Line {line_num}: Pattern '{name}' must "
+                            f"contain exactly one capturing group (). "
+                            f"Found {num_groups} groups. Use "
+                            f"non-capturing groups (?:...) for additional "
+                            f"matching logic. Skipping."
+                        )
+                        continue
+
+                    # Store in map, log if overriding existing keyword
+                    # name.
+                    if name in self.regexp_map:
+                        self.log_info(
+                            f"Line {line_num}: Duplicate name '{name}'. "
+                            f"Previous pattern will be overwritten."
+                        )
+                    self.regexp_map[name] = compiled_pattern
+                    self.log_debug(f"Loaded pattern '{name}': {pattern}")
+
+                except re.error as e:
+                    self.log_error(
+                        f"Line {line_num}: Invalid regex pattern "
+                        f"for '{name}': {e}. Skipping."
+                    )
+                    continue
+
+        self.log_info(f"Loaded {len(self.regexp_map)} regexp patterns")
+        return []
+
+    def set_parser(self, parser):
+        """Transfer loaded patterns to the regexp parser.
+
+        This should be called after patterns are loaded to give the
+        parser access to the compiled patterns and their keywords.
+        """
+        parser.regexp_patterns = self.regexp_map
+        self.log_debug(
+            f"Transferred {len(self.regexp_map)} patterns to parser"
+        )
+
+# vim: set et ts=4 sw=4 :

--- a/sos/collector/__init__.py
+++ b/sos/collector/__init__.py
@@ -516,6 +516,12 @@ class SoSCollector(SoSComponent):
         cleaner_grp.add_argument('--keyword-file', default=None,
                                  dest='keyword_file',
                                  help='Provide a file a keywords to obfuscate')
+        cleaner_grp.add_argument(
+            '--regexp-file',
+            default='/etc/sos/cleaner/regexp_patterns.conf',
+            dest='regexp_file',
+            help='Provide a file of regular expressions to obfuscate'
+        )
         cleaner_grp.add_argument('--no-update', action='store_true',
                                  default=False, dest='no_update',
                                  help='Do not update the default cleaner map')

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -108,6 +108,7 @@ class SoSReport(SoSComponent):
         'journal_size': 100,
         'keywords': [],
         'keyword_file': None,
+        'regexp_file': '/etc/sos/cleaner/regexp_patterns.conf',
         'plugopts': [],
         'label': '',
         'list_plugins': False,
@@ -389,6 +390,12 @@ class SoSReport(SoSComponent):
         cleaner_grp.add_argument('--keyword-file', default=None,
                                  dest='keyword_file',
                                  help='Provide a file a keywords to obfuscate')
+        cleaner_grp.add_argument(
+            '--regexp-file',
+            default='/etc/sos/cleaner/regexp_patterns.conf',
+            dest='regexp_file',
+            help='Provide a file of regular expressions to obfuscate'
+        )
         cleaner_grp.add_argument('--no-update', action='store_true',
                                  default=False, dest='no_update',
                                  help='Do not update the default cleaner map')

--- a/tests/cleaner_tests/regexp_test/regexp.py
+++ b/tests/cleaner_tests/regexp_test/regexp.py
@@ -1,0 +1,20 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class RegexpTest(Plugin, IndependentPlugin):
+    """Test plugin for testing custom regexp obfuscation with --clean
+    """
+
+    plugin_name = 'regexp'
+    short_desc = 'test plugin for custom regexp obfuscation'
+
+    def setup(self):
+        self.add_copy_spec('/tmp/sos-test-regexp.txt')

--- a/tests/cleaner_tests/regexp_test/regexp_patterns.conf
+++ b/tests/cleaner_tests/regexp_test/regexp_patterns.conf
@@ -1,0 +1,12 @@
+# Custom regexp patterns for obfuscation testing
+#
+# Format: <keyword> <pattern>
+# - keyword: lowercase alphanumeric, ending with letter
+# - pattern: Python regex with EXACTLY ONE capturing group ()
+
+# Pattern to match host=VALUE, or host=VALUE at end of line
+# Captures the value but not the comma
+shorthost host=([^,\s]+)(?:,|$)
+
+# Pattern to match HOST VALUE (uppercase HOST followed by space and value)
+hostspace HOST (\S+)

--- a/tests/cleaner_tests/regexp_test/regexp_test.py
+++ b/tests/cleaner_tests/regexp_test/regexp_test.py
@@ -1,0 +1,104 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos_tests import StageTwoReportTest
+
+MOCK_FILE = '/tmp/sos-test-regexp.txt'
+
+
+class RegexpTest(StageTwoReportTest):
+    """Test custom regexp obfuscation feature using --regexp-file option.
+
+    Tests that user-defined regular expression patterns from a config file
+    are properly loaded and applied to obfuscate sensitive data.
+
+    :avocado: tags=stagetwo
+    """
+
+    install_plugins = ['regexp']
+    sos_cmd = '--clean -o regexp --no-update'
+    # Place mock file with test data and regexp config file
+    files = [
+        ('sos-test-regexp.txt', MOCK_FILE),
+        ('regexp_patterns.conf', '/etc/sos/cleaner/regexp_patterns.conf')
+    ]
+
+    def test_shorthost_pattern_with_comma(self):
+        """Test pattern: shorthost host=([^,\\s]+)(?:,|$)"""
+        self.assertFileCollected(MOCK_FILE)
+        # Verify the pattern matched and obfuscated
+        self.assertFileHasContent(MOCK_FILE, 'host=obfuscatedshorthost')
+        # Verify original value is not present
+        self.assertFileNotHasContent(MOCK_FILE, 'host=SECRET,')
+        # Verify the rest of the line is preserved
+        self.assertFileHasContent(MOCK_FILE, 'os=rhel9')
+
+    def test_shorthost_pattern_at_eol(self):
+        """Test pattern matches at end of line"""
+        self.assertFileHasContent(MOCK_FILE, 'host=obfuscatedshorthost')
+        self.assertFileNotHasContent(MOCK_FILE, 'host=SECRETHOST')
+
+    def test_shorthost_pattern_no_match_with_space(self):
+        """Test pattern does NOT match when delimiter is missing"""
+        # This line should NOT be obfuscated because no comma or EOL
+        # after value
+        self.assertFileHasContent(
+            MOCK_FILE, 'host=okhost due to the space'
+        )
+
+    def test_hostspace_pattern_uppercase(self):
+        """Test pattern: hostspace HOST (\\S+)"""
+        self.assertFileHasContent(MOCK_FILE, 'HOST obfuscatedhostspace')
+        self.assertFileNotHasContent(MOCK_FILE, 'HOST VALUE')
+
+    def test_hostspace_pattern_alphanumeric(self):
+        """Test pattern matches alphanumeric values"""
+        self.assertFileHasContent(MOCK_FILE, 'HOST obfuscatedhostspace')
+        self.assertFileNotHasContent(MOCK_FILE, 'HOST val4ue')
+
+    def test_obfuscation_consistency(self):
+        """Test same value gets same obfuscation across file"""
+        content = self.get_file_content(MOCK_FILE)
+        lines = content.splitlines()
+
+        # Find lines with obfuscatedshorthost
+        obfuscated_values = []
+        for line in lines:
+            if 'host=obfuscatedshorthost' in line:
+                # Extract the obfuscated value
+                import re
+                match = re.search(r'host=(obfuscatedshorthost\d+)', line)
+                if match:
+                    obfuscated_values.append(match.group(1))
+
+        # lines 4, 8, 11, 23 and 26 do match, so 5 matches should be found
+        self.assertEqual(
+            len(obfuscated_values), 5,
+            f"Expected 5 obfuscated values, "
+            f"found {len(obfuscated_values)}"
+        )
+
+        # 2nd and 4th should be identical (both are "SECRET")
+        self.assertEqual(
+            obfuscated_values[1], obfuscated_values[3],
+            "Same input value 'SECRET' should get same obfuscation"
+        )
+
+        # Third should be different (it's "ANOTHER")
+        self.assertNotEqual(
+            obfuscated_values[0], obfuscated_values[2],
+            "Different input values should get different obfuscations"
+        )
+
+    def test_different_keywords_independent_counters(self):
+        """Test different keywords have independent counters"""
+        content = self.get_file_content(MOCK_FILE)
+
+        # Both shorthost and hostspace should start from 0
+        self.assertRegex(content, r'obfuscatedshorthost0')
+        self.assertRegex(content, r'obfuscatedhostspace0')

--- a/tests/cleaner_tests/regexp_test/sos-test-regexp.txt
+++ b/tests/cleaner_tests/regexp_test/sos-test-regexp.txt
@@ -1,0 +1,26 @@
+# Test data for regexp obfuscation tests
+#
+# These lines test the patterns defined in regexp_patterns.conf:
+# - shorthost host=([^,\s]+)(?:,|$)
+# - hostspace HOST (\S+)
+
+# Test shorthost pattern with comma delimiter
+host=SECRET,os=rhel9
+
+# Test shorthost pattern at end of line
+host=SECRETHOST
+
+# Test shorthost pattern - should NOT match (no comma or EOL after value)
+host=okhost due to the space
+
+# Test hostspace pattern with uppercase
+The HOST VALUE here
+
+# Test hostspace pattern with alphanumeric
+HOST val4ue was found
+
+# Test consistency - same value should get same obfuscation
+host=SECRET,version=9.2
+
+# Test different keywords have independent counters
+host=ANOTHER,HOST ANOTHERVALUE


### PR DESCRIPTION
Add Regexp prepper/parser/mapping to allow users to declare own patterns with sensitive data to clean. The feature is enabled by presence of /etc/sos/cleaner/regexp_patterns.conf file.

Man pages updated, avocado tests added.

Resolves: #4394
Closes: #4404

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
