### PR TITLE
[cleaner] Improve performance of extracting single archive

### DIFF
--- a/sos/cleaner/__init__.py
+++ b/sos/cleaner/__init__.py
@@ -444,6 +444,19 @@ third party.
         for parser in self.parsers:
             if parser.name == 'Hostname Parser':
                 parser.mapping.set_initial_counts()
+
+        # Optimize single-archive cleaning: extract once before prepping
+        # instead of using tarfile.extractfile() for each file during prep,
+        # then extracting the full archive again during obfuscation.
+        # Multi-archive (sos-collect) keeps original prep-before-extract
+        # behavior for cross-archive obfuscation consistency.
+        single_tarball = (len(self.report_paths) == 1
+                          and self.report_paths[0].is_tarfile
+                          and not self.nested_archive)
+        if single_tarball:
+            self.log_debug("Single tarball detected, extracting before prep.")
+            self.report_paths[0].extract()
+
         self.preload_all_archives_into_maps()
         self.generate_parser_item_regexes()
         self.obfuscate_report_paths()


### PR DESCRIPTION
When cleaning a standalone archive (sos clean sosreport.tar.xz), tarfile.extractfile() is repeatedly called by preppers before we unpack the tarball - that is redundant.

So for the standalone archive cleanup, move its extraction before preppers work.

For in_file and nested (i.e. sos-collect) archives, keep current behaviour.

Relevant: #4403
Closes: #4405

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
