### PR TITLE
[utilities] Report stdin writer errors as strings

### DIFF
--- a/sos/utilities.py
+++ b/sos/utilities.py
@@ -661,13 +661,13 @@ class StdinWriter(threading.Thread):
                 self._stdin.flush()
         except (BrokenPipeError, ValueError) as exc:
             # pass error to the main thread
-            self.error = exc
+            self.error = str(exc)
         finally:
             try:
                 self._stdin.close()
             except (BrokenPipeError, ValueError) as exc:
                 # pass error to the main thread
-                self.error += exc
+                self.error += str(exc)
 
 
 class FakeReader():

--- a/tests/unittests/utilities_tests.py
+++ b/tests/unittests/utilities_tests.py
@@ -7,13 +7,14 @@
 # See the LICENSE file in the source distribution for further information.
 import os.path
 import tempfile
+import threading
 import unittest
 
 # PYCOMPAT
 from io import StringIO
 
 from sos.utilities import (grep, is_executable, sos_get_command_output,
-                           find, tail, shell_out, tac_logs)
+                           find, tail, shell_out, tac_logs, StdinWriter)
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -209,5 +210,27 @@ class TacTest(unittest.TestCase):
 
         self.assertEqual(self.tac_logs_str(tac, True), cat)
         self.assertEqual(self.tac_logs_str(tac, False), cat)
+
+
+class StdinWriterTest(unittest.TestCase):
+
+    def test_write_failure_recorded_as_text(self):
+        thread_errors = []
+
+        def collect(args):
+            thread_errors.append(args.exc_type)
+
+        read_fd, write_fd = os.pipe()
+        os.close(read_fd)
+        original_hook = threading.excepthook
+        threading.excepthook = collect
+        try:
+            writer = StdinWriter(os.fdopen(write_fd, 'wb'), b'sos')
+            writer.join()
+        finally:
+            threading.excepthook = original_hook
+        self.assertEqual(thread_errors, [])
+        self.assertIsInstance(writer.error, str)
+        self.assertNotEqual(writer.error, '')
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
When a command closes its stdin before sos finishes writing to it, the write and the following close of that pipe both fail. StdinWriter assigns the first exception object to self.error, which is declared as a string, and the close handler then runs self.error += exc, which raises TypeError inside the writer thread, so the thread dies with an unhandled traceback and the close failure is never recorded.

Both handlers now store str(exc) so self.error stays the string the class declares. Successful stdin writes and every other path through run() are unchanged.

Test: python3 -m unittest tests.unittests.utilities_tests (Ran 24 tests in 0.031s, OK).

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?