### PR TITLE
[openvswitch] Declare the OVS units in the services tuple

### DIFF
--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -18,6 +18,15 @@ class OpenVSwitch(Plugin):
     short_desc = 'OpenVSwitch networking'
     plugin_name = "openvswitch"
     profiles = ('network', 'virt')
+
+    services = (
+        'openvswitch',
+        'openvswitch-nonetwork',
+        'ovs-vswitchd',
+        'ovsdb-server',
+        'ovs-configuration',
+        'openvswitch-ipsec',
+    )
     actl = "ovs-appctl"
     vctl = "ovs-vsctl"
     ofctl = "ovs-ofctl"
@@ -160,13 +169,6 @@ class OpenVSwitch(Plugin):
         self.add_cmd_output(f"{self.vctl} -t 5 show",
                             tags="ovs_vsctl_show")
 
-        # Gather systemd services logs
-        self.add_journal(units="openvswitch")
-        self.add_journal(units="openvswitch-nonetwork")
-        self.add_journal(units="ovs-vswitchd")
-        self.add_journal(units="ovsdb-server")
-        self.add_journal(units="ovs-configuration")
-        self.add_journal(units="openvswitch-ipsec")
         self.collect_ovs_info()
         self.collect_datapath()
         self.collect_ovs_bridge_info()


### PR DESCRIPTION
`setup()` calls `add_journal()` for six units — `openvswitch`,
`openvswitch-nonetwork`, `ovs-vswitchd`, `ovsdb-server`, `ovs-configuration`
and `openvswitch-ipsec` — but the plugin declares no `services` tuple and
collects no service status for any of them.

An sosreport from a host where `ovs-vswitchd` or `ovsdb-server` has failed to
start therefore has the journal but nothing showing the unit state, which is
usually the first thing checked when OVS is down.

`Plugin._collect_services()` runs each entry of the tuple through
`is_service()` and calls both `add_service_status()` and `add_journal()`, so
declaring the units adds the six missing statuses and replaces the explicit
calls.

The tuple is declared on the shared base class so it applies to both
distribution subclasses.

The `virtual-accelerator` journal in `collect_ovs_info()` is deliberately left
as an explicit call: it is guarded by an `is_installed()` check for
`6windgate-fp` and so is conditional rather than a property of the plugin.

Follows @TurboTurtle's review comment on #4429, and the same change made in
#4436, #4437 and #4438. The before/after behaviour is demonstrated on #4437,
where `systemctl_status_chronyd` appears only with the change applied.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?