### PR TITLE
[radius] Obfuscate passwords on Debian and Ubuntu

### DIFF
--- a/sos/report/plugins/radius.py
+++ b/sos/report/plugins/radius.py
@@ -50,4 +50,8 @@ class DebianRadius(Radius, DebianPlugin, UbuntuPlugin):
             "/var/log/freeradius"
         ])
 
+    def postproc(self):
+        self.do_path_regex_sub(
+            "/etc/freeradius/.*", r"(\s*password\s*=\s*)\S+", r"\1***")
+
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
`RedHatRadius` collects `/etc/raddb` and redacts the SQL password in
`postproc()`. `DebianRadius` collects the equivalent `/etc/freeradius` tree but
defines no `postproc()`, so the same credentials are included in the archive in
cleartext on Debian and Ubuntu.

This adds a `postproc()` to `DebianRadius` mirroring the Red Hat one.
`do_path_regex_sub()` is used rather than `do_file_sub()` because FreeRADIUS on
Debian nests its configuration under a version directory, so a fixed filename
would not match reliably.

Per the contributor guidelines, the substitution example:

    password = s3cret     ->     password = ***

I do not have a Debian FreeRADIUS system to test against, so a check of the path
regex against a real `/etc/freeradius` layout would be welcome.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?