### PR TITLE
Fix "overriden" misspelling

### DIFF
--- a/sos/component.py
+++ b/sos/component.py
@@ -241,7 +241,7 @@ class SoSComponent():
                         setattr(opts, oopt, [x for x in getattr(opts, oopt)
                                 if x not in common])
 
-            # plugin options as a list should be concatenated, not overriden
+            # plugin options as a list should be concatenated, not overridden
             # BUT if cmdline plugoption overrides same option in opts, we must
             # drop the opts's value; since the items are in form
             # 'apache.log=on', we must separate the *name* of each option

--- a/sos/policies/distros/suse.py
+++ b/sos/policies/distros/suse.py
@@ -45,7 +45,7 @@ class SuSEPolicy(LinuxPolicy):
     @classmethod
     def check(cls, remote=''):
         """This method checks to see if we are running on SuSE. It must be
-        overriden by concrete subclasses to return True when running on an
+        overridden by concrete subclasses to return True when running on an
         OpenSuSE, SLES or other Suse distribution and False otherwise."""
         return False
 

--- a/sos/policies/init_systems/__init__.py
+++ b/sos/policies/init_systems/__init__.py
@@ -130,7 +130,7 @@ class InitSystem():
         """Parses the output returned by the query command to make a
         determination of what the state of the service is
 
-        This should be overriden by anything that subclasses InitSystem
+        This should be overridden by anything that subclasses InitSystem
 
         :param output: The raw output from querying the service with the
                        configured `query_cmd`

--- a/sos/report/__init__.py
+++ b/sos/report/__init__.py
@@ -1016,7 +1016,7 @@ class SoSReport(SoSComponent):
         msg = "\nEstimate-only mode enabled"
         ext_msg = []
         if self.opts.threads > 1:
-            ext_msg += [f"--threads={self.opts.threads} overriden to 1", ]
+            ext_msg += [f"--threads={self.opts.threads} overridden to 1", ]
             self.opts.threads = 1
         if not self.opts.build:
             ext_msg += ["--build enabled", ]


### PR DESCRIPTION
The estimate-only mode message printed to the user reads:

    --threads=N overriden to 1

"overriden" should be "overridden". The same misspelling appears in three
comments and docstrings; all four occurrences are corrected for consistency.

No functional change. `flake8` passes clean over `setup.py plugins_overview.py
sos tests` after the change, and no occurrences of "overriden" remain.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?

Note on the third box: the change spans `sos/report/`, `sos/policies/` and
`sos/component.py`, so no single section tag applies. Happy to retitle if the
maintainers prefer a specific prefix.