### PR TITLE
[chrony] Declare the chrony units in the services tuple

### DIFF
--- a/sos/report/plugins/chrony.py
+++ b/sos/report/plugins/chrony.py
@@ -42,16 +42,21 @@ class Chrony(Plugin):
 
 
 class RedHatChrony(Chrony, RedHatPlugin):
+
+    services = ('chronyd',)
+
     def setup(self):
         super().setup()
         self.add_copy_spec([
             "/etc/chrony.conf",
             "/var/lib/chrony/drift"
         ])
-        self.add_journal(units="chronyd")
 
 
 class DebianChrony(Chrony, DebianPlugin, UbuntuPlugin):
+
+    services = ('chrony',)
+
     def setup(self):
         super().setup()
         self.add_copy_spec([
@@ -61,6 +66,5 @@ class DebianChrony(Chrony, DebianPlugin, UbuntuPlugin):
             "/var/lib/chrony/chrony.drift",
             "/etc/default/chrony"
         ])
-        self.add_journal(units="chrony")
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Both distribution subclasses call `add_journal()` for their unit but neither
declares a `services` tuple, and neither collects the service status. An
sosreport from a host with clock synchronisation problems therefore has
`chronyc` output and the journal, but nothing showing whether the daemon is
enabled, running or failing to start.

`Plugin._collect_services()` runs each entry of the tuple through
`is_service()` and calls both `add_service_status()` and `add_journal()`, so
declaring the unit adds the missing status, keeps the journal, and removes the
explicit call.

It also gives the plugin an enablement trigger beyond the package name, which
matters here because the unit differs between distributions: `chronyd` on Red
Hat, `chrony` on Debian and Ubuntu.

Follows @TurboTurtle's review comment on #4429, and the same change made for
haproxy in #4436. Unlike those, this one also adds data that is not collected
today — neither chrony subclass collects service status at present.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a