### PR TITLE
[redhat] Restrict SSO client and token URLs to RHELPolicy

### DIFF
--- a/sos/policies/distros/redhat.py
+++ b/sos/policies/distros/redhat.py
@@ -42,10 +42,11 @@ class RedHatPolicy(LinuxPolicy):
     default_container_runtime = 'podman'
     sos_pkg_name = 'sos'
     sos_bin_path = '/usr/sbin'
-    client_identifier_url = "https://sso.redhat.com/auth/"\
-        "realms/redhat-external/protocol/openid-connect/auth/device"
-    token_endpoint = "https://sso.redhat.com/auth/realms/"\
-        "redhat-external/protocol/openid-connect/token"
+    # These endpoints are specific to RHEL and should not
+    # be inherted by the non-RHEL distributions that subclass
+    # RedHatPolicy.
+    client_identifier_url = None
+    token_endpoint = None
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):
@@ -214,6 +215,10 @@ support representative.
     _device_token = None
     # Max size for an http single request is 1Gb
     _max_size_request = 1073741824
+    client_identifier_url = "https://sso.redhat.com/auth/"\
+        "realms/redhat-external/protocol/openid-connect/auth/device"
+    token_endpoint = "https://sso.redhat.com/auth/realms/"\
+        "redhat-external/protocol/openid-connect/token"
 
     def __init__(self, sysroot=None, init=None, probe_runtime=True,
                  remote_exec=None):


### PR DESCRIPTION
Subclasses of RedHatPolicy were inheriting RHEL-specific client_identifier_url and token_endpoint values introduced in commit dd2e395.

Move these endpoints down to RHELPolicy (and default to None in RedHatPolicy) so non-RHEL derived distributions do not inherit RHEL authentication URLs.

Related: #4482, #4483, SOSTR-10

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [X] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [X] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
