### PR TITLE
[plugins] Document that sizelimit=0 means no limit

### DIFF
--- a/sos/report/plugins/__init__.py
+++ b/sos/report/plugins/__init__.py
@@ -1684,7 +1684,7 @@ class Plugin():
         :type copyspecs: ``str`` or a ``list`` of strings
 
         :param sizelimit: Limit the total size of collections from `copyspecs`
-                          to this size in MB
+                          to this size in MB. Use 0 for no size limit.
         :type sizelimit: ``int``
 
         :param maxage: Collect files with `mtime` not older than this many
@@ -1953,7 +1953,8 @@ class Plugin():
         :param timeout: Timeout in seconds to allow each `cmd` to run
         :type timeout: ``int``
 
-        :param sizelimit: Maximum amount of output to collect, in MB
+        :param sizelimit: Maximum amount of output to collect, in MB.
+                          Use 0 for no size limit.
         :type sizelimit: ``int``
 
         :param chroot: Should sos chroot the command(s) being run
@@ -2160,7 +2161,8 @@ class Plugin():
         :param binary: Is the command expected to produce binary output
         :type binary: ``bool``
 
-        :param sizelimit: Maximum amount of output in MB to save
+        :param sizelimit: Maximum amount of output in MB to save.
+                          Use 0 for no size limit.
         :type sizelimit: ``int``
 
         :param pred: A predicate to gate if `cmds` should be collected or not
@@ -2416,7 +2418,8 @@ class Plugin():
                                         overriding chroot
             :param env:                 Dict of env vars to set for the cmd
             :param binary:              Is the output in binary?
-            :param sizelimit:           Maximum size in MB of output to save
+            :param sizelimit:           Maximum size in MB of output to save.
+                                        Use 0 for no size limit.
             :param subdir:              Subdir in plugin directory to save to
             :param changes:             Does this cmd potentially make a change
                                         on the system?


### PR DESCRIPTION
The sizelimit parameter in add_copy_spec, add_cmd_output, add_device_cmd, and _collect_cmd_output accepts 0 to indicate no size limit, but this was not documented in the docstrings.

Closes: #4205

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
