### PR TITLE
[booth] Add plugin for the Booth cluster ticket manager

### DIFF
--- a/sos/report/plugins/booth.py
+++ b/sos/report/plugins/booth.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Booth(Plugin, IndependentPlugin):
+
+    short_desc = 'Booth cluster ticket manager'
+
+    plugin_name = 'booth'
+    profiles = ('cluster',)
+
+    packages = ('booth', 'booth-core', 'booth-arbitrator', 'booth-site')
+    files = ('/etc/booth/booth.conf',)
+
+    def setup(self):
+        # A site or arbitrator may set "authfile" in booth.conf, pointing
+        # at a shared secret used to authenticate ticket messages. The
+        # default location is under the configuration directory, so
+        # exclude key material before collecting it.
+        self.add_forbidden_path([
+            '/etc/booth/*.key',
+            '/etc/booth/authkey',
+        ])
+
+        self.add_copy_spec('/etc/booth/*.conf')
+
+        self.add_copy_spec('/var/log/booth.log')
+
+        if self.get_option('all_logs'):
+            self.add_copy_spec('/var/log/booth.log*')
+
+        self.add_dir_listing('/var/run/booth', tags='booth_run_dir')
+
+        self.add_cmd_output([
+            'booth list',
+            'booth peers',
+            'booth status',
+        ], tags='booth_status')
+
+        self.add_service_status('booth-arbitrator')
+        self.add_journal(units=['booth-arbitrator', 'booth@*'])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Booth manages tickets across geographically separate Pacemaker clusters and is
packaged for Fedora, RHEL and SUSE. sos has a pacemaker plugin but nothing for
booth, and no other plugin references it, so an sosreport from a booth site or
arbitrator contains no configuration, ticket state or logs.

Paths and unit names are taken from upstream. `src/booth.h` defines the
configuration directory as `/etc/booth`, the run directory as `/var/run/booth`
and the log as `/var/log/booth.log`. `conf/` ships `booth-arbitrator.service`
and the templated `booth@.service`, the latter keyed on `/etc/booth/%i.conf`.

`booth list` is the command the OCF resource agent itself uses to check ticket
state; peers and status are collected alongside it.

`src/config.c` parses an `authfile` option and `src/main.c` reads that file as
a shared secret used to authenticate ticket messages between sites. Key
material under the configuration directory is added to the forbidden paths so
it cannot be collected.

Confirmation of the packaged `authfile` default location would be welcome — I
have excluded `*.key` and `authkey` under `/etc/booth`, but the option accepts
an arbitrary path, so a reviewer with a real deployment may know of a
conventional location I have missed.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?