### PR TITLE
[cron,anacron] Fix cronie package name typo

### DIFF
--- a/sos/report/plugins/anacron.py
+++ b/sos/report/plugins/anacron.py
@@ -15,7 +15,7 @@ class Anacron(Plugin, IndependentPlugin):
 
     plugin_name = 'anacron'
     profiles = ('system',)
-    packages = ('anacron', 'chronie-anacron')
+    packages = ('anacron', 'cronie-anacron')
 
     # anacron may be provided by anacron, cronie-anacron etc.
     # just look for the configuration file which is common

--- a/sos/report/plugins/cron.py
+++ b/sos/report/plugins/cron.py
@@ -15,7 +15,7 @@ class Cron(Plugin, IndependentPlugin):
 
     plugin_name = "cron"
     profiles = ('system',)
-    packages = ('cron', 'anacron', 'chronie')
+    packages = ('cron', 'anacron', 'cronie')
 
     files = ('/etc/crontab',)
 


### PR DESCRIPTION
Both plugins spell the package `chronie`:

    cron.py:18     packages = ('cron', 'anacron', 'chronie')
    anacron.py:18  packages = ('anacron', 'chronie-anacron')

The correct name is `cronie`, the cron implementation shipped by Fedora and
RHEL. The comment two lines below the anacron declaration already spells it
correctly:

    # anacron may be provided by anacron, cronie-anacron etc.

Neither plugin fails to run today — `cron` enables via its `files` tuple and
`anacron` matches the plain `anacron` package — but the `cronie` and
`cronie-anacron` checks have never matched anything on any distribution.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?