### PR TITLE
plugins: add sysroles plugin to collect /var/log/sysroles.jsonl

### DIFF
--- a/sos/report/plugins/sysroles.py
+++ b/sos/report/plugins/sysroles.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Red Hat, Inc.
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, RedHatPlugin
+
+
+class SysRoles(Plugin, RedHatPlugin):
+
+    short_desc = 'RHEL System Roles fingerprint data'
+
+    plugin_name = 'sysroles'
+    packages = ('rhel-system-roles',)
+    files = ('/var/log/sysroles.jsonl',)
+
+    def setup(self):
+        self.add_copy_spec('/var/log/sysroles.jsonl')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
## Summary

RHEL System Roles ships an `sr_fingerprint` Ansible module that writes role execution fingerprint data to `/var/log/sysroles.jsonl` in JSONL format (one JSON object per line, max 2 MB self-managed). This plugin collects that file for inclusion in sos reports.

Each record contains: `date`, `role_name`, `role_path`, `status`, `ansible_version`, `managed_node_distro`, `play_hosts_number`, `ansible_check_mode`.

The plugin is scoped to Red Hat systems via `RedHatPlugin` and triggers on either the `rhel-system-roles` package or the presence of the log file.

## Test plan

- [ ] Install `rhel-system-roles` and run a role with `write_log_file: true`
- [ ] Verify `/var/log/sysroles.jsonl` is present and contains records
- [ ] Run `sos report` and confirm `var/log/sysroles.jsonl` appears in the archive
- [ ] Confirm plugin is skipped when neither the package nor the file is present