### PR TITLE
[gfs2] Fix option name for lock dump collection

### DIFF
--- a/sos/report/plugins/gfs2.py
+++ b/sos/report/plugins/gfs2.py
@@ -32,7 +32,7 @@ class Gfs2(Plugin, IndependentPlugin):
             "gfs_control dump"
         ])
 
-        if self.get_option("gfs2lockdump"):
+        if self.get_option("lockdump"):
             self.add_copy_spec("/sys/kernel/debug/gfs2/*")
 
         tunegfs2_opts = '-l'


### PR DESCRIPTION
The plugin declares its option as `lockdump`:

    PluginOpt('lockdump', default=False,
              desc='collect lock dumps for all GFS2 filesystems')

but `setup()` reads a different name:

    if self.get_option("gfs2lockdump"):

`get_option()` checks the global option list, then the plugin's own declared
options, then returns the default. `gfs2lockdump` is in neither, so the call
always returns 0 and `/sys/kernel/debug/gfs2/*` is never collected regardless
of what the user passes to `-k gfs2.lockdump=on`.

Confirmed by importing the plugin:

    Declared option names: ['lockdump']
    Name read in setup():  'gfs2lockdump'
    'gfs2lockdump' in globals?  False
    'gfs2lockdump' in declared? False

The declared name is the one exposed to users, so the `get_option()` call is
corrected to match it. This also aligns gfs2 with `dlm`, which uses the same
option name and wires it correctly:

    PluginOpt('lockdump', default=False, desc='capture lock dumps for DLM')
    ...
    if self.get_option("lockdump"):

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?