### PR TITLE
[aap_eda] Remove duplicate variable definition

### DIFF
--- a/sos/report/plugins/aap_eda.py
+++ b/sos/report/plugins/aap_eda.py
@@ -61,9 +61,6 @@ class AAPEDAControllerPlugin(Plugin, RedHatPlugin):
         self.add_cmd_output("su - eda -c 'env'",
                             suggest_filename="eda_environment")
 
-        pkg_name = 'automation-eda-controller'
-        pkg = self.policy.package_manager.pkg_by_name(f'{pkg_name}')
-
         # EDA version in 2.5 release starts with 1.1.0 version
         eda_pkg_ver = getattr(self, 'eda_pkg_ver', '0.0.0')
         if sos_parse_version(eda_pkg_ver) > sos_parse_version('1.0.99'):


### PR DESCRIPTION
Lines 64 and 65 were likely duplicated by mistake from lines 25 and 26, the latter of which then uses the result of `pkg` to set the `eda_pkg_ver`, which is what is being checked following the former's duplicate definition.

The `eda_pkg_ver` check does not reference the re-defined `pkg` var on lines 64 and 65, so it was unsued.

Remove the duplicate definitions to make CodeQL happy.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
