### PR TITLE
[logs] Collect /var/lib/rsyslog/ directory listings

### DIFF
--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -96,6 +96,10 @@ class LogsBase(Plugin):
                 ])
 
         self.add_cmd_output("rsyslogd -N3 -o /dev/stdout",)
+        self.add_cmd_output([
+            "ls -ldZ /var/ /var/lib/ /var/lib/rsyslog/",
+            "ls -lZ /var/lib/rsyslog/",
+        ])
 
     def postproc(self):
         regex = r"(ActionLibdbiPassword |pwd=)(.*)"


### PR DESCRIPTION
Add directory listings for /var/lib/rsyslog/ to help diagnose
rsyslog state file issues and verify SELinux contexts on the
path hierarchy. Commands fail gracefully when rsyslog is not
installed or uses a non-default WorkDirectory.

Collects:
- `ls -ldZ /var/ /var/lib/ /var/lib/rsyslog/` — path hierarchy with SELinux labels
- `ls -lZ /var/lib/rsyslog/` — directory contents with SELinux labels

---

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs properly referenced via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR obfuscated?