### PR TITLE
[man] Document usernames and treat-certificates for sos clean

### DIFF
--- a/man/en/sos-clean.1
+++ b/man/en/sos-clean.1
@@ -8,8 +8,10 @@ sos_clean, sos_mask \- Obfuscate sensitive data from one or more sos reports
     [\-\-skip-cleaning-files|\-\-skip-masking-files]
     [\-\-keywords]
     [\-\-keyword-file]
+    [\-\-usernames]
+    [\-\-treat-certificates]
     [\-\-map-file]
-    [\-\-jobs]
+    [\-j|\-\-jobs]
     [\-\-no-update]
     [\-\-keep-binary-files]
     [\-\-archive-type]
@@ -84,6 +86,18 @@ both standalone words and in substring matches.
 Provide a file that contains a list of keywords that should be obfuscated. Each word must
 be specified on a newline within the file.
 .TP
+.B \-\-usernames USERNAMES
+Provide a comma-delimited list of usernames to obfuscate in addition to those
+discovered by the username parser.
+.TP
+.B \-\-treat-certificates {obfuscate|keep|remove}
+How to treat certificate files (.csr, .crt, .pem) found in the archive.
+\fBobfuscate\fR converts the file to text and then obfuscates it, \fBkeep\fR
+leaves it in place unmodified, and \fBremove\fR deletes it. Files identified as
+private keys are always removed regardless of this setting.
+
+Default: obfuscate
+.TP
 .B \-\-map-file FILE
 Provide a location to a valid mapping file to use as a reference for existing obfuscation pairs.
 If one is found, the contents are loaded before parsing is started. This allows consistency between
@@ -93,7 +107,7 @@ option to reference a map file from a different run (perhaps one that was done o
 
 Default: /etc/sos/cleaner/default_mapping
 .TP
-.B \-\-jobs JOBS
+.B \-j, \-\-jobs JOBS
 The number of concurrent archives to process, if more than one. If this utility is called by
 \fBsos collect\fR then the value of the jobs option for that utility will be used here.
 


### PR DESCRIPTION
`sos clean` accepts `--usernames` and `--treat-certificates` but neither is
documented in `sos-clean.1`, `sos-mask.1` or `sos-report.1`, so there is no man
page reference for either.

`--treat-certificates` in particular decides whether certificate files found in
an archive are obfuscated, kept, or removed before that archive is passed to a
third party, which is a decision users should be able to find documented.

This adds both to the synopsis and the option list, alongside the other
obfuscation inputs.

Follows the same gap found in #4430, where the S3 upload options were missing
from sos-report.1.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?