### PR TITLE
[docs] Fix Utilities typo in the API documentation title

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1,5 +1,5 @@
-``sos.utilities`` --- Utilites Interface
-========================================
+``sos.utilities`` --- Utilities Interface
+=========================================
 
 .. automodule:: sos.utilities
     :members:


### PR DESCRIPTION
The page title in `docs/utilities.rst` reads "Utilites Interface". It is
rendered as the heading of the `sos.utilities` API page.

The section underline is extended by one character to match the corrected
title. Every other page under `docs/` has the underline exactly the same length
as its title, and a short underline produces a Sphinx warning.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?