### PR TITLE
[puppet] Extend puppet to include more services, logs, and configurations

### DIFF
--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -24,6 +24,8 @@ class Puppet(Plugin, IndependentPlugin):
     def setup(self):
         _hostname = self.exec_cmd('hostname')['output']
         _hostname = _hostname.strip()
+        curl = '/opt/puppetlabs/puppet/bin/curl'
+        openssl = '/opt/puppetlabs/puppet/bin/openssl'
         self.add_default_cmd_environment({
             'PATH': os.environ['PATH'] + ':/opt/puppetlabs/bin'
         })
@@ -62,6 +64,8 @@ class Puppet(Plugin, IndependentPlugin):
             "/var/log/puppetlabs/puppetdb/*.log*",
             "/var/log/puppetlabs/puppetserver/*.log*",
             # Certs/Inventory
+            "/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem",
+            "/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem",
             "/etc/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/ca/inventory.txt",
@@ -77,11 +81,21 @@ class Puppet(Plugin, IndependentPlugin):
             'facter',
             'puppet --version',
             'puppet config print --section main',
+            '/opt/puppetlabs/puppet/bin/gem list --local',
             # Server
             'puppet config print --section server',
             'puppetserver --version',
+            'puppetserver gem list --local',
             # Code
             'puppet module list --tree',
+            # State
+            curl + ' -k https://localhost:8140/status/v1/services?level=debug',
+            curl + ' http://localhost:8080/pdb/admin/v1/summary-stats',
+            curl + ' http://localhost:8080/status/v1/services?level=debug',
+            # Certs/Inventory
+            openssl + ' x509 -in /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem -noout -dates -subject',
+            openssl + ' x509 -in /etc/puppetlabs/puppet/ssl/certs/ca.pem -noout -dates -subject',
+            openssl + ' crl -in /etc/puppetlabs/puppet/ssl/crl.pem -noout -lastupdate -nextupdate -issuer -crlnumber',
         ])
 
         self.add_dir_listing([

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -8,7 +8,7 @@
 
 from glob import glob
 from sos.report.plugins import Plugin, IndependentPlugin
-
+import os
 
 class Puppet(Plugin, IndependentPlugin):
 
@@ -24,6 +24,9 @@ class Puppet(Plugin, IndependentPlugin):
     def setup(self):
         _hostname = self.exec_cmd('hostname')['output']
         _hostname = _hostname.strip()
+        self.add_default_cmd_environment({
+            'PATH': os.environ['PATH'] + ':/opt/puppetlabs/bin'
+        })
 
         self.add_copy_spec([
             # Agent
@@ -70,8 +73,15 @@ class Puppet(Plugin, IndependentPlugin):
                            tags="puppet_ssl_cert_ca_pem")
 
         self.add_cmd_output([
+            # Agent
             'facter',
             'puppet --version',
+            'puppet config print --section main',
+            # Server
+            'puppet config print --section server',
+            'puppetserver --version',
+            # Code
+            'puppet module list --tree',
         ])
 
         self.add_dir_listing([

--- a/sos/report/plugins/puppet.py
+++ b/sos/report/plugins/puppet.py
@@ -12,30 +12,54 @@ from sos.report.plugins import Plugin, IndependentPlugin
 
 class Puppet(Plugin, IndependentPlugin):
 
-    short_desc = 'Puppet service'
+    short_desc = 'Pupppet/Openvox services'
 
     plugin_name = 'puppet'
     profiles = ('services',)
-    packages = ('openvox-agent', 'openvox-server',
+    packages = ('openvox-agent', 'openvox-server', 'openvoxdb',
                 'puppet', 'puppet-agent', 'puppet-common', 'puppet-server',
-                'puppetserver', 'puppetmaster', 'puppet-master')
+                'puppetserver', 'puppetmaster', 'puppet-master', 'puppetdb')
+    services = ('puppet', 'puppetserver', 'puppetdb')
 
     def setup(self):
         _hostname = self.exec_cmd('hostname')['output']
         _hostname = _hostname.strip()
 
         self.add_copy_spec([
+            # Agent
             "/etc/puppet/*.conf",
+            "/etc/puppet/hiera.yaml",
             "/etc/puppet/rack/*",
             "/etc/puppet/manifests/*",
-            "/etc/puppet/ssl/ca/inventory.txt",
-            "/var/log/puppet/*.log*",
             "/etc/puppetlabs/puppet/*.conf",
-            "/etc/puppetlabs/puppetserver/conf.d/*.conf",
-            "/etc/puppetlabs/puppet/rack/*",
-            "/etc/puppetlabs/puppet/manifests/*",
-            "/etc/puppetlabs/puppet/ssl/ca/inventory.txt",
+            "/etc/puppetlabs/puppet/hiera.yaml",
+            "/etc/puppetlabs/puppet/routes.yaml",
+            # Server
+            "/etc/puppetlabs/puppetserver/*.xml",
+            "/etc/puppetlabs/puppetserver/conf.d/*",
+            "/etc/puppetlabs/puppetserver/services.d/*",
+            # Database
+            "/etc/puppetlabs/puppetdb/*.cfg",
+            "/etc/puppetlabs/puppetdb/*.xml",
+            "/etc/puppetlabs/puppetdb/conf.d/*",
+            # Code
+            "/etc/puppetlabs/code/hiera.yaml",
+            "/etc/puppetlabs/r10k/r10k.yaml",
+            # Startup
+            "/etc/sysconfig/puppet*",
+            "/etc/default/pupppet*",
+            # State
+            "/opt/puppetlabs/puppet/cache/state/*.txt",
+            "/opt/puppetlabs/puppet/cache/state/*.lock",
+            "/opt/puppetlabs/puppet/cache/state/*.yaml",
+            "/opt/puppetlabs/puppet/public/last_run_summary.yaml",
+            # Logs
+            "/var/log/puppet/*.log*",
+            "/var/log/puppetlabs/puppet/*.log*",
+            "/var/log/puppetlabs/puppetdb/*.log*",
             "/var/log/puppetlabs/puppetserver/*.log*",
+            # Certs/Inventory
+            "/etc/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppetlabs/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/ca/inventory.txt",
             "/var/lib/puppet/ssl/certs/ca.pem",


### PR DESCRIPTION
Frankly, the puppet plugin was collecting a lot of dust. Most of the configuration, logging, and command output it was looking for haven't been valid since the pre-4.x days, back in 2016. It's time to update it after a decade!

I've also collected local gems, certificate expiry, and service status. If I extend this any further I'll probably want to start splitting out sections into switch cases detecting the presence of services.

My one question and hesitation is whether there's a more elegant, built-in way of extending the `$PATH` without importing `os`. I couldn't find anything but if there is, I'd love to know. And any other feedback is of course welcome.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?

