### PR TITLE
[man] Document S3 upload options for sos report

### DIFF
--- a/man/en/sos-report.1
+++ b/man/en/sos-report.1
@@ -43,6 +43,12 @@ sos_report \- Collect and package diagnostic and support data
           [--upload-directory dir] [--upload-pass pass]\fR
           [--upload-no-ssl-verify] [--upload-method]\fR
           [--upload-protocol protocol]\fR
+          [--upload-s3-endpoint endpoint]\fR
+          [--upload-s3-region region]\fR
+          [--upload-s3-bucket bucket]\fR
+          [--upload-s3-access-key key]\fR
+          [--upload-s3-secret-key key]\fR
+          [--upload-s3-object-prefix prefix]\fR
           [--experimental]\fR
           [-h|--help]\fR
 
@@ -495,7 +501,25 @@ For RHEL systems, setting this option to \fBsftp\fR will skip the initial attemp
 upload to the Red Hat Customer Portal, and only attempt an upload to Red Hat's SFTP server,
 which is typically used as a fallback target.
 
-Valid values for PROTO are: 'auto' (default), 'https', 'ftp', 'sftp'.
+Valid values for PROTO are: 'auto' (default), 'https', 'ftp', 'sftp', 's3'.
+.TP
+.B \--upload-s3-endpoint ENDPOINT
+Endpoint to upload to for S3 bucket
+.TP
+.B \--upload-s3-region REGION
+Region to upload to for S3 bucket
+.TP
+.B \--upload-s3-bucket BUCKET
+Name of the S3 bucket to upload to
+.TP
+.B \--upload-s3-access-key KEY
+Access key for the S3 bucket
+.TP
+.B \--upload-s3-secret-key KEY
+Secret key for the S3 bucket
+.TP
+.B \--upload-s3-object-prefix PREFIX
+Prefix for the S3 object/key
 .TP
 .B \--experimental
 Enable plugins marked as experimental. Experimental plugins may not have

--- a/man/en/sos-upload.1
+++ b/man/en/sos-upload.1
@@ -113,27 +113,27 @@ If this option is not called, sos will try to determine the local target
 and use it for uploads.
 
 .TP
-.B \---upload-s3-endpoint ENDPOINT
+.B \--upload-s3-endpoint ENDPOINT
 Endpoint to upload to for S3 bucket
 
 .TP
-.B \---upload-s3-region REGION
+.B \--upload-s3-region REGION
 Region to upload to for S3 bucket
 
 .TP
-.B \---upload-s3-bucket BUCKET
+.B \--upload-s3-bucket BUCKET
 Name of the S3 bucket to upload to
 
 .TP
-.B \---upload-s3-access-key KEY
+.B \--upload-s3-access-key KEY
 Access key for the S3 bucket
 
 .TP
-.B \-  --upload-s3-secret-key KEY
+.B \--upload-s3-secret-key KEY
 Secret key for the S3 bucket
 
 .TP
-.B \-  --upload-s3-object-prefix PREFIX
+.B \--upload-s3-object-prefix PREFIX
 Prefix for the S3 object/key
 
 .SH TOKEN STORAGE


### PR DESCRIPTION
`sos report` accepts six S3 upload options — endpoint, region, bucket,
access-key, secret-key and object-prefix — but `sos-report.1` does not mention
any of them. `sos-upload.1` documents the same six options in full, so the two
man pages disagree about what sos can do.

The `--upload-protocol` entry compounds this: it lists the valid values as
`auto`, `https`, `ftp` and `sftp`, while argparse accepts
`{auto,https,ftp,sftp,s3}`. A reader of the man page would conclude S3 upload
is not supported.

This adds the six options to the synopsis and the option list, using the same
wording as `sos-upload.1` so the two pages stay consistent, and adds `s3` to
the documented protocol values.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?