### PR TITLE
[openstack_mistral] Fix all_logs option name

### DIFF
--- a/sos/report/plugins/openstack_mistral.py
+++ b/sos/report/plugins/openstack_mistral.py
@@ -40,7 +40,7 @@ class OpenStackMistral(Plugin, RedHatPlugin):
     containers = ('.*mistral_engine',)
 
     def setup(self):
-        if self.get_option('all_log'):
+        if self.get_option('all_logs'):
             self.add_copy_spec(MISTRAL_DIRECTORIES)
         else:
             self.add_copy_spec(MISTRAL_LOGS)


### PR DESCRIPTION
`setup()` gates the full directory collection on `all_log`:

    if self.get_option('all_log'):
        self.add_copy_spec(MISTRAL_DIRECTORIES)

The global option is `all_logs`. `get_option()` checks the global option list,
then the plugin's own declared options, then returns the default. This plugin
declares no options and `all_log` is not global, so the call always returns 0
and `MISTRAL_DIRECTORIES` is never collected, even with `--all-logs`.

That leaves `/var/log/mistral/` and `/var/lib/mistral/` uncollected in full,
including the ansible run logs the plugin docstring describes as the reason for
gathering them.

Every other plugin reading this option uses `all_logs` — `openstack_ceilometer`,
`chrony`, `nginx`, `kimchi`, `aap_eda`. This is the only occurrence of `all_log`
in the tree.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?