### PR TITLE
[containerd] Declare containerd in the services tuple

### DIFF
--- a/sos/report/plugins/containerd.py
+++ b/sos/report/plugins/containerd.py
@@ -15,6 +15,7 @@ class Containerd(Plugin, IndependentPlugin):
     plugin_name = 'containerd'
     profiles = ('container',)
     packages = ('containerd', 'containerd.io',)
+    services = ('containerd',)
     option_list = [
         PluginOpt('stackdump', False, desc='collect containerd stack dump(s)')
     ]
@@ -34,9 +35,6 @@ class Containerd(Plugin, IndependentPlugin):
             f'{pre_cmd} image ls',
             f'{pre_cmd} container ls',
         ])
-
-        # collect the containerd logs.
-        self.add_journal(units='containerd')
 
         if self.get_option('stackdump'):
             for pid in self.signal_process_usr1(r'^/usr/bin/containerd$'):


### PR DESCRIPTION
`setup()` calls `add_journal()` for the containerd unit but the plugin declares
no `services` tuple and never collects the service status. An sosreport from a
node where containerd has failed to start therefore contains the journal but
nothing showing whether the unit is loaded, enabled or running — which is the
first thing checked when kubelet cannot reach the CRI socket.

`Plugin._collect_services()` runs each entry of the tuple through
`is_service()` and calls both `add_service_status()` and `add_journal()`, so
declaring the unit adds the missing status and replaces the explicit call.

It also gives the plugin an enablement trigger beyond the package name.
containerd ships as `containerd` or `containerd.io` depending on the source,
and neither matches on a node where it arrived through a bundled installer,
while the unit name is the same in every case.

`docker.py` has the same gap at line 42; happy to follow up with that
separately if this approach is acceptable.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?