### PR TITLE
[tang] Add plugin for the Tang NBDE server

### DIFF
--- a/sos/report/plugins/tang.py
+++ b/sos/report/plugins/tang.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Tang(Plugin, IndependentPlugin):
+
+    short_desc = 'Tang network-bound disk encryption server'
+
+    plugin_name = 'tang'
+    profiles = ('security', 'storage', 'services')
+    packages = ('tang',)
+
+    def setup(self):
+        # The key database holds Tang's signing and exchange keys. The
+        # private key material must never leave the host, so forbid the
+        # JWK files outright and collect only a listing of the directory,
+        # which is enough to review the key set, rotation state (keys
+        # renamed with a leading '.' are no longer advertised) and file
+        # ownership.
+        self.add_forbidden_path([
+            '/var/db/tang/*.jwk',
+            '/var/db/tang/.*.jwk',
+            '/usr/share/tang/db/*.jwk',
+            '/usr/share/tang/db/.*.jwk',
+        ])
+
+        self.add_dir_listing([
+            '/var/db/tang',
+            '/usr/share/tang/db',
+        ], tags='tang_keydir')
+
+        self.add_copy_spec('/etc/systemd/system/tangd.socket.d/')
+
+        # Advertised key thumbprints only; no private key material.
+        self.add_cmd_output('tang-show-keys', tags='tang_show_keys')
+
+        self.add_service_status('tangd.socket')
+        self.add_journal(units=['tangd.socket', 'tangd@.service'])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
sos covers the client side of network-bound disk encryption — `block.py` runs
`clevis luks list` against LUKS devices — but has no plugin for the Tang server
itself. An sosreport taken from a Tang host currently contains nothing about
the service, which is the side most often at fault when clients hang at boot
waiting to unlock.

The plugin collects the socket unit drop-in directory, service status, the
tangd journal, and `tang-show-keys`, which reports only the thumbprints of
advertised keys.

The key database is handled deliberately. `/var/db/tang` holds Tang's signing
and exchange keys; collecting that material would expose the ability to unlock
every volume bound to the server. The JWK files are therefore added to the
forbidden paths and only a directory listing is taken. That listing still shows
the key set, ownership and rotation state, since retired keys are renamed with
a leading dot rather than deleted.

Both the default `/var/db/tang` and the older `/usr/share/tang/db` location are
covered.

I do not have a Tang server to test against, so confirmation of the key
database path on current releases and of the `tangd@.service` unit name would
be welcome. The forbidden-path handling is the part I would most like a second
opinion on — the intent is that no private key material can be collected under
any option combination, including `--all-logs`.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?