### PR TITLE
[docs] Fix typos in published API docstrings

### DIFF
--- a/sos/cleaner/mappings/ipv6_map.py
+++ b/sos/cleaner/mappings/ipv6_map.py
@@ -252,7 +252,7 @@ class ObfuscatedIPv6Network():
         addresses to match the general format/syntax of the address it is
         replacing. For the moment, it is assumed that being able to maintain a
         quick mental note of "unobfuscated device ff00::1 is obfuscated device
-        53ad::a1b2" is more desireable than "ff00::1 is now obfuscated as
+        53ad::a1b2" is more desirable than "ff00::1 is now obfuscated as
         53ad::1234:abcd:9876:a1b2:".
 
         :param addr:        The unobfuscated IPv6 address

--- a/sos/cleaner/parsers/__init__.py
+++ b/sos/cleaner/parsers/__init__.py
@@ -16,7 +16,7 @@ import re
 class SoSCleanerParser():
     """Parsers are used to build objects that will take a line as input,
     parse it for a particular pattern (E.G. IP addresses) and then make any
-    necessary subtitutions by referencing the SoSMap() associated with the
+    necessary substitutions by referencing the SoSMap() associated with the
     parser.
 
     Ideally a new parser subclass will only need to set the class level attrs

--- a/sos/policies/__init__.py
+++ b/sos/policies/__init__.py
@@ -189,8 +189,8 @@ any third party.
     @classmethod
     def set_forbidden_paths(cls):
         """Use this to *append* policy-specifc forbidden paths that apply to
-        all plugins. Setting this classmethod on an invidual policy will *not*
-        override subclass-specific paths
+        all plugins. Setting this classmethod on an individual policy will
+        *not* override subclass-specific paths
         """
         return [
             '*.egg',
@@ -214,7 +214,7 @@ any third party.
 
     def get_preferred_archive(self):
         """
-        Return the class object of the prefered archive format for this
+        Return the class object of the preferred archive format for this
         platform
         """
         from sos.archive import TarFileArchive
@@ -540,7 +540,7 @@ any third party.
         return None
 
     def probe_preset(self):
-        """Return a ``PresetDefaults`` object matching the runing host.
+        """Return a ``PresetDefaults`` object matching the running host.
 
             Stub method to be implemented by derived policy classes.
 

--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -79,7 +79,7 @@ class SoSPredicate:
 
     A predicate gates the collection of data by an sos plugin. For any
     `add_cmd_output()`, `add_copy_spec()` or `add_journal()` call, the
-    passed predicate will be evaulated and collection will proceed if
+    passed predicate will be evaluated and collection will proceed if
     the result is `True`, and not otherwise.
 
     Predicates may be used to control conditional data collection
@@ -688,7 +688,7 @@ class Plugin():
         determined by either the value provided via the
         plugin.timeout or plugin.cmd-timeout option, the global timeout or
         cmd-timeout options, or the default value set by the plugin or the
-        collection, in that order of precendence.
+        collection, in that order of precedence.
 
         :param optname: The name of the cmdline option being checked, either
                         'plugin_timeout' or 'timeout'
@@ -1346,7 +1346,7 @@ class Plugin():
         :param regexp: A regex to match against the contents of each file
         :type regexp: ``str`` or compiled ``re`` object
 
-        :param subst: The substituion string to be used to replace matches
+        :param subst: The substitution string to be used to replace matches
         :type subst: ``str``
         """
         if not hasattr(pathexp, "match"):

--- a/sos/upload/targets/__init__.py
+++ b/sos/upload/targets/__init__.py
@@ -273,7 +273,7 @@ class UploadTarget():
         :_upload_user:    Default username, if any else None
         :_upload_password: Default password, if any else None
 
-        The following Class Attrs may optionally be overidden by the Target
+        The following Class Attrs may optionally be overridden by the Target
 
         :_upload_directory:     Default FTP server directory, if any
 
@@ -456,7 +456,7 @@ class UploadTarget():
         upload password or one provided by the user
 
         A user provided password, either via option or the 'SOSUPLOADPASSWORD'
-        environment variable will have precendent over any target value
+        environment variable will have precedence over any target value
 
         :returns: The password to use for upload
         :rtype: ``str``

--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -566,7 +566,7 @@ def path_join(path, *p, sysroot=os.sep):
 
 def bold(text):
     """Helper to make text bold in console output, without pulling in
-    dependencies to the project unneccessarily.
+    dependencies to the project unnecessarily.
 
     :param text:    The text to make bold
     :type text:     ``str``
@@ -591,7 +591,7 @@ def recursive_dict_values_by_key(dobj, keys=[]):
     Any elements passed here that are _not_ keys within the dict or any nested
     dicts will also be returned.
 
-    :param dobj:    The 'top-level' dict to intially search by
+    :param dobj:    The 'top-level' dict to initially search by
     :type dobj:     ``dict``
 
     :param keys:    Which keys to compile elements from within ``dobj``. If no


### PR DESCRIPTION
The pages under `docs/` are generated with Sphinx `automodule`, so the
docstrings in those modules are published documentation rather than internal
comments. Twelve misspellings appear in them:

    subtitutions, desireable, invidual, prefered, runing, evaulated,
    precendence, substituion, overidden, precendent, unneccessarily, intially

Several are on the plugin authoring interface, which is the page a new plugin
author reads: `substituion` is in the `:param subst:` description of
`do_file_sub`, and `precendence` describes the order in which collection
methods apply.

Correcting `invidual` pushes its docstring line one character past the flake8
limit, so that line is rewrapped — which is why the diff shows 13 changes for
12 typos.

Typos in ordinary code comments are left alone; only text that Sphinx renders
is changed here.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?