### PR TITLE
[avahi] Add plugin for the Avahi mDNS/DNS-SD stack

### DIFF
--- a/sos/report/plugins/avahi.py
+++ b/sos/report/plugins/avahi.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Avahi(Plugin, IndependentPlugin):
+
+    short_desc = 'Avahi mDNS/DNS-SD stack'
+
+    plugin_name = 'avahi'
+    profiles = ('network', 'services')
+
+    packages = ('avahi', 'avahi-daemon', 'avahi-dnsconfd')
+    files = ('/etc/avahi/avahi-daemon.conf',)
+
+    def setup(self):
+        self.add_copy_spec([
+            '/etc/avahi/avahi-daemon.conf',
+            '/etc/avahi/hosts',
+            '/etc/avahi/services/',
+            '/etc/avahi/avahi-dnsconfd.action',
+        ])
+
+        self.add_cmd_output([
+            'avahi-browse --all --terminate --resolve',
+            'avahi-daemon --check',
+        ], tags='avahi_browse')
+
+        self.add_service_status([
+            'avahi-daemon',
+            'avahi-daemon.socket',
+            'avahi-dnsconfd',
+        ])
+
+        self.add_journal(units=['avahi-daemon', 'avahi-dnsconfd'])
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Avahi is installed by default on Fedora, RHEL, Debian and Ubuntu, but sos has
no plugin for it and no other plugin references it. Neither its configuration
nor the services it advertises reach an sosreport, which matters when `.local`
name resolution or multicast service discovery is misbehaving.

Paths are taken from upstream. `avahi-daemon/Makefile.am` defines the
configuration file as `$(pkgsysconfdir)/avahi-daemon.conf` and the service
directory as `$(pkgsysconfdir)/services`, and `static-hosts.c` reads
`AVAHI_CONFIG_DIR "/hosts"`.

Unit names come from the shipped units: `avahi-daemon.service`, which requires
`avahi-daemon.socket`, and `avahi-dnsconfd.service`.

`avahi-browse --all --terminate --resolve` records what the host can see on the
link at collection time, and `avahi-daemon --check` reports whether a daemon is
already running.

The daemon holds no credentials, so no forbidden paths or postproc handling are
needed.

Paths and unit names are taken from upstream rather than a running system.
`avahi-browse --all --terminate --resolve` produces network traffic at
collection time — if maintainers would prefer that behind `--all-logs` or a
plugin option rather than run by default, I am happy to move it.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs