### PR TITLE
[exim] Add plugin for the Exim mail transfer agent

### DIFF
--- a/sos/report/plugins/exim.py
+++ b/sos/report/plugins/exim.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import (Plugin, RedHatPlugin, DebianPlugin,
+                                UbuntuPlugin)
+
+
+class Exim(Plugin):
+
+    short_desc = 'Exim mail transfer agent'
+
+    plugin_name = 'exim'
+    profiles = ('mail', 'services')
+
+    def setup(self):
+        self.add_cmd_output([
+            'exim -bV',
+            'exim -bp',
+        ], tags='exim_queue')
+
+        self.add_service_status('exim')
+
+
+class RedHatExim(Exim, RedHatPlugin):
+
+    packages = ('exim',)
+    files = ('/etc/exim/exim.conf',)
+
+    def setup(self):
+        super().setup()
+
+        # SMTP authentication credentials are held in the passwd maps
+        # referenced by the authenticators; they must not be collected.
+        self.add_forbidden_path([
+            '/etc/exim/passwd',
+            '/etc/exim/passwd.client',
+        ])
+
+        self.add_copy_spec('/etc/exim')
+
+        self.add_copy_spec([
+            '/var/log/exim/main.log',
+            '/var/log/exim/reject.log',
+            '/var/log/exim/panic.log',
+        ])
+
+        if self.get_option('all_logs'):
+            self.add_copy_spec('/var/log/exim/')
+
+        self.add_journal(units='exim')
+
+
+class DebianExim(Exim, DebianPlugin, UbuntuPlugin):
+
+    packages = ('exim4', 'exim4-base', 'exim4-daemon-light',
+                'exim4-daemon-heavy')
+    files = ('/etc/exim4/update-exim4.conf.conf',)
+
+    def setup(self):
+        super().setup()
+
+        # As above; exim4 keeps its client and server credentials under
+        # the split configuration directory.
+        self.add_forbidden_path([
+            '/etc/exim4/passwd',
+            '/etc/exim4/passwd.client',
+        ])
+
+        self.add_copy_spec('/etc/exim4')
+
+        self.add_copy_spec([
+            '/var/log/exim4/mainlog',
+            '/var/log/exim4/rejectlog',
+            '/var/log/exim4/paniclog',
+        ])
+
+        if self.get_option('all_logs'):
+            self.add_copy_spec('/var/log/exim4/')
+
+        self.add_journal(units='exim4')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
sos has plugins for postfix, sendmail and dovecot, but nothing for exim, and no
other plugin references it. Exim is the default MTA on Debian and Ubuntu and is
also packaged for Fedora and EPEL, so an sosreport from one of those hosts
currently contains no mail configuration, queue state or logs.

The layout differs enough between distributions to need subclasses: Red Hat
ships a single `/etc/exim/exim.conf` with logs named `main.log`, `reject.log`
and `panic.log` under `/var/log/exim`, while Debian uses the split
configuration under `/etc/exim4` with `mainlog`, `rejectlog` and `paniclog`
under `/var/log/exim4`, and the `exim4` unit name.

Common to both, the plugin runs `exim -bV` for the build and configuration
summary and `exim -bp` for the queue.

The `passwd` and `passwd.client` maps hold SMTP authentication credentials in
cleartext, including those used to relay through a smarthost. Both are added to
the forbidden paths in each subclass so they cannot be collected under any
option combination.

I do not have an exim deployment to test against. The Debian log filenames and
the `exim4` unit name are taken from the packaging rather than a live system,
so confirmation would be welcome.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?