### PR TITLE
[coredump] Add all-cores option to collect oversized dumps

### DIFF
--- a/sos/report/plugins/coredump.py
+++ b/sos/report/plugins/coredump.py
@@ -39,6 +39,11 @@ class Coredump(Plugin, IndependentPlugin):
     The dump files collected are compressed, and users should be aware that
     when inflated these files can be orders of magnitude larger than their
     collected sizes.
+
+    By default, coredumps larger than 200 MiB are skipped. The `all-cores`
+    option collects them regardless of size, ignoring both the plugin's
+    200 MiB cap and the global `--log-size` limit. Use with care, as this
+    can produce very large archives.
     """
 
     short_desc = 'systemd-coredump related information and dump files'
@@ -51,7 +56,10 @@ class Coredump(Plugin, IndependentPlugin):
         PluginOpt("dumps", default=3, desc="number of dump files to collect"),
         PluginOpt("executable", default='',
                   desc=("only collect info and dump output for executables "
-                        "matching this regex"))
+                        "matching this regex")),
+        PluginOpt("all-cores", default=False,
+                  desc="collect coredumps regardless of size (ignores "
+                       "--log-size)")
     ]
 
     def setup(self):
@@ -88,12 +96,20 @@ class Coredump(Plugin, IndependentPlugin):
                     # limit, move on to the next
                     # TODO: do not hardcode this. Extend log-size to per-plugin
                     # TODO: option and link this to that value
-                    if os.stat(core_path).st_size > 209715200:
+                    all_cores = self.get_option("all-cores")
+                    if (not all_cores
+                            and os.stat(core_path).st_size > 209715200):
                         self._log_info(
                             f"Skipping core dump file {core_path} due to size"
                         )
                         continue
-                    self.add_copy_spec(core_path, tailit=False, sizelimit=200)
+                    # all-cores bypasses both the 200 MiB pre-check above and
+                    # the copy sizelimit below. sizelimit=0 means "no cap" and
+                    # also overrides the global --log-size for these files, so
+                    # archives can grow very large.
+                    sizelimit = 0 if all_cores else 200
+                    self.add_copy_spec(core_path, tailit=False,
+                                       sizelimit=sizelimit)
                     plugpath = self.path_join(
                         self.commons['cmddir'],
                         self.name(),


### PR DESCRIPTION
By default coredumps larger than 200 MiB are skipped, and even --all-logs cannot pull them due to the hardcoded pre-check. Add an `all-cores` option that bypasses both the 200 MiB cap and the global --log-size limit, allowing large cores to be collected when needed.

Related: RHEL-131895

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
