### PR TITLE
[ipa] Use webserver profile instead of apache

### DIFF
--- a/sos/report/plugins/ipa.py
+++ b/sos/report/plugins/ipa.py
@@ -17,7 +17,7 @@ class Ipa(Plugin, RedHatPlugin):
     short_desc = 'Identity, policy, audit'
 
     plugin_name = 'ipa'
-    profiles = ('identity', 'apache')
+    profiles = ('identity', 'webserver')
 
     ipa_server = False
     ipa_client = False


### PR DESCRIPTION
`ipa` is the only plugin in the tree declaring an `apache` profile. Eleven
plugins use `webserver`, including `apache` itself, which declares
`('webserver', 'openshift')`:

    apache, ceph_rgw, collectd, haproxy, java, keepalived, memcached,
    nginx, perl, squid, tomcat

The result is that `sos report -p apache` enables `ipa` and not `apache`, while
`-p webserver` does not pick up `ipa` even though it runs httpd for the web UI
and collects its configuration.

Treating `apache` as a slip for `webserver` resolves both and aligns `ipa` with
the other httpd-adjacent plugins.

If the `apache` profile was intentional, happy to close this — but as it stands
`-p apache` does not enable the apache plugin, which seems unlikely to be the
intent.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?