### PR TITLE
[haproxy] Declare haproxy in the services tuple

### DIFF
--- a/sos/report/plugins/haproxy.py
+++ b/sos/report/plugins/haproxy.py
@@ -25,6 +25,7 @@ class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
     profiles = ('webserver',)
 
     packages = ('haproxy',)
+    services = ('haproxy',)
     var_puppet_gen = '/var/lib/config-data/puppet-generated/haproxy'
     files = (var_puppet_gen, )
 
@@ -37,9 +38,6 @@ class HAProxy(Plugin, RedHatPlugin, DebianPlugin):
         self.add_cmd_output("haproxy -f /etc/haproxy/haproxy.cfg -c")
 
         self.add_copy_spec("/var/log/haproxy.log")
-
-        self.add_service_status('haproxy')
-        self.add_journal(units='haproxy')
 
         # collect haproxy overview - curl to IP address taken from haproxy.cfg
         # as 2nd word on line below "haproxy.stats"


### PR DESCRIPTION
`setup()` calls `add_service_status()` and `add_journal()` for the haproxy unit
rather than declaring it in the `services` tuple.
`Plugin._collect_services()` already runs each entry of that tuple through
`is_service()` and calls both, so the explicit calls are redundant.

Declaring the unit also gives the plugin an additional enablement trigger.
haproxy currently enables on the package or on the puppet-generated config
directory, so a host running the service without the package installed locally
is missed.

haproxy is the only plugin in the tree still using the explicit form for a unit
it collects both status and journal for.

This follows @TurboTurtle's review comment on #4429.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords