### PR TITLE
[wireguard] Add plugin for WireGuard VPN tunnels

### DIFF
--- a/sos/report/plugins/wireguard.py
+++ b/sos/report/plugins/wireguard.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class WireGuard(Plugin, IndependentPlugin):
+
+    short_desc = 'WireGuard VPN tunnels'
+
+    plugin_name = 'wireguard'
+    profiles = ('network', 'security')
+
+    packages = ('wireguard-tools',)
+    files = ('/etc/wireguard',)
+    kernel_mods = ('wireguard',)
+
+    def setup(self):
+        self.add_copy_spec('/etc/wireguard/*.conf')
+
+        # "wg show" masks private and preshared keys as "(hidden)" unless
+        # WG_HIDE_KEYS=never is set in the environment, so the default
+        # output is safe to collect. "wg showconf" is deliberately not
+        # run, as it prints the private key verbatim.
+        self.add_cmd_output('wg show all', tags='wg_show')
+
+        self.add_service_status('wg-quick@*')
+        self.add_journal(units='wg-quick@*')
+
+    def postproc(self):
+        # Interface configuration files hold the interface private key
+        # and any per-peer preshared key in cleartext.
+        #
+        # PrivateKey = 8Gt...=    ->    PrivateKey = ********
+        self.do_path_regex_sub(
+            '/etc/wireguard/.*',
+            r'((?:Private|Preshared)Key\s*=\s*)\S+',
+            r'\1********')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
WireGuard is in the mainline kernel and `wireguard-tools` is packaged for RHEL,
Fedora, Debian and Ubuntu, but sos has no plugin for it and no other plugin
references it. Neither the interface configuration nor the runtime tunnel state
reaches an sosreport.

The plugin collects `/etc/wireguard/*.conf`, the output of `wg show all`, and
the status and journal of the templated `wg-quick@` unit.

`wg showconf` is deliberately not run: it prints the interface private key
verbatim. `wg show` masks private and preshared keys as `(hidden)` unless
`WG_HIDE_KEYS=never` is set in the environment, per `masked_key()` in
`src/show.c`, so its default output is safe.

The configuration files themselves hold the private key and any per-peer
preshared key in cleartext, so `postproc()` redacts both. Public keys,
endpoints and allowed IPs are left intact, since those are what a tunnel
problem is usually diagnosed from.

Example of the substitution:

    PrivateKey = 8Gt...=    ->    PrivateKey = ********

Paths, unit name and key-masking behaviour are taken from upstream
`wireguard-tools` (`src/show.c`, `src/config.c`,
`src/systemd/wg-quick@.service`) rather than a running deployment. The
`postproc()` regex was tested against sample config lines: `PrivateKey` and
`PresharedKey` are redacted while `PublicKey`, `Endpoint` and `AllowedIPs` are
left intact.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message