### PR TITLE
[kernel] Collect sysctl.d from additional paths

### DIFF
--- a/sos/report/plugins/kernel.py
+++ b/sos/report/plugins/kernel.py
@@ -123,6 +123,8 @@ class Kernel(Plugin, IndependentPlugin):
             "/etc/sysctl.conf",
             "/etc/sysctl.d",
             "/lib/sysctl.d",
+            "/run/sysctl.d",
+            "/usr/local/lib/sysctl.d",
             "/proc/cmdline",
             "/proc/driver",
             "/proc/sys/kernel/tainted",


### PR DESCRIPTION
Collect /run/sysctl.d and /usr/local/lib/sysctl.d to ensure we collect all documented paths that sysctl.d uses:
https://www.freedesktop.org/software/systemd/man/latest/sysctl.d.html

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?