### PR TITLE
[keylime] Add plugin for Keylime remote attestation

### DIFF
--- a/sos/report/plugins/keylime.py
+++ b/sos/report/plugins/keylime.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Keylime(Plugin, IndependentPlugin):
+
+    short_desc = 'Keylime remote attestation'
+
+    plugin_name = 'keylime'
+    profiles = ('security', 'services')
+
+    packages = (
+        'keylime',
+        'keylime-base',
+        'keylime-agent',
+        'keylime-verifier',
+        'keylime-registrar',
+        'keylime-tenant',
+        'keylime-agent-rust',
+    )
+    files = ('/etc/keylime',)
+
+    def setup(self):
+        # The CA directory under /var/lib/keylime holds the deployment's
+        # private keys, written as <name>-private.pem, and the same tree
+        # is used for decrypted payloads. None of it is collected; a
+        # listing is taken instead. PEM files are forbidden outright so
+        # that no key material can be picked up from either location.
+        self.add_forbidden_path([
+            '/etc/keylime/**/*.pem',
+            '/var/lib/keylime/**',
+        ])
+
+        self.add_copy_spec([
+            '/etc/keylime/*.conf',
+            '/etc/keylime/agent.conf.d/',
+            '/etc/keylime/ca.conf.d/',
+            '/etc/keylime/logging.conf.d/',
+            '/etc/keylime/registrar.conf.d/',
+            '/etc/keylime/tenant.conf.d/',
+            '/etc/keylime/verifier.conf.d/',
+        ])
+
+        self.add_dir_listing('/var/lib/keylime', recursive=True,
+                             tags='keylime_data_dir')
+
+        self.add_service_status([
+            'keylime_agent',
+            'keylime_registrar',
+            'keylime_verifier',
+        ])
+
+        self.add_journal(units=[
+            'keylime_agent',
+            'keylime_registrar',
+            'keylime_verifier',
+        ])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Keylime is packaged for Fedora and RHEL and provides TPM-based remote
attestation, but sos has no plugin for it and no other plugin references it. An
sosreport from a verifier, registrar or agent host currently contains none of
its configuration or service state.

The paths and unit names are taken from the upstream packaging:
`services/keylime-tmpfiles.conf` creates `/etc/keylime` with the per-component
`.conf.d` drop-in directories and `/var/lib/keylime` at mode 0700, and the
units are `keylime_agent`, `keylime_registrar` and `keylime_verifier`.

`/var/lib/keylime` is deliberately not copied. `keylime/ca_util.py` writes the
deployment CA key there as `<name>-private.pem`, and the same tree holds
decrypted payloads. A recursive listing is taken instead, which still shows the
CA state and file ownership. PEM files are added to the forbidden paths so no
key material can be collected from either location.

Paths and unit names come from upstream `services/keylime-tmpfiles.conf` and
`docs/man/` rather than a running deployment, so confirmation against a
packaged install would be welcome — particularly whether the distribution
packages split the config differently.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a