### PR TITLE
[rsync] Add plugin for the rsync daemon

### DIFF
--- a/sos/report/plugins/rsync.py
+++ b/sos/report/plugins/rsync.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Rsync(Plugin, IndependentPlugin):
+
+    short_desc = 'Rsync file synchronisation daemon'
+
+    plugin_name = 'rsync'
+    profiles = ('services', 'network')
+
+    packages = ('rsync', 'rsync-daemon')
+    files = ('/etc/rsyncd.conf',)
+    services = ('rsyncd', 'rsyncd.socket')
+
+    def setup(self):
+        # The secrets file referenced by an "auth users" module holds
+        # username:password pairs in cleartext. It must never be
+        # collected, at either of its conventional locations or under
+        # the drop-in directory.
+        self.add_forbidden_path([
+            '/etc/rsyncd.secrets',
+            '/etc/rsync.secrets',
+            '/etc/rsyncd.d/*.secrets',
+        ])
+
+        self.add_copy_spec([
+            '/etc/rsyncd.conf',
+            '/etc/rsyncd.d/',
+            '/etc/default/rsync',
+            '/etc/sysconfig/rsyncd',
+        ])
+
+        self.add_copy_spec('/var/log/rsyncd.log')
+
+        if self.get_option('all_logs'):
+            self.add_copy_spec('/var/log/rsyncd.log*')
+
+        self.add_cmd_output('rsync --version', tags='rsync_version')
+
+        # Templated unit, not covered by the services tuple.
+        self.add_journal(units='rsyncd@.service')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
`rsyncd` is packaged and shipped as a service on RHEL, Fedora, Debian and
Ubuntu, but sos has no plugin for it and no other plugin references rsync. An
sosreport taken from an rsync server currently contains none of its
configuration, logs or service state.

The plugin collects `rsyncd.conf` and the drop-in directory, the distribution
defaults files, the daemon log, `rsync --version`, and the service status and
journal for both the service and socket-activated forms.

A module using `auth users` points at a secrets file holding
`username:password` pairs in cleartext. Those paths are added to the forbidden
list so they cannot be collected under any option combination, including
`--all-logs`.

I do not have an rsyncd deployment to test against. Confirmation of the
`/etc/rsyncd.d/` drop-in path and of the systemd unit names across
distributions would be welcome — the forbidden-path list is the part I would
most like a second opinion on.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?