### PR TITLE
[atd] Add plugin for the at job scheduler

### DIFF
--- a/sos/report/plugins/atd.py
+++ b/sos/report/plugins/atd.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Atd(Plugin, IndependentPlugin):
+
+    short_desc = 'At job scheduler'
+
+    plugin_name = 'atd'
+    profiles = ('system',)
+
+    packages = ('at',)
+    files = ('/etc/at.deny', '/etc/at.allow')
+    services = ('atd',)
+
+    def setup(self):
+        self.add_copy_spec([
+            '/etc/at.allow',
+            '/etc/at.deny',
+            '/etc/sysconfig/atd',
+            '/etc/default/atd',
+        ])
+
+        # Queued jobs under /var/spool/at are complete shell scripts
+        # carrying the submitting user's environment, so their contents
+        # are not collected. A listing still shows which jobs are
+        # pending, their queue, ownership and submission time.
+        self.add_dir_listing('/var/spool/at', recursive=True,
+                             tags='at_spool')
+
+        self.add_cmd_output('atq', tags='atq')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
`cron.py` covers cron, but nothing in the tree references `atd`,
`/etc/at.allow`, `/etc/at.deny`, `/var/spool/at` or `atq`. An sosreport from a
host using `at` contains no record of the daemon, its access control files or
its pending queue.

The plugin collects the allow and deny lists, the distribution defaults files,
`atq` output, and the service status and journal for `atd`.

Queued jobs under `/var/spool/at` are not copied. Each is a complete shell
script that embeds the submitting user's environment, which frequently includes
exported credentials. A recursive directory listing is taken instead, which
still shows the pending jobs, their queue, ownership and submission time.

I do not have a system with pending at jobs to test the spool listing against.
The decision not to copy job bodies is the part I would most like a second
opinion on — `cron.py` does collect `/var/spool/cron`, so there is an argument
for consistency, but at job files embed the submitter's environment in a way
crontabs do not.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?