### PR TITLE
[docker] Declare docker in the services tuple

### DIFF
--- a/sos/report/plugins/docker.py
+++ b/sos/report/plugins/docker.py
@@ -18,6 +18,7 @@ class Docker(Plugin, CosPlugin):
     short_desc = 'Docker containers'
     plugin_name = 'docker'
     profiles = ('container',)
+    services = ('docker',)
 
     option_list = [
         PluginOpt('all', default=False,
@@ -39,7 +40,6 @@ class Docker(Plugin, CosPlugin):
             'DOCKER_RUN_PROXY'
         ])
 
-        self.add_journal(units="docker")
         self.add_dir_listing('/etc/docker', recursive=True)
 
         self.set_cmd_predicate(SoSPredicate(self, services=["docker"]))


### PR DESCRIPTION
`setup()` calls `add_journal()` for the docker unit but the plugin declares no
`services` tuple and never collects the service status. An sosreport from a
host where dockerd has failed to start therefore contains the journal but
nothing showing whether the unit is loaded, enabled or running.

`Plugin._collect_services()` runs each entry of the tuple through
`is_service()` and calls both `add_service_status()` and `add_journal()`, so
declaring the unit adds the missing status and replaces the explicit call.

It also gives the plugin an enablement trigger beyond the package name. The
base class declares no `packages` and the two distribution subclasses list ten
names between them, while the unit is `docker` in every case.

The `SoSPredicate` on the following line is unaffected — it gates whether the
docker subcommands run, which is separate from the plugin's `services`
attribute.

Follow-up to #4443, as offered there.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?