### PR TITLE
[networkmanager] Declare NetworkManager in the services tuple

### DIFF
--- a/sos/report/plugins/networkmanager.py
+++ b/sos/report/plugins/networkmanager.py
@@ -16,6 +16,7 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
     plugin_name = 'networkmanager'
     profiles = ('network', 'hardware', 'system')
     packages = ('NetworkManager', 'network-manager')
+    services = ('NetworkManager',)
 
     def setup(self):
         self.system_connection_files = [
@@ -41,8 +42,6 @@ class NetworkManager(Plugin, RedHatPlugin, UbuntuPlugin):
         self.add_forbidden_path(
             "/var/run/NetworkManager/secret_key"
         )
-
-        self.add_journal(units="NetworkManager")
 
         self.add_cmd_output("NetworkManager --print-config")
 


### PR DESCRIPTION
`setup()` calls `add_journal()` for the NetworkManager unit but the plugin
declares no `services` tuple and never collects the service status. An
sosreport from a host with a networking problem therefore contains the journal
but nothing showing whether the daemon is enabled, running, or failing to
start.

`Plugin._collect_services()` runs each entry of the tuple through
`is_service()` and calls both `add_service_status()` and `add_journal()`, so
declaring the unit adds the missing status and replaces the explicit call.

It also gives the plugin an enablement trigger beyond the package name. The
package differs between distributions — `NetworkManager` on Red Hat,
`network-manager` on Debian and Ubuntu — while the unit is `NetworkManager` on
both.

Follows @TurboTurtle's review comment on #4429, and the same change made in
#4436 and #4437.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?