### PR TITLE
[clamav] Add plugin for ClamAV

### DIFF
--- a/sos/report/plugins/clamav.py
+++ b/sos/report/plugins/clamav.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2026 Suraj Patil <surajpatil522@gmail.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class ClamAV(Plugin, IndependentPlugin):
+
+    short_desc = 'ClamAV antivirus'
+
+    plugin_name = 'clamav'
+    profiles = ('security', 'services')
+
+    packages = ('clamav', 'clamd', 'clamav-freshclam', 'clamav-daemon')
+    files = ('/etc/clamd.conf', '/etc/clamav/clamd.conf')
+    services = ('clamav-daemon', 'clamav-freshclam', 'freshclam')
+
+    def setup(self):
+        # Red Hat splits the daemon configuration into /etc/clamd.d/,
+        # Debian keeps everything under /etc/clamav/.
+        self.add_copy_spec([
+            '/etc/clamd.conf',
+            '/etc/clamd.d/',
+            '/etc/freshclam.conf',
+            '/etc/clamav/',
+            '/etc/sysconfig/clamav-milter',
+        ])
+
+        self.add_copy_spec([
+            '/var/log/clamav/*.log',
+            '/var/log/freshclam.log',
+            '/var/log/clamd.scan',
+        ])
+
+        if self.get_option('all_logs'):
+            self.add_copy_spec([
+                '/var/log/clamav/',
+                '/var/log/freshclam.log*',
+            ])
+
+        # DatabaseDirectory is configurable; fall back to the upstream
+        # default if freshclam.conf does not set it or cannot be read.
+        db_dir = '/var/lib/clamav'
+        config_files = (
+            '/etc/freshclam.conf',
+            '/etc/clamav/freshclam.conf',
+        )
+        for config_file in config_files:
+            try:
+                with open(config_file, 'r', encoding='UTF-8') as cfile:
+                    for line in cfile.read().splitlines():
+                        words = line.split()
+                        if words and words[0] == 'DatabaseDirectory':
+                            db_dir = words[1]
+            except IOError:
+                continue
+
+        # The signature database is large and binary; a listing is enough
+        # to show which definitions are present and how old they are.
+        self.add_dir_listing(db_dir, tags='clamav_database')
+
+        self.add_cmd_output('clamconf', tags='clamconf')
+
+    def postproc(self):
+        # freshclam.conf may hold credentials for an outbound proxy.
+        #
+        # HTTPProxyPassword mypass    ->    HTTPProxyPassword ********
+        self.do_path_regex_sub(
+            r'/etc/(clamav/)?freshclam\.conf',
+            r'(HTTPProxy(?:Password|Username)\s+)\S+',
+            r'\1********')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
ClamAV is packaged for Fedora, RHEL via EPEL, Debian and Ubuntu, but sos has no
plugin for it and no other plugin references it. Neither the daemon
configuration, the freshclam update state nor the signature database age
reaches an sosreport.

The configuration layout differs by distribution: Red Hat splits the daemon
configuration into `/etc/clamd.d/` while Debian keeps everything under
`/etc/clamav/`, so both are collected. Defaults are taken from the upstream
samples in `etc/`, which set `DatabaseDirectory` to `/var/lib/clamav` and
`UpdateLogFile` to `/var/log/freshclam.log`.

`clamconf` is ClamAV's own configuration dump utility and is run in preference
to parsing the files directly.

The signature database is not copied. It is hundreds of megabytes of binary
`.cvd` data; a directory listing still shows which definitions are present and
how old they are.

`etc/freshclam.conf.sample` documents `HTTPProxyUsername` and
`HTTPProxyPassword` for outbound proxy access, so `postproc()` redacts both.
`HTTPProxyServer` is left intact.

Example of the substitution:

    HTTPProxyPassword mypass    ->    HTTPProxyPassword ********

Paths and defaults are taken from the upstream configuration samples rather
than a running system. The `postproc()` regex was tested against sample lines.
Unit names vary between distributions — I have covered `clamav-daemon`,
`clamav-freshclam`, `clamd@scan` and `freshclam`; confirmation of the packaged
names would be welcome.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?