### PR TITLE
[ovn_central,ovn_host] Declare the OVN units in the services tuple

### DIFF
--- a/sos/report/plugins/ovn_central.py
+++ b/sos/report/plugins/ovn_central.py
@@ -25,6 +25,7 @@ class OVNCentral(Plugin):
     short_desc = 'OVN Northd'
     plugin_name = "ovn_central"
     profiles = ('network', 'virt')
+    services = ('ovn-northd',)
     containers = ('ovn-dbs-bundle.*', 'ovn_cluster_north_db_server')
     container_name = ""
     ovn_nbdb_socket = ""
@@ -222,8 +223,6 @@ class OVNCentral(Plugin):
 
             if ovs_dbdir:
                 self.add_copy_spec(self.path_join(ovs_dbdir, dbfile))
-
-        self.add_journal(units="ovn-northd")
 
 
 class RedHatOVNCentral(OVNCentral, RedHatPlugin):

--- a/sos/report/plugins/ovn_host.py
+++ b/sos/report/plugins/ovn_host.py
@@ -17,6 +17,7 @@ class OVNHost(Plugin):
     short_desc = 'OVN Controller'
     plugin_name = "ovn_host"
     profiles = ('network', 'virt', 'openstack_edpm')
+    services = ('ovn-controller',)
     pidfile = 'ovn-controller.pid'
     pid_paths = [
         '/var/lib/openvswitch/ovn',
@@ -44,8 +45,6 @@ class OVNHost(Plugin):
             f'{self.ovs_cmd_pre}ovs-vsctl list-br',
             f'{self.ovs_cmd_pre}ovs-vsctl list Open_vSwitch',
         ])
-
-        self.add_journal(units="ovn-controller")
 
         # Collect Certificate Validity Dates
         for path in ['/etc/ovn/ovn-chassis.crt', '/etc/ovn/cert_host']:


### PR DESCRIPTION
Both plugins call `add_journal()` for their unit — `ovn-northd` and
`ovn-controller` respectively — but neither declares a `services` tuple, and
neither collects the service status. An sosreport from a host where the daemon
has failed to start therefore has the journal but nothing showing whether the
unit is loaded, enabled or running.

`Plugin._collect_services()` runs each entry of the tuple through
`is_service()` and calls both `add_service_status()` and `add_journal()`, so
declaring the unit adds the missing status and replaces the explicit call.

It also gives both plugins an enablement trigger beyond the package name, which
matters here because they are written for deployments where OVN runs in
containers: the package names differ between distributions and are frequently
absent on a containerised host, while the unit name is the same.

The tuples are declared on the shared base classes so they apply to both
distribution subclasses.

Companion to #4439, which made the same change for openvswitch. Both plugins
are grouped in one PR since they are the two halves of the same stack and the
change is identical.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?