### PR TITLE
[nvme] Add NVMe-oF fabric topology and ANA multipath captures

### DIFF
--- a/sos/report/plugins/nvme.py
+++ b/sos/report/plugins/nvme.py
@@ -11,7 +11,9 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 class Nvme(Plugin, IndependentPlugin):
     """Collects nvme device configuration information for each nvme device that
-    is installed on the system.
+    is installed on the system, including NVMe-oF fabric topology, ANA
+    (Asymmetric Namespace Access) multipath state, and NVMe target
+    configuration.
 
     Basic information is collected via the `smartctl` utility, however detailed
     information will be collected via the `nvme` CLI if the `nvme-cli` package
@@ -31,11 +33,16 @@ class Nvme(Plugin, IndependentPlugin):
             "/sys/class/nvme-fabrics/ctl/nvme*",
             "/sys/class/nvme-subsystem/nvme-subsys*/*",
             "/sys/module/nvme_core/parameters/*",
+            "/sys/block/nvme*/ana_state",
+            "/sys/block/nvme*/*/ana_state",
+            "/sys/kernel/config/nvmet/subsystems/*/attr_*",
+            "/sys/kernel/config/nvmet/subsystems/*/namespaces/*/*",
         ])
 
         self.add_cmd_output([
             "nvme list",
             "nvme list-subsys",
+            "nvme list-subsys -v",
         ])
 
         cmds = [
@@ -48,7 +55,7 @@ class Nvme(Plugin, IndependentPlugin):
             "nvme id-ns -H %(dev)s",
             "nvme smart-log %(dev)s",
             "nvme error-log %(dev)s",
-            "nvme show-regs %(dev)s"
+            "nvme show-regs %(dev)s",
         ]
         self.add_device_cmd(cmds, devices='block', whitelist='nvme.*')
 


### PR DESCRIPTION
Collect ANA state sysfs files, verbose subsystem listing, NVMe target configfs, and /dev/disk/by-id/ to support NVMe-oF and native multipath diagnostics.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
