### PR TITLE
[irqbalance] Add plugin for the IRQ balancing daemon

### DIFF
--- a/sos/report/plugins/irqbalance.py
+++ b/sos/report/plugins/irqbalance.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class IrqBalance(Plugin, IndependentPlugin):
+
+    short_desc = 'IRQ balancing daemon'
+
+    plugin_name = 'irqbalance'
+    profiles = ('system', 'hardware', 'performance')
+
+    packages = ('irqbalance',)
+    services = ('irqbalance',)
+
+    def setup(self):
+        # The unit reads its arguments from two environment files: the
+        # packaged defaults and an optional administrator override. Which
+        # of the two paths is used depends on how the package was built,
+        # so collect both conventional locations.
+        self.add_copy_spec([
+            '/etc/sysconfig/irqbalance',
+            '/etc/default/irqbalance',
+            '/usr/lib/systemd/system/irqbalance.service.d/',
+            '/etc/systemd/system/irqbalance.service.d/',
+        ])
+
+        self.add_dir_listing('/run/irqbalance', tags='irqbalance_run_dir')
+
+        self.add_cmd_output('irqbalance --version',
+                            tags='irqbalance_version')
+
+        self.add_journal(units='irqbalance')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
irqbalance is installed by default on Fedora, RHEL, Debian and Ubuntu, but sos
has no plugin for it and no other plugin references it. Its configuration never
reaches an sosreport, which matters when interrupts are not landing on the CPUs
an administrator expects.

The unit reads two environment files:

    EnvironmentFile=@pkgconfdir@/irqbalance.env
    EnvironmentFile=-@usrconfdir@/irqbalance

`configure.ac` resolves those to `$prefix/etc/default` and
`${sysconfdir}/default`, so the effective path differs between distributions.
Both conventional locations are collected, along with any systemd drop-ins,
since `IRQBALANCE_BANNED_CPUS`, `IRQBALANCE_BANNED_CPULIST` and
`IRQBALANCE_ARGS` are set there.

`irqbalance.h` defines the runtime socket directory as `/run/irqbalance`,
matching `RuntimeDirectory=irqbalance/` in the unit; a listing of it is taken
rather than the sockets themselves.

The daemon holds no credentials, so no forbidden paths are needed.

Paths and the unit's environment file handling are taken from upstream
(`misc/irqbalance.service.in`, `configure.ac`, `irqbalance.h`) rather than a
running system. Confirmation of which of `/etc/sysconfig/irqbalance` and
`/etc/default/irqbalance` each distribution actually ships would be welcome —
I have collected both rather than guess.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?