### PR TITLE
[lldpd] Add plugin for the LLDP daemon

### DIFF
--- a/sos/report/plugins/lldpd.py
+++ b/sos/report/plugins/lldpd.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Lldpd(Plugin, IndependentPlugin):
+
+    short_desc = 'LLDP daemon'
+
+    plugin_name = 'lldpd'
+    profiles = ('network', 'hardware')
+
+    packages = ('lldpd',)
+    services = ('lldpd',)
+
+    def setup(self):
+        # The unit sources its arguments from whichever of the two
+        # conventional environment files the distribution ships.
+        self.add_copy_spec([
+            '/etc/lldpd.conf',
+            '/etc/lldpd.d/',
+            '/etc/default/lldpd',
+            '/etc/sysconfig/lldpd',
+        ])
+
+        self.add_cmd_output([
+            'lldpcli show chassis',
+            'lldpcli show configuration',
+            'lldpcli show interfaces details',
+            'lldpcli show neighbors details',
+            'lldpcli show statistics',
+        ], tags='lldpcli_show')
+
+        self.add_journal(units='lldpd')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
lldpd is packaged for Fedora, RHEL via EPEL, Debian and Ubuntu, but sos has no
plugin for it. `networking.py` collects `/var/lib/lldpad/`, which belongs to
lldpad, a separate implementation; nothing in the tree covers lldpd itself.

Paths are taken from upstream. `src/daemon/lldpd.c` passes
`SYSCONFDIR "/lldpd.conf"` and `SYSCONFDIR "/lldpd.d"` on resume, and
`src/daemon/lldpd.service.in` sources both `/etc/default/lldpd` and
`/etc/sysconfig/lldpd` as optional environment files, so both are collected
rather than assuming which one a distribution ships.

The lldpcli subcommands are those registered in `src/client/show.c`.
`show neighbors details` is the useful one for support: it records which switch
and port each interface is attached to, which cannot otherwise be recovered
from an sosreport.

The daemon holds no credentials, so no forbidden paths are needed.

Worth noting `networking.py` already collects `/var/lib/lldpad/` for the
separate lldpad implementation — this plugin does not overlap with it, but a
reviewer may prefer the two be reconciled.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs