### PR TITLE
[cs] Remove duplicate errors copy spec

### DIFF
--- a/sos/report/plugins/cs.py
+++ b/sos/report/plugins/cs.py
@@ -70,7 +70,6 @@ class CertificateSystem(Plugin, RedHatPlugin):
                 "/opt/redhat-cs/cert-*/errors",
                 "/opt/redhat-cs/cert-*/config/CS.cfg",
                 "/opt/redhat-cs/cert-*/access",
-                "/opt/redhat-cs/cert-*/errors",
                 "/opt/redhat-cs/cert-*/system",
                 "/opt/redhat-cs/cert-*/transactions",
                 "/opt/redhat-cs/cert-*/debug",


### PR DESCRIPTION
`/opt/redhat-cs/cert-*/errors` is listed twice in the same `add_copy_spec()`
list in the Certificate System 7.1 branch:

    self.add_copy_spec([
        ...
        "/opt/redhat-cs/cert-*/errors",
        "/opt/redhat-cs/cert-*/config/CS.cfg",
        "/opt/redhat-cs/cert-*/access",
        "/opt/redhat-cs/cert-*/errors",
        ...
    ])

Both entries are in a single list literal rather than separate version or
container branches, so the second is a plain duplicate.

`add_copy_spec()` feeds `self.copy_paths`, which is a `set()`, so nothing was
collected twice. This removes the redundant entry for clarity; there is no
change to what is collected.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?