### PR TITLE
[pacemaker] Remove duplicate bundles copy spec

### DIFF
--- a/sos/report/plugins/pacemaker.py
+++ b/sos/report/plugins/pacemaker.py
@@ -97,7 +97,6 @@ class Pacemaker(Plugin):
 
             # Pacemaker 1.x default log locations
             "/var/log/pacemaker.log",
-            "/var/log/pacemaker/bundles/*/",
 
             # Common user-specified locations
             "/var/log/cluster/pacemaker.log*",


### PR DESCRIPTION
"/var/log/pacemaker/bundles/*/" is listed twice in `setup()`, once under the
Pacemaker 2.x log locations and again under the 1.x locations.

The second entry appears to be a copy-paste slip. That path is part of the 2.x
layout; Pacemaker 1.x logs to the flat /var/log/pacemaker.log, which is already
listed immediately above it.

`add_copy_spec()` feeds `self.copy_paths`, which is a `set()`, so the duplicate
is absorbed and nothing was collected twice. The listing is misleading rather
than harmful, but it implies 1.x uses a path it does not.

No change to what is collected.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?